### PR TITLE
[Feature] 네이버 CalDAV 오류 분류 및 복구 전략 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ PYTHONPATH=src python3 -m yule_orchestrator doctor
 - 네이버 웹 화면의 할 일이 항상 CalDAV `VTODO`로 제공되는지는 계정 상태와 클라이언트 설정에 따라 달라질 수 있습니다.
 - `todo_count`가 0이면 현재 CalDAV 응답에 할 일이 포함되지 않았을 가능성이 큽니다.
 - `VTODO`는 기본적으로 지정한 기간 안에 해당하는 항목만 출력합니다.
+- `yule calendar events --json` 실행 중 실패가 발생하면 `error.code`, `error.category`, `retryable`, `manual_action_required`, `alert_recommended`를 포함한 구조화된 에러 JSON을 반환합니다.
+- 현재 에러 분류는 `configuration`, `validation`, `authentication`, `network`, `query`, `parsing`, `dependency`, `unknown` 범주를 사용합니다.
+- `retry_strategy`는 `none` 또는 `backoff`를 사용하며, 이후 Planning Agent / Discord 알림 흐름에서 그대로 재사용할 수 있습니다.
+- 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](/Users/masterway/local-dev/yule-studio-agent/policies/runtime/common/calendar-error-handling.md)에 정리합니다.
 
 ## 로컬 전용 파일
 

--- a/policies/runtime/common/calendar-error-handling.md
+++ b/policies/runtime/common/calendar-error-handling.md
@@ -1,0 +1,78 @@
+# Calendar Error Handling
+
+Naver CalDAV 연동 실패는 아래 분류를 기준으로 해석한다.
+
+## Error Categories
+
+- `configuration`
+  - 예: 누락된 환경 변수, 잘못된 timeout/cache 설정값
+  - 자동 재시도하지 않는다
+  - 수동 조치가 필요하다
+
+- `validation`
+  - 예: 잘못된 CLI 날짜 입력값
+  - 자동 재시도하지 않는다
+  - 입력 수정 후 다시 실행한다
+
+- `authentication`
+  - 예: 401, 403, unauthorized, forbidden
+  - 자동 재시도하지 않는다
+  - 앱 비밀번호/계정 설정을 수동 확인한다
+
+- `network`
+  - 예: timeout, connection reset, DNS 실패, connection refused
+  - backoff 재시도 대상이다
+  - 반복 실패 시 알림 대상으로 승격할 수 있다
+
+- `query`
+  - 예: 일시적 provider 오류, 조회 중 일반 요청 실패
+  - 원인에 따라 backoff 재시도 가능하다
+  - 반복 실패 시 수동 점검 또는 알림 대상으로 승격한다
+
+- `parsing`
+  - 예: CalDAV payload 추출 실패, 일정 파싱 실패
+  - 기본적으로 자동 재시도하지 않는다
+  - 원본 데이터 점검이 필요하다
+
+- `dependency`
+  - 예: `caldav`, `icalendar` 패키지 누락
+  - 자동 재시도하지 않는다
+  - 실행 환경을 수동으로 복구한다
+
+- `unknown`
+  - 명확한 분류가 어려운 실패
+  - 제한된 backoff 재시도 후 알림 대상으로 본다
+
+## Retry Strategy
+
+- `none`
+  - 자동 재시도를 수행하지 않는다
+
+- `backoff`
+  - 짧은 지연을 두고 재시도한다
+  - 권장 재시도 횟수는 에러 payload의 `recommended_retry_count`를 따른다
+
+## Alerting Guidance
+
+- `alert_recommended=true`
+  - Discord, 로그 집계, 운영 알림 채널에 연결하기 좋은 실패
+
+- `alert_recommended=false`
+  - 단기 재시도 또는 사용자 입력 수정으로 해결 가능한 실패
+
+## Payload Contract
+
+`yule calendar events --json` 실패 응답은 아래 필드를 포함한다.
+
+- `error.code`
+- `error.category`
+- `error.message`
+- `error.retryable`
+- `error.retry_strategy`
+- `error.recommended_retry_count`
+- `error.manual_action_required`
+- `error.alert_recommended`
+- `error.recovery_hint`
+- `error.raw_message`
+
+Planning Agent, Discord 브리핑, 자동 재시도 로직은 위 payload를 그대로 재사용한다.

