### PR TITLE
[Feature] engineering-agent 공통 LLM 러너 추상화 추가

### DIFF
--- a/agents/engineering-agent/agent.json
+++ b/agents/engineering-agent/agent.json
@@ -19,6 +19,7 @@
     "policies/runtime/agents/engineering-agent/team-structure.md",
     "policies/runtime/agents/engineering-agent/mvp-scope.md",
     "policies/runtime/agents/engineering-agent/role-weights-v0.md",
+    "policies/runtime/agents/engineering-agent/runners.md",
     "policies/runtime/agents/engineering-agent/version-control.md",
     "policies/runtime/agents/engineering-agent/workflow.md",
     "policies/runtime/agents/engineering-agent/testing.md"

--- a/policies/runtime/agents/engineering-agent/runners.md
+++ b/policies/runtime/agents/engineering-agent/runners.md
@@ -1,0 +1,63 @@
+# Engineering Agent Runner Policy (v0)
+
+이 문서는 engineering-agent 부서가 LLM 백엔드를 호출하는 공통 런너 추상화의 정책 기준선이다. 본 정책은 **부서 단위 participants 풀**(claude / codex / gemini / ollama / github-copilot)에 적용되며, 멤버(tech-lead / backend-engineer / frontend-engineer / product-designer / qa-engineer)는 이 풀을 공유한다.
+
+## Scope
+- in scope: 런너 인터페이스 계약, 가용성 검사, dry-run, 확장 포인트(reference / ranking / performance) 사용 규약.
+- out of scope: 멤버 디스패치 로직, Discord 통합, 자동 reference 수집기 구현체, 멀티봇 토큰 운용.
+
+## Contract
+런너는 `src/yule_orchestrator/agents/runners/base.py`의 다음 계약을 구현한다.
+
+- `AgentRunner.is_available()` — 백엔드 호출 가능 여부를 빠르게 반환한다. doctor 명령과 레지스트리 빌드 시점에서 호출된다.
+- `AgentRunner.submit(request)` — 실제 백엔드 호출. 실패는 예외 대신 `AgentResponse.status`로 표현한다 (`OK` / `ERROR` / `UNAVAILABLE`).
+- `AgentRunner.dry_run(request)` — 백엔드를 건드리지 않고 결정적 응답을 반환한다. 테스트와 운영자 dry-run 경로에서 사용한다.
+- `AgentRunner.run(request, dry_run=False)` — 위 메서드를 감싸 reference 자동 수집과 performance 기록을 적용하는 공식 진입점.
+
+`AgentRequest`는 prompt, role, task_id, repository, write_allowed, references, context, metadata만 가진다. Discord/플래닝/GitHub 스키마를 그대로 흘리지 않는다.
+
+## Capabilities
+런너는 자기 능력을 `RunnerCapability`로 선언한다. 디스패처는 이 값으로 1차 필터링한 뒤 `role-weights-v0.md`의 가중치를 적용한다.
+
+| 백엔드 | capabilities |
+|---|---|
+| claude | execute, advise, review, patch_propose |
+| codex | advise, review, patch_propose |
+| gemini | advise, long_context |
+| ollama | advise, local_private |
+| github-copilot | github_native, patch_propose |
+
+`execute`(쓰기 권한)는 풀 전체에서 한 번에 한 런너만 갖는다. `agent.json`의 `write_policy.max_write_executors_per_run=1` 규칙과 일치해야 한다.
+
+## Extension Points
+런너 본문은 `RunnerHooks`를 통해 선택적으로 다음을 받는다.
+
+- `ReferenceCollector` — request.references가 비어 있을 때 `run()`이 1회 호출한다. UI/UX/마케팅 작업의 최소 3건(이상 5건) reference 정책을 자동화하는 슬롯.
+- `RankingSignal` — 디스패처가 런너 선택 단계에서 사용한다. 런너 본문에서는 호출하지 않는다.
+- `PerformanceTracker` — 모든 `run()` 결과를 받는다. 실패도 기록해 성공률/지연/비용 대시보드의 입력으로 사용한다.
+
+세 훅 모두 런너 본문은 알지 못해도 동작해야 한다. 미주입 시 기본 동작은 reference 보강 없음, 성능 기록 없음, 랭킹 영향 없음이다.
+
+## Dry-run 전략
+실제 백엔드 호출 전에 다음 경로에서 dry-run을 사용한다.
+
+- 신규 wrapper 추가 시: `runner.run(request, dry_run=True)`로 hook 호출 순서, metrics 누적, 응답 스키마를 검증한다.
+- 운영자 점검 시: `yule doctor`(예정)에서 각 런너의 `is_available()`만 실행해 가벼운 헬스체크를 수행한다.
+- 디스패처 회귀 검증 시: 풀 전체를 `factories=` 인자로 fake runner로 교체해 분배 결정만 검증한다.
+
+dry-run 응답은 `RunnerStatus.DRY_RUN`을 반환하며 backend가 컨택트되지 않았음을 detail에 명시한다.
+
+## 최소 테스트 기준
+- 레지스트리 로딩이 `engineering-agent/agent.json`의 5종 id를 모두 인식한다.
+- 매핑 누락 id는 warnings로만 노출되고 풀 빌드를 막지 않는다.
+- dry-run 경로에서 `submit`이 호출되지 않는다.
+- `PerformanceTracker.record`가 매 실행마다 한 번 호출된다.
+- request.references가 비어 있으면 `ReferenceCollector.collect`가 호출되고, 채워져 있으면 호출되지 않는다.
+
+테스트는 `tests/test_agent_runners.py`에서 유지한다.
+
+## 후속 작업
+- 각 wrapper의 실제 백엔드 호출 본문(claude/codex/gemini CLI 인자, ollama generate API, gh copilot extension 호출).
+- 디스패처: role × capability × ranking signal × write_policy를 결합해 단일 executor와 다수 advisor를 결정한다.
+- ReferenceCollector 구현체와 reference-pack.md의 매핑.
+- PerformanceTracker SQLite 스키마와 대시보드.

