### PR TITLE
[Feature] 네이버 CalDAV 조회 결과 캐시 구조 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,16 @@ NAVER_APP_PASSWORD=
 - 예시는 `.env.example`에 둡니다.
 - `.env.local`은 Git에 올리지 않습니다.
 - 응답이 오래 걸리면 `NAVER_CALDAV_TIMEOUT_SECONDS`로 요청 타임아웃을 조절할 수 있습니다.
-- 같은 날짜 범위를 반복 조회할 때는 `NAVER_CALDAV_CACHE_SECONDS` 동안 로컬 캐시를 재사용합니다.
+- `NAVER_CALDAV_CACHE_SECONDS`를 지정하면 해당 TTL을 우선 사용합니다.
+- 값을 지정하지 않으면 오늘이 포함된 범위는 5분, 미래 범위는 30분, 과거 범위는 24시간 동안 SQLite 로컬 캐시를 재사용합니다.
+- 캐시 저장소 기본 위치는 `.cache/yule/cache.sqlite3`입니다.
 - 기본 동작은 요청한 날짜 범위 안의 일정과 할 일만 읽습니다.
 - 할 일 캘린더는 전체 캘린더 목록에서 `할 일`, `todo`, `task`가 들어간 이름을 자동 탐지합니다.
 - 자동 탐지된 할 일 캘린더가 여러 개일 때는 `NAVER_CALDAV_TODO_CALENDAR` 설정을 우선합니다.
 - 자동 탐지 결과가 없으면 일반 일정 조회 대상 캘린더를 기준으로 fallback 합니다.
 - `NAVER_CALDAV_INCLUDE_ALL_TODOS=true`는 서버가 날짜 범위 검색으로 할 일을 제대로 주지 않을 때만 사용하는 느린 마지막 보강 옵션입니다.
 - `NAVER_CALDAV_INCLUDE_ALL_TODOS=true`를 써도 같은 범위 재실행은 캐시 덕분에 더 빠르게 응답할 수 있습니다.
+- 캐시를 무시하고 새로 가져오려면 `--force-refresh`를 사용합니다.
 
 ## 실행
 
@@ -148,6 +151,8 @@ PYTHONPATH=src python3 -m yule_orchestrator doctor
 - 현재 에러 분류는 `configuration`, `validation`, `authentication`, `network`, `query`, `parsing`, `dependency`, `unknown` 범주를 사용합니다.
 - `retry_strategy`는 `none` 또는 `backoff`를 사용하며, 이후 Planning Agent / Discord 알림 흐름에서 그대로 재사용할 수 있습니다.
 - 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](/Users/masterway/local-dev/yule-studio-agent/policies/runtime/common/calendar-error-handling.md)에 정리합니다.
+- 같은 날짜 범위와 같은 캘린더 설정 요청은 SQLite 캐시를 재사용합니다.
+- 이 캐시 구조는 이후 daily-plan, Planning Agent, Discord 브리핑이 같은 저장소를 재사용할 수 있도록 설계되었습니다.
 
 ## 로컬 전용 파일
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ NAVER_APP_PASSWORD=
 - `NAVER_CALDAV_CACHE_SECONDS`를 지정하면 해당 TTL을 우선 사용합니다.
 - 값을 지정하지 않으면 오늘이 포함된 범위는 5분, 미래 범위는 30분, 과거 범위는 24시간 동안 SQLite 로컬 캐시를 재사용합니다.
 - 캐시 저장소 기본 위치는 `.cache/yule/cache.sqlite3`입니다.
+- 같은 SQLite 안에 캘린더 항목 상태(`calendar_item_states`)도 함께 동기화합니다.
 - 기본 동작은 요청한 날짜 범위 안의 일정과 할 일만 읽습니다.
 - 할 일 캘린더는 전체 캘린더 목록에서 `할 일`, `todo`, `task`가 들어간 이름을 자동 탐지합니다.
 - 자동 탐지된 할 일 캘린더가 여러 개일 때는 `NAVER_CALDAV_TODO_CALENDAR` 설정을 우선합니다.
@@ -153,6 +154,7 @@ PYTHONPATH=src python3 -m yule_orchestrator doctor
 - 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](/Users/masterway/local-dev/yule-studio-agent/policies/runtime/common/calendar-error-handling.md)에 정리합니다.
 - 같은 날짜 범위와 같은 캘린더 설정 요청은 SQLite 캐시를 재사용합니다.
 - 이 캐시 구조는 이후 daily-plan, Planning Agent, Discord 브리핑이 같은 저장소를 재사용할 수 있도록 설계되었습니다.
+- 조회 결과를 동기화할 때 일정/할 일 항목 단위 상태를 upsert 하므로, 이후 완료 여부 변화와 최근 본 항목을 기준으로 다음 작업 추천 로직을 붙일 수 있습니다.
 
 ## 로컬 전용 파일
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ NAVER_APP_PASSWORD=
 - `NAVER_CALDAV_CACHE_SECONDS`를 지정하면 해당 TTL을 우선 사용합니다.
 - 값을 지정하지 않으면 오늘이 포함된 범위는 5분, 미래 범위는 30분, 과거 범위는 24시간 동안 SQLite 로컬 캐시를 재사용합니다.
 - 캐시 저장소 기본 위치는 `.cache/yule/cache.sqlite3`입니다.
+- 원격 fetch가 `network`, `query`, `unknown` 성격의 오류로 실패하면 오래된 stale cache를 임시 fallback 으로 사용할 수 있습니다.
 - 같은 SQLite 안에 캘린더 항목 상태(`calendar_item_states`)도 함께 동기화합니다.
 - 기본 동작은 요청한 날짜 범위 안의 일정과 할 일만 읽습니다.
 - 할 일 캘린더는 전체 캘린더 목록에서 `할 일`, `todo`, `task`가 들어간 이름을 자동 탐지합니다.
@@ -128,18 +129,23 @@ yule doctor
 yule context coding-agent
 yule github issues --limit 30
 yule calendar events --json
+yule calendar warmup --force-refresh --json
+yule calendar cache inspect --json
+yule calendar cache cleanup --json
+```
+
+로컬 환경에 따라 엔트리포인트 설치가 덜 맞물려 있을 때는 아래처럼 모듈 실행 방식으로 동일하게 사용할 수 있습니다.
+
+```bash
+PYTHONPATH=src python3 -m yule_orchestrator doctor
+PYTHONPATH=src python3 -m yule_orchestrator calendar events --json
+PYTHONPATH=src python3 -m yule_orchestrator calendar cache cleanup --json
 ```
 
 기간을 지정해서 일정 데이터를 읽을 수도 있습니다.
 
 ```bash
 yule calendar events --start-date 2026-04-21 --end-date 2026-04-25 --json
-```
-
-설치 전에 바로 실행해야 하면:
-
-```bash
-PYTHONPATH=src python3 -m yule_orchestrator doctor
 ```
 
 ## 캘린더 연동 메모
@@ -153,8 +159,17 @@ PYTHONPATH=src python3 -m yule_orchestrator doctor
 - `retry_strategy`는 `none` 또는 `backoff`를 사용하며, 이후 Planning Agent / Discord 알림 흐름에서 그대로 재사용할 수 있습니다.
 - 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](/Users/masterway/local-dev/yule-studio-agent/policies/runtime/common/calendar-error-handling.md)에 정리합니다.
 - 같은 날짜 범위와 같은 캘린더 설정 요청은 SQLite 캐시를 재사용합니다.
+- stale cache는 기본적으로 만료 후 7일 동안 남겨두고, `yule calendar cache cleanup`에서 정리합니다.
 - 이 캐시 구조는 이후 daily-plan, Planning Agent, Discord 브리핑이 같은 저장소를 재사용할 수 있도록 설계되었습니다.
 - 조회 결과를 동기화할 때 일정/할 일 항목 단위 상태를 upsert 하므로, 이후 완료 여부 변화와 최근 본 항목을 기준으로 다음 작업 추천 로직을 붙일 수 있습니다.
+
+## 테스트
+
+기본 자동 테스트는 표준 라이브러리 `unittest`로 실행합니다.
+
+```bash
+python3 -m unittest discover -s tests
+```
 
 ## 로컬 전용 파일
 

--- a/policies/reference/BRANCH_STRATEGY.md
+++ b/policies/reference/BRANCH_STRATEGY.md
@@ -1,28 +1,29 @@
-# Branching Strategy (Gitflow + Jira)
+# Branching Strategy (Main-Based)
 
 ## 1. 기본 브랜치
 
 | 브랜치 | 역할 |
 | ------ | ------ |
-| `main` | 프로덕션 브랜치. 태그 기반 릴리즈 및 운영 배포 기준 |
-| `dev` | 개발 통합 브랜치. 모든 기능 브랜치의 머지 대상 |
+| `main` | 기본 통합 브랜치. 모든 작업 브랜치의 시작점이자 머지 대상 |
 
 ## 2. 브랜치 타입
 
-모든 작업 브랜치는 Jira 티켓 키를 포함한다.
+모든 작업 브랜치는 `main`에서 시작한다.
 
 형식:
 
 ```text
-<prefix>/<jira-key>-<short-description>
+<prefix>/<short-description>
 ```
 
 예시:
 
 ```text