--- a/src/yule_orchestrator/cli/calendar.py
+++ b/src/yule_orchestrator/cli/calendar.py
@@ -5,10 +5,12 @@ from datetime import date
 from typing import Optional
 
 from ..integrations.calendar import (
+    CalendarIntegrationError,
     CalendarQueryResult,
     list_naver_calendar_items,
     render_calendar_items,
 )
+from ..integrations.calendar.errors import build_calendar_validation_error
 
 
 def run_calendar_events_command(
@@ -16,8 +18,19 @@ def run_calendar_events_command(
     end_date_text: Optional[str],
     json_output: bool,
 ) -> int:
-    start_date, end_date = _resolve_date_range(start_date_text, end_date_text)
-    result = list_naver_calendar_items(start_date=start_date, end_date=end_date)
+    try:
+        start_date, end_date = _resolve_date_range(start_date_text, end_date_text)
+        result = list_naver_calendar_items(start_date=start_date, end_date=end_date)
+    except ValueError as exc:
+        if not json_output:
+            raise
+        print(json.dumps({"error": build_calendar_validation_error(str(exc)).to_dict()}, ensure_ascii=False, indent=2))
+        return 1
+    except CalendarIntegrationError as exc:
+        if not json_output:
+            raise
+        print(json.dumps({"error": exc.to_dict()}, ensure_ascii=False, indent=2))
+        return 1
 
     if json_output:
         print(json.dumps(_result_to_dict(result), ensure_ascii=False, indent=2))

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -6,8 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-from ..integrations.calendar.naver_caldav import CalendarIntegrationError
 from ..core import ContextError, load_env_files
+from ..integrations.calendar import CalendarIntegrationError
 from ..integrations.github.issues import GitHubIssueError
 from .calendar import run_calendar_events_command
 from .context import run_context_command
@@ -117,10 +117,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     except GitHubIssueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    except CalendarIntegrationError as exc:
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    except ValueError as exc:
+    except CalendarIntegrationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/src/yule_orchestrator/integrations/calendar/__init__.py
+++ b/src/yule_orchestrator/integrations/calendar/__init__.py
@@ -1,8 +1,10 @@
+from .errors import CalendarErrorDetails, CalendarIntegrationError
 from .models import CalendarEvent, CalendarQueryResult, CalendarTodo
-from .naver_caldav import CalendarIntegrationError, list_naver_calendar_events, list_naver_calendar_items
+from .naver_caldav import list_naver_calendar_events, list_naver_calendar_items
 from .rendering import render_calendar_events, render_calendar_items
 
 __all__ = [
+    "CalendarErrorDetails",
     "CalendarEvent",
     "CalendarIntegrationError",
     "CalendarQueryResult",

--- a/src/yule_orchestrator/integrations/calendar/errors.py
+++ b/src/yule_orchestrator/integrations/calendar/errors.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class CalendarErrorDetails:
+    source: str
+    code: str
+    category: str
+    message: str
+    retryable: bool
+    retry_strategy: str
+    recommended_retry_count: int
+    manual_action_required: bool
+    alert_recommended: bool
+    recovery_hint: str
+    raw_message: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "code": self.code,
+            "category": self.category,
+            "message": self.message,
+            "retryable": self.retryable,
+            "retry_strategy": self.retry_strategy,
+            "recommended_retry_count": self.recommended_retry_count,
+            "manual_action_required": self.manual_action_required,
+            "alert_recommended": self.alert_recommended,
+            "recovery_hint": self.recovery_hint,
+            "raw_message": self.raw_message,
+        }
+
+
+class CalendarIntegrationError(Exception):
+    """Raised when calendar items cannot be loaded or interpreted safely."""
+
+    def __init__(self, details: CalendarErrorDetails):
+        super().__init__(details.message)
+        self.details = details
+
+    @property
+    def retryable(self) -> bool:
+        return self.details.retryable
+
+    def to_dict(self) -> dict:
+        return self.details.to_dict()
+
+
+def build_calendar_error(
+    *,
+    code: str,
+    category: str,
+    message: str,
+    retryable: bool,
+    retry_strategy: str,
+    recommended_retry_count: int,
+    manual_action_required: bool,
+    alert_recommended: bool,
+    recovery_hint: str,
+    raw_message: Optional[str] = None,
+    source: str = "naver-caldav",
+) -> CalendarIntegrationError:
+    return CalendarIntegrationError(
+        CalendarErrorDetails(
+            source=source,
+            code=code,
+            category=category,
+            message=message,
+            retryable=retryable,
+            retry_strategy=retry_strategy,
+            recommended_retry_count=recommended_retry_count,
+            manual_action_required=manual_action_required,
+            alert_recommended=alert_recommended,
+            recovery_hint=recovery_hint,
+            raw_message=raw_message,
+        )
+    )
+
+
+def build_calendar_validation_error(message: str) -> CalendarIntegrationError:
+    return build_calendar_error(
+        code="invalid_request",
+        category="validation",
+        message=message,
+        retryable=False,
+        retry_strategy="none",
+        recommended_retry_count=0,
+        manual_action_required=True,
+        alert_recommended=False,
+        recovery_hint="입력 값을 수정한 뒤 다시 실행하세요.",
+        source="calendar-cli",
+        raw_message=message,
+    )

--- a/src/yule_orchestrator/integrations/calendar/naver_caldav.py
+++ b/src/yule_orchestrator/integrations/calendar/naver_caldav.py
@@ -6,14 +6,11 @@ import logging
 import os
 from typing import Any, Iterable, List, Optional
 
+from .errors import CalendarIntegrationError, build_calendar_error
 from .cache import build_calendar_cache_key, load_calendar_cache, save_calendar_cache
 from .models import CalendarQueryResult
 from .parsing import build_event, build_todo, todo_matches_range
 from .rendering import render_calendar_events, render_calendar_items
-
-
-class CalendarIntegrationError(Exception):
-    """Raised when Naver calendar items cannot be loaded."""
 
 
 @dataclass(frozen=True)
@@ -127,9 +124,7 @@ def list_naver_calendar_items(start_date: date, end_date: date) -> CalendarQuery
     except CalendarIntegrationError:
         raise
     except Exception as exc:
-        raise CalendarIntegrationError(
-            _describe_caldav_error(exc, timeout_seconds=config.timeout_seconds)
-        ) from exc
+        raise _classify_caldav_error(exc, timeout_seconds=config.timeout_seconds) from exc
 
     events.sort(key=lambda event: event.sort_key())
     todos.sort(key=lambda todo: todo.sort_key())
@@ -165,8 +160,17 @@ def load_naver_caldav_config() -> NaverCalDAVConfig:
         missing.append("NAVER_CALDAV_PASSWORD or NAVER_APP_PASSWORD")
 
     if missing:
-        raise CalendarIntegrationError(
-            "Missing Naver CalDAV credentials: " + ", ".join(missing)
+        raise build_calendar_error(
+            code="missing_credentials",
+            category="configuration",
+            message="Missing Naver CalDAV credentials: " + ", ".join(missing),
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="`.env.local`에 NAVER_ID와 NAVER_APP_PASSWORD를 채운 뒤 다시 실행하세요.",
+            raw_message=", ".join(missing),
         )
 
     return NaverCalDAVConfig(
@@ -185,15 +189,33 @@ def _load_caldav_dependencies() -> tuple[Any, Any]:
     try:
         from caldav import DAVClient
     except ImportError as exc:
-        raise CalendarIntegrationError(
-            "The `caldav` package is required. Run `python3 -m pip install -e .`."
+        raise build_calendar_error(
+            code="missing_dependency",
+            category="dependency",
+            message="The `caldav` package is required. Run `python3 -m pip install -e .`.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="가상환경을 활성화한 뒤 `python3 -m pip install -e .`를 다시 실행하세요.",
+            raw_message=str(exc).strip() or None,
         ) from exc
 
     try:
         from icalendar import Calendar
     except ImportError as exc:
-        raise CalendarIntegrationError(
-            "The `icalendar` package is required. Run `python3 -m pip install -e .`."
+        raise build_calendar_error(
+            code="missing_dependency",
+            category="dependency",
+            message="The `icalendar` package is required. Run `python3 -m pip install -e .`.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="가상환경을 활성화한 뒤 `python3 -m pip install -e .`를 다시 실행하세요.",
+            raw_message=str(exc).strip() or None,
         ) from exc
 
     logging.getLogger("caldav").setLevel(logging.ERROR)
@@ -310,7 +332,17 @@ def _collect_search_todos(
 def _select_calendars(calendars: Iterable[Any], calendar_name: Optional[str]) -> List[Any]:
     calendars = list(calendars)
     if not calendars:
-        raise CalendarIntegrationError("No calendars were found for the authenticated Naver account.")
+        raise build_calendar_error(
+            code="calendar_not_found",
+            category="query",
+            message="No calendars were found for the authenticated Naver account.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="네이버 계정에 CalDAV로 노출되는 캘린더가 있는지 확인하세요.",
+        )
 
     if calendar_name is None:
         return calendars
@@ -320,8 +352,17 @@ def _select_calendars(calendars: Iterable[Any], calendar_name: Optional[str]) ->
         return selected
 
     available = ", ".join(sorted(_calendar_label(calendar) for calendar in calendars))
-    raise CalendarIntegrationError(
-        f"Calendar `{calendar_name}` was not found. Available calendars: {available}"
+    raise build_calendar_error(
+        code="calendar_selection_failed",
+        category="query",
+        message=f"Calendar `{calendar_name}` was not found. Available calendars: {available}",
+        retryable=False,
+        retry_strategy="none",
+        recommended_retry_count=0,
+        manual_action_required=True,
+        alert_recommended=True,
+        recovery_hint="NAVER_CALDAV_CALENDAR 또는 NAVER_CALDAV_TODO_CALENDAR 값을 실제 캘린더 이름과 맞춰주세요.",
+        raw_message=available,
     )
 
 
@@ -424,7 +465,17 @@ def _resource_ical_payload(resource: Any) -> str:
         except Exception:
             pass
 
-    raise CalendarIntegrationError("Could not extract calendar item payload from a CalDAV resource.")
+    raise build_calendar_error(
+        code="calendar_payload_parse_failed",
+        category="parsing",
+        message="Could not extract calendar item payload from a CalDAV resource.",
+        retryable=False,
+        retry_strategy="none",
+        recommended_retry_count=0,
+        manual_action_required=True,
+        alert_recommended=True,
+        recovery_hint="CalDAV 응답 형식이 예상과 다른지 확인하고, 반복되면 원본 응답을 점검하세요.",
+    )
 
 
 def _list_todo_resources(calendar: Any) -> List[Any]:
@@ -448,13 +499,31 @@ def _load_timeout_seconds() -> int:
     try:
         timeout = int(raw_value)
     except ValueError as exc:
-        raise CalendarIntegrationError(
-            "NAVER_CALDAV_TIMEOUT_SECONDS must be an integer."
+        raise build_calendar_error(
+            code="invalid_timeout_configuration",
+            category="configuration",
+            message="NAVER_CALDAV_TIMEOUT_SECONDS must be an integer.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="`.env.local`의 NAVER_CALDAV_TIMEOUT_SECONDS 값을 정수로 수정하세요.",
+            raw_message=raw_value,
         ) from exc
 
     if timeout <= 0:
-        raise CalendarIntegrationError(
-            "NAVER_CALDAV_TIMEOUT_SECONDS must be greater than 0."
+        raise build_calendar_error(
+            code="invalid_timeout_configuration",
+            category="configuration",
+            message="NAVER_CALDAV_TIMEOUT_SECONDS must be greater than 0.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="`.env.local`의 NAVER_CALDAV_TIMEOUT_SECONDS 값을 1 이상의 정수로 수정하세요.",
+            raw_message=raw_value,
         )
 
     return timeout
@@ -465,13 +534,31 @@ def _load_cache_seconds() -> int:
     try:
         ttl = int(raw_value)
     except ValueError as exc:
-        raise CalendarIntegrationError(
-            "NAVER_CALDAV_CACHE_SECONDS must be an integer."
+        raise build_calendar_error(
+            code="invalid_cache_configuration",
+            category="configuration",
+            message="NAVER_CALDAV_CACHE_SECONDS must be an integer.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="`.env.local`의 NAVER_CALDAV_CACHE_SECONDS 값을 정수로 수정하세요.",
+            raw_message=raw_value,
         ) from exc
 
     if ttl < 0:
-        raise CalendarIntegrationError(
-            "NAVER_CALDAV_CACHE_SECONDS must be 0 or greater."
+        raise build_calendar_error(
+            code="invalid_cache_configuration",
+            category="configuration",
+            message="NAVER_CALDAV_CACHE_SECONDS must be 0 or greater.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="`.env.local`의 NAVER_CALDAV_CACHE_SECONDS 값을 0 이상의 정수로 수정하세요.",
+            raw_message=raw_value,
         )
 
     return ttl
@@ -488,33 +575,139 @@ def _load_bool_env(name: str, default: bool) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
 
-    raise CalendarIntegrationError(
-        f"{name} must be one of: true, false, 1, 0, yes, no, on, off."
+    raise build_calendar_error(
+        code="invalid_boolean_configuration",
+        category="configuration",
+        message=f"{name} must be one of: true, false, 1, 0, yes, no, on, off.",
+        retryable=False,
+        retry_strategy="none",
+        recommended_retry_count=0,
+        manual_action_required=True,
+        alert_recommended=True,
+        recovery_hint=f"`.env.local`의 {name} 값을 true/false 형식으로 수정하세요.",
+        raw_message=raw_value,
     )
 
 
-def _describe_caldav_error(exc: Exception, timeout_seconds: int) -> str:
+def _classify_caldav_error(exc: Exception, timeout_seconds: int) -> CalendarIntegrationError:
     class_name = exc.__class__.__name__.lower()
     message = str(exc).strip()
     message_lower = message.lower()
 
     if "timeout" in class_name or "timed out" in message_lower or "read timed out" in message_lower:
-        return (
-            "Naver CalDAV request timed out. "
-            f"Check your network or reduce server delay, then try again. "
-            f"Current timeout: {timeout_seconds}s."
+        return build_calendar_error(
+            code="request_timeout",
+            category="network",
+            message=(
+                "Naver CalDAV request timed out. "
+                f"Check your network or reduce server delay, then try again. "
+                f"Current timeout: {timeout_seconds}s."
+            ),
+            retryable=True,
+            retry_strategy="backoff",
+            recommended_retry_count=3,
+            manual_action_required=False,
+            alert_recommended=False,
+            recovery_hint="잠시 후 재시도하고, 반복되면 NAVER_CALDAV_TIMEOUT_SECONDS 값을 늘리세요.",
+            raw_message=message or None,
         )
 
     if "401" in message_lower or "403" in message_lower or "unauthorized" in message_lower or "forbidden" in message_lower:
-        return (
-            "Naver CalDAV authentication failed. "
-            "Check NAVER_ID, NAVER_APP_PASSWORD, and CalDAV app-password settings."
+        return build_calendar_error(
+            code="authentication_failed",
+            category="authentication",
+            message=(
+                "Naver CalDAV authentication failed. "
+                "Check NAVER_ID, NAVER_APP_PASSWORD, and CalDAV app-password settings."
+            ),
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="앱 비밀번호와 CalDAV 사용 가능 여부를 다시 확인하세요.",
+            raw_message=message or None,
+        )
+
+    if any(
+        keyword in message_lower
+        for keyword in (
+            "connection refused",
+            "connection reset",
+            "remote disconnected",
+            "name or service not known",
+            "temporary failure in name resolution",
+            "failed to establish a new connection",
+            "max retries exceeded",
+            "nodename nor servname provided",
+        )
+    ):
+        return build_calendar_error(
+            code="network_unreachable",
+            category="network",
+            message="Naver CalDAV network connection failed. Check your network and try again.",
+            retryable=True,
+            retry_strategy="backoff",
+            recommended_retry_count=3,
+            manual_action_required=False,
+            alert_recommended=False,
+            recovery_hint="네트워크 상태를 확인한 뒤 잠시 후 다시 시도하세요.",
+            raw_message=message or None,
+        )
+
+    if any(keyword in message_lower for keyword in ("500", "502", "503", "504", "bad gateway", "service unavailable")):
+        return build_calendar_error(
+            code="provider_unavailable",
+            category="query",
+            message="Naver CalDAV provider is temporarily unavailable.",
+            retryable=True,
+            retry_strategy="backoff",
+            recommended_retry_count=3,
+            manual_action_required=False,
+            alert_recommended=False,
+            recovery_hint="잠시 후 재시도하고, 반복되면 서비스 상태를 확인하세요.",
+            raw_message=message or None,
+        )
+
+    if any(keyword in message_lower for keyword in ("parse", "ical", "invalid calendar", "component")):
+        return build_calendar_error(
+            code="calendar_parse_failed",
+            category="parsing",
+            message="Naver CalDAV response could not be parsed.",
+            retryable=False,
+            retry_strategy="none",
+            recommended_retry_count=0,
+            manual_action_required=True,
+            alert_recommended=True,
+            recovery_hint="반복되면 원본 CalDAV 응답이나 특정 일정 데이터를 확인하세요.",
+            raw_message=message or None,
         )
 
     if message:
-        return f"Naver CalDAV request failed: {message}"
+        return build_calendar_error(
+            code="request_failed",
+            category="query",
+            message=f"Naver CalDAV request failed: {message}",
+            retryable=True,
+            retry_strategy="backoff",
+            recommended_retry_count=2,
+            manual_action_required=False,
+            alert_recommended=True,
+            recovery_hint="한두 번 재시도해보고, 반복되면 수동 점검 또는 알림 전송 대상으로 분류하세요.",
+            raw_message=message,
+        )
 
-    return "Naver CalDAV request failed for an unknown reason."
+    return build_calendar_error(
+        code="unknown_error",
+        category="unknown",
+        message="Naver CalDAV request failed for an unknown reason.",
+        retryable=True,
+        retry_strategy="backoff",
+        recommended_retry_count=2,
+        manual_action_required=False,
+        alert_recommended=True,
+        recovery_hint="재시도 후에도 반복되면 원인 분석을 위해 원시 오류를 수집하세요.",
+    )
 
 
 def _to_local_datetime(value: date) -> datetime:


### PR DESCRIPTION
## 📌 관련 이슈
- #11 

## ✨ 과제 내용
네이버 CalDAV 연동 실패를 문자열 메시지 중심에서 구조화된 에러 payload 중심으로 정리했습니다.

이번 작업에서는 다음을 반영했습니다.

- 인증 실패, 네트워크 실패, 조회 실패, 파싱 실패, 설정 오류를 구분하는 에러 분류 추가
- retry 가능 여부와 retry strategy 정의
- 수동 조치 필요 여부와 알림 권장 여부 정의
- `yule calendar events --json` 실패 시 구조화된 에러 JSON 출력 지원
- Planning Agent / Discord 연동에서 재사용 가능한 공통 에러 계약 정리
- 캘린더 오류 처리 운영 기준 문서 추가

## :camera_with_flash: 스크린샷(선택)
없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 현재 에러 범주는 `configuration`, `validation`, `authentication`, `network`, `query`, `parsing`, `dependency`, `unknown` 입니다.
- `retry_strategy`는 현재 `none`, `backoff`를 사용합니다.
- 이후 Discord 알림, 자동 재시도, Planning Agent 입력 구조에 그대로 연결할 수 있습니다.