--- a/src/yule_orchestrator/agents/__init__.py
+++ b/src/yule_orchestrator/agents/__init__.py
@@ -1,1 +1,17 @@
 """Engineering-agent department runtime: runners, registry, hooks."""
+
+from .registry import (
+    DEFAULT_RUNNER_FACTORIES,
+    ParticipantsPool,
+    RegistryError,
+    RunnerFactory,
+    build_participants_pool,
+)
+
+__all__ = [
+    "DEFAULT_RUNNER_FACTORIES",
+    "ParticipantsPool",
+    "RegistryError",
+    "RunnerFactory",
+    "build_participants_pool",
+]

--- a/src/yule_orchestrator/agents/__init__.py
+++ b/src/yule_orchestrator/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Engineering-agent department runtime: runners, registry, hooks."""

--- a/src/yule_orchestrator/agents/registry.py
+++ b/src/yule_orchestrator/agents/registry.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence
+
+from ..core.context_loader import ContextError, load_agent_context
+from .runners.base import AgentRunner, RunnerHooks
+from .runners.claude_code import ClaudeCodeRunner
+from .runners.codex import CodexRunner
+from .runners.gemini import GeminiRunner
+from .runners.github_copilot import GitHubCopilotRunner
+from .runners.ollama import OllamaRunner
+
+
+class RegistryError(RuntimeError):
+    """Raised when the participants pool cannot be assembled."""
+
+
+RunnerFactory = Callable[[Mapping[str, Any], RunnerHooks], AgentRunner]
+
+
+def _factory(cls: type[AgentRunner]) -> RunnerFactory:
+    def build(config: Mapping[str, Any], hooks: RunnerHooks) -> AgentRunner:
+        return cls(config=config, hooks=hooks)
+
+    return build
+
+
+DEFAULT_RUNNER_FACTORIES: Dict[str, RunnerFactory] = {
+    "claude": _factory(ClaudeCodeRunner),
+    "codex": _factory(CodexRunner),
+    "gemini": _factory(GeminiRunner),
+    "ollama": _factory(OllamaRunner),
+    "github-copilot": _factory(GitHubCopilotRunner),
+}
+
+
+@dataclass(frozen=True)
+class ParticipantsPool:
+    """Department-level pool of runners loaded from a single agent.json.
+
+    Members (tech-lead, backend-engineer, ...) do *not* own runners. They
+    request work from the gateway, which selects from this shared pool based
+    on role-weights-v0.md and ranking signals.
+    """
+
+    agent_id: str
+    runners: Mapping[str, AgentRunner]
+    warnings: Sequence[str]
+
+    def get(self, runner_id: str) -> AgentRunner:
+        try:
+            return self.runners[runner_id]
+        except KeyError as exc:
+            raise RegistryError(f"runner not in pool: {runner_id}") from exc
+
+    def available(self) -> Sequence[AgentRunner]:
+        return tuple(runner for runner in self.runners.values() if runner.is_available())
+
+    def ids(self) -> Sequence[str]:
+        return tuple(self.runners.keys())
+
+
+def build_participants_pool(
+    repo_root: Path,
+    agent_id: str = "engineering-agent",
+    *,
+    hooks: Optional[RunnerHooks] = None,
+    factories: Optional[Mapping[str, RunnerFactory]] = None,
+) -> ParticipantsPool:
+    """Load *agent_id*'s manifest and instantiate one runner per pool entry.
+
+    *factories* lets tests inject fakes without touching the default mapping.
+    Unknown ids are skipped with a warning instead of raising — that way a
+    new participant can be referenced in agent.json before its wrapper lands.
+    """
+
+    try:
+        loaded = load_agent_context(repo_root=repo_root, agent_id=agent_id)
+    except ContextError as exc:
+        raise RegistryError(str(exc)) from exc
+
+    manifest = loaded.manifest
+    factory_map = dict(factories) if factories is not None else dict(DEFAULT_RUNNER_FACTORIES)
+    hooks = hooks or RunnerHooks()
+    runners: Dict[str, AgentRunner] = {}
+    warnings: list[str] = list(loaded.warnings)
+
+    for entry in _iter_pool_entries(manifest):
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not entry_id:
+            warnings.append("Skipping participants/integrations entry without id")
+            continue
+
+        factory = factory_map.get(entry_id)
+        if factory is None:
+            warnings.append(f"No runner factory registered for '{entry_id}', skipped")
+            continue
+
+        if entry_id in runners:
+            warnings.append(f"Duplicate participant id '{entry_id}', keeping first")
+            continue
+
+        runners[entry_id] = factory(entry, hooks)
+
+    return ParticipantsPool(agent_id=agent_id, runners=runners, warnings=tuple(warnings))
+
+
+def _iter_pool_entries(manifest: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    for key in ("participants", "integrations"):
+        entries = manifest.get(key, [])
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                yield entry

--- a/src/yule_orchestrator/agents/runners/__init__.py
+++ b/src/yule_orchestrator/agents/runners/__init__.py
@@ -1,0 +1,23 @@
+"""LLM runner abstractions for the engineering-agent participants pool."""
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerError,
+    RunnerHooks,
+    RunnerStatus,
+    RunnerUnavailableError,
+)
+
+__all__ = [
+    "AgentRequest",
+    "AgentResponse",
+    "AgentRunner",
+    "RunnerCapability",
+    "RunnerError",
+    "RunnerHooks",
+    "RunnerStatus",
+    "RunnerUnavailableError",
+]

--- a/src/yule_orchestrator/agents/runners/__init__.py
+++ b/src/yule_orchestrator/agents/runners/__init__.py
@@ -10,11 +10,21 @@ from .base import (
     RunnerStatus,
     RunnerUnavailableError,
 )
+from .claude_code import ClaudeCodeRunner
+from .codex import CodexRunner
+from .gemini import GeminiRunner
+from .github_copilot import GitHubCopilotRunner
+from .ollama import OllamaRunner
 
 __all__ = [
     "AgentRequest",
     "AgentResponse",
     "AgentRunner",
+    "ClaudeCodeRunner",
+    "CodexRunner",
+    "GeminiRunner",
+    "GitHubCopilotRunner",
+    "OllamaRunner",
     "RunnerCapability",
     "RunnerError",
     "RunnerHooks",

--- a/src/yule_orchestrator/agents/runners/base.py
+++ b/src/yule_orchestrator/agents/runners/base.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
+
+
+class RunnerCapability(str, Enum):
+    """High-level capabilities a backend can claim.
+
+    The dispatcher uses these to filter the participants pool before applying
+    role-weights. They are intentionally coarse — fine-grained selection is
+    expressed as ranking signals via :class:`RunnerHooks`.
+    """
+
+    EXECUTE = "execute"
+    ADVISE = "advise"
+    REVIEW = "review"
+    PATCH_PROPOSE = "patch_propose"
+    LONG_CONTEXT = "long_context"
+    LOCAL_PRIVATE = "local_private"
+    GITHUB_NATIVE = "github_native"
+
+
+class RunnerStatus(str, Enum):
+    OK = "ok"
+    ERROR = "error"
+    UNAVAILABLE = "unavailable"
+    DRY_RUN = "dry_run"
+
+
+class RunnerError(RuntimeError):
+    """Base class for runner-side failures."""
+
+
+class RunnerUnavailableError(RunnerError):
+    """Raised when the backend (CLI, network, model) cannot be used right now."""
+
+
+@dataclass(frozen=True)
+class AgentRequest:
+    """Single unit of work handed to a runner.
+
+    The shape is intentionally narrow: prompt + structured context. Files,
+    diffs, and reference packs are passed as opaque dicts so the contract
+    does not depend on Discord, planning-agent, or GitHub schemas.
+    """
+
+    prompt: str
+    role: str
+    task_id: str
+    repository: Optional[str] = None
+    write_allowed: bool = False
+    references: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    context: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentResponse:
+    runner_id: str
+    status: RunnerStatus
+    text: str
+    detail: Optional[str] = None
+    proposed_patch: Optional[str] = None
+    artifacts: Mapping[str, Any] = field(default_factory=dict)
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+
+class ReferenceCollector(Protocol):
+    """Pulls reference packs (Pinterest, Notefolio, Mobbin, ...) for a request.
+
+    Implementations are added in a later milestone — runners only know about
+    the protocol so they can call it when references=() and the role policy
+    requires them.
+    """
+
+    def collect(self, request: AgentRequest) -> Sequence[Mapping[str, Any]]:
+        ...
+
+
+class RankingSignal(Protocol):
+    """Reports a (runner_id, score) signal for a request.
+
+    The dispatcher combines these with role-weights-v0.md to pick a runner.
+    Runners themselves do not consume rankings; they only forward the hook
+    so the dispatcher can call it before submit().
+    """
+
+    def score(self, runner_id: str, request: AgentRequest) -> float:
+        ...
+
+
+class PerformanceTracker(Protocol):
+    """Records runner outcomes for later analysis.
+
+    Called by :meth:`AgentRunner.submit` regardless of success so we can build
+    per-runner success rate, latency, and cost dashboards.
+    """
+
+    def record(self, runner_id: str, request: AgentRequest, response: AgentResponse) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class RunnerHooks:
+    """Optional pluggable extension points injected at registry-build time."""
+
+    reference_collector: Optional[ReferenceCollector] = None
+    ranking_signal: Optional[RankingSignal] = None
+    performance_tracker: Optional[PerformanceTracker] = None
+
+
+class AgentRunner(ABC):
+    """Common contract for every backend in the engineering-agent pool.
+
+    Concrete runners (Claude, Codex, Gemini, Ollama, GitHub Copilot) wrap a
+    CLI, HTTP API, or workflow integration. They do **not** know about roles,
+    Discord, or planning-agent — those concerns live in the dispatcher.
+    """
+
+    runner_id: str
+    provider: str
+    capabilities: Sequence[RunnerCapability] = ()
+
+    def __init__(self, *, config: Optional[Mapping[str, Any]] = None, hooks: Optional[RunnerHooks] = None) -> None:
+        self.config: Dict[str, Any] = dict(config or {})
+        self.hooks: RunnerHooks = hooks or RunnerHooks()
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if this runner can handle a real request right now.
+
+        Cheap check only (e.g., shutil.which for CLI, env var presence). The
+        registry calls this at boot and the doctor command surfaces the result.
+        """
+
+    @abstractmethod
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        """Execute *request* and return the structured response.
+
+        Implementations must always return an :class:`AgentResponse`; raising
+        is reserved for unrecoverable wiring bugs. Use ``RunnerStatus.ERROR``
+        for backend-side failures and ``RunnerStatus.UNAVAILABLE`` when the
+        backend disappeared between :meth:`is_available` and :meth:`submit`.
+        """
+
+    def dry_run(self, request: AgentRequest) -> AgentResponse:
+        """Return a deterministic response without contacting the backend.
+
+        Used by tests and by the ``--dry-run`` operator path to verify that
+        wiring (registry, role-weights, hooks) is correct without consuming
+        any LLM tokens or hitting the network.
+        """
+
+        return AgentResponse(
+            runner_id=self.runner_id,
+            status=RunnerStatus.DRY_RUN,
+            text=f"[dry-run] {self.runner_id} would handle role={request.role} task={request.task_id}",
+            detail="dry-run: backend was not contacted",
+        )