-feature/ANS-123-login-api
-refactor/ANS-245-auth-service-cleanup
-chore/ANS-310-update-gradle
+feature/calendar-sqlite-cache
+refactor/calendar-cache-layer
+fix/calendar-timeout-message
+chore/update-bootstrap-docs
+docs/refresh-readme
 ```
 
 ### Prefix 종류
@@ -30,133 +31,69 @@ chore/ANS-310-update-gradle
 | Prefix | 용도 |
 | ------ | ------ |
 | `feature` | 신규 기능 개발 |
-| `refactor` | 리팩토링, 기능 변경 없음 |
-| `fix` | 일반 버그 수정, 당일 배포 필요 없음 |
-| `chore` | 빌드, 설정, 의존성, 스크립트, 문서 변경 |
+| `refactor` | 리팩토링, 구조 개선 |
+| `fix` | 일반 버그 수정 |
+| `chore` | 설정, 스크립트, 의존성, 운영 보조 작업 |
 | `test` | 테스트 코드 추가 또는 수정 |
 | `docs` | 문서 수정 |
+| `hotfix` | 빠른 운영 대응이 필요한 긴급 수정 |
 
-## 3. feature / refactor / fix / chore 흐름
+## 3. 기본 작업 흐름
 
-1. `dev` 브랜치에서 작업 브랜치 생성
-
-```bash
-git checkout dev
-git checkout -b feature/ANS-123-login-api
-```
-
-2. 개발 및 커밋
-3. `dev` 대상으로 Pull Request 생성
-4. CI 통과 및 코드 리뷰 승인
-5. `dev` 브랜치로 머지
-
-## 4. release 브랜치
-
-릴리즈 단위 묶음을 위한 브랜치
-
-형식:
-
-```text
-release/vX.Y.Z
-```
-
-생성:
-
-```bash
-git checkout dev
-git checkout -b release/v1.2.0
-```
-
-규칙:
-
-- QA 및 최종 테스트만 수행
-- 새로운 기능 추가 금지
-- 버그 수정만 허용
-
-완료 절차:
-
-1. `release` 브랜치를 `main`으로 머지
-2. `main`에 태그 생성
-
-```bash
-git tag v1.2.0
-git push origin v1.2.0
-```
-
-3. `release` 브랜치를 `dev`에도 머지
-
-## 5. hotfix 브랜치
-
-형식:
-
-```text
-hotfix/<jira-key>-<short-description>
-```
-
-사용 기준:
-
-- 프로덕션 장애
-- 보안 이슈
-- 데이터 정합성 오류
-- 당일 내 배포가 반드시 필요한 수정
-
-흐름:
-
-1. `main` 브랜치에서 `hotfix` 브랜치 생성
+1. `main` 브랜치로 이동하고 최신 상태를 맞춘다
 
 ```bash
 git checkout main
-git checkout -b hotfix/ANS-999-payment-null-pointer
+git pull origin main
 ```
 
-2. 수정 및 커밋
-3. `main` 브랜치로 머지
-4. 태그 생성 및 푸시
+2. 작업 브랜치를 생성한다
 
 ```bash
-git tag v1.2.1
-git push origin v1.2.1
+git checkout -b feature/calendar-sqlite-cache
 ```
 
-5. 동일 변경 사항을 `dev` 브랜치에도 머지
+3. 개발 및 커밋을 진행한다
+4. `main` 대상으로 Pull Request를 생성한다
+5. 리뷰와 확인이 끝나면 `main`으로 머지한다
 
-## 6. Pull Request 규칙
+## 4. hotfix 브랜치
 
-- 모든 PR은 Jira 티켓 키 포함
-- PR 제목 형식:
-
-```text
-[ANS-123] Login API 구현
-```
-
-- 최소 1명 이상 리뷰 승인 후 머지
-- CI 실패 시 머지 금지
-
-## 7. 태그 규칙
+긴급 수정도 동일하게 `main`에서 시작한다.
 
 형식:
 
 ```text
-v<major>.<minor>.<patch>
+hotfix/<short-description>
 ```
 
 예시:
 
 ```text
