### PR TITLE
[Refactor] 네이버 캘린더 일정 수집 기능 보안

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ yule calendar events --start-date 2026-04-21 --end-date 2026-04-25 --json
 - `yule calendar events --json` 실행 중 실패가 발생하면 `error.code`, `error.category`, `retryable`, `manual_action_required`, `alert_recommended`를 포함한 구조화된 에러 JSON을 반환합니다.
 - 현재 에러 분류는 `configuration`, `validation`, `authentication`, `network`, `query`, `parsing`, `dependency`, `unknown` 범주를 사용합니다.
 - `retry_strategy`는 `none` 또는 `backoff`를 사용하며, 이후 Planning Agent / Discord 알림 흐름에서 그대로 재사용할 수 있습니다.
-- 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](/Users/masterway/local-dev/yule-studio-agent/policies/runtime/common/calendar-error-handling.md)에 정리합니다.
+- 세부 운영 기준은 [policies/runtime/common/calendar-error-handling.md](policies/runtime/common/calendar-error-handling.md)에 정리합니다.
 - 같은 날짜 범위와 같은 캘린더 설정 요청은 SQLite 캐시를 재사용합니다.
 - stale cache는 기본적으로 만료 후 7일 동안 남겨두고, `yule calendar cache cleanup`에서 정리합니다.
 - 이 캐시 구조는 이후 daily-plan, Planning Agent, Discord 브리핑이 같은 저장소를 재사용할 수 있도록 설계되었습니다.

--- a/src/yule_orchestrator/integrations/calendar/cache.py
+++ b/src/yule_orchestrator/integrations/calendar/cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from hashlib import sha256
+import json
 from typing import Optional
 
 from ...storage import list_json_cache_entries, load_json_cache, save_json_cache