--- a/src/yule_orchestrator/agents/runners/base.py
+++ b/src/yule_orchestrator/agents/runners/base.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
 
@@ -160,3 +161,37 @@ class AgentRunner(ABC):
             text=f"[dry-run] {self.runner_id} would handle role={request.role} task={request.task_id}",
             detail="dry-run: backend was not contacted",
         )
+
+    def run(self, request: AgentRequest, *, dry_run: bool = False) -> AgentResponse:
+        """Public entry point that applies hooks around :meth:`submit`.
+
+        - Calls ``reference_collector`` when the request has no references.
+        - Routes to :meth:`dry_run` when *dry_run* is True.
+        - Records elapsed time and forwards to ``performance_tracker``.
+
+        ``ranking_signal`` is intentionally not used here — it is consumed by
+        the dispatcher to pick *which* runner to call, not by the runner itself.
+        """
+
+        enriched = self._collect_references(request)
+        start = time.monotonic()
+        if dry_run:
+            response = self.dry_run(enriched)
+        else:
+            response = self.submit(enriched)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        if "elapsed_ms" not in response.metrics:
+            response = replace(response, metrics={**response.metrics, "elapsed_ms": elapsed_ms})
+        tracker = self.hooks.performance_tracker
+        if tracker is not None:
+            tracker.record(self.runner_id, enriched, response)
+        return response
+
+    def _collect_references(self, request: AgentRequest) -> AgentRequest:
+        collector = self.hooks.reference_collector
+        if collector is None or request.references:
+            return request
+        gathered = tuple(collector.collect(request))
+        if not gathered:
+            return request
+        return replace(request, references=gathered)