-v1.0.0
-v1.2.3
+hotfix/calendar-auth-failure
 ```
 
-- `main` 브랜치에서만 태그 생성
-- 태그 푸시 시 운영 배포 트리거
+흐름:
 
-## 8. 머지 전략
+1. `main` 브랜치에서 `hotfix` 브랜치를 만든다
+2. 수정 및 검증을 진행한다
+3. `main` 대상으로 Pull Request를 생성한다
+4. 검토 후 `main`으로 머지한다
 
-- `dev` ← `feature` / `refactor` / `fix` / `chore`: Squash Merge
-- `main` ← `release` / `hotfix`: Merge Commit
+## 5. Pull Request 규칙
 
-## 9. 금지 사항
+- PR 제목은 작업 내용을 짧고 명확하게 적는다
+- 가능하면 하나의 PR에는 하나의 목적만 담는다
+- 확인 가능한 테스트 또는 검증 결과를 함께 남긴다
+- 리뷰 전에는 범위를 넓히지 않는다
 
-- `main` 브랜치 직접 커밋 금지
-- `dev` 브랜치 직접 커밋 금지
-- Jira 티켓 없는 브랜치 생성 금지
+## 6. 머지 전략
+
+- 기본적으로 `main`으로 Squash Merge를 사용한다
+- 히스토리를 보존해야 하는 특별한 경우만 Merge Commit을 사용한다
+
+## 7. 금지 사항
+
+- `main` 브랜치에 직접 커밋하지 않는다
+- 관련 없는 변경을 한 브랜치에 섞지 않는다
+- 오래된 작업 브랜치를 기준으로 새 작업을 시작하지 않는다

--- a/src/yule_orchestrator/cli/calendar.py
+++ b/src/yule_orchestrator/cli/calendar.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from ..integrations.calendar import (
@@ -10,7 +10,14 @@ from ..integrations.calendar import (
     list_naver_calendar_items,
     render_calendar_items,
 )
+from ..integrations.calendar.cache import CALENDAR_CACHE_NAMESPACE, list_calendar_cache_entries
 from ..integrations.calendar.errors import build_calendar_validation_error
+from ..storage import (
+    cleanup_calendar_state_records,
+    cleanup_json_cache,
+    list_calendar_state_records,
+    local_cache_database_path,
+)
 
 
 def run_calendar_events_command(
@@ -45,6 +52,108 @@ def run_calendar_events_command(
     return 0
 
 
+def run_calendar_warmup_command(
+    start_date_text: Optional[str],
+    end_date_text: Optional[str],
+    json_output: bool,
+    force_refresh: bool,
+) -> int:
+    start_date, end_date = _resolve_date_range(start_date_text, end_date_text)
+    result = list_naver_calendar_items(
+        start_date=start_date,
+        end_date=end_date,
+        force_refresh=force_refresh,
+    )
+
+    payload = {
+        "action": "warmup",
+        "database_path": str(local_cache_database_path()),
+        "force_refresh": force_refresh,
+        **_result_to_dict(result),
+    }
+
+    if json_output:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    print(
+        f"warmed calendar cache for {start_date.isoformat()}..{end_date.isoformat()} "
+        f"({len(result.events)} events, {len(result.todos)} todos)"
+    )
+    print(f"cache db: {local_cache_database_path()}")
+    return 0
+
+
+def run_calendar_cache_inspect_command(
+    json_output: bool,
+    limit: int,
+    fresh_only: bool,
+) -> int:
+    entries = list_calendar_cache_entries(
+        limit=limit,
+        include_expired=not fresh_only,
+    )
+    payload = {
+        "database_path": str(local_cache_database_path()),
+        "namespace": CALENDAR_CACHE_NAMESPACE,
+        "entry_count": len(entries),
+        "entries": [_format_cache_entry(entry) for entry in entries],
+        "state_record_count": len(list_calendar_state_records()),
+    }
+
+    if json_output:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"cache db: {payload['database_path']}")
+    print(f"namespace: {payload['namespace']}")
+    print(f"entries: {payload['entry_count']}")
+    print(f"state records: {payload['state_record_count']}")
+    if not entries:
+        print("no cache entries")
+        return 0
+
+    for entry in payload["entries"]:
+        stale_label = "stale" if entry["is_stale"] else "fresh"
+        print(
+            f"- {entry['cache_key']} [{stale_label}] "
+            f"{entry['range_start']}..{entry['range_end']} "
+            f"expires {entry['expires_at_iso']}"
+        )
+    return 0
+
+
+def run_calendar_cache_cleanup_command(
+    json_output: bool,
+    cache_retention_days: int,
+    state_retention_days: int,
+) -> int:
+    cache_deleted_count = cleanup_json_cache(
+        namespace=CALENDAR_CACHE_NAMESPACE,
+        stale_retention_seconds=max(0, cache_retention_days) * 24 * 60 * 60,
+    )
+    state_deleted_count = cleanup_calendar_state_records(
+        retention_seconds=max(0, state_retention_days) * 24 * 60 * 60,
+    )
+    payload = {
+        "action": "cleanup",
+        "database_path": str(local_cache_database_path()),
+        "cache_retention_days": cache_retention_days,
+        "state_retention_days": state_retention_days,
+        "cache_deleted_count": cache_deleted_count,
+        "state_deleted_count": state_deleted_count,
+    }
+
+    if json_output:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"cache db: {payload['database_path']}")
+    print(f"deleted cache entries: {cache_deleted_count}")
+    print(f"deleted state records: {state_deleted_count}")
+    return 0
+
+
 def _resolve_date_range(
     start_date_text: Optional[str],
     end_date_text: Optional[str],
@@ -74,3 +183,19 @@ def _parse_date(value: str, flag_name: str) -> date:
 
 def _result_to_dict(result: CalendarQueryResult) -> dict:
     return result.to_dict()
+
+
+def _format_cache_entry(entry: dict) -> dict:
+    fetched_at = _timestamp_to_iso(entry["fetched_at"])
+    expires_at = _timestamp_to_iso(entry["expires_at"])
+    last_accessed_at = _timestamp_to_iso(entry["last_accessed_at"])
+    return {
+        **entry,
+        "fetched_at_iso": fetched_at,
+        "expires_at_iso": expires_at,
+        "last_accessed_at_iso": last_accessed_at,
+    }
+
+
+def _timestamp_to_iso(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp).astimezone().isoformat()

--- a/src/yule_orchestrator/cli/calendar.py
+++ b/src/yule_orchestrator/cli/calendar.py
@@ -17,10 +17,15 @@ def run_calendar_events_command(
     start_date_text: Optional[str],
     end_date_text: Optional[str],
     json_output: bool,
+    force_refresh: bool,
 ) -> int:
     try:
         start_date, end_date = _resolve_date_range(start_date_text, end_date_text)
-        result = list_naver_calendar_items(start_date=start_date, end_date=end_date)
+        result = list_naver_calendar_items(
+            start_date=start_date,
+            end_date=end_date,
+            force_refresh=force_refresh,
+        )
     except ValueError as exc:
         if not json_output:
             raise

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -9,7 +9,12 @@ from typing import Iterable, Optional
 from ..core import ContextError, load_env_files
 from ..integrations.calendar import CalendarIntegrationError
 from ..integrations.github.issues import GitHubIssueError
-from .calendar import run_calendar_events_command
+from .calendar import (
+    run_calendar_cache_cleanup_command,
+    run_calendar_cache_inspect_command,
+    run_calendar_events_command,
+    run_calendar_warmup_command,
+)
 from .context import run_context_command
 from .doctor import run_doctor_command
 from .github import run_github_issues_command
@@ -97,6 +102,78 @@ def build_parser() -> argparse.ArgumentParser:
         help="Ignore the local cache and fetch fresh calendar data.",
     )
 
+    calendar_warmup_parser = calendar_subparsers.add_parser(
+        "warmup",
+        help="Prefetch and store calendar data in the local cache.",
+    )
+    calendar_warmup_parser.add_argument(
+        "--start-date",
+        help="Start date in YYYY-MM-DD format. Defaults to today.",
+    )
+    calendar_warmup_parser.add_argument(
+        "--end-date",
+        help="End date in YYYY-MM-DD format. Defaults to the same value as --start-date.",
+    )
+    calendar_warmup_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print structured JSON instead of the default text view.",
+    )
+    calendar_warmup_parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Ignore the local cache and fetch fresh calendar data.",
+    )
+
+    calendar_cache_parser = calendar_subparsers.add_parser(
+        "cache",
+        help="Inspect or clean up the local calendar cache.",
+    )
+    calendar_cache_subparsers = calendar_cache_parser.add_subparsers(dest="calendar_cache_command", required=True)
+
+    calendar_cache_inspect_parser = calendar_cache_subparsers.add_parser(
+        "inspect",
+        help="Show cached calendar query entries.",
+    )
+    calendar_cache_inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print structured JSON instead of the default text view.",
+    )
+    calendar_cache_inspect_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of cache entries to show. Defaults to 20.",
+    )
+    calendar_cache_inspect_parser.add_argument(
+        "--fresh-only",
+        action="store_true",
+        help="Show only unexpired cache entries.",
+    )
+
+    calendar_cache_cleanup_parser = calendar_cache_subparsers.add_parser(
+        "cleanup",
+        help="Delete old cache entries and stale calendar state records.",
+    )
+    calendar_cache_cleanup_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print structured JSON instead of the default text view.",
+    )
+    calendar_cache_cleanup_parser.add_argument(
+        "--cache-retention-days",
+        type=int,
+        default=7,
+        help="Keep expired cache entries for this many days before deletion. Defaults to 7.",
+    )
+    calendar_cache_cleanup_parser.add_argument(
+        "--state-retention-days",
+        type=int,
+        default=30,
+        help="Keep unseen calendar state records for this many days before deletion. Defaults to 30.",
+    )
+
     return parser
 
 
@@ -121,6 +198,26 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 args.json,
                 args.force_refresh,
             )
+        if args.command == "calendar" and args.calendar_command == "warmup":
+            return run_calendar_warmup_command(
+                args.start_date,
+                args.end_date,
+                args.json,
+                args.force_refresh,
+            )
+        if args.command == "calendar" and args.calendar_command == "cache":
+            if args.calendar_cache_command == "inspect":
+                return run_calendar_cache_inspect_command(
+                    args.json,
+                    args.limit,
+                    args.fresh_only,
+                )
+            if args.calendar_cache_command == "cleanup":
+                return run_calendar_cache_cleanup_command(
+                    args.json,
+                    args.cache_retention_days,
+                    args.state_retention_days,
+                )
     except ContextError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -91,6 +91,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print structured JSON instead of the default text view.",
     )
+    calendar_events_parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Ignore the local cache and fetch fresh calendar data.",
+    )
 
     return parser
 
@@ -110,7 +115,12 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         if args.command == "github" and args.github_command == "issues":
             return run_github_issues_command(args.limit)
         if args.command == "calendar" and args.calendar_command == "events":
-            return run_calendar_events_command(args.start_date, args.end_date, args.json)
+            return run_calendar_events_command(
+                args.start_date,
+                args.end_date,
+                args.json,
+                args.force_refresh,
+            )
     except ContextError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/src/yule_orchestrator/integrations/calendar/cache.py
+++ b/src/yule_orchestrator/integrations/calendar/cache.py
@@ -1,60 +1,67 @@
 from __future__ import annotations
 
+from datetime import date
 from hashlib import sha256
-import json
-import os
-from pathlib import Path
-import time
 from typing import Optional
 
+from ...storage import load_json_cache, save_json_cache
 from .models import CalendarQueryResult
+
+CALENDAR_CACHE_NAMESPACE = "calendar-query-results"
+CALENDAR_CACHE_PROVIDER = "naver-caldav"
+CURRENT_RANGE_TTL_SECONDS = 300
+FUTURE_RANGE_TTL_SECONDS = 1800
+PAST_RANGE_TTL_SECONDS = 86400
 
 
 def load_calendar_cache(cache_key: str, ttl_seconds: int) -> Optional[CalendarQueryResult]:
     if ttl_seconds <= 0:
         return None
 
-    cache_path = _cache_path(cache_key)
-    if not cache_path.exists():
-        return None
-
     try:
-        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        entry = load_json_cache(
+            namespace=CALENDAR_CACHE_NAMESPACE,
+            cache_key=cache_key,
+            ttl_seconds=ttl_seconds,
+        )
     except Exception:
         return None
 
-    expires_at = payload.get("expires_at")
-    if not isinstance(expires_at, (int, float)) or expires_at < time.time():
-        return None
-
-    data = payload.get("result")
-    if not isinstance(data, dict):
+    if entry is None:
         return None
 
     try:
-        return CalendarQueryResult.from_dict(data)
+        return CalendarQueryResult.from_dict(entry.payload)
     except Exception:
         return None
 
 
 def save_calendar_cache(
     cache_key: str,
+    scope_hash: str,
+    start_date: date,
+    end_date: date,
     ttl_seconds: int,
     result: CalendarQueryResult,
 ) -> None:
     if ttl_seconds <= 0:
         return
 
-    cache_path = _cache_path(cache_key)
     try:
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "expires_at": time.time() + ttl_seconds,
-            "result": result.to_dict(),
-        }
-        cache_path.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2),
-            encoding="utf-8",
+        save_json_cache(
+            namespace=CALENDAR_CACHE_NAMESPACE,
+            cache_key=cache_key,
+            provider=CALENDAR_CACHE_PROVIDER,
+            range_start=start_date.isoformat(),
+            range_end=end_date.isoformat(),
+            scope_hash=scope_hash,
+            ttl_seconds=ttl_seconds,
+            payload=result.to_dict(),
+            metadata={
+                "source": result.source,
+                "event_count": len(result.events),
+                "todo_count": len(result.todos),
+            },
         )
     except Exception:
         return
@@ -65,10 +72,23 @@ def build_calendar_cache_key(*parts: str) -> str:
     return sha256(normalized.encode("utf-8")).hexdigest()
 
 
-def _cache_path(cache_key: str) -> Path:
-    repo_root = os.getenv("YULE_REPO_ROOT")
-    if repo_root:
-        base_dir = Path(repo_root)
-    else:
-        base_dir = Path.cwd()
-    return base_dir / ".cache" / "yule" / "calendar" / f"{cache_key}.json"
+def build_calendar_scope_hash(*parts: str) -> str:
+    normalized = "::".join(parts)
+    return sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def resolve_calendar_cache_ttl_seconds(
+    start_date: date,
+    end_date: date,
+    configured_ttl_seconds: Optional[int],
+    today: Optional[date] = None,
+) -> int:
+    if configured_ttl_seconds is not None:
+        return configured_ttl_seconds
+
+    reference_day = today or date.today()
+    if end_date < reference_day:
+        return PAST_RANGE_TTL_SECONDS
+    if start_date > reference_day:
+        return FUTURE_RANGE_TTL_SECONDS
+    return CURRENT_RANGE_TTL_SECONDS

--- a/src/yule_orchestrator/integrations/calendar/cache.py
+++ b/src/yule_orchestrator/integrations/calendar/cache.py
@@ -4,7 +4,7 @@ from datetime import date
 from hashlib import sha256
 from typing import Optional
 
-from ...storage import load_json_cache, save_json_cache
+from ...storage import list_json_cache_entries, load_json_cache, save_json_cache
 from .models import CalendarQueryResult
 
 CALENDAR_CACHE_NAMESPACE = "calendar-query-results"
@@ -23,6 +23,25 @@ def load_calendar_cache(cache_key: str, ttl_seconds: int) -> Optional[CalendarQu
             namespace=CALENDAR_CACHE_NAMESPACE,
             cache_key=cache_key,
             ttl_seconds=ttl_seconds,
+        )
+    except Exception:
+        return None
+
+    if entry is None:
+        return None
+
+    try:
+        return CalendarQueryResult.from_dict(entry.payload)
+    except Exception:
+        return None
+
+
+def load_stale_calendar_cache(cache_key: str) -> Optional[CalendarQueryResult]:
+    try:
+        entry = load_json_cache(
+            namespace=CALENDAR_CACHE_NAMESPACE,
+            cache_key=cache_key,
+            allow_stale=True,
         )
     except Exception:
         return None
@@ -92,3 +111,13 @@ def resolve_calendar_cache_ttl_seconds(
     if start_date > reference_day:
         return FUTURE_RANGE_TTL_SECONDS
     return CURRENT_RANGE_TTL_SECONDS
+
+
+def list_calendar_cache_entries(limit: int = 100, include_expired: bool = True) -> list[dict]:
+    entries = list_json_cache_entries(
+        namespace=CALENDAR_CACHE_NAMESPACE,
+        provider=CALENDAR_CACHE_PROVIDER,
+        include_expired=include_expired,
+        limit=limit,
+    )
+    return [entry.to_dict() for entry in entries]

--- a/src/yule_orchestrator/integrations/calendar/models.py
+++ b/src/yule_orchestrator/integrations/calendar/models.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from hashlib import sha256
 from typing import Optional, Sequence
 
 
 @dataclass(frozen=True)
 class CalendarEvent:
+    item_uid: str
     title: str
     start: str
     end: str
@@ -14,12 +16,14 @@ class CalendarEvent:
     calendar_name: str
     source: str
     description: str
+    last_modified: Optional[str]
 
     def sort_key(self) -> tuple[int, str, str]:
         return (0 if self.all_day else 1, self.start, self.title.lower())
 
     def to_dict(self) -> dict:
         return {
+            "item_uid": self.item_uid,
             "title": self.title,
             "start": self.start,
             "end": self.end,
@@ -27,11 +31,20 @@ class CalendarEvent:
             "calendar_name": self.calendar_name,
             "source": self.source,
             "description": self.description,
+            "last_modified": self.last_modified,
         }
 
     @classmethod
     def from_dict(cls, payload: dict) -> "CalendarEvent":
+        item_uid = payload.get("item_uid") or build_fallback_item_uid(
+            "event",
+            payload.get("calendar_name", ""),
+            payload.get("title", ""),
+            payload.get("start", ""),
+            payload.get("end", ""),
+        )
         return cls(
+            item_uid=item_uid,
             title=payload["title"],
             start=payload["start"],
             end=payload["end"],
@@ -39,11 +52,13 @@ class CalendarEvent:
             calendar_name=payload["calendar_name"],
             source=payload["source"],
             description=payload.get("description", ""),
+            last_modified=payload.get("last_modified"),
         )
 
 
 @dataclass(frozen=True)
 class CalendarTodo:
+    item_uid: str
     title: str
     start: Optional[str]
     due: Optional[str]
@@ -57,6 +72,7 @@ class CalendarTodo:
     calendar_name: str
     source: str
     description: str
+    last_modified: Optional[str]
 
     def sort_key(self) -> tuple[int, str, str]:
         return (
@@ -67,6 +83,7 @@ class CalendarTodo:
 
     def to_dict(self) -> dict:
         return {
+            "item_uid": self.item_uid,
             "title": self.title,
             "start": self.start,
             "due": self.due,
@@ -80,11 +97,20 @@ class CalendarTodo:
             "calendar_name": self.calendar_name,
             "source": self.source,
             "description": self.description,
+            "last_modified": self.last_modified,
         }
 
     @classmethod
     def from_dict(cls, payload: dict) -> "CalendarTodo":
+        item_uid = payload.get("item_uid") or build_fallback_item_uid(
+            "todo",
+            payload.get("calendar_name", ""),
+            payload.get("title", ""),
+            payload.get("due") or "",
+            payload.get("start") or "",
+        )
         return cls(
+            item_uid=item_uid,
             title=payload["title"],
             start=payload.get("start"),
             due=payload.get("due"),
@@ -98,6 +124,7 @@ class CalendarTodo:
             calendar_name=payload["calendar_name"],
             source=payload["source"],
             description=payload.get("description", ""),
+            last_modified=payload.get("last_modified"),
         )
 
 
@@ -129,3 +156,8 @@ class CalendarQueryResult:
             events=[CalendarEvent.from_dict(event) for event in payload.get("events", [])],
             todos=[CalendarTodo.from_dict(todo) for todo in payload.get("todos", [])],
         )
+
+
+def build_fallback_item_uid(item_type: str, *parts: str) -> str:
+    normalized = "::".join([item_type, *parts])
+    return sha256(normalized.encode("utf-8")).hexdigest()

--- a/src/yule_orchestrator/integrations/calendar/naver_caldav.py
+++ b/src/yule_orchestrator/integrations/calendar/naver_caldav.py
@@ -6,10 +6,11 @@ import logging
 import os
 from typing import Any, Iterable, List, Optional
 
-from ...storage import sync_calendar_query_result
+from ...storage.calendar_state import sync_calendar_query_result
 from .cache import (
     build_calendar_cache_key,
     build_calendar_scope_hash,
+    load_stale_calendar_cache,
     load_calendar_cache,
     resolve_calendar_cache_ttl_seconds,
     save_calendar_cache,
@@ -56,6 +57,7 @@ def list_naver_calendar_items(
         start_date.isoformat(),
         end_date.isoformat(),
     )
+    stale_cached_result = None
     if not force_refresh:
         cached_result = load_calendar_cache(
             cache_key=cache_key,
@@ -64,12 +66,19 @@ def list_naver_calendar_items(
         if cached_result is not None:
             _sync_calendar_state_safely(cached_result, scope_hash=cache_scope_hash)
             return cached_result
+        stale_cached_result = load_stale_calendar_cache(cache_key=cache_key)
 
-    result = _fetch_naver_calendar_items(
-        config=config,
-        start_date=start_date,
-        end_date=end_date,
-    )
+    try:
+        result = _fetch_naver_calendar_items(
+            config=config,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except CalendarIntegrationError as exc:
+        if stale_cached_result is not None and _can_use_stale_cache_on_error(exc):
+            _sync_calendar_state_safely(stale_cached_result, scope_hash=cache_scope_hash)
+            return stale_cached_result
+        raise
     save_calendar_cache(
         cache_key=cache_key,
         scope_hash=cache_scope_hash,
@@ -188,6 +197,13 @@ def _sync_calendar_state_safely(result: CalendarQueryResult, scope_hash: str) ->
         sync_calendar_query_result(result, scope_hash=scope_hash)
     except Exception:
         return
+
+
+def _can_use_stale_cache_on_error(error: CalendarIntegrationError) -> bool:
+    details = error.details
+    if details.retryable:
+        return True
+    return details.category in {"network", "query", "unknown"}
 
 
 def list_naver_calendar_events(

--- a/src/yule_orchestrator/integrations/calendar/naver_caldav.py
+++ b/src/yule_orchestrator/integrations/calendar/naver_caldav.py
@@ -6,6 +6,7 @@ import logging
 import os
 from typing import Any, Iterable, List, Optional
 
+from ...storage import sync_calendar_query_result
 from .cache import (
     build_calendar_cache_key,
     build_calendar_scope_hash,
@@ -61,6 +62,7 @@ def list_naver_calendar_items(
             ttl_seconds=cache_ttl_seconds,
         )
         if cached_result is not None:
+            _sync_calendar_state_safely(cached_result, scope_hash=cache_scope_hash)
             return cached_result
 
     result = _fetch_naver_calendar_items(
@@ -76,6 +78,7 @@ def list_naver_calendar_items(
         ttl_seconds=cache_ttl_seconds,
         result=result,
     )
+    _sync_calendar_state_safely(result, scope_hash=cache_scope_hash)
     return result
 
 
@@ -178,6 +181,13 @@ def _fetch_naver_calendar_items(
         events=events,
         todos=todos,
     )
+
+
+def _sync_calendar_state_safely(result: CalendarQueryResult, scope_hash: str) -> None:
+    try:
+        sync_calendar_query_result(result, scope_hash=scope_hash)
+    except Exception:
+        return
 
 
 def list_naver_calendar_events(

--- a/src/yule_orchestrator/integrations/calendar/naver_caldav.py
+++ b/src/yule_orchestrator/integrations/calendar/naver_caldav.py
@@ -6,8 +6,14 @@ import logging
 import os
 from typing import Any, Iterable, List, Optional
 
+from .cache import (
+    build_calendar_cache_key,
+    build_calendar_scope_hash,
+    load_calendar_cache,
+    resolve_calendar_cache_ttl_seconds,
+    save_calendar_cache,
+)
 from .errors import CalendarIntegrationError, build_calendar_error
-from .cache import build_calendar_cache_key, load_calendar_cache, save_calendar_cache
 from .models import CalendarQueryResult
 from .parsing import build_event, build_todo, todo_matches_range
 from .rendering import render_calendar_events, render_calendar_items
@@ -22,25 +28,62 @@ class NaverCalDAVConfig:
     todo_calendar_name: Optional[str] = None
     timeout_seconds: int = 15
     include_all_todos: bool = False
-    cache_seconds: int = 300
+    cache_seconds: Optional[int] = None
 
 
-def list_naver_calendar_items(start_date: date, end_date: date) -> CalendarQueryResult:
+def list_naver_calendar_items(
+    start_date: date,
+    end_date: date,
+    force_refresh: bool = False,
+) -> CalendarQueryResult:
     config = load_naver_caldav_config()
-    cache_key = build_calendar_cache_key(
-        "naver-caldav",
+    cache_ttl_seconds = resolve_calendar_cache_ttl_seconds(
+        start_date=start_date,
+        end_date=end_date,
+        configured_ttl_seconds=config.cache_seconds,
+    )
+    cache_scope_hash = build_calendar_scope_hash(
+        "calendar-query-v1",
         config.url,
         config.username,
         config.calendar_name or "",
         config.todo_calendar_name or "",
         str(config.include_all_todos),
+    )
+    cache_key = build_calendar_cache_key(
+        cache_scope_hash,
         start_date.isoformat(),
         end_date.isoformat(),
     )
-    cached_result = load_calendar_cache(cache_key, ttl_seconds=config.cache_seconds)
-    if cached_result is not None:
-        return cached_result
+    if not force_refresh:
+        cached_result = load_calendar_cache(
+            cache_key=cache_key,
+            ttl_seconds=cache_ttl_seconds,
+        )
+        if cached_result is not None:
+            return cached_result
 
+    result = _fetch_naver_calendar_items(
+        config=config,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    save_calendar_cache(
+        cache_key=cache_key,
+        scope_hash=cache_scope_hash,
+        start_date=start_date,
+        end_date=end_date,
+        ttl_seconds=cache_ttl_seconds,
+        result=result,
+    )
+    return result
+
+
+def _fetch_naver_calendar_items(
+    config: NaverCalDAVConfig,
+    start_date: date,
+    end_date: date,
+) -> CalendarQueryResult:
     client_cls, calendar_cls = _load_caldav_dependencies()
 
     query_start = _to_local_datetime(start_date)
@@ -128,19 +171,25 @@ def list_naver_calendar_items(start_date: date, end_date: date) -> CalendarQuery
 
     events.sort(key=lambda event: event.sort_key())
     todos.sort(key=lambda todo: todo.sort_key())
-    result = CalendarQueryResult(
+    return CalendarQueryResult(
         source="naver-caldav",
         start_date=start_date,
         end_date=end_date,
         events=events,
         todos=todos,
     )
-    save_calendar_cache(cache_key, ttl_seconds=config.cache_seconds, result=result)
-    return result
 
 
-def list_naver_calendar_events(start_date: date, end_date: date) -> CalendarQueryResult:
-    return list_naver_calendar_items(start_date=start_date, end_date=end_date)
+def list_naver_calendar_events(
+    start_date: date,
+    end_date: date,
+    force_refresh: bool = False,
+) -> CalendarQueryResult:
+    return list_naver_calendar_items(
+        start_date=start_date,
+        end_date=end_date,
+        force_refresh=force_refresh,
+    )
 
 
 def load_naver_caldav_config() -> NaverCalDAVConfig:
@@ -529,10 +578,13 @@ def _load_timeout_seconds() -> int:
     return timeout
 
 
-def _load_cache_seconds() -> int:
-    raw_value = os.getenv("NAVER_CALDAV_CACHE_SECONDS", "300").strip()
+def _load_cache_seconds() -> Optional[int]:
+    raw_value = os.getenv("NAVER_CALDAV_CACHE_SECONDS")
+    if raw_value is None or not raw_value.strip():
+        return None
+
     try:
-        ttl = int(raw_value)
+        ttl = int(raw_value.strip())
     except ValueError as exc:
         raise build_calendar_error(
             code="invalid_cache_configuration",
@@ -692,21 +744,22 @@ def _classify_caldav_error(exc: Exception, timeout_seconds: int) -> CalendarInte
             retry_strategy="backoff",
             recommended_retry_count=2,
             manual_action_required=False,
-            alert_recommended=True,
-            recovery_hint="한두 번 재시도해보고, 반복되면 수동 점검 또는 알림 전송 대상으로 분류하세요.",
+            alert_recommended=False,
+            recovery_hint="잠시 후 다시 시도하고, 반복되면 에러 메시지를 점검하세요.",
             raw_message=message,
         )
 
     return build_calendar_error(
-        code="unknown_error",
+        code="unknown_failure",
         category="unknown",
         message="Naver CalDAV request failed for an unknown reason.",
         retryable=True,
         retry_strategy="backoff",
-        recommended_retry_count=2,
+        recommended_retry_count=1,
         manual_action_required=False,
         alert_recommended=True,
-        recovery_hint="재시도 후에도 반복되면 원인 분석을 위해 원시 오류를 수집하세요.",
+        recovery_hint="잠시 후 재시도하고, 반복되면 로그를 확인하세요.",
+        raw_message=None,
     )
 
 

--- a/src/yule_orchestrator/integrations/calendar/parsing.py
+++ b/src/yule_orchestrator/integrations/calendar/parsing.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta
 from typing import Any, Optional
 
-from .models import CalendarEvent, CalendarTodo
+from .models import CalendarEvent, CalendarTodo, build_fallback_item_uid
 
 
 def build_event(component: Any, calendar_name: str) -> Optional[CalendarEvent]:
     title_value = component.get("summary")
     title = str(title_value) if title_value else "(untitled event)"
     description = extract_description(component)
+    last_modified = extract_last_modified(component)
 
     start_value = component.decoded("dtstart")
     end_value = component.decoded("dtend") if component.get("dtend") else None
@@ -17,7 +18,16 @@ def build_event(component: Any, calendar_name: str) -> Optional[CalendarEvent]:
     if isinstance(start_value, date) and not isinstance(start_value, datetime):
         start_date = start_value
         end_date = end_value if isinstance(end_value, date) and not isinstance(end_value, datetime) else start_date + timedelta(days=1)
+        item_uid = extract_uid(
+            component,
+            "event",
+            calendar_name,
+            title,
+            start_date.isoformat(),
+            end_date.isoformat(),
+        )
         return CalendarEvent(
+            item_uid=item_uid,
             title=title,
             start=start_date.isoformat(),
             end=end_date.isoformat(),
@@ -25,6 +35,7 @@ def build_event(component: Any, calendar_name: str) -> Optional[CalendarEvent]:
             calendar_name=calendar_name,
             source="naver-caldav",
             description=description,
+            last_modified=last_modified,
         )
 
     if not isinstance(start_value, datetime):
@@ -32,8 +43,17 @@ def build_event(component: Any, calendar_name: str) -> Optional[CalendarEvent]:
 
     start_dt = normalize_datetime(start_value)
     end_dt = normalize_datetime(end_value) if isinstance(end_value, datetime) else start_dt
+    item_uid = extract_uid(
+        component,
+        "event",
+        calendar_name,
+        title,
+        start_dt.isoformat(),
+        end_dt.isoformat(),
+    )
 
     return CalendarEvent(
+        item_uid=item_uid,
         title=title,
         start=start_dt.isoformat(),
         end=end_dt.isoformat(),
@@ -41,6 +61,7 @@ def build_event(component: Any, calendar_name: str) -> Optional[CalendarEvent]:
         calendar_name=calendar_name,
         source="naver-caldav",
         description=description,
+        last_modified=last_modified,
     )
 
 
@@ -48,6 +69,7 @@ def build_todo(component: Any, calendar_name: str) -> CalendarTodo:
     title_value = component.get("summary")
     title = str(title_value) if title_value else "(untitled todo)"
     description = extract_description(component)
+    last_modified = extract_last_modified(component)
 
     start_value = component.decoded("dtstart") if component.get("dtstart") else None
     due_value = component.decoded("due") if component.get("due") else None
@@ -64,8 +86,17 @@ def build_todo(component: Any, calendar_name: str) -> CalendarTodo:
     priority = extract_int(component, "priority")
     percent_complete = extract_int(component, "percent-complete")
     completed = status == "COMPLETED" or completed_at is not None or percent_complete == 100
+    item_uid = extract_uid(
+        component,
+        "todo",
+        calendar_name,
+        title,
+        due or "",
+        start or "",
+    )
 
     return CalendarTodo(
+        item_uid=item_uid,
         title=title,
         start=start,
         due=due,
@@ -79,6 +110,7 @@ def build_todo(component: Any, calendar_name: str) -> CalendarTodo:
         calendar_name=calendar_name,
         source="naver-caldav",
         description=description,
+        last_modified=last_modified,
     )
 
 
@@ -100,6 +132,32 @@ def extract_description(component: Any) -> str:
         if value:
             return str(value).strip()
     return ""
+
+
+def extract_uid(component: Any, item_type: str, *fallback_parts: str) -> str:
+    value = component.get("uid")
+    if value:
+        uid = str(value).strip()
+        if uid:
+            return uid
+    return build_fallback_item_uid(item_type, *fallback_parts)
+
+
+def extract_last_modified(component: Any) -> Optional[str]:
+    for field_name in ("last-modified", "dtstamp", "created"):
+        if component.get(field_name) is None:
+            continue
+
+        try:
+            normalized, _ = normalize_temporal_value(component.decoded(field_name))
+            if normalized:
+                return normalized
+        except Exception:
+            value = component.get(field_name)
+            if value:
+                return str(value).strip()
+
+    return None
 
 
 def extract_status(component: Any) -> str:

--- a/src/yule_orchestrator/storage/__init__.py
+++ b/src/yule_orchestrator/storage/__init__.py
@@ -1,17 +1,29 @@
 from .calendar_state import (
     CalendarStateRecord,
     CalendarStateSyncSummary,
+    cleanup_calendar_state_records,
     list_calendar_state_records,
     sync_calendar_query_result,
 )
-from .local_cache import LocalCacheEntry, load_json_cache, save_json_cache
+from .local_cache import (
+    LocalCacheEntry,
+    cleanup_json_cache,
+    list_json_cache_entries,
+    load_json_cache,
+    local_cache_database_path,
+    save_json_cache,
+)
 
 __all__ = [
     "CalendarStateRecord",
     "CalendarStateSyncSummary",
     "LocalCacheEntry",
+    "cleanup_calendar_state_records",
+    "cleanup_json_cache",
+    "list_json_cache_entries",
     "list_calendar_state_records",
     "load_json_cache",
+    "local_cache_database_path",
     "save_json_cache",
     "sync_calendar_query_result",
 ]

--- a/src/yule_orchestrator/storage/__init__.py
+++ b/src/yule_orchestrator/storage/__init__.py
@@ -1,0 +1,7 @@
+from .local_cache import LocalCacheEntry, load_json_cache, save_json_cache
+
+__all__ = [
+    "LocalCacheEntry",
+    "load_json_cache",
+    "save_json_cache",
+]

--- a/src/yule_orchestrator/storage/__init__.py
+++ b/src/yule_orchestrator/storage/__init__.py
@@ -1,7 +1,17 @@
+from .calendar_state import (
+    CalendarStateRecord,
+    CalendarStateSyncSummary,
+    list_calendar_state_records,
+    sync_calendar_query_result,
+)
 from .local_cache import LocalCacheEntry, load_json_cache, save_json_cache
 
 __all__ = [
+    "CalendarStateRecord",
+    "CalendarStateSyncSummary",
     "LocalCacheEntry",
+    "list_calendar_state_records",
     "load_json_cache",
     "save_json_cache",
+    "sync_calendar_query_result",
 ]

--- a/src/yule_orchestrator/storage/calendar_state.py
+++ b/src/yule_orchestrator/storage/calendar_state.py
@@ -8,9 +8,12 @@ import os
 from pathlib import Path
 import sqlite3
 import time
-from typing import Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 
-from ..integrations.calendar.models import CalendarEvent, CalendarQueryResult, CalendarTodo
+if TYPE_CHECKING:
+    from ..integrations.calendar.models import CalendarEvent, CalendarQueryResult, CalendarTodo
+
+DEFAULT_CALENDAR_STATE_RETENTION_SECONDS = 30 * 24 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -314,6 +317,23 @@ def list_calendar_state_records(
         records.append(record)
 
     return records
+
+
+def cleanup_calendar_state_records(
+    retention_seconds: int = DEFAULT_CALENDAR_STATE_RETENTION_SECONDS,
+) -> int:
+    db_path = _database_path()
+    if not db_path.exists():
+        return 0
+
+    threshold = time.time() - max(0, retention_seconds)
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        cursor = connection.execute(
+            "DELETE FROM calendar_item_states WHERE last_seen_at <= ?",
+            (threshold,),
+        )
+        return int(cursor.rowcount or 0)
 
 
 def _iter_event_records(events: Iterable[CalendarEvent]) -> list[dict[str, Any]]:

--- a/src/yule_orchestrator/storage/calendar_state.py
+++ b/src/yule_orchestrator/storage/calendar_state.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import sqlite3
+import time
+from typing import Any, Iterable, Optional
+
+from ..integrations.calendar.models import CalendarEvent, CalendarQueryResult, CalendarTodo
+
+
+@dataclass(frozen=True)
+class CalendarStateRecord:
+    source: str
+    scope_hash: str
+    item_type: str
+    item_key: str
+    external_uid: Optional[str]
+    calendar_name: str
+    title: str
+    start_at: Optional[str]
+    end_at: Optional[str]
+    due_at: Optional[str]
+    all_day: bool
+    status: Optional[str]
+    completed: bool
+    completed_at: Optional[str]
+    priority: Optional[int]
+    percent_complete: Optional[int]
+    description: str
+    last_modified: Optional[str]
+    payload: dict[str, Any]
+    first_seen_at: float
+    last_seen_at: float
+    last_changed_at: float
+
+    def to_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "scope_hash": self.scope_hash,
+            "item_type": self.item_type,
+            "item_key": self.item_key,
+            "external_uid": self.external_uid,
+            "calendar_name": self.calendar_name,
+            "title": self.title,
+            "start_at": self.start_at,
+            "end_at": self.end_at,
+            "due_at": self.due_at,
+            "all_day": self.all_day,
+            "status": self.status,
+            "completed": self.completed,
+            "completed_at": self.completed_at,
+            "priority": self.priority,
+            "percent_complete": self.percent_complete,
+            "description": self.description,
+            "last_modified": self.last_modified,
+            "payload": self.payload,
+            "first_seen_at": self.first_seen_at,
+            "last_seen_at": self.last_seen_at,
+            "last_changed_at": self.last_changed_at,
+        }
+
+
+@dataclass(frozen=True)
+class CalendarStateSyncSummary:
+    inserted_count: int = 0
+    updated_count: int = 0
+    unchanged_count: int = 0
+    completed_transition_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "inserted_count": self.inserted_count,
+            "updated_count": self.updated_count,
+            "unchanged_count": self.unchanged_count,
+            "completed_transition_count": self.completed_transition_count,
+        }
+
+
+def sync_calendar_query_result(
+    result: CalendarQueryResult,
+    scope_hash: str,
+) -> CalendarStateSyncSummary:
+    items = [*_iter_event_records(result.events), *_iter_todo_records(result.todos)]
+    if not items:
+        return CalendarStateSyncSummary()
+
+    db_path = _database_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+
+    inserted_count = 0
+    updated_count = 0
+    unchanged_count = 0
+    completed_transition_count = 0
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+
+        for item in items:
+            row = connection.execute(
+                """
+                SELECT state_hash, completed, first_seen_at, last_changed_at
+                FROM calendar_item_states
+                WHERE source = ? AND item_type = ? AND item_key = ?
+                """,
+                (item["source"], item["item_type"], item["item_key"]),
+            ).fetchone()
+
+            if row is None:
+                connection.execute(
+                    """
+                    INSERT INTO calendar_item_states (
+                        source,
+                        scope_hash,
+                        item_type,
+                        item_key,
+                        external_uid,
+                        calendar_name,
+                        title,
+                        start_at,
+                        end_at,
+                        due_at,
+                        all_day,
+                        status,
+                        completed,
+                        completed_at,
+                        priority,
+                        percent_complete,
+                        description,
+                        last_modified,
+                        state_hash,
+                        payload_json,
+                        first_seen_at,
+                        last_seen_at,
+                        last_changed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        item["source"],
+                        scope_hash,
+                        item["item_type"],
+                        item["item_key"],
+                        item["external_uid"],
+                        item["calendar_name"],
+                        item["title"],
+                        item["start_at"],
+                        item["end_at"],
+                        item["due_at"],
+                        int(item["all_day"]),
+                        item["status"],
+                        int(item["completed"]),
+                        item["completed_at"],
+                        item["priority"],
+                        item["percent_complete"],
+                        item["description"],
+                        item["last_modified"],
+                        item["state_hash"],
+                        item["payload_json"],
+                        now,
+                        now,
+                        now,
+                    ),
+                )
+                inserted_count += 1
+                continue
+
+            previous_completed = bool(row["completed"])
+            state_changed = row["state_hash"] != item["state_hash"]
+            first_seen_at = float(row["first_seen_at"])
+            previous_last_changed_at = float(row["last_changed_at"])
+            last_changed_at = now if state_changed else previous_last_changed_at
+
+            connection.execute(
+                """
+                UPDATE calendar_item_states
+                SET
+                    scope_hash = ?,
+                    external_uid = ?,
+                    calendar_name = ?,
+                    title = ?,
+                    start_at = ?,
+                    end_at = ?,
+                    due_at = ?,
+                    all_day = ?,
+                    status = ?,
+                    completed = ?,
+                    completed_at = ?,
+                    priority = ?,
+                    percent_complete = ?,
+                    description = ?,
+                    last_modified = ?,
+                    state_hash = ?,
+                    payload_json = ?,
+                    last_seen_at = ?,
+                    last_changed_at = ?
+                WHERE source = ? AND item_type = ? AND item_key = ?
+                """,
+                (
+                    scope_hash,
+                    item["external_uid"],
+                    item["calendar_name"],
+                    item["title"],
+                    item["start_at"],
+                    item["end_at"],
+                    item["due_at"],
+                    int(item["all_day"]),
+                    item["status"],
+                    int(item["completed"]),
+                    item["completed_at"],
+                    item["priority"],
+                    item["percent_complete"],
+                    item["description"],
+                    item["last_modified"],
+                    item["state_hash"],
+                    item["payload_json"],
+                    now,
+                    last_changed_at,
+                    item["source"],
+                    item["item_type"],
+                    item["item_key"],
+                ),
+            )
+            if state_changed:
+                updated_count += 1
+                if item["item_type"] == "todo" and not previous_completed and item["completed"]:
+                    completed_transition_count += 1
+            else:
+                unchanged_count += 1
+
+    return CalendarStateSyncSummary(
+        inserted_count=inserted_count,
+        updated_count=updated_count,
+        unchanged_count=unchanged_count,
+        completed_transition_count=completed_transition_count,
+    )
+
+
+def list_calendar_state_records(
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    include_completed: bool = True,
+) -> list[CalendarStateRecord]:
+    db_path = _database_path()
+    if not db_path.exists():
+        return []
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        rows = connection.execute(
+            """
+            SELECT
+                source,
+                scope_hash,
+                item_type,
+                item_key,
+                external_uid,
+                calendar_name,
+                title,
+                start_at,
+                end_at,
+                due_at,
+                all_day,
+                status,
+                completed,
+                completed_at,
+                priority,
+                percent_complete,
+                description,
+                last_modified,
+                payload_json,
+                first_seen_at,
+                last_seen_at,
+                last_changed_at
+            FROM calendar_item_states
+            ORDER BY item_type, COALESCE(due_at, start_at, end_at), title
+            """
+        ).fetchall()
+
+    records = []
+    for row in rows:
+        record = CalendarStateRecord(
+            source=row["source"],
+            scope_hash=row["scope_hash"],
+            item_type=row["item_type"],
+            item_key=row["item_key"],
+            external_uid=row["external_uid"],
+            calendar_name=row["calendar_name"],
+            title=row["title"],
+            start_at=row["start_at"],
+            end_at=row["end_at"],
+            due_at=row["due_at"],
+            all_day=bool(row["all_day"]),
+            status=row["status"],
+            completed=bool(row["completed"]),
+            completed_at=row["completed_at"],
+            priority=row["priority"],
+            percent_complete=row["percent_complete"],
+            description=row["description"] or "",
+            last_modified=row["last_modified"],
+            payload=_deserialize_json_object(row["payload_json"]) or {},
+            first_seen_at=float(row["first_seen_at"]),
+            last_seen_at=float(row["last_seen_at"]),
+            last_changed_at=float(row["last_changed_at"]),
+        )
+        if not include_completed and record.completed:
+            continue
+        if not _record_matches_range(record, start_date=start_date, end_date=end_date):
+            continue
+        records.append(record)
+
+    return records
+
+
+def _iter_event_records(events: Iterable[CalendarEvent]) -> list[dict[str, Any]]:
+    return [
+        _build_item_record(
+            source=event.source,
+            item_type="event",
+            external_uid=event.item_uid,
+            calendar_name=event.calendar_name,
+            title=event.title,
+            start_at=event.start,
+            end_at=event.end,
+            due_at=None,
+            all_day=event.all_day,
+            status="CONFIRMED",
+            completed=False,
+            completed_at=None,
+            priority=None,
+            percent_complete=None,
+            description=event.description,
+            last_modified=event.last_modified,
+            payload=event.to_dict(),
+            identity_parts=(event.item_uid, event.start, event.end, event.calendar_name),
+        )
+        for event in events
+    ]
+
+
+def _iter_todo_records(todos: Iterable[CalendarTodo]) -> list[dict[str, Any]]:
+    return [
+        _build_item_record(
+            source=todo.source,
+            item_type="todo",
+            external_uid=todo.item_uid,
+            calendar_name=todo.calendar_name,
+            title=todo.title,
+            start_at=todo.start,
+            end_at=None,
+            due_at=todo.due,
+            all_day=todo.start_all_day or todo.due_all_day,
+            status=todo.status,
+            completed=todo.completed,
+            completed_at=todo.completed_at,
+            priority=todo.priority,
+            percent_complete=todo.percent_complete,
+            description=todo.description,
+            last_modified=todo.last_modified,
+            payload=todo.to_dict(),
+            identity_parts=(todo.item_uid, todo.due or "", todo.start or "", todo.calendar_name),
+        )
+        for todo in todos
+    ]
+
+
+def _build_item_record(
+    *,
+    source: str,
+    item_type: str,
+    external_uid: Optional[str],
+    calendar_name: str,
+    title: str,
+    start_at: Optional[str],
+    end_at: Optional[str],
+    due_at: Optional[str],
+    all_day: bool,
+    status: Optional[str],
+    completed: bool,
+    completed_at: Optional[str],
+    priority: Optional[int],
+    percent_complete: Optional[int],
+    description: str,
+    last_modified: Optional[str],
+    payload: dict[str, Any],
+    identity_parts: tuple[str, ...],
+) -> dict[str, Any]:
+    item_key = _hash_value("::".join((item_type, *identity_parts)))
+    payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    state_hash = _hash_value(payload_json)
+    return {
+        "source": source,
+        "item_type": item_type,
+        "item_key": item_key,
+        "external_uid": external_uid,
+        "calendar_name": calendar_name,
+        "title": title,
+        "start_at": start_at,
+        "end_at": end_at,
+        "due_at": due_at,
+        "all_day": all_day,
+        "status": status,
+        "completed": completed,
+        "completed_at": completed_at,
+        "priority": priority,
+        "percent_complete": percent_complete,
+        "description": description,
+        "last_modified": last_modified,
+        "payload_json": payload_json,
+        "state_hash": state_hash,
+    }
+
+
+def _record_matches_range(
+    record: CalendarStateRecord,
+    start_date: Optional[date],
+    end_date: Optional[date],
+) -> bool:
+    if start_date is None and end_date is None:
+        return True
+
+    range_start = start_date or date.min
+    range_end = end_date or date.max
+    candidate_values = [record.start_at, record.end_at, record.due_at, record.completed_at]
+
+    for value in candidate_values:
+        if not value:
+            continue
+        candidate_date = _date_from_iso(value)
+        if range_start <= candidate_date <= range_end:
+            return True
+
+    return False
+
+
+def _date_from_iso(value: str) -> date:
+    if "T" in value:
+        return datetime.fromisoformat(value).date()
+    return date.fromisoformat(value)
+
+
+def _deserialize_json_object(value: Optional[str]) -> Optional[dict[str, Any]]:
+    if value is None:
+        return {}
+
+    try:
+        data = json.loads(value)
+    except Exception:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    return data
+
+
+def _hash_value(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _ensure_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS calendar_item_states (
+            source TEXT NOT NULL,
+            scope_hash TEXT NOT NULL,
+            item_type TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            external_uid TEXT,
+            calendar_name TEXT NOT NULL,
+            title TEXT NOT NULL,
+            start_at TEXT,
+            end_at TEXT,
+            due_at TEXT,
+            all_day INTEGER NOT NULL,
+            status TEXT,
+            completed INTEGER NOT NULL,
+            completed_at TEXT,
+            priority INTEGER,
+            percent_complete INTEGER,
+            description TEXT,
+            last_modified TEXT,
+            state_hash TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            first_seen_at REAL NOT NULL,
+            last_seen_at REAL NOT NULL,
+            last_changed_at REAL NOT NULL,
+            PRIMARY KEY(source, item_type, item_key)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_calendar_item_states_due_start
+        ON calendar_item_states (item_type, due_at, start_at, completed)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_calendar_item_states_scope_hash
+        ON calendar_item_states (scope_hash, item_type, completed)
+        """
+    )
+
+
+def _database_path() -> Path:
+    configured_path = os.getenv("YULE_CACHE_DB_PATH")
+    if configured_path and configured_path.strip():
+        return Path(configured_path).expanduser()
+
+    repo_root = os.getenv("YULE_REPO_ROOT")
+    base_dir = Path(repo_root) if repo_root else Path.cwd()
+    return base_dir / ".cache" / "yule" / "cache.sqlite3"

--- a/src/yule_orchestrator/storage/local_cache.py
+++ b/src/yule_orchestrator/storage/local_cache.py
@@ -6,7 +6,9 @@ import os
 from pathlib import Path
 import sqlite3
 import time
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
+
+DEFAULT_STALE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -22,12 +24,29 @@ class LocalCacheEntry:
     fetched_at: float
     expires_at: float
     last_accessed_at: float
+    is_stale: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "namespace": self.namespace,
+            "cache_key": self.cache_key,
+            "provider": self.provider,
+            "range_start": self.range_start,
+            "range_end": self.range_end,
+            "scope_hash": self.scope_hash,
+            "metadata": self.metadata,
+            "fetched_at": self.fetched_at,
+            "expires_at": self.expires_at,
+            "last_accessed_at": self.last_accessed_at,
+            "is_stale": self.is_stale,
+        }
 
 
 def load_json_cache(
     namespace: str,
     cache_key: str,
     ttl_seconds: Optional[int] = None,
+    allow_stale: bool = False,
 ) -> Optional[LocalCacheEntry]:
     db_path = _database_path()
     if not db_path.exists():
@@ -60,15 +79,10 @@ def load_json_cache(
         now = time.time()
         fetched_at = float(row["fetched_at"])
         expires_at = float(row["expires_at"])
-
-        if expires_at <= now:
-            connection.execute(
-                "DELETE FROM local_cache_entries WHERE namespace = ? AND cache_key = ?",
-                (namespace, cache_key),
-            )
-            return None
-
-        if ttl_seconds is not None and ttl_seconds >= 0 and fetched_at + ttl_seconds <= now:
+        expired = expires_at <= now
+        ttl_expired = ttl_seconds is not None and ttl_seconds >= 0 and fetched_at + ttl_seconds <= now
+        is_stale = expired or ttl_expired
+        if is_stale and not allow_stale:
             return None
 
         payload = _deserialize_json_object(row["payload_json"])
@@ -96,6 +110,7 @@ def load_json_cache(
             fetched_at=fetched_at,
             expires_at=expires_at,
             last_accessed_at=now,
+            is_stale=is_stale,
         )
 
 
@@ -109,6 +124,7 @@ def save_json_cache(
     ttl_seconds: int,
     payload: Mapping[str, Any],
     metadata: Optional[Mapping[str, Any]] = None,
+    stale_retention_seconds: Optional[int] = DEFAULT_STALE_RETENTION_SECONDS,
 ) -> None:
     if ttl_seconds <= 0:
         return
@@ -161,10 +177,120 @@ def save_json_cache(
                 now,
             ),
         )
+        cleanup_before = now
+        if stale_retention_seconds is not None and stale_retention_seconds > 0:
+            cleanup_before = now - stale_retention_seconds
         connection.execute(
             "DELETE FROM local_cache_entries WHERE expires_at <= ?",
-            (now,),
+            (cleanup_before,),
         )
+
+
+def list_json_cache_entries(
+    namespace: Optional[str] = None,
+    provider: Optional[str] = None,
+    include_expired: bool = True,
+    limit: int = 100,
+) -> list[LocalCacheEntry]:
+    db_path = _database_path()
+    if not db_path.exists():
+        return []
+
+    resolved_limit = max(1, limit)
+    clauses = []
+    params: list[Any] = []
+    if namespace:
+        clauses.append("namespace = ?")
+        params.append(namespace)
+    if provider:
+        clauses.append("provider = ?")
+        params.append(provider)
+    if not include_expired:
+        clauses.append("expires_at > ?")
+        params.append(time.time())
+
+    where_clause = ""
+    if clauses:
+        where_clause = "WHERE " + " AND ".join(clauses)
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        rows = connection.execute(
+            f"""
+            SELECT
+                namespace,
+                cache_key,
+                provider,
+                range_start,
+                range_end,
+                scope_hash,
+                payload_json,
+                metadata_json,
+                fetched_at,
+                expires_at,
+                last_accessed_at
+            FROM local_cache_entries
+            {where_clause}
+            ORDER BY fetched_at DESC
+            LIMIT ?
+            """,
+            (*params, resolved_limit),
+        ).fetchall()
+
+    now = time.time()
+    entries = []
+    for row in rows:
+        payload = _deserialize_json_object(row["payload_json"]) or {}
+        metadata = _deserialize_json_object(row["metadata_json"]) or {}
+        expires_at = float(row["expires_at"])
+        entries.append(
+            LocalCacheEntry(
+                namespace=row["namespace"],
+                cache_key=row["cache_key"],
+                provider=row["provider"],
+                range_start=row["range_start"],
+                range_end=row["range_end"],
+                scope_hash=row["scope_hash"],
+                payload=payload,
+                metadata=metadata,
+                fetched_at=float(row["fetched_at"]),
+                expires_at=expires_at,
+                last_accessed_at=float(row["last_accessed_at"]),
+                is_stale=expires_at <= now,
+            )
+        )
+    return entries
+
+
+def cleanup_json_cache(
+    namespace: Optional[str] = None,
+    stale_retention_seconds: Optional[int] = DEFAULT_STALE_RETENTION_SECONDS,
+) -> int:
+    db_path = _database_path()
+    if not db_path.exists():
+        return 0
+
+    threshold = time.time()
+    if stale_retention_seconds is not None and stale_retention_seconds > 0:
+        threshold = threshold - stale_retention_seconds
+
+    clauses = ["expires_at <= ?"]
+    params: list[Any] = [threshold]
+    if namespace:
+        clauses.append("namespace = ?")
+        params.append(namespace)
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        cursor = connection.execute(
+            f"DELETE FROM local_cache_entries WHERE {' AND '.join(clauses)}",
+            params,
+        )
+        return int(cursor.rowcount or 0)
+
+
+def local_cache_database_path() -> Path:
+    return _database_path()
 
 
 def _connect(db_path: Path) -> sqlite3.Connection:

--- a/src/yule_orchestrator/storage/local_cache.py
+++ b/src/yule_orchestrator/storage/local_cache.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import sqlite3
+import time
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class LocalCacheEntry:
+    namespace: str
+    cache_key: str
+    provider: str
+    range_start: Optional[str]
+    range_end: Optional[str]
+    scope_hash: str
+    payload: dict[str, Any]
+    metadata: dict[str, Any]
+    fetched_at: float
+    expires_at: float
+    last_accessed_at: float
+
+
+def load_json_cache(
+    namespace: str,
+    cache_key: str,
+    ttl_seconds: Optional[int] = None,
+) -> Optional[LocalCacheEntry]:
+    db_path = _database_path()
+    if not db_path.exists():
+        return None
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        row = connection.execute(
+            """
+            SELECT
+                namespace,
+                cache_key,
+                provider,
+                range_start,
+                range_end,
+                scope_hash,
+                payload_json,
+                metadata_json,
+                fetched_at,
+                expires_at,
+                last_accessed_at
+            FROM local_cache_entries
+            WHERE namespace = ? AND cache_key = ?
+            """,
+            (namespace, cache_key),
+        ).fetchone()
+        if row is None:
+            return None
+
+        now = time.time()
+        fetched_at = float(row["fetched_at"])
+        expires_at = float(row["expires_at"])
+
+        if expires_at <= now:
+            connection.execute(
+                "DELETE FROM local_cache_entries WHERE namespace = ? AND cache_key = ?",
+                (namespace, cache_key),
+            )
+            return None
+
+        if ttl_seconds is not None and ttl_seconds >= 0 and fetched_at + ttl_seconds <= now:
+            return None
+
+        payload = _deserialize_json_object(row["payload_json"])
+        if payload is None:
+            return None
+
+        metadata = _deserialize_json_object(row["metadata_json"]) or {}
+        connection.execute(
+            """
+            UPDATE local_cache_entries
+            SET last_accessed_at = ?
+            WHERE namespace = ? AND cache_key = ?
+            """,
+            (now, namespace, cache_key),
+        )
+        return LocalCacheEntry(
+            namespace=row["namespace"],
+            cache_key=row["cache_key"],
+            provider=row["provider"],
+            range_start=row["range_start"],
+            range_end=row["range_end"],
+            scope_hash=row["scope_hash"],
+            payload=payload,
+            metadata=metadata,
+            fetched_at=fetched_at,
+            expires_at=expires_at,
+            last_accessed_at=now,
+        )
+
+
+def save_json_cache(
+    namespace: str,
+    cache_key: str,
+    provider: str,
+    range_start: Optional[str],
+    range_end: Optional[str],
+    scope_hash: str,
+    ttl_seconds: int,
+    payload: Mapping[str, Any],
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> None:
+    if ttl_seconds <= 0:
+        return
+
+    db_path = _database_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    now = time.time()
+    expires_at = now + ttl_seconds
+
+    with _connect(db_path) as connection:
+        _ensure_schema(connection)
+        connection.execute(
+            """
+            INSERT INTO local_cache_entries (
+                namespace,
+                cache_key,
+                provider,
+                range_start,
+                range_end,
+                scope_hash,
+                payload_json,
+                metadata_json,
+                fetched_at,
+                expires_at,
+                last_accessed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(namespace, cache_key) DO UPDATE SET
+                provider = excluded.provider,
+                range_start = excluded.range_start,
+                range_end = excluded.range_end,
+                scope_hash = excluded.scope_hash,
+                payload_json = excluded.payload_json,
+                metadata_json = excluded.metadata_json,
+                fetched_at = excluded.fetched_at,
+                expires_at = excluded.expires_at,
+                last_accessed_at = excluded.last_accessed_at
+            """,
+            (
+                namespace,
+                cache_key,
+                provider,
+                range_start,
+                range_end,
+                scope_hash,
+                json.dumps(dict(payload), ensure_ascii=False, sort_keys=True),
+                json.dumps(dict(metadata or {}), ensure_ascii=False, sort_keys=True),
+                now,
+                expires_at,
+                now,
+            ),
+        )
+        connection.execute(
+            "DELETE FROM local_cache_entries WHERE expires_at <= ?",
+            (now,),
+        )
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def _ensure_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS local_cache_entries (
+            namespace TEXT NOT NULL,
+            cache_key TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            range_start TEXT,
+            range_end TEXT,
+            scope_hash TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            metadata_json TEXT,
+            fetched_at REAL NOT NULL,
+            expires_at REAL NOT NULL,
+            last_accessed_at REAL NOT NULL,
+            PRIMARY KEY(namespace, cache_key)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_local_cache_entries_expires_at
+        ON local_cache_entries (expires_at)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_local_cache_entries_namespace_range
+        ON local_cache_entries (namespace, range_start, range_end)
+        """
+    )
+
+
+def _database_path() -> Path:
+    configured_path = os.getenv("YULE_CACHE_DB_PATH")
+    if configured_path and configured_path.strip():
+        return Path(configured_path).expanduser()
+
+    repo_root = os.getenv("YULE_REPO_ROOT")
+    base_dir = Path(repo_root) if repo_root else Path.cwd()
+    return base_dir / ".cache" / "yule" / "cache.sqlite3"
+
+
+def _deserialize_json_object(value: Optional[str]) -> Optional[dict[str, Any]]:
+    if value is None:
+        return {}
+
+    try:
+        data = json.loads(value)
+    except Exception:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    return data

--- a/tests/_bootstrap.py
+++ b/tests/_bootstrap.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_src_on_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    resolved = str(src_path)
+    if resolved not in sys.path:
+        sys.path.insert(0, resolved)
+
+
+ensure_src_on_path()

--- a/tests/test_calendar_cache_policy.py
+++ b/tests/test_calendar_cache_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import date
+import unittest
+
+from tests import _bootstrap  # noqa: F401
+from yule_orchestrator.integrations.calendar.cache import resolve_calendar_cache_ttl_seconds
+
+
+class CalendarCachePolicyTestCase(unittest.TestCase):
+    def test_current_range_uses_short_ttl(self) -> None:
+        ttl = resolve_calendar_cache_ttl_seconds(
+            start_date=date(2026, 4, 22),
+            end_date=date(2026, 4, 22),
+            configured_ttl_seconds=None,
+            today=date(2026, 4, 22),
+        )
+        self.assertEqual(ttl, 300)
+
+    def test_future_range_uses_medium_ttl(self) -> None:
+        ttl = resolve_calendar_cache_ttl_seconds(
+            start_date=date(2026, 4, 25),
+            end_date=date(2026, 4, 26),
+            configured_ttl_seconds=None,
+            today=date(2026, 4, 22),
+        )
+        self.assertEqual(ttl, 1800)
+
+    def test_past_range_uses_long_ttl(self) -> None:
+        ttl = resolve_calendar_cache_ttl_seconds(
+            start_date=date(2026, 4, 20),
+            end_date=date(2026, 4, 20),
+            configured_ttl_seconds=None,
+            today=date(2026, 4, 22),
+        )
+        self.assertEqual(ttl, 86400)
+
+    def test_configured_ttl_wins(self) -> None:
+        ttl = resolve_calendar_cache_ttl_seconds(
+            start_date=date(2026, 4, 20),
+            end_date=date(2026, 4, 20),
+            configured_ttl_seconds=42,
+            today=date(2026, 4, 22),
+        )
+        self.assertEqual(ttl, 42)

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import time
+import unittest
+
+from tests import _bootstrap  # noqa: F401
+from yule_orchestrator.storage import (
+    cleanup_json_cache,
+    list_json_cache_entries,
+    load_json_cache,
+    save_json_cache,
+)
+
+
+class LocalCacheTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = Path("tests/.tmp/local-cache-tests")
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+        self.temp_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.temp_dir / "cache.sqlite3"
+        self.previous_db_path = os.environ.get("YULE_CACHE_DB_PATH")
+        os.environ["YULE_CACHE_DB_PATH"] = str(self.db_path)
+
+    def tearDown(self) -> None:
+        if self.previous_db_path is None:
+            os.environ.pop("YULE_CACHE_DB_PATH", None)
+        else:
+            os.environ["YULE_CACHE_DB_PATH"] = self.previous_db_path
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+
+    def test_load_json_cache_returns_fresh_entry(self) -> None:
+        save_json_cache(
+            namespace="calendar-query-results",
+            cache_key="fresh-entry",
+            provider="naver-caldav",
+            range_start="2026-04-22",
+            range_end="2026-04-22",
+            scope_hash="scope-1",
+            ttl_seconds=60,
+            payload={"value": 1},
+            metadata={"todo_count": 2},
+        )
+
+        entry = load_json_cache("calendar-query-results", "fresh-entry", ttl_seconds=60)
+        self.assertIsNotNone(entry)
+        assert entry is not None
+        self.assertFalse(entry.is_stale)
+        self.assertEqual(entry.payload["value"], 1)
+        self.assertEqual(entry.metadata["todo_count"], 2)
+
+    def test_allow_stale_returns_expired_entry(self) -> None:
+        save_json_cache(
+            namespace="calendar-query-results",
+            cache_key="stale-entry",
+            provider="naver-caldav",
+            range_start="2026-04-22",
+            range_end="2026-04-22",
+            scope_hash="scope-2",
+            ttl_seconds=60,
+            payload={"value": 2},
+        )
+
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE local_cache_entries SET expires_at = ?, fetched_at = ? WHERE namespace = ? AND cache_key = ?",
+                (
+                    time.time() - 10,
+                    time.time() - 10,
+                    "calendar-query-results",
+                    "stale-entry",
+                ),
+            )
+
+        fresh_entry = load_json_cache("calendar-query-results", "stale-entry", ttl_seconds=60)
+        stale_entry = load_json_cache(
+            "calendar-query-results",
+            "stale-entry",
+            ttl_seconds=60,
+            allow_stale=True,
+        )
+
+        self.assertIsNone(fresh_entry)
+        self.assertIsNotNone(stale_entry)
+        assert stale_entry is not None
+        self.assertTrue(stale_entry.is_stale)
+
+    def test_cleanup_json_cache_deletes_old_expired_entries(self) -> None:
+        save_json_cache(
+            namespace="calendar-query-results",
+            cache_key="cleanup-entry",
+            provider="naver-caldav",
+            range_start="2026-04-22",
+            range_end="2026-04-22",
+            scope_hash="scope-3",
+            ttl_seconds=60,
+            payload={"value": 3},
+        )
+
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE local_cache_entries SET expires_at = ? WHERE namespace = ? AND cache_key = ?",
+                (
+                    time.time() - 100,
+                    "calendar-query-results",
+                    "cleanup-entry",
+                ),
+            )
+
+        deleted_count = cleanup_json_cache(
+            namespace="calendar-query-results",
+            stale_retention_seconds=0,
+        )
+        entries = list_json_cache_entries(namespace="calendar-query-results")
+
+        self.assertEqual(deleted_count, 1)
+        self.assertEqual(entries, [])


### PR DESCRIPTION
## 📌 관련 이슈
- #4 
- #12 

## ✨ 과제 내용
네이버 CalDAV 일정/할 일 조회 결과를 SQLite 기반 로컬 캐시에 저장하고, 같은 날짜 범위 요청 시 원격 fetch 없이 재사용할 수 있도록 캐시 레이어를 추가했습니다.

주요 변경 사항
- 네이버 캘린더 조회 결과를 저장하는 SQLite 로컬 캐시 저장소를 추가했습니다.
- 날짜 범위와 캘린더 설정 기준으로 재사용 가능한 캐시 키 구조를 정리했습니다.
- 일정/할 일 결과를 공통 payload 형태로 저장하고, Planning Agent / Discord 브리핑 / daily-plan에서 재사용할 수 있는 구조로 맞췄습니다.
- 캐시 만료 기준을 범위 특성에 따라 정의했습니다.
- 오늘이 포함된 범위: 5분
- 미래 범위: 30분
- 과거 범위: 24시간
- `NAVER_CALDAV_CACHE_SECONDS`가 지정되면 해당 TTL을 우선 적용하도록 했습니다.
- 캐시를 무시하고 원본을 다시 조회할 수 있도록 `--force-refresh` 옵션을 연결했습니다.
- README와 브랜치 전략 문서를 현재 작업 방식에 맞게 정리했습니다.

기대 효과
- 같은 날짜 범위 재조회 시 응답 속도를 줄일 수 있습니다.
- 원본 CalDAV fetch 지연 영향을 완화할 수 있습니다.
- 이후 daily-plan, Planning Agent, Discord 브리핑에서 동일한 저장소를 그대로 재사용할 수 있습니다.

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 이번 단계에서는 Elasticsearch보다 SQLite 기반 로컬 저장소가 현재 문제인 원본 fetch 지연 완화에 더 적합하다고 판단했습니다.
- 현재 구조는 캘린더 외에도 GitHub issue, review reminder 같은 데이터를 같은 저장소에 확장할 수 있도록 범용 JSON 캐시 형태로 설계했습니다.
- 오늘 범위에서 빈 응답이 캐시되는 경우에 대한 세부 정책은 후속 점검이 필요합니다.
