### PR TITLE
[Feature] engineering-agent 게이트웨이 디스패처 추가 

### DIFF
--- a/agents/engineering-agent/agent.json
+++ b/agents/engineering-agent/agent.json
@@ -22,6 +22,7 @@
     "policies/runtime/agents/engineering-agent/runners.md",
     "policies/runtime/agents/engineering-agent/env-strategy.md",
     "policies/runtime/agents/engineering-agent/multi-bot-launcher.md",
+    "policies/runtime/agents/engineering-agent/dispatcher.md",
     "policies/runtime/agents/engineering-agent/version-control.md",
     "policies/runtime/agents/engineering-agent/workflow.md",
     "policies/runtime/agents/engineering-agent/testing.md"

--- a/policies/runtime/agents/engineering-agent/dispatcher.md
+++ b/policies/runtime/agents/engineering-agent/dispatcher.md
@@ -1,0 +1,138 @@
+# Engineering Agent Gateway Dispatcher (v0)
+
+이 문서는 engineering-agent 게이트웨이가 들어온 요청 하나를 받아 **역할 순서, executor/advisor 모델, 참고 reference, write 게이트**를 결정하는 디스패처의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/agents/dispatcher.py`이며, 본 문서는 운영자가 읽고 수정 절차를 따르는 규약이다.
+
+## 1. 입력과 출력
+
+### 입력 — `DispatchRequest`
+- `prompt: str` — 자연어 요청.
+- `task_type: TaskType | None` — 명시 분류. 비어 있으면 키워드 분류기로 추정.
+- `write_requested: bool` — 이 실행에서 코드/문서 쓰기를 요청하는지.
+- `user_approved: bool` — 사용자가 명시적으로 승인했는지.
+- `repository: str | None`, `extra: Mapping` — 컨텍스트.
+
+### 출력 — `DispatchPlan`
+- `task_type` — 최종 분류.
+- `role_sequence: tuple[str, ...]` — tech-lead로 시작하는 역할 호출 순서.
+- `assignments: tuple[RoleAssignment, ...]` — 역할마다 (runner_id, is_executor, score, rationale).
+- `reference_sources: tuple[str, ...]` — task_type에 매핑된 추천 소스.
+- `write_blocked: bool`, `write_block_reason: str | None`.
+- `notes: tuple[str, ...]` — 부분 풀, 게이트 차단 사유 등.
+
+## 2. 분류 (`Dispatcher.classify`)
+
+1. `task_type`이 명시되어 있으면 그대로 사용.
+2. 비어 있으면 prompt(소문자)에서 키워드를 순서대로 검사한다. 첫 매치가 결과.
+3. 매치 없음 → `TaskType.UNKNOWN`.
+
+키워드 우선순위 (구체 → 일반):
+1. VISUAL_POLISH (`polish`, `visual `, `리디자인`, `redesign`, ...)
+2. ONBOARDING_FLOW (`onboarding`, `온보딩`, ...)
+3. EMAIL_CAMPAIGN (`email`, `캠페인`, `광고`, ...)
+4. LANDING_PAGE (`landing`, `랜딩`, `marketing page`)
+5. QA_TEST, PLATFORM_INFRA, FRONTEND_FEATURE, BACKEND_FEATURE
+
+이유: `히어로 visual polish 정리`처럼 두 개 이상 시그널이 섞이면 더 구체적인 의도가 우선되어야 한다.
+
+## 3. 역할 순서
+
+| task_type | sequence | executor |
+|---|---|---|
+| backend-feature | tech-lead → backend-engineer → qa-engineer | backend-engineer |
+| frontend-feature | tech-lead → product-designer → frontend-engineer → qa-engineer | frontend-engineer |
+| landing-page | tech-lead → product-designer → frontend-engineer → qa-engineer | frontend-engineer |
+| onboarding-flow | tech-lead → product-designer → frontend-engineer → backend-engineer → qa-engineer | frontend-engineer |
+| visual-polish | tech-lead → product-designer → frontend-engineer | frontend-engineer |
+| email-campaign | tech-lead → product-designer → frontend-engineer → qa-engineer | frontend-engineer |
+| qa-test | tech-lead → qa-engineer → backend-engineer | qa-engineer |
+| platform-infra | tech-lead → backend-engineer → qa-engineer | backend-engineer |
+| unknown | tech-lead | tech-lead |
+
+원칙
+- tech-lead는 **항상** 첫 자리. 작업 분해와 의존 순서를 책임진다.
+- executor는 task_type별로 정확히 1명. 나머지는 advisor.
+- visual-polish의 executor는 frontend-engineer (코드 산출물). product-designer는 advisor로 시각 결정만 한다. 향후 design-agent가 분리되면 visual-only 작업의 executor 위임은 그쪽으로 이전한다.
+
+## 4. 모델 선택
+
+각 역할마다 다음 합산을 적용해 가장 높은 점수의 runner를 고른다.
+
+```
+score = base_weight + task_bonus + (ranking_signal × ranking_weight)
+```
+
+- `base_weight` — `role-weights-v0.md` 표를 그대로 옮긴 `ROLE_DEFAULT_WEIGHTS`.
+- `task_bonus` — task_type × role × runner의 작은 보정. 음수 허용. 합산 결과가 0 이하면 제외.
+- `ranking_signal` — 외부 신호(LMSys 등). MVP 기본 `ranking_weight=0`으로 무력화. 슬롯만 예약.
+- `pool에 없는 runner는 후보에서 제외` — 새 백엔드를 등록하기 전이라도 기존 세트로 동작.
+
+현재 task_bonus 매트릭스 (코드 `TASK_BONUSES`):
+
+| task_type | role | runner | 보정 |
+|---|---|---|---|
+| landing-page | product-designer | gemini | +2 |
+| landing-page | frontend-engineer | codex | +1 |
+| visual-polish | product-designer | gemini | +3 |
+| visual-polish | frontend-engineer | gemini | +1 |
+| onboarding-flow | tech-lead | gemini | +1 |
+| onboarding-flow | product-designer | gemini | +1 |
+| email-campaign | product-designer | gemini | +2 |
+| email-campaign | frontend-engineer | codex | +1 |
+| qa-test | qa-engineer | codex | +2 |
+| platform-infra | backend-engineer | claude | +1 |
+| platform-infra | qa-engineer | codex | +1 |
+| backend-feature | backend-engineer | codex | +1 |
+
+타이브레이커: 점수 동률이면 runner_id 알파벳순.
+
+## 5. Reference Pack 추천
+
+| task_type | sources |
+|---|---|
+| landing-page | Wix Templates, Awwwards, Behance, Pinterest Trends |
+| onboarding-flow | Mobbin, Page Flows |
+| visual-polish | Pinterest Trends, Notefolio, Behance, Canva Design School |
+| email-campaign | Really Good Emails, Meta Ad Library, TikTok Creative Center, Google Trends |
+| 기타 | (없음 — 백엔드/QA/인프라는 시각 reference 강제 안 함) |
+
+규약
+- 자동 수집이 약관상 민감한 소스(Notefolio, Behance, Mobbin 등)는 사용자 제공 링크와 수동 참고로만 사용한다 (env-strategy.md §7, reference-pack.md §자동 수집 정책).
+- 디스패처는 소스 이름만 추천하고, 실제 페치는 후속 reference fetcher 마일스톤에서 처리한다.
+
+## 6. Write 게이트
+
+```
+if write_requested and not user_approved:
+    write_blocked = True
+    write_block_reason = "write is requested for <role> but user_approved=False. Block until the operator confirms."
+```
+
+- 게이트는 **실행 단계**에서 검사한다. 디스패처는 plan을 생성하더라도 executor가 실제로 쓰기를 시도하기 전에 이 플래그를 확인해야 한다.
+- single-executor 원칙은 `write_policy.max_write_executors_per_run=1`(agent.json)과 일치한다.
+
+## 7. RankingSignal 슬롯
+
+`Dispatcher(pool, ranking_signal=…)` 또는 `dispatcher.ranking_signal = …`로 주입한다. 호출 측에서 `dispatch(request, ranking_weight=...)`를 사용해 가중치를 명시한다. MVP에서는 `ranking_weight=0`(기본)로 무력화한다.
+
+이 슬롯이 채워지는 시점은:
+- 로컬 성과(승인률, 회귀률) 수집기가 도입될 때.
+- 외부 리더보드(LMSys, HumanEval) 변동이 안정화될 때.
+
+자동 점수 반영은 별도 정책 변경으로 결정한다 (`role-weights-v0.md` §외부 신호 처리 정책).
+
+## 8. 변경 절차
+
+가중치 / task bonus / sequence 변경 시:
+
+1. PR 본문에 변경 이유와 어느 task_type에서 발견된 문제를 적는다.
+2. `dispatcher.py`의 상수와 `dispatcher.md`의 표를 함께 수정한다 (둘이 어긋나면 정합성 테스트가 실패).
+3. role-weights-v0.md의 base 가중치를 바꾸는 경우, dispatcher의 `ROLE_DEFAULT_WEIGHTS`도 같이 갱신한다.
+4. 새 task_type 추가 시: TaskType enum, TASK_ROLE_SEQUENCE, TASK_EXECUTOR_ROLE, (선택) TASK_BONUSES, (선택) TASK_REFERENCE_SOURCES, _KEYWORD_RULES 모두 갱신.
+5. 테스트 추가 (분류, 시퀀스, 가중치 표 일치, references 표 일치).
+
+## 9. 후속 작업
+
+- 멤버 봇 IPC: dispatcher 결과를 멤버 봇 큐에 넣어 advisor → executor 순서 실행.
+- 게이트 자동 yes/no: Discord 체크포인트 yes/no 응답을 `user_approved`로 매핑.
+- Reference fetcher: 소스 이름만 노출하던 슬롯에 실제 자료를 채운다 (`format_references_block` 사용).
+- PerformanceTracker → ranking_signal 입력으로 연결.

--- a/src/yule_orchestrator/agents/__init__.py
+++ b/src/yule_orchestrator/agents/__init__.py
@@ -1,5 +1,13 @@
 """Engineering-agent department runtime: runners, registry, hooks."""
 
+from .dispatcher import (
+    DispatchPlan,
+    DispatchRequest,
+    Dispatcher,
+    RoleAssignment,
+    TaskType,
+    render_plan_summary,
+)
 from .registry import (
     DEFAULT_RUNNER_FACTORIES,
     ParticipantsPool,
@@ -10,8 +18,14 @@ from .registry import (
 
 __all__ = [
     "DEFAULT_RUNNER_FACTORIES",
+    "DispatchPlan",
+    "DispatchRequest",
+    "Dispatcher",
     "ParticipantsPool",
     "RegistryError",
+    "RoleAssignment",
     "RunnerFactory",
+    "TaskType",
     "build_participants_pool",
+    "render_plan_summary",
 ]

--- a/src/yule_orchestrator/agents/dispatcher.py
+++ b/src/yule_orchestrator/agents/dispatcher.py
@@ -1,0 +1,347 @@
+"""Engineering-agent gateway dispatcher.
+
+Decides, for one incoming request, the role sequence, the executor/advisor
+runner picks, the reference pack to consult, and whether a write may proceed.
+
+Single-executor, multi-advisor: at most one role writes; everyone else
+proposes patches or reviews. Source-of-truth for default weights is
+``policies/runtime/agents/engineering-agent/role-weights-v0.md``; for
+reference packs, ``reference-pack.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
+
+from .registry import ParticipantsPool
+
+
+class TaskType(str, Enum):
+    BACKEND_FEATURE = "backend-feature"
+    FRONTEND_FEATURE = "frontend-feature"
+    LANDING_PAGE = "landing-page"
+    ONBOARDING_FLOW = "onboarding-flow"
+    VISUAL_POLISH = "visual-polish"
+    EMAIL_CAMPAIGN = "email-campaign"
+    QA_TEST = "qa-test"
+    PLATFORM_INFRA = "platform-infra"
+    UNKNOWN = "unknown"
+
+
+# role × runner default weights mirroring role-weights-v0.md
+ROLE_DEFAULT_WEIGHTS: Mapping[str, Mapping[str, int]] = {
+    "tech-lead": {"claude": 9, "gemini": 7, "codex": 5, "ollama": 3},
+    "backend-engineer": {"claude": 9, "codex": 7, "gemini": 5, "ollama": 3},
+    "frontend-engineer": {"claude": 8, "codex": 8, "gemini": 5, "ollama": 3},
+    "product-designer": {"gemini": 9, "claude": 8, "codex": 4, "ollama": 3},
+    "qa-engineer": {"codex": 9, "claude": 8, "gemini": 5, "ollama": 3},
+}
+
+
+# tech-lead always leads; implementing roles follow per task type.
+TASK_ROLE_SEQUENCE: Mapping[TaskType, Sequence[str]] = {
+    TaskType.BACKEND_FEATURE: ("tech-lead", "backend-engineer", "qa-engineer"),
+    TaskType.FRONTEND_FEATURE: ("tech-lead", "product-designer", "frontend-engineer", "qa-engineer"),
+    TaskType.LANDING_PAGE: ("tech-lead", "product-designer", "frontend-engineer", "qa-engineer"),
+    TaskType.ONBOARDING_FLOW: (
+        "tech-lead",
+        "product-designer",
+        "frontend-engineer",
+        "backend-engineer",
+        "qa-engineer",
+    ),
+    TaskType.VISUAL_POLISH: ("tech-lead", "product-designer", "frontend-engineer"),
+    TaskType.EMAIL_CAMPAIGN: ("tech-lead", "product-designer", "frontend-engineer", "qa-engineer"),
+    TaskType.QA_TEST: ("tech-lead", "qa-engineer", "backend-engineer"),
+    TaskType.PLATFORM_INFRA: ("tech-lead", "backend-engineer", "qa-engineer"),
+    TaskType.UNKNOWN: ("tech-lead",),
+}
+
+
+# The single role allowed to write per task type. tech-lead writes only when
+# the task is unclassified (planning-only).
+TASK_EXECUTOR_ROLE: Mapping[TaskType, str] = {
+    TaskType.BACKEND_FEATURE: "backend-engineer",
+    TaskType.FRONTEND_FEATURE: "frontend-engineer",
+    TaskType.LANDING_PAGE: "frontend-engineer",
+    TaskType.ONBOARDING_FLOW: "frontend-engineer",
+    TaskType.VISUAL_POLISH: "frontend-engineer",
+    TaskType.EMAIL_CAMPAIGN: "frontend-engineer",
+    TaskType.QA_TEST: "qa-engineer",
+    TaskType.PLATFORM_INFRA: "backend-engineer",
+    TaskType.UNKNOWN: "tech-lead",
+}
+
+
+# task_type → reference sources (per spec).
+TASK_REFERENCE_SOURCES: Mapping[TaskType, Sequence[str]] = {
+    TaskType.LANDING_PAGE: ("Wix Templates", "Awwwards", "Behance", "Pinterest Trends"),
+    TaskType.ONBOARDING_FLOW: ("Mobbin", "Page Flows"),
+    TaskType.VISUAL_POLISH: ("Pinterest Trends", "Notefolio", "Behance", "Canva Design School"),
+    TaskType.EMAIL_CAMPAIGN: (
+        "Really Good Emails",
+        "Meta Ad Library",
+        "TikTok Creative Center",
+        "Google Trends",
+    ),
+}
+
+
+# Small, conservative bonuses on top of role defaults. Negative bonuses are
+# allowed; final negative scores collapse to 0 (= excluded).
+TASK_BONUSES: Mapping[TaskType, Mapping[str, Mapping[str, int]]] = {
+    TaskType.LANDING_PAGE: {
+        "product-designer": {"gemini": 2},
+        "frontend-engineer": {"codex": 1},
+    },
+    TaskType.VISUAL_POLISH: {
+        "product-designer": {"gemini": 3},
+        "frontend-engineer": {"gemini": 1},
+    },
+    TaskType.ONBOARDING_FLOW: {
+        "tech-lead": {"gemini": 1},
+        "product-designer": {"gemini": 1},
+    },
+    TaskType.EMAIL_CAMPAIGN: {
+        "product-designer": {"gemini": 2},
+        "frontend-engineer": {"codex": 1},
+    },
+    TaskType.QA_TEST: {"qa-engineer": {"codex": 2}},
+    TaskType.PLATFORM_INFRA: {
+        "backend-engineer": {"claude": 1},
+        "qa-engineer": {"codex": 1},
+    },
+    TaskType.BACKEND_FEATURE: {"backend-engineer": {"codex": 1}},
+}
+
+
+# Keyword fallback when DispatchRequest.task_type is not provided.
+# Order matters: more specific intents (polish/onboarding/email) are checked
+# before generic surface keywords (landing/frontend/backend) so that a prompt
+# like "히어로 visual polish 정리" classifies as VISUAL_POLISH.
+_KEYWORD_RULES: Sequence[tuple[TaskType, Sequence[str]]] = (
+    (TaskType.VISUAL_POLISH, ("polish", "visual ", "리디자인", "redesign", "시각 정리", "visual cleanup")),
+    (TaskType.ONBOARDING_FLOW, ("onboarding", "온보딩", "signup flow", "가입 흐름", "first-run")),
+    (TaskType.EMAIL_CAMPAIGN, ("email", "이메일", "campaign", "캠페인", "광고", "ad creative")),
+    (TaskType.LANDING_PAGE, ("landing", "랜딩", "marketing page")),
+    (TaskType.QA_TEST, ("regression", "회귀", "qa", "test plan", "테스트 시나리오")),
+    (
+        TaskType.PLATFORM_INFRA,
+        ("infra", "deploy", "ci ", " ci", "docker", "k8s", "terraform", "github action"),
+    ),
+    (TaskType.FRONTEND_FEATURE, ("frontend", "ui ", "component", "컴포넌트", "react", "next.js", "vue")),
+    (
+        TaskType.BACKEND_FEATURE,
+        ("backend", "api ", "schema", "database", "migration", "도메인", "service layer"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class DispatchRequest:
+    """Request handed to the gateway dispatcher.
+
+    *task_type* is optional: when ``None``, the prompt is classified by
+    keyword. *user_approved* is the explicit operator approval needed
+    before any writing role is allowed to execute.
+    """
+
+    prompt: str
+    task_type: Optional[TaskType] = None
+    write_requested: bool = False
+    user_approved: bool = False
+    repository: Optional[str] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RoleAssignment:
+    role: str
+    runner_id: Optional[str]
+    is_executor: bool
+    score: int
+    rationale: str
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    task_type: TaskType
+    role_sequence: Sequence[str]
+    assignments: Sequence[RoleAssignment]
+    reference_sources: Sequence[str]
+    write_blocked: bool
+    write_block_reason: Optional[str]
+    notes: Sequence[str] = field(default_factory=tuple)
+
+    def executor(self) -> Optional[RoleAssignment]:
+        for assignment in self.assignments:
+            if assignment.is_executor:
+                return assignment
+        return None
+
+    def advisors(self) -> Sequence[RoleAssignment]:
+        return tuple(a for a in self.assignments if not a.is_executor)
+
+
+class RankingSignal(Protocol):
+    """Optional external signal: returns a small additive nudge for one (role, runner).
+
+    MVP applies the result with weight 0 by default — see
+    ``Dispatcher.dispatch(ranking_weight=...)``. The slot exists so a future
+    score source (LMSys, local success rate) can be plugged in without
+    touching the dispatcher.
+    """
+
+    def score(self, role: str, runner_id: str, request: DispatchRequest) -> float:
+        ...
+
+
+class Dispatcher:
+    """Stateless dispatcher; instances hold only configuration / hooks."""
+
+    def __init__(
+        self,
+        pool: ParticipantsPool,
+        *,
+        ranking_signal: Optional[RankingSignal] = None,
+    ) -> None:
+        self.pool = pool
+        self.ranking_signal = ranking_signal
+
+    def classify(self, request: DispatchRequest) -> TaskType:
+        if request.task_type is not None:
+            return request.task_type
+        prompt = request.prompt.lower()
+        for task_type, keywords in _KEYWORD_RULES:
+            for keyword in keywords:
+                if keyword in prompt:
+                    return task_type
+        return TaskType.UNKNOWN
+
+    def dispatch(
+        self,
+        request: DispatchRequest,
+        *,
+        ranking_weight: float = 0.0,
+    ) -> DispatchPlan:
+        task_type = self.classify(request)
+        role_sequence = TASK_ROLE_SEQUENCE[task_type]
+        executor_role = TASK_EXECUTOR_ROLE[task_type]
+        bonuses = TASK_BONUSES.get(task_type, {})
+
+        assignments: list[RoleAssignment] = []
+        notes: list[str] = []
+
+        for role in role_sequence:
+            base_weights = ROLE_DEFAULT_WEIGHTS.get(role, {})
+            role_bonus = bonuses.get(role, {})
+            scored = self._score_runners_for_role(
+                role=role,
+                request=request,
+                base_weights=base_weights,
+                role_bonus=role_bonus,
+                ranking_weight=ranking_weight,
+            )
+            best = scored[0] if scored else (None, 0, "no candidate runner in pool")
+            runner_id, score, rationale = best
+            assignments.append(
+                RoleAssignment(
+                    role=role,
+                    runner_id=runner_id,
+                    is_executor=(role == executor_role),
+                    score=int(score),
+                    rationale=rationale,
+                )
+            )
+            if runner_id is None:
+                notes.append(f"role '{role}' has no eligible runner in the pool")
+
+        write_blocked, write_block_reason = self._evaluate_write_gate(request, executor_role)
+        if write_blocked and write_block_reason:
+            notes.append(write_block_reason)
+
+        return DispatchPlan(
+            task_type=task_type,
+            role_sequence=tuple(role_sequence),
+            assignments=tuple(assignments),
+            reference_sources=tuple(TASK_REFERENCE_SOURCES.get(task_type, ())),
+            write_blocked=write_blocked,
+            write_block_reason=write_block_reason,
+            notes=tuple(notes),
+        )
+
+    def _score_runners_for_role(
+        self,
+        *,
+        role: str,
+        request: DispatchRequest,
+        base_weights: Mapping[str, int],
+        role_bonus: Mapping[str, int],
+        ranking_weight: float,
+    ) -> Sequence[tuple[Optional[str], int, str]]:
+        candidates: list[tuple[Optional[str], int, str]] = []
+        for runner_id, base in base_weights.items():
+            if runner_id not in self.pool.runners:
+                continue
+            bonus = role_bonus.get(runner_id, 0)
+            ranking_score = 0.0
+            if self.ranking_signal is not None and ranking_weight > 0:
+                ranking_score = float(self.ranking_signal.score(role, runner_id, request)) * ranking_weight
+            score = max(0, int(round(base + bonus + ranking_score)))
+            if score == 0:
+                continue
+            rationale = self._format_rationale(base, bonus, ranking_score)
+            candidates.append((runner_id, score, rationale))
+
+        candidates.sort(key=lambda item: (-item[1], item[0] or ""))
+        return candidates
+
+    def _evaluate_write_gate(
+        self,
+        request: DispatchRequest,
+        executor_role: str,
+    ) -> tuple[bool, Optional[str]]:
+        if not request.write_requested:
+            return False, None
+        if request.user_approved:
+            return False, None
+        return (
+            True,
+            (
+                f"write is requested for {executor_role} but user_approved=False. "
+                f"Block until the operator confirms."
+            ),
+        )
+
+    @staticmethod
+    def _format_rationale(base: int, bonus: int, ranking_score: float) -> str:
+        parts = [f"base={base}"]
+        if bonus:
+            parts.append(f"task_bonus={bonus:+d}")
+        if ranking_score:
+            parts.append(f"ranking={ranking_score:+.1f}")
+        return ", ".join(parts)
+
+
+def render_plan_summary(plan: DispatchPlan) -> str:
+    """Operator-facing summary of a dispatch decision."""
+
+    lines: list[str] = [
+        f"task_type: {plan.task_type.value}",
+        f"role sequence: {' → '.join(plan.role_sequence)}",
+    ]
+    for assignment in plan.assignments:
+        marker = "[exec]" if assignment.is_executor else "[advisor]"
+        runner = assignment.runner_id or "<no runner>"
+        lines.append(
+            f"  {marker} {assignment.role}: {runner} (score={assignment.score}, {assignment.rationale})"
+        )
+    if plan.reference_sources:
+        lines.append(f"references: {', '.join(plan.reference_sources)}")
+    if plan.write_blocked:
+        lines.append(f"write blocked: {plan.write_block_reason}")
+    for note in plan.notes:
+        lines.append(f"note: {note}")
+    return "\n".join(lines)

--- a/tests/test_agent_dispatcher.py
+++ b/tests/test_agent_dispatcher.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    DispatchRequest,
+    TaskType,
+    build_participants_pool,
+)
+from yule_orchestrator.agents.dispatcher import (
+    ROLE_DEFAULT_WEIGHTS,
+    TASK_REFERENCE_SOURCES,
+    render_plan_summary,
+)
+from yule_orchestrator.agents.runners import (
+    AgentRequest,
+    AgentResponse,
+    AgentRunner,
+    RunnerCapability,
+    RunnerHooks,
+    RunnerStatus,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _StaticRunner(AgentRunner):
+    capabilities: Sequence[RunnerCapability] = (RunnerCapability.ADVISE,)
+
+    def __init__(
+        self,
+        runner_id: str,
+        provider: str,
+        *,
+        config: Mapping[str, Any] | None = None,
+        hooks: RunnerHooks | None = None,
+    ) -> None:
+        super().__init__(config=config, hooks=hooks)
+        self.runner_id = runner_id
+        self.provider = provider
+
+    def is_available(self) -> bool:
+        return True
+
+    def submit(self, request: AgentRequest) -> AgentResponse:
+        return AgentResponse(runner_id=self.runner_id, status=RunnerStatus.OK, text="")
+
+
+def _build_full_pool() -> "Dispatcher":
+    factories = {
+        runner_id: lambda config, hooks, rid=runner_id: _StaticRunner(rid, "test", config=config, hooks=hooks)
+        for runner_id in ("claude", "codex", "gemini", "ollama", "github-copilot")
+    }
+    pool = build_participants_pool(REPO_ROOT, "engineering-agent", factories=factories)
+    return Dispatcher(pool)
+
+
+class ClassifyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_full_pool()
+
+    def test_explicit_task_type_wins(self) -> None:
+        request = DispatchRequest(prompt="something", task_type=TaskType.QA_TEST)
+        self.assertEqual(self.disp.classify(request), TaskType.QA_TEST)
+
+    def test_landing_keyword(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="새 랜딩페이지 hero 섹션 정리")),
+            TaskType.LANDING_PAGE,
+        )
+
+    def test_onboarding_keyword(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="onboarding step 2 흐름 개선")),
+            TaskType.ONBOARDING_FLOW,
+        )
+
+    def test_visual_polish_keyword(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="히어로 visual polish 정리")),
+            TaskType.VISUAL_POLISH,
+        )
+
+    def test_email_campaign_keyword(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="welcome email 캠페인 설계")),
+            TaskType.EMAIL_CAMPAIGN,
+        )
+
+    def test_backend_keyword(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="users API schema 추가")),
+            TaskType.BACKEND_FEATURE,
+        )
+
+    def test_falls_back_to_unknown(self) -> None:
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt="회의록 요약")),
+            TaskType.UNKNOWN,
+        )
+
+
+class RoleSequenceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_full_pool()
+
+    def test_tech_lead_starts_every_sequence(self) -> None:
+        for task_type in TaskType:
+            plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=task_type))
+            self.assertEqual(plan.role_sequence[0], "tech-lead", task_type)
+
+    def test_landing_page_executor_is_frontend(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.LANDING_PAGE))
+        executor = plan.executor()
+        self.assertIsNotNone(executor)
+        self.assertEqual(executor.role, "frontend-engineer")
+        self.assertTrue(executor.is_executor)
+
+    def test_backend_feature_executor_is_backend(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE))
+        self.assertEqual(plan.executor().role, "backend-engineer")
+
+    def test_unknown_executor_is_tech_lead(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="회의록"))
+        self.assertEqual(plan.executor().role, "tech-lead")
+
+    def test_only_one_executor_per_plan(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.ONBOARDING_FLOW))
+        executors = [a for a in plan.assignments if a.is_executor]
+        self.assertEqual(len(executors), 1)
+
+
+class WeightSelectionTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_full_pool()
+
+    def test_visual_polish_picks_gemini_for_designer(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.VISUAL_POLISH))
+        designer = next(a for a in plan.assignments if a.role == "product-designer")
+        self.assertEqual(designer.runner_id, "gemini")
+        # base 9 + bonus 3 = 12
+        self.assertEqual(designer.score, 12)
+
+    def test_qa_test_picks_codex_for_qa(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.QA_TEST))
+        qa = next(a for a in plan.assignments if a.role == "qa-engineer")
+        self.assertEqual(qa.runner_id, "codex")
+        # base 9 + bonus 2 = 11
+        self.assertEqual(qa.score, 11)
+
+    def test_runner_missing_from_pool_is_skipped(self) -> None:
+        # Build pool that only has gemini + ollama
+        factories = {
+            "gemini": lambda config, hooks: _StaticRunner("gemini", "test", config=config, hooks=hooks),
+            "ollama": lambda config, hooks: _StaticRunner("ollama", "test", config=config, hooks=hooks),
+        }
+        pool = build_participants_pool(REPO_ROOT, "engineering-agent", factories=factories)
+        disp = Dispatcher(pool)
+
+        plan = disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE))
+        backend = next(a for a in plan.assignments if a.role == "backend-engineer")
+        self.assertIn(backend.runner_id, {"gemini", "ollama"})
+
+    def test_weights_match_policy_doc(self) -> None:
+        # Defensive: dispatcher's defaults must agree with role-weights-v0.md.
+        self.assertEqual(ROLE_DEFAULT_WEIGHTS["product-designer"]["gemini"], 9)
+        self.assertEqual(ROLE_DEFAULT_WEIGHTS["qa-engineer"]["codex"], 9)
+        self.assertEqual(ROLE_DEFAULT_WEIGHTS["tech-lead"]["claude"], 9)
+
+
+class ReferencesTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_full_pool()
+
+    def test_landing_page_references(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.LANDING_PAGE))
+        self.assertEqual(
+            plan.reference_sources,
+            ("Wix Templates", "Awwwards", "Behance", "Pinterest Trends"),
+        )
+
+    def test_email_campaign_references(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.EMAIL_CAMPAIGN))
+        self.assertIn("Really Good Emails", plan.reference_sources)
+        self.assertIn("Meta Ad Library", plan.reference_sources)
+        self.assertIn("TikTok Creative Center", plan.reference_sources)
+        self.assertIn("Google Trends", plan.reference_sources)
+
+    def test_backend_feature_has_no_visual_references(self) -> None:
+        plan = self.disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE))
+        self.assertEqual(plan.reference_sources, ())
+
+    def test_table_matches_spec(self) -> None:
+        self.assertEqual(
+            TASK_REFERENCE_SOURCES[TaskType.VISUAL_POLISH],
+            ("Pinterest Trends", "Notefolio", "Behance", "Canva Design School"),
+        )
+
+
+class WriteGateTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_full_pool()
+
+    def test_no_write_requested_no_block(self) -> None:
+        plan = self.disp.dispatch(
+            DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE, write_requested=False)
+        )
+        self.assertFalse(plan.write_blocked)
+        self.assertIsNone(plan.write_block_reason)
+
+    def test_write_without_approval_is_blocked(self) -> None:
+        plan = self.disp.dispatch(
+            DispatchRequest(
+                prompt="x",
+                task_type=TaskType.BACKEND_FEATURE,
+                write_requested=True,
+                user_approved=False,
+            )
+        )
+        self.assertTrue(plan.write_blocked)
+        self.assertIn("backend-engineer", plan.write_block_reason)
+
+    def test_write_with_approval_passes(self) -> None:
+        plan = self.disp.dispatch(
+            DispatchRequest(
+                prompt="x",
+                task_type=TaskType.BACKEND_FEATURE,
+                write_requested=True,
+                user_approved=True,
+            )
+        )
+        self.assertFalse(plan.write_blocked)
+
+
+class RankingSlotTestCase(unittest.TestCase):
+    def test_ranking_signal_slot_unused_by_default(self) -> None:
+        disp = _build_full_pool()
+        plan = disp.dispatch(DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE))
+        backend = next(a for a in plan.assignments if a.role == "backend-engineer")
+        # claude defaults to 9, codex with backend bonus = 8; claude wins.
+        self.assertEqual(backend.runner_id, "claude")
+        self.assertEqual(backend.score, 9)
+
+    def test_ranking_signal_applied_when_weight_positive(self) -> None:
+        class FavorOllama:
+            def score(self, role, runner_id, request):
+                return 10.0 if runner_id == "ollama" else 0.0
+
+        disp = _build_full_pool()
+        disp.ranking_signal = FavorOllama()
+        plan = disp.dispatch(
+            DispatchRequest(prompt="x", task_type=TaskType.BACKEND_FEATURE),
+            ranking_weight=1.0,
+        )
+        backend = next(a for a in plan.assignments if a.role == "backend-engineer")
+        # ollama base 3 + ranking 10 = 13 — beats claude 9.
+        self.assertEqual(backend.runner_id, "ollama")
+
+
+class RenderTestCase(unittest.TestCase):
+    def test_summary_includes_key_lines(self) -> None:
+        disp = _build_full_pool()
+        plan = disp.dispatch(
+            DispatchRequest(
+                prompt="x",
+                task_type=TaskType.LANDING_PAGE,
+                write_requested=True,
+                user_approved=False,
+            )
+        )
+        summary = render_plan_summary(plan)
+        self.assertIn("task_type: landing-page", summary)
+        self.assertIn("[exec] frontend-engineer", summary)
+        self.assertIn("references:", summary)
+        self.assertIn("write blocked", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- #36

## ✨ 과제 내용
engineering-agent 게이트웨이가 들어온 요청 1건을 받아
작업 유형을 분류하고, 역할 호출 순서와 executor/advisor 모델 선택,
참고 reference 추천, write gate 여부를 결정하는 디스패처를 추가했습니다.

이번 PR은 "멀티봇이 실제로 협업하는 전체 흐름"을 끝내는 단계는 아니고,
그 전에 필요한 조율 로직의 기준선과 정책-코드 정합성을 먼저 만드는 것이 목표입니다.

## :camera_with_flash: 스크린샷(선택)
- dispatcher summary 출력 예시
<img width="2092" height="167" alt="image" src="https://github.com/user-attachments/assets/9acf2cb5-6730-4849-9fe5-02a170bdcf26" />

- task_type 분류 결과 예시
- write blocked summary 예시

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- `policies/runtime/agents/engineering-agent/role-weights-v0.md`
- `policies/runtime/agents/engineering-agent/reference-pack.md`
- `policies/runtime/agents/engineering-agent/dispatcher.md`
- 이번 PR은 조율 "판단"을 구현한 단계이며, 실제 멤버 간 실행 연결은 후속 이슈에서 담당함