--- a/src/yule_orchestrator/agents/runners/claude_code.py
+++ b/src/yule_orchestrator/agents/runners/claude_code.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import shutil
+from typing import Sequence
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerStatus,
+)
+
+
+class ClaudeCodeRunner(AgentRunner):
+    """Wraps the local ``claude`` CLI from Anthropic's Claude Code package.
+
+    MVP body is intentionally a stub: ``submit`` defers to ``dry_run`` so the
+    rest of the engineering-agent (registry, dispatcher, hooks) can be wired
+    up before we shell out to the real CLI.
+    """
+
+    runner_id = "claude"
+    provider = "anthropic"
+    capabilities: Sequence[RunnerCapability] = (
+        RunnerCapability.EXECUTE,
+        RunnerCapability.ADVISE,
+        RunnerCapability.REVIEW,
+        RunnerCapability.PATCH_PROPOSE,
+    )
+
+    def is_available(self) -> bool:
+        return shutil.which("claude") is not None
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        if not self.is_available():
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.UNAVAILABLE,
+                text="",
+                detail="claude CLI not found on PATH",
+            )
+        return self.dry_run(request)

--- a/src/yule_orchestrator/agents/runners/codex.py
+++ b/src/yule_orchestrator/agents/runners/codex.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import shutil
+from typing import Sequence
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerStatus,
+)
+
+
+class CodexRunner(AgentRunner):
+    """Wraps the OpenAI ``codex`` CLI as an advisor / patch-proposer.
+
+    MVP scope: availability check + dry-run pass-through. Real subprocess
+    invocation lives in a follow-up milestone.
+    """
+
+    runner_id = "codex"
+    provider = "openai"
+    capabilities: Sequence[RunnerCapability] = (
+        RunnerCapability.ADVISE,
+        RunnerCapability.REVIEW,
+        RunnerCapability.PATCH_PROPOSE,
+    )
+
+    def is_available(self) -> bool:
+        return shutil.which("codex") is not None
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        if not self.is_available():
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.UNAVAILABLE,
+                text="",
+                detail="codex CLI not found on PATH",
+            )
+        return self.dry_run(request)