@@ -87,13 +88,11 @@ def save_calendar_cache(
 
 
 def build_calendar_cache_key(*parts: str) -> str:
-    normalized = "::".join(parts)
-    return sha256(normalized.encode("utf-8")).hexdigest()
+    return _hash_parts(parts)
 
 
 def build_calendar_scope_hash(*parts: str) -> str:
-    normalized = "::".join(parts)
-    return sha256(normalized.encode("utf-8")).hexdigest()
+    return _hash_parts(parts)
 
 
 def resolve_calendar_cache_ttl_seconds(
@@ -121,3 +120,8 @@ def list_calendar_cache_entries(limit: int = 100, include_expired: bool = True) 
         limit=limit,
     )
     return [entry.to_dict() for entry in entries]
+
+
+def _hash_parts(parts: tuple[str, ...]) -> str:
+    normalized = json.dumps(list(parts), ensure_ascii=False, separators=(",", ":"))
+    return sha256(normalized.encode("utf-8")).hexdigest()

--- a/src/yule_orchestrator/integrations/calendar/models.py
+++ b/src/yule_orchestrator/integrations/calendar/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from hashlib import sha256
+import json
 from typing import Optional, Sequence
 
 
@@ -159,5 +160,5 @@ class CalendarQueryResult:
 
 
 def build_fallback_item_uid(item_type: str, *parts: str) -> str:
-    normalized = "::".join([item_type, *parts])
+    normalized = json.dumps([item_type, *parts], ensure_ascii=False, separators=(",", ":"))
     return sha256(normalized.encode("utf-8")).hexdigest()

--- a/src/yule_orchestrator/integrations/calendar/naver_caldav.py
+++ b/src/yule_orchestrator/integrations/calendar/naver_caldav.py
@@ -103,8 +103,8 @@ def _fetch_naver_calendar_items(
 
     events = []
     todos = []
-    seen_events: set[tuple[str, str, str, str]] = set()
-    seen_todos: set[tuple[str, Optional[str], Optional[str], str, str]] = set()
+    seen_events: set[tuple[str, str, str]] = set()
+    seen_todos: set[tuple[str, Optional[str], Optional[str], str]] = set()
 
     try:
         with client_cls(
@@ -115,13 +115,14 @@ def _fetch_naver_calendar_items(
         ) as client:
             principal = client.principal()
             all_calendars = list(principal.calendars())
+            selected_calendars = _select_calendars(all_calendars, config.calendar_name)
             todo_calendars = _select_todo_calendars(
                 all_calendars=all_calendars,
                 todo_calendar_name=config.todo_calendar_name,
-                fallback_calendars=_select_calendars(all_calendars, config.calendar_name),
+                fallback_calendars=selected_calendars,
             )
             event_calendars = _select_event_calendars(
-                all_calendars=all_calendars,
+                selected_calendars=selected_calendars,
                 calendar_name=config.calendar_name,
                 todo_calendars=todo_calendars,
             )
@@ -307,8 +308,8 @@ def _collect_dated_items(
     include_todos: bool,
     events: List[Any],
     todos: List[Any],
-    seen_events: set[tuple[str, str, str, str]],
-    seen_todos: set[tuple[str, Optional[str], Optional[str], str, str]],
+    seen_events: set[tuple[str, str, str]],
+    seen_todos: set[tuple[str, Optional[str], Optional[str], str]],
 ) -> None:
     resources = calendar.date_search(start=query_start, end=query_end, expand=True)
 
@@ -321,7 +322,7 @@ def _collect_dated_items(
                 event = build_event(component, calendar_label)
                 if event is None:
                     continue
-                dedupe_key = (event.title, event.start, event.end, event.calendar_name)
+                dedupe_key = (event.item_uid, event.start, event.end)
                 if dedupe_key in seen_events:
                     continue
                 seen_events.add(dedupe_key)
@@ -330,7 +331,7 @@ def _collect_dated_items(
         if include_todos:
             for component in calendar_obj.walk("VTODO"):
                 todo = build_todo(component, calendar_label)
-                dedupe_key = (todo.title, todo.start, todo.due, todo.status, todo.calendar_name)
+                dedupe_key = (todo.item_uid, todo.start, todo.due, todo.status)
                 if dedupe_key in seen_todos:
                     continue
                 seen_todos.add(dedupe_key)
@@ -344,7 +345,7 @@ def _collect_all_todos(
     start_date: date,
     end_date: date,
     todos: List[Any],
-    seen_todos: set[tuple[str, Optional[str], Optional[str], str, str]],
+    seen_todos: set[tuple[str, Optional[str], Optional[str], str]],
 ) -> None:
     for resource in _list_todo_resources(calendar):
         raw_ical = _resource_ical_payload(resource)
@@ -355,7 +356,7 @@ def _collect_all_todos(
             if not todo_matches_range(todo, start_date, end_date):
                 continue
 
-            dedupe_key = (todo.title, todo.start, todo.due, todo.status, todo.calendar_name)
+            dedupe_key = (todo.item_uid, todo.start, todo.due, todo.status)
             if dedupe_key in seen_todos:
                 continue
             seen_todos.add(dedupe_key)
@@ -371,7 +372,7 @@ def _collect_search_todos(
     start_date: date,
     end_date: date,
     todos: List[Any],
-    seen_todos: set[tuple[str, Optional[str], Optional[str], str, str]],
+    seen_todos: set[tuple[str, Optional[str], Optional[str], str]],
 ) -> None:
     search = getattr(calendar, "search", None)
     if not callable(search):
@@ -397,7 +398,7 @@ def _collect_search_todos(
             if not todo_matches_range(todo, start_date, end_date):
                 continue
 
-            dedupe_key = (todo.title, todo.start, todo.due, todo.status, todo.calendar_name)
+            dedupe_key = (todo.item_uid, todo.start, todo.due, todo.status)
             if dedupe_key in seen_todos:
                 continue
             seen_todos.add(dedupe_key)
@@ -469,11 +470,11 @@ def _select_todo_calendars(
 
 
 def _select_event_calendars(
-    all_calendars: Iterable[Any],
+    selected_calendars: Iterable[Any],
     calendar_name: Optional[str],
     todo_calendars: Iterable[Any],
 ) -> List[Any]:
-    selected = _select_calendars(all_calendars, calendar_name)
+    selected = list(selected_calendars)
     if calendar_name is not None:
         return selected
 
@@ -507,18 +508,33 @@ def _calendar_label(calendar: Any) -> str:
     if isinstance(name, str) and name:
         return name
 
-    url = getattr(calendar, "url", None)
-    if isinstance(url, str) and url:
-        return url.rstrip("/").split("/")[-1] or "unnamed-calendar"
+    normalized_url = _normalize_calendar_url(getattr(calendar, "url", None))
+    if normalized_url:
+        return normalized_url.rstrip("/").split("/")[-1] or "unnamed-calendar"
 
     return "unnamed-calendar"
 
 
 def _calendar_identifier(calendar: Any) -> str:
-    url = getattr(calendar, "url", None)
-    if isinstance(url, str) and url:
-        return url
+    normalized_url = _normalize_calendar_url(getattr(calendar, "url", None))
+    if normalized_url:
+        return normalized_url
     return _calendar_label(calendar)
+
+
+def _normalize_calendar_url(url: Any) -> Optional[str]:
+    if url is None:
+        return None
+
+    try:
+        normalized = str(url).strip()
+    except Exception:
+        return None
+
+    if not normalized:
+        return None
+
+    return normalized
 
 
 def _looks_like_todo_calendar(label: str) -> bool:

--- a/tests/test_calendar_cache_policy.py
+++ b/tests/test_calendar_cache_policy.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from datetime import date
 import unittest
 
-from tests import _bootstrap  # noqa: F401
-from yule_orchestrator.integrations.calendar.cache import resolve_calendar_cache_ttl_seconds
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+from yule_orchestrator.integrations.calendar.cache import build_calendar_cache_key, resolve_calendar_cache_ttl_seconds
+from yule_orchestrator.integrations.calendar.models import build_fallback_item_uid
 
 
 class CalendarCachePolicyTestCase(unittest.TestCase):
@@ -43,3 +47,15 @@ class CalendarCachePolicyTestCase(unittest.TestCase):
             today=date(2026, 4, 22),
         )
         self.assertEqual(ttl, 42)
+
+    def test_cache_key_normalization_avoids_delimiter_collisions(self) -> None:
+        left = build_calendar_cache_key("a", "b::c")
+        right = build_calendar_cache_key("a::b", "c")
+
+        self.assertNotEqual(left, right)
+
+    def test_fallback_item_uid_normalization_avoids_delimiter_collisions(self) -> None:
+        left = build_fallback_item_uid("todo", "a", "b::c")
+        right = build_fallback_item_uid("todo", "a::b", "c")
+
+        self.assertNotEqual(left, right)

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -7,7 +7,10 @@ import sqlite3
 import time
 import unittest
 
-from tests import _bootstrap  # noqa: F401
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
 from yule_orchestrator.storage import (
     cleanup_json_cache,
     list_json_cache_entries,
@@ -120,3 +123,31 @@ class LocalCacheTestCase(unittest.TestCase):
 
         self.assertEqual(deleted_count, 1)
         self.assertEqual(entries, [])
+
+    def test_shorter_runtime_ttl_marks_cache_as_stale(self) -> None:
+        save_json_cache(
+            namespace="calendar-query-results",
+            cache_key="runtime-ttl-entry",
+            provider="naver-caldav",
+            range_start="2026-04-22",
+            range_end="2026-04-22",
+            scope_hash="scope-4",
+            ttl_seconds=3600,
+            payload={"value": 4},
+        )
+
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                "UPDATE local_cache_entries SET fetched_at = ? WHERE namespace = ? AND cache_key = ?",
+                (
+                    time.time() - 120,
+                    "calendar-query-results",
+                    "runtime-ttl-entry",
+                ),
+            )
+
+        fresh_entry = load_json_cache("calendar-query-results", "runtime-ttl-entry", ttl_seconds=3600)
+        stale_entry = load_json_cache("calendar-query-results", "runtime-ttl-entry", ttl_seconds=60)
+
+        self.assertIsNotNone(fresh_entry)
+        self.assertIsNone(stale_entry)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #4 
- #16 

## ✨ 과제 내용
- CalDAV 캘린더 식별자 처리 보강
- cache key / scope hash 생성 시 delimiter collision 가능성 제거
- fallback item uid 생성 방식 보강
- event / todo dedupe 기준을 `item_uid` 중심으로 보강
- `_select_calendars()` 결과 재사용으로 중복 선택 로직 정리
- README 상대 경로 링크 수정
- unittest import 호환성 보강
- TTL / cache key / fallback uid 관련 회귀 테스트 추가

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- Copilot review feedback 기반으로 식별자 충돌, dedupe 기준, 실행 경로 문제를 함께 정리했습니다.
- `load_calendar_cache()`의 runtime TTL 문제는 현재 구현에서 이미 read-time 검증이 들어가 있어 회귀 테스트로 보강했습니다.