--- a/src/yule_orchestrator/agents/runners/gemini.py
+++ b/src/yule_orchestrator/agents/runners/gemini.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import shutil
+from typing import Sequence
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerStatus,
+)
+
+
+class GeminiRunner(AgentRunner):
+    """Wraps Google's ``gemini`` CLI for long-context analysis and planning.
+
+    The role-weights policy favours Gemini for product-designer and long-file
+    review tasks; this wrapper exposes those capabilities so the dispatcher
+    can pick it up. Body is a stub for the MVP.
+    """
+
+    runner_id = "gemini"
+    provider = "google"
+    capabilities: Sequence[RunnerCapability] = (
+        RunnerCapability.ADVISE,
+        RunnerCapability.LONG_CONTEXT,
+    )
+
+    def is_available(self) -> bool:
+        return shutil.which("gemini") is not None
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        if not self.is_available():
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.UNAVAILABLE,
+                text="",
+                detail="gemini CLI not found on PATH",
+            )
+        return self.dry_run(request)

--- a/src/yule_orchestrator/agents/runners/github_copilot.py
+++ b/src/yule_orchestrator/agents/runners/github_copilot.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Sequence
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerStatus,
+)
+
+
+class GitHubCopilotRunner(AgentRunner):
+    """GitHub-native executor (Copilot workspace / `gh copilot`).
+
+    Modeled as an *integration* in agent.json rather than a standalone CLI:
+    this runner is the entry point for issue → branch → draft-PR flows that
+    happen entirely on GitHub. Body is a stub for the MVP.
+    """
+
+    runner_id = "github-copilot"
+    provider = "github"
+    capabilities: Sequence[RunnerCapability] = (
+        RunnerCapability.GITHUB_NATIVE,
+        RunnerCapability.PATCH_PROPOSE,
+    )
+
+    def is_available(self) -> bool:
+        if shutil.which("gh") is None:
+            return False
+        result = subprocess.run(
+            ["gh", "extension", "list"],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return False
+        return "copilot" in result.stdout.lower()
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        if not self.is_available():
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.UNAVAILABLE,
+                text="",
+                detail="gh copilot extension not installed",
+            )
+        return self.dry_run(request)

--- a/src/yule_orchestrator/agents/runners/ollama.py
+++ b/src/yule_orchestrator/agents/runners/ollama.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from typing import Sequence
+
+from .base import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerStatus,
+)
+
+
+class OllamaRunner(AgentRunner):
+    """Local Ollama HTTP wrapper for private, low-cost work.
+
+    Uses the same endpoint shape as ``planning.ollama`` so we can later share
+    a single client. MVP only does a tags-endpoint reachability check; real
+    generate/chat calls come once the dispatcher is in place.
+    """
+
+    runner_id = "ollama"
+    provider = "local"
+    capabilities: Sequence[RunnerCapability] = (
+        RunnerCapability.ADVISE,
+        RunnerCapability.LOCAL_PRIVATE,
+    )
+
+    DEFAULT_ENDPOINT = "http://localhost:11434"
+
+    @property
+    def endpoint(self) -> str:
+        endpoint = self.config.get("endpoint")
+        if isinstance(endpoint, str) and endpoint:
+            return endpoint
+        return self.DEFAULT_ENDPOINT
+
+    def is_available(self) -> bool:
+        url = self.endpoint.rstrip("/") + "/api/tags"
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                return 200 <= response.status < 300
+        except (urllib.error.URLError, TimeoutError, OSError):
+            return False
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        if not self.is_available():
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.UNAVAILABLE,
+                text="",
+                detail=f"ollama endpoint {self.endpoint} unreachable",
+            )
+        return self.dry_run(request)

--- a/tests/test_agent_runners.py
+++ b/tests/test_agent_runners.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    ParticipantsPool,
+    RegistryError,
+    build_participants_pool,
+)
+from yule_orchestrator.agents.runners import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerHooks,
+    RunnerStatus,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FakeRunner(AgentRunner):
+    runner_id = "fake"
+    provider = "fake"
+    capabilities: Sequence[RunnerCapability] = (RunnerCapability.ADVISE,)
+
+    def __init__(self, *, config: Mapping[str, Any] | None = None, hooks: RunnerHooks | None = None) -> None:
+        super().__init__(config=config, hooks=hooks)
+        self.submitted: list[AgentRequest] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        self.submitted.append(request)
+        return AgentResponse(
+            runner_id=self.runner_id,
+            status=RunnerStatus.OK,
+            text=f"echo:{request.prompt}",
+        )
+
+
+class _RecordingTracker:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, AgentRequest, AgentResponse]] = []
+
+    def record(self, runner_id: str, request: AgentRequest, response: AgentResponse) -> None:
+        self.calls.append((runner_id, request, response))
+
+
+class _StaticReferenceCollector:
+    def __init__(self, payload: Sequence[Mapping[str, Any]]) -> None:
+        self.payload = payload
+        self.calls = 0
+
+    def collect(self, request: AgentRequest) -> Sequence[Mapping[str, Any]]:
+        self.calls += 1
+        return self.payload
+
+
+class RegistryLoadingTestCase(unittest.TestCase):
+    def test_engineering_agent_pool_resolves_known_ids(self) -> None:
+        pool = build_participants_pool(REPO_ROOT, "engineering-agent")
+
+        self.assertIsInstance(pool, ParticipantsPool)
+        self.assertEqual(pool.agent_id, "engineering-agent")
+        self.assertEqual(
+            set(pool.ids()),
+            {"claude", "codex", "gemini", "ollama", "github-copilot"},
+        )
+
+    def test_unknown_id_is_skipped_with_warning(self) -> None:
+        pool = build_participants_pool(
+            REPO_ROOT,
+            "engineering-agent",
+            factories={
+                "claude": lambda config, hooks: _FakeRunner(config=config, hooks=hooks),
+            },
+        )
+
+        self.assertEqual(set(pool.ids()), {"claude"})
+        skipped = [w for w in pool.warnings if "github-copilot" in w]
+        self.assertTrue(skipped, "expected warning for unmapped participant")
+
+    def test_unknown_agent_raises_registry_error(self) -> None:
+        with self.assertRaises(RegistryError):
+            build_participants_pool(REPO_ROOT, "no-such-agent")
+
+
+class RunnerHookTestCase(unittest.TestCase):
+    def test_dry_run_returns_status_dry_run_without_calling_submit(self) -> None:
+        runner = _FakeRunner()
+        request = AgentRequest(prompt="ignored", role="qa-engineer", task_id="t-1")
+
+        response = runner.run(request, dry_run=True)
+
+        self.assertEqual(response.status, RunnerStatus.DRY_RUN)
+        self.assertEqual(runner.submitted, [])
+        self.assertIn("elapsed_ms", response.metrics)
+
+    def test_performance_tracker_receives_outcome(self) -> None:
+        tracker = _RecordingTracker()
+        runner = _FakeRunner(hooks=RunnerHooks(performance_tracker=tracker))
+        request = AgentRequest(prompt="hello", role="backend-engineer", task_id="t-2")
+
+        response = runner.run(request)
+
+        self.assertEqual(response.status, RunnerStatus.OK)
+        self.assertEqual(len(tracker.calls), 1)
+        runner_id, recorded_request, recorded_response = tracker.calls[0]
+        self.assertEqual(runner_id, "fake")
+        self.assertEqual(recorded_request.task_id, "t-2")
+        self.assertEqual(recorded_response, response)
+
+    def test_reference_collector_fills_empty_references(self) -> None:
+        collector = _StaticReferenceCollector(payload=({"src": "Mobbin", "url": "x"},))
+        runner = _FakeRunner(hooks=RunnerHooks(reference_collector=collector))
+        request = AgentRequest(prompt="design", role="product-designer", task_id="t-3")
+
+        runner.run(request)
+
+        self.assertEqual(collector.calls, 1)
+        self.assertEqual(runner.submitted[0].references, ({"src": "Mobbin", "url": "x"},))
+
+    def test_reference_collector_skipped_when_request_already_has_refs(self) -> None:
+        collector = _StaticReferenceCollector(payload=({"src": "Mobbin"},))
+        runner = _FakeRunner(hooks=RunnerHooks(reference_collector=collector))
+        request = AgentRequest(
+            prompt="design",
+            role="product-designer",
+            task_id="t-4",
+            references=({"src": "Notefolio"},),
+        )
+
+        runner.run(request)
+
+        self.assertEqual(collector.calls, 0)
+        self.assertEqual(runner.submitted[0].references, ({"src": "Notefolio"},))
+
+
+class RunnerAvailabilityTestCase(unittest.TestCase):
+    def test_unavailable_runner_returns_unavailable_status(self) -> None:
+        from yule_orchestrator.agents.runners.claude_code import ClaudeCodeRunner
+
+        runner = ClaudeCodeRunner()
+        request = AgentRequest(prompt="hi", role="tech-lead", task_id="t-5")
+        with patch("yule_orchestrator.agents.runners.claude_code.shutil.which", return_value=None):
+            response = runner.submit(request)
+
+        self.assertEqual(response.status, RunnerStatus.UNAVAILABLE)
+        self.assertIn("claude", response.detail or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- #33

## ✨ 과제 내용
engineering-agent가 부서 단위 participants pool을 공통 방식으로 다룰 수 있도록
LLM runner abstraction 계층을 추가했습니다.

이번 PR은 각 역할이 모델을 직접 소유하는 구조가 아니라,
`engineering-agent/agent.json`에 정의된 participants/integrations 풀을
공통 인터페이스로 로딩하고 호출할 수 있는 기반을 만드는 것이 목표입니다.

## :camera_with_flash: 스크린샷(선택)
해당 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- engineering-agent는 role별 개별 runner 소유 구조가 아니라 department-level shared participants pool 구조를 따른다.
- 이번 PR은 실행 기반 계층만 다루며, 실제 orchestration은 후속 이슈에서 연결한다.
