### PR TITLE
[Feature] engineering-agent Discord 작업 위임 워크플로우 추가

### DIFF
--- a/agents/engineering-agent/agent.json
+++ b/agents/engineering-agent/agent.json
@@ -23,6 +23,7 @@
     "policies/runtime/agents/engineering-agent/env-strategy.md",
     "policies/runtime/agents/engineering-agent/multi-bot-launcher.md",
     "policies/runtime/agents/engineering-agent/dispatcher.md",
+    "policies/runtime/agents/engineering-agent/discord-workflow.md",
     "policies/runtime/agents/engineering-agent/version-control.md",
     "policies/runtime/agents/engineering-agent/workflow.md",
     "policies/runtime/agents/engineering-agent/testing.md"

--- a/policies/runtime/agents/engineering-agent/discord-workflow.md
+++ b/policies/runtime/agents/engineering-agent/discord-workflow.md
@@ -1,0 +1,112 @@
+# Engineering Agent Discord Workflow (v0)
+
+이 문서는 Discord 안에서 engineering-agent에게 작업을 위임하는 **접수(intake) → 승인(approve) → 진행(progress) → 완료(complete)** 흐름의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/agents/workflow.py` + `workflow_state.py`, CLI는 `yule engineer`, Discord 슬래시 커맨드는 `commands.py`의 `engineer_intake` / `engineer_show`.
+
+## 1. 접수 채널 규칙
+
+- **CONVERSATION 채널**에서만 접수한다. DAILY 채널은 broadcast 전용으로 잠겨 있다 (DAILY 채널 정책과 동일).
+- 슬래시 커맨드 `/engineer_intake` 사용을 권장한다.
+  - `prompt`: 자연어 작업 요청 (필수).
+  - `task_type`: 명시 분류 (선택, 생략 시 키워드 분류).
+  - `write_requested`: 코드/문서 쓰기 요청 여부.
+- 향후 멤버 봇 분리(Phase 2) 시 부서 게이트웨이 봇만 접수한다. 멤버 봇은 외부와 직접 대화하지 않는다 (engineering-agent CLAUDE.md 규약).
+- 작업 단위가 길어지면 게이트웨이가 thread를 만들어 진행 보고/완료 보고를 같은 thread에 묶는 운영을 권장한다 (thread 자동 생성은 후속 마일스톤).
+
+## 2. 승인 게이트
+
+- `write_requested=True`로 접수된 세션은 `intake → approved` 전이 전까지 **어떤 write도 시작하지 않는다**.
+- 승인 방법:
+  - **CLI**: `yule engineer approve --session <id>`.
+  - **Discord** (예정): 접수 메시지의 ✅ 반응 → 게이트웨이가 reaction을 감지해 승인. 본 마일스톤에서는 슬래시 커맨드 `/engineer_show`로 상태만 확인 가능, 승인은 CLI에서 진행한다. reaction 핸들러는 후속 이슈에서 추가.
+- 거절은 `yule engineer reject --session <id> --reason "..."`. 거절된 세션은 progress/complete가 모두 차단된다.
+- write 게이트는 dispatcher의 `write_block_reason`을 그대로 받아 표시한다 (dispatcher.md §6).
+
+## 3. 메시지 포맷
+
+### 3.1 접수 메시지 (`format_intake_message`)
+표준 섹션:
+1. 헤더: `**[engineering-agent] 새 작업 접수**`, 세션 ID, 분류, 역할 순서, 실행자, 어드바이저.
+2. **참고 레퍼런스 (제안)**:
+   - 사용자 제공 (1순위): prompt 안의 URL을 추출해 노출 (`extract_urls`).
+   - task_type 추천 카테고리: dispatcher가 매핑한 소스 이름.
+   - 둘 다 없으면 "이 task_type에는 시각 reference를 강제하지 않습니다" 명시.
+3. **승인 필요** 섹션: write 게이트 차단 시 사유 + 승인 명령 안내.
+
+### 3.2 진행 메시지 (`format_progress_message`)
+- 상태, 실행자, 최근 메모 5건 (FIFO 누적).
+- 메모는 짧게(한 줄). 자세한 내용은 thread 또는 PR 링크로 풀어쓴다.
+
+### 3.3 완료 메시지 (`format_completion_message`)
+- 분류, 실행자, **요약**, **반영한 레퍼런스**.
+- 반영한 레퍼런스는 `{title, source, url, rationale}` 키 4종을 가진 객체 배열. rationale은 "차용한 패턴 + 어떻게 재구성했는지" 한 줄.
+- 제안된 reference가 있었지만 실제 인용이 없으면 `- (없음 — 본 작업은 reference를 직접 인용하지 않았습니다)`로 명시 (감추지 않는다).
+
+## 4. Reference 정책
+
+### 4.1 우선순위
+1. **사용자 제공 링크/스크린샷** — prompt 안의 URL을 자동 추출. 슬래시 커맨드 인자에 없어도 prompt 본문에 붙어 있으면 1순위로 인식.
+2. **task_type 추천 카테고리** — dispatcher의 `reference_sources` (landing-page / onboarding-flow / visual-polish / email-campaign 4종).
+3. (이번 단계는 자동 fetch 없음. 후속 마일스톤에서 `REFERENCE_*` env 슬롯이 채워졌을 때만 동작.)
+
+### 4.2 산출 양식
+완료 보고에 반영한 레퍼런스는 `reference-pack.md`의 4가지 명문화 항목 중 적어도 `차용 패턴(rationale)`을 포함해야 한다. 단순 복제는 금지(공통 정책).
+
+### 4.3 자동 수집 민감 소스
+- Notefolio, Behance, Mobbin, Page Flows, Awwwards 등은 약관상 자동 수집 금지. 사용자 제공 링크 또는 운영자 수동 참고로만 사용한다.
+- env-strategy.md §7 슬롯이 채워지더라도 위 소스는 fetcher 대상에서 제외된다.
+
+## 5. 상태 모델 (`WorkflowState`)
+
+```
+intake ──approve──▶ approved ──progress──▶ in_progress ──complete──▶ completed
+   │                    │                       │
+   │                    └─reject─▶ rejected     └─reject─▶ rejected (open notes 보존)
+   └─reject─▶ rejected
+```
+
+규약
+- `progress` / `complete`는 `intake` 상태에서 직접 호출 불가 — 승인 단계를 강제한다.
+- `completed` / `rejected`는 종료 상태. 재접수가 필요하면 새 세션을 만든다.
+- 세션은 SQLite JSON 캐시(`engineering-agent-workflow` 네임스페이스)에 저장되며 30일 보존.
+
+## 6. CLI 사용 예 (운영자 e2e 검증)
+
+```bash
+# 접수
+yule engineer intake \
+  --prompt "우리 새 랜딩페이지 hero 섹션 다시 짜야 해 — https://stripe.com/pricing" \
+  --write
+# stderr에 session_id=<sid>가 출력됨
+
+yule engineer approve --session <sid>
+yule engineer progress --session <sid> --note "designer 시안 1차 정리"
+yule engineer complete --session <sid> \
+  --summary "hero 카피 + CTA 색 정리, 모바일 반응형 보정" \
+  --references-used /tmp/refs.json
+yule engineer show --session <sid>     # JSON 상태
+```
+
+`refs.json` 예:
+```json
+[
+  {"title": "Stripe Pricing", "source": "Mobbin", "url": "https://example.com/stripe", "rationale": "step copy + CTA 강조 패턴 차용"},
+  {"title": "Wix Templates 6선", "source": "Wix Templates", "rationale": "히어로 grid 분해 참고"}
+]
+```
+
+## 7. Discord 사용 (Phase 2 토큰 활성 후)
+
+```
+/engineer_intake prompt:"우리 랜딩 hero..." write_requested:true
+/engineer_show session_id:<sid>
+```
+
+승인은 본 마일스톤에서 CLI 전용. reaction-기반 승인은 후속 이슈에서 추가한다.
+
+## 8. 후속 작업
+
+1. **승인 reaction 핸들러** — 접수 메시지의 ✅ 반응으로 승인, ❌로 거절.
+2. **Thread 자동 생성** — 작업 단위가 긴 경우 접수 시 thread를 만들어 progress/complete를 묶는다.
+3. **멤버 봇 IPC 연결** — approve된 세션이 dispatcher의 executor_role 멤버 봇 큐에 흘러들어가 실제 실행. write 게이트는 실행 시점에서 한 번 더 검사.
+4. **Reference fetcher** — `REFERENCE_*` env 슬롯이 채워졌을 때만 동작. fetch 결과를 references_suggested에 채운다.
+5. **PR 본문 자동 생성** — 완료 메시지 포맷을 그대로 PR description으로 옮기는 헬퍼 (reference-pack.md §산출 양식과 일치).

--- a/src/yule_orchestrator/agents/__init__.py
+++ b/src/yule_orchestrator/agents/__init__.py
@@ -15,17 +15,40 @@ from .registry import (
     RunnerFactory,
     build_participants_pool,
 )
+from .workflow import (
+    CompletionResult,
+    IntakeResult,
+    ProgressResult,
+    WorkflowError,
+    WorkflowOrchestrator,
+    extract_urls,
+    format_completion_message,
+    format_intake_message,
+    format_progress_message,
+)
+from .workflow_state import WorkflowSession, WorkflowState
 
 __all__ = [
+    "CompletionResult",
     "DEFAULT_RUNNER_FACTORIES",
     "DispatchPlan",
     "DispatchRequest",
     "Dispatcher",
+    "IntakeResult",
     "ParticipantsPool",
+    "ProgressResult",
     "RegistryError",
     "RoleAssignment",
     "RunnerFactory",
     "TaskType",
+    "WorkflowError",
+    "WorkflowOrchestrator",
+    "WorkflowSession",
+    "WorkflowState",
     "build_participants_pool",
+    "extract_urls",
+    "format_completion_message",
+    "format_intake_message",
+    "format_progress_message",
     "render_plan_summary",
 ]

--- a/src/yule_orchestrator/agents/workflow.py
+++ b/src/yule_orchestrator/agents/workflow.py
@@ -1,0 +1,318 @@
+"""Engineering-agent Discord workflow orchestrator.
+
+Walks one task through ``intake → approved → in_progress → completed``
+(or → ``rejected``). Composes the dispatcher's plan with reference picking
+(user-provided URLs first, then task_type fallback) and produces the three
+standard Discord messages: intake, progress, completion.
+
+Single-executor + write gate is enforced here too: ``approve()`` is the
+only path that flips a write-requested session into ``approved``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence
+
+from .dispatcher import Dispatcher, DispatchPlan, DispatchRequest, TaskType
+from .workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    new_session_id,
+    save_session,
+    update_session,
+)
+
+
+_URL_PATTERN = re.compile(r"https?://[\w\-./?=&%#:+,@!~*'();$]+", re.IGNORECASE)
+
+
+class WorkflowError(RuntimeError):
+    """Raised when a state transition is not allowed."""
+
+
+@dataclass(frozen=True)
+class IntakeResult:
+    session: WorkflowSession
+    plan: DispatchPlan
+    message: str
+
+
+@dataclass(frozen=True)
+class ProgressResult:
+    session: WorkflowSession
+    message: str
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    session: WorkflowSession
+    message: str
+
+
+class WorkflowOrchestrator:
+    """Pure-Python orchestrator. Discord layer wraps this; CLI uses it directly.
+
+    *now_fn* is injected so tests can pin time without monkeypatching.
+    """
+
+    def __init__(
+        self,
+        dispatcher: Dispatcher,
+        *,
+        now_fn: Optional[callable] = None,
+    ) -> None:
+        self.dispatcher = dispatcher
+        self.now_fn = now_fn or datetime.now
+
+    def intake(
+        self,
+        prompt: str,
+        *,
+        task_type: Optional[TaskType] = None,
+        write_requested: bool = False,
+        channel_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+        thread_id: Optional[int] = None,
+        extra_user_links: Sequence[str] = (),
+    ) -> IntakeResult:
+        if not prompt.strip():
+            raise WorkflowError("prompt must not be empty")
+
+        request = DispatchRequest(
+            prompt=prompt,
+            task_type=task_type,
+            write_requested=write_requested,
+            user_approved=False,
+        )
+        plan = self.dispatcher.dispatch(request)
+        executor = plan.executor()
+        now = self.now_fn()
+        user_links = _merge_user_links(extract_urls(prompt), extra_user_links)
+
+        session = WorkflowSession(
+            session_id=new_session_id(),
+            prompt=prompt,
+            task_type=plan.task_type.value,
+            state=WorkflowState.INTAKE,
+            created_at=now,
+            updated_at=now,
+            role_sequence=tuple(plan.role_sequence),
+            executor_role=executor.role if executor else None,
+            executor_runner=executor.runner_id if executor else None,
+            references_user=user_links,
+            references_suggested=tuple(plan.reference_sources),
+            channel_id=channel_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            write_requested=write_requested,
+            write_blocked_reason=plan.write_block_reason,
+        )
+        save_session(session)
+        return IntakeResult(
+            session=session,
+            plan=plan,
+            message=format_intake_message(session, plan),
+        )
+
+    def approve(self, session_id: str) -> WorkflowSession:
+        session = self._require_session(session_id)
+        if session.state not in {WorkflowState.INTAKE}:
+            raise WorkflowError(
+                f"session {session_id} is in state {session.state.value}; cannot approve"
+            )
+        approved = replace(
+            session,
+            state=WorkflowState.APPROVED,
+            write_blocked_reason=None,
+        )
+        return update_session(approved, now=self.now_fn())
+
+    def reject(self, session_id: str, *, reason: str) -> WorkflowSession:
+        session = self._require_session(session_id)
+        if session.state in {WorkflowState.COMPLETED, WorkflowState.REJECTED}:
+            raise WorkflowError(
+                f"session {session_id} is already {session.state.value}"
+            )
+        rejected = replace(
+            session,
+            state=WorkflowState.REJECTED,
+            rejection_reason=reason or "rejected",
+        )
+        return update_session(rejected, now=self.now_fn())
+
+    def progress(self, session_id: str, *, note: str) -> ProgressResult:
+        session = self._require_session(session_id)
+        if session.state == WorkflowState.INTAKE:
+            raise WorkflowError(
+                f"session {session_id} not yet approved; intake must be approved first"
+            )
+        if session.state in {WorkflowState.COMPLETED, WorkflowState.REJECTED}:
+            raise WorkflowError(
+                f"session {session_id} already {session.state.value}; progress is closed"
+            )
+        notes = tuple(session.progress_notes) + ((note.strip() or "(empty note)"),)
+        in_progress = replace(session, state=WorkflowState.IN_PROGRESS, progress_notes=notes)
+        updated = update_session(in_progress, now=self.now_fn())
+        return ProgressResult(session=updated, message=format_progress_message(updated))
+
+    def complete(
+        self,
+        session_id: str,
+        *,
+        summary: str,
+        references_used: Sequence[Mapping[str, Any]] = (),
+    ) -> CompletionResult:
+        session = self._require_session(session_id)
+        if session.state in {WorkflowState.COMPLETED, WorkflowState.REJECTED}:
+            raise WorkflowError(
+                f"session {session_id} already {session.state.value}"
+            )
+        if session.state == WorkflowState.INTAKE:
+            raise WorkflowError(
+                f"session {session_id} not yet approved; cannot complete from intake"
+            )
+        completed = replace(
+            session,
+            state=WorkflowState.COMPLETED,
+            summary=(summary or "").strip() or None,
+            references_used=tuple(dict(item) for item in references_used),
+        )
+        updated = update_session(completed, now=self.now_fn())
+        return CompletionResult(session=updated, message=format_completion_message(updated))
+
+    def get(self, session_id: str) -> Optional[WorkflowSession]:
+        return load_session(session_id)
+
+    def _require_session(self, session_id: str) -> WorkflowSession:
+        session = load_session(session_id)
+        if session is None:
+            raise WorkflowError(f"session {session_id} not found")
+        return session
+
+
+def extract_urls(text: str) -> tuple[str, ...]:
+    matches = _URL_PATTERN.findall(text or "")
+    seen: dict[str, None] = {}
+    for url in matches:
+        cleaned = url.rstrip(".,);")
+        if cleaned and cleaned not in seen:
+            seen[cleaned] = None
+    return tuple(seen.keys())
+
+
+def _merge_user_links(prompt_links: Sequence[str], extra: Sequence[str]) -> tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for url in tuple(prompt_links) + tuple(extra):
+        cleaned = url.strip().rstrip(".,);") if isinstance(url, str) else ""
+        if cleaned and cleaned not in seen:
+            seen[cleaned] = None
+    return tuple(seen.keys())
+
+
+# --- Message formatters ----------------------------------------------------
+
+
+def format_intake_message(session: WorkflowSession, plan: DispatchPlan) -> str:
+    lines: list[str] = [
+        "**[engineering-agent] 새 작업 접수**",
+        f"세션 ID: `{session.session_id}`",
+        f"분류: {plan.task_type.value}",
+        f"역할 순서: {' → '.join(plan.role_sequence)}",
+    ]
+    executor = plan.executor()
+    if executor:
+        runner = executor.runner_id or "<no runner>"
+        lines.append(f"실행자: {executor.role} ({runner}, score={executor.score})")
+    advisors = plan.advisors()
+    if advisors:
+        advisor_text = ", ".join(
+            f"{a.role}/{a.runner_id or '?'}" for a in advisors
+        )
+        lines.append(f"어드바이저: {advisor_text}")
+
+    lines.append("")
+    lines.append("**참고 레퍼런스 (제안)**")
+    if session.references_user:
+        lines.append("- 사용자 제공 (1순위):")
+        for url in session.references_user:
+            lines.append(f"  - {url}")
+    if session.references_suggested:
+        lines.append("- task_type 추천 카테고리:")
+        for source in session.references_suggested:
+            lines.append(f"  - {source}")
+    if not session.references_user and not session.references_suggested:
+        lines.append("- (이 task_type에는 시각 reference를 강제하지 않습니다)")
+
+    lines.append("")
+    if session.write_requested and session.write_blocked_reason:
+        lines.append("**승인 필요**")
+        lines.append(f"- {session.write_blocked_reason}")
+        lines.append(
+            f"- 진행하려면 `yule engineer approve --session {session.session_id}` 또는 Discord에서 ✅로 승인해주세요."
+        )
+    else:
+        lines.append("승인 없이 진행 가능 (write 작업 없음 또는 사전 승인됨).")
+
+    return "\n".join(lines)
+
+
+def format_progress_message(session: WorkflowSession) -> str:
+    lines: list[str] = [
+        "**[engineering-agent] 진행 상황**",
+        f"세션 ID: `{session.session_id}`",
+        f"상태: {session.state.value}",
+        f"실행자: {session.executor_role} ({session.executor_runner or '?'})",
+    ]
+    if session.progress_notes:
+        lines.append("")
+        lines.append("**최근 메모**")
+        for idx, note in enumerate(session.progress_notes[-5:], start=1):
+            lines.append(f"{idx}. {note}")
+    return "\n".join(lines)
+
+
+def format_completion_message(session: WorkflowSession) -> str:
+    lines: list[str] = [
+        "**[engineering-agent] 완료 보고**",
+        f"세션 ID: `{session.session_id}`",
+        f"분류: {session.task_type}",
+        f"실행자: {session.executor_role} ({session.executor_runner or '?'})",
+    ]
+    if session.summary:
+        lines.append("")
+        lines.append("**요약**")
+        lines.append(session.summary)
+
+    if session.references_used:
+        lines.append("")
+        lines.append("**반영한 레퍼런스**")
+        for item in session.references_used:
+            lines.append(_format_used_reference(item))
+    elif session.references_user or session.references_suggested:
+        lines.append("")
+        lines.append("**반영한 레퍼런스**")
+        lines.append("- (없음 — 본 작업은 reference를 직접 인용하지 않았습니다)")
+
+    if session.write_requested and not session.summary:
+        lines.append("")
+        lines.append("note: 요약이 비어 있습니다. 다음 작업 전 보강이 필요합니다.")
+    return "\n".join(lines)
+
+
+def _format_used_reference(item: Mapping[str, Any]) -> str:
+    title = str(item.get("title") or "").strip() or "(제목 없음)"
+    source = str(item.get("source") or "").strip()
+    url = str(item.get("url") or "").strip()
+    rationale = str(item.get("rationale") or item.get("takeaway") or "").strip()
+    head = f"- **{title}**"
+    if source:
+        head += f" · {source}"
+    if url:
+        head += f" — {url}"
+    if rationale:
+        head += f"\n  ↪ {rationale}"
+    return head

--- a/src/yule_orchestrator/agents/workflow_state.py
+++ b/src/yule_orchestrator/agents/workflow_state.py
@@ -1,0 +1,166 @@
+"""SQLite-backed state for the engineering-agent Discord workflow.
+
+Each task started by ``/engineer-intake`` (or the ``yule engineer`` CLI) is
+tracked as a :class:`WorkflowSession`. State transitions are guarded by the
+orchestrator (``workflow.py``), but the persistence shape is here so tests
+and operators can introspect a session without going through Discord.
+
+Stored via the existing ``save_json_cache`` / ``load_json_cache`` layer to
+match the checkpoint state pattern.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+from ..storage import load_json_cache, save_json_cache
+
+
+WORKFLOW_NAMESPACE = "engineering-agent-workflow"
+WORKFLOW_TTL_SECONDS = 30 * 24 * 60 * 60
+
+
+class WorkflowState(str, Enum):
+    INTAKE = "intake"
+    APPROVED = "approved"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class WorkflowSession:
+    session_id: str
+    prompt: str
+    task_type: str
+    state: WorkflowState
+    created_at: datetime
+    updated_at: datetime
+    role_sequence: Sequence[str] = ()
+    executor_role: Optional[str] = None
+    executor_runner: Optional[str] = None
+    references_user: Sequence[str] = ()
+    references_suggested: Sequence[str] = ()
+    references_used: Sequence[Mapping[str, Any]] = ()
+    progress_notes: Sequence[str] = ()
+    summary: Optional[str] = None
+    rejection_reason: Optional[str] = None
+    channel_id: Optional[int] = None
+    user_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    write_requested: bool = False
+    write_blocked_reason: Optional[str] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+def new_session_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def save_session(session: WorkflowSession) -> None:
+    payload = _to_payload(session)
+    save_json_cache(
+        namespace=WORKFLOW_NAMESPACE,
+        cache_key=session.session_id,
+        provider="engineering-agent-workflow",
+        range_start=session.created_at.isoformat(),
+        range_end=session.updated_at.isoformat(),
+        scope_hash=session.task_type,
+        ttl_seconds=WORKFLOW_TTL_SECONDS,
+        payload=payload,
+    )
+
+
+def load_session(session_id: str) -> Optional[WorkflowSession]:
+    entry = load_json_cache(
+        namespace=WORKFLOW_NAMESPACE,
+        cache_key=session_id,
+        allow_stale=True,
+        touch=False,
+    )
+    if entry is None:
+        return None
+    return _from_payload(entry.payload)
+
+
+def update_session(session: WorkflowSession, *, now: datetime) -> WorkflowSession:
+    """Bump updated_at and persist; returns the updated copy."""
+
+    updated = replace(session, updated_at=now)
+    save_session(updated)
+    return updated
+
+
+def _to_payload(session: WorkflowSession) -> Mapping[str, Any]:
+    return {
+        "session_id": session.session_id,
+        "prompt": session.prompt,
+        "task_type": session.task_type,
+        "state": session.state.value,
+        "created_at": session.created_at.isoformat(),
+        "updated_at": session.updated_at.isoformat(),
+        "role_sequence": list(session.role_sequence),
+        "executor_role": session.executor_role,
+        "executor_runner": session.executor_runner,
+        "references_user": list(session.references_user),
+        "references_suggested": list(session.references_suggested),
+        "references_used": [dict(item) for item in session.references_used],
+        "progress_notes": list(session.progress_notes),
+        "summary": session.summary,
+        "rejection_reason": session.rejection_reason,
+        "channel_id": session.channel_id,
+        "user_id": session.user_id,
+        "thread_id": session.thread_id,
+        "write_requested": session.write_requested,
+        "write_blocked_reason": session.write_blocked_reason,
+        "extra": dict(session.extra),
+    }
+
+
+def _from_payload(payload: Mapping[str, Any]) -> WorkflowSession:
+    return WorkflowSession(
+        session_id=str(payload["session_id"]),
+        prompt=str(payload.get("prompt", "")),
+        task_type=str(payload.get("task_type", "unknown")),
+        state=WorkflowState(str(payload.get("state", WorkflowState.INTAKE.value))),
+        created_at=datetime.fromisoformat(str(payload["created_at"])),
+        updated_at=datetime.fromisoformat(str(payload["updated_at"])),
+        role_sequence=tuple(str(item) for item in payload.get("role_sequence", [])),
+        executor_role=_optional_str(payload.get("executor_role")),
+        executor_runner=_optional_str(payload.get("executor_runner")),
+        references_user=tuple(str(item) for item in payload.get("references_user", [])),
+        references_suggested=tuple(str(item) for item in payload.get("references_suggested", [])),
+        references_used=tuple(
+            dict(item) if isinstance(item, dict) else {"title": str(item)}
+            for item in payload.get("references_used", [])
+        ),
+        progress_notes=tuple(str(item) for item in payload.get("progress_notes", [])),
+        summary=_optional_str(payload.get("summary")),
+        rejection_reason=_optional_str(payload.get("rejection_reason")),
+        channel_id=_optional_int(payload.get("channel_id")),
+        user_id=_optional_int(payload.get("user_id")),
+        thread_id=_optional_int(payload.get("thread_id")),
+        write_requested=bool(payload.get("write_requested", False)),
+        write_blocked_reason=_optional_str(payload.get("write_blocked_reason")),
+        extra=dict(payload.get("extra") or {}),
+    )
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/yule_orchestrator/cli/engineer.py
+++ b/src/yule_orchestrator/cli/engineer.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ..agents import (
+    Dispatcher,
+    TaskType,
+    WorkflowError,
+    WorkflowOrchestrator,
+    build_participants_pool,
+)
+
+
+def _build_orchestrator(repo_root: Path, agent_id: str) -> WorkflowOrchestrator:
+    pool = build_participants_pool(repo_root, agent_id)
+    return WorkflowOrchestrator(Dispatcher(pool))
+
+
+def run_engineer_intake_command(
+    repo_root: Path,
+    agent_id: str,
+    prompt: str,
+    *,
+    task_type: Optional[str],
+    write: bool,
+) -> int:
+    if not prompt.strip():
+        raise ValueError("--prompt must not be empty")
+
+    parsed_task_type: Optional[TaskType] = None
+    if task_type:
+        try:
+            parsed_task_type = TaskType(task_type)
+        except ValueError as exc:
+            raise ValueError(
+                f"--task-type must be one of {[t.value for t in TaskType]}, got {task_type!r}"
+            ) from exc
+
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    result = orchestrator.intake(
+        prompt=prompt,
+        task_type=parsed_task_type,
+        write_requested=write,
+    )
+    print(result.message)
+    print(f"\nsession_id={result.session.session_id}", file=sys.stderr)
+    return 0
+
+
+def run_engineer_approve_command(repo_root: Path, agent_id: str, session_id: str) -> int:
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    session = orchestrator.approve(session_id)
+    print(f"approved session={session.session_id} state={session.state.value}", file=sys.stderr)
+    return 0
+
+
+def run_engineer_reject_command(
+    repo_root: Path,
+    agent_id: str,
+    session_id: str,
+    reason: str,
+) -> int:
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    session = orchestrator.reject(session_id, reason=reason)
+    print(
+        f"rejected session={session.session_id} reason={session.rejection_reason}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def run_engineer_progress_command(
+    repo_root: Path,
+    agent_id: str,
+    session_id: str,
+    note: str,
+) -> int:
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    result = orchestrator.progress(session_id, note=note)
+    print(result.message)
+    return 0
+
+
+def run_engineer_complete_command(
+    repo_root: Path,
+    agent_id: str,
+    session_id: str,
+    summary: str,
+    references_used_path: Optional[str],
+) -> int:
+    references = []
+    if references_used_path:
+        path = Path(references_used_path)
+        if not path.exists():
+            raise ValueError(f"--references-used file not found: {references_used_path}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"--references-used is not valid JSON: {exc}") from exc
+        if not isinstance(data, list):
+            raise ValueError("--references-used must be a JSON array of objects")
+        references = [item for item in data if isinstance(item, dict)]
+
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    result = orchestrator.complete(session_id, summary=summary, references_used=references)
+    print(result.message)
+    return 0
+
+
+def run_engineer_show_command(repo_root: Path, agent_id: str, session_id: str) -> int:
+    orchestrator = _build_orchestrator(repo_root, agent_id)
+    session = orchestrator.get(session_id)
+    if session is None:
+        raise ValueError(f"session {session_id} not found")
+    payload = {
+        "session_id": session.session_id,
+        "state": session.state.value,
+        "task_type": session.task_type,
+        "executor_role": session.executor_role,
+        "executor_runner": session.executor_runner,
+        "write_requested": session.write_requested,
+        "write_blocked_reason": session.write_blocked_reason,
+        "references_user": list(session.references_user),
+        "references_suggested": list(session.references_suggested),
+        "references_used": [dict(item) for item in session.references_used],
+        "progress_notes": list(session.progress_notes),
+        "summary": session.summary,
+        "rejection_reason": session.rejection_reason,
+        "created_at": session.created_at.isoformat(),
+        "updated_at": session.updated_at.isoformat(),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def adapt_workflow_error(exc: WorkflowError) -> ValueError:
+    return ValueError(str(exc))

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -21,6 +21,16 @@ from .context import run_context_command
 from .daily import run_daily_warmup_command
 from .discord import run_discord_bot_command
 from .discord_member import run_discord_member_command
+from .engineer import (
+    adapt_workflow_error,
+    run_engineer_approve_command,
+    run_engineer_complete_command,
+    run_engineer_intake_command,
+    run_engineer_progress_command,
+    run_engineer_reject_command,
+    run_engineer_show_command,
+)
+from ..agents.workflow import WorkflowError
 from .doctor import run_doctor_command
 from .github import run_github_issues_command
 from .planning import (
@@ -444,6 +454,73 @@ def build_parser() -> argparse.ArgumentParser:
         help="Validate env wiring and print the activation summary without contacting Discord.",
     )
 
+    engineer_parser = subparsers.add_parser(
+        "engineer",
+        help="Drive the engineering-agent Discord workflow (intake/approve/progress/complete).",
+    )
+    engineer_parser.add_argument(
+        "--agent",
+        default="engineering-agent",
+        help="Department agent id. Defaults to engineering-agent.",
+    )
+    engineer_subparsers = engineer_parser.add_subparsers(dest="engineer_command", required=True)
+
+    engineer_intake_parser = engineer_subparsers.add_parser(
+        "intake",
+        help="Accept a new task and produce the dispatcher plan + intake message.",
+    )
+    engineer_intake_parser.add_argument("--prompt", required=True, help="Natural-language task prompt.")
+    engineer_intake_parser.add_argument(
+        "--task-type",
+        help="Explicit task type override (e.g. landing-page, backend-feature).",
+    )
+    engineer_intake_parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Mark the task as write-requested. Stays blocked until `engineer approve`.",
+    )
+
+    engineer_approve_parser = engineer_subparsers.add_parser(
+        "approve",
+        help="Approve a session that is waiting for write confirmation.",
+    )
+    engineer_approve_parser.add_argument("--session", required=True, help="Session id.")
+
+    engineer_reject_parser = engineer_subparsers.add_parser(
+        "reject",
+        help="Reject a session and stop the workflow.",
+    )
+    engineer_reject_parser.add_argument("--session", required=True, help="Session id.")
+    engineer_reject_parser.add_argument("--reason", required=True, help="Rejection reason.")
+
+    engineer_progress_parser = engineer_subparsers.add_parser(
+        "progress",
+        help="Append a progress note to an approved session.",
+    )
+    engineer_progress_parser.add_argument("--session", required=True, help="Session id.")
+    engineer_progress_parser.add_argument("--note", required=True, help="Progress note.")
+
+    engineer_complete_parser = engineer_subparsers.add_parser(
+        "complete",
+        help="Finalize a session and produce the completion report.",
+    )
+    engineer_complete_parser.add_argument("--session", required=True, help="Session id.")
+    engineer_complete_parser.add_argument(
+        "--summary",
+        required=True,
+        help="Final summary text for the completion report.",
+    )
+    engineer_complete_parser.add_argument(
+        "--references-used",
+        help="Path to a JSON array of {title, source, url, rationale} reference items.",
+    )
+
+    engineer_show_parser = engineer_subparsers.add_parser(
+        "show",
+        help="Print a session's current state as JSON.",
+    )
+    engineer_show_parser.add_argument("--session", required=True, help="Session id.")
+
     return parser
 
 
@@ -591,6 +668,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 args.role,
                 dry_run=args.dry_run,
             )
+        if args.command == "engineer":
+            return _dispatch_engineer_command(repo_root, args)
     except ContextError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -603,6 +682,37 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     except CalendarIntegrationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    except WorkflowError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
     parser.error(f"unknown command: {args.command}")
     return 2
+
+
+def _dispatch_engineer_command(repo_root: Path, args) -> int:
+    if args.engineer_command == "intake":
+        return run_engineer_intake_command(
+            repo_root,
+            args.agent,
+            args.prompt,
+            task_type=args.task_type,
+            write=args.write,
+        )
+    if args.engineer_command == "approve":
+        return run_engineer_approve_command(repo_root, args.agent, args.session)
+    if args.engineer_command == "reject":
+        return run_engineer_reject_command(repo_root, args.agent, args.session, args.reason)
+    if args.engineer_command == "progress":
+        return run_engineer_progress_command(repo_root, args.agent, args.session, args.note)
+    if args.engineer_command == "complete":
+        return run_engineer_complete_command(
+            repo_root,
+            args.agent,
+            args.session,
+            args.summary,
+            args.references_used,
+        )
+    if args.engineer_command == "show":
+        return run_engineer_show_command(repo_root, args.agent, args.session)
+    raise ValueError(f"unknown engineer command: {args.engineer_command}")

--- a/src/yule_orchestrator/discord/commands.py
+++ b/src/yule_orchestrator/discord/commands.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import date, datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 
+from ..agents import (
+    Dispatcher,
+    TaskType,
+    WorkflowError,
+    WorkflowOrchestrator,
+    build_participants_pool,
+)
 from .formatter import (
     format_checkpoints_message,
     format_plan_today_message,
@@ -88,6 +97,94 @@ def register_discord_commands(
             discord_module=discord,
         )
 
+    @bot.tree.command(
+        name="engineer_intake",
+        description="engineering-agent에게 작업을 위임합니다 (접수 메시지를 채널에 게시).",
+        guild=guild,
+    )
+    @app_commands.describe(
+        prompt="자연어 작업 요청.",
+        task_type="명시 task type (생략 시 키워드 분류).",
+        write_requested="이 작업이 코드/문서 쓰기를 요구하는지 여부.",
+    )
+    async def engineer_intake(
+        interaction: "discord.Interaction",
+        prompt: str,
+        task_type: Optional[str] = None,
+        write_requested: bool = False,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            result = await asyncio.to_thread(
+                _run_engineer_intake,
+                prompt=prompt,
+                task_type=task_type,
+                write_requested=write_requested,
+                channel_id=interaction.channel_id,
+                user_id=interaction.user.id,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer intake 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            result.message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
+    @bot.tree.command(
+        name="engineer_show",
+        description="engineering-agent 워크플로 세션 상태를 조회합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(session_id="조회할 워크플로 세션 id.")
+    async def engineer_show(
+        interaction: "discord.Interaction",
+        session_id: str,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            session = await asyncio.to_thread(_load_engineer_session, session_id=session_id)
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer show 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        if session is None:
+            await _send_message_chunks(
+                interaction,
+                f"session `{session_id}` 을 찾을 수 없습니다.",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        summary = (
+            f"**[engineering-agent] 세션 상태**\n"
+            f"세션 ID: `{session.session_id}`\n"
+            f"상태: {session.state.value}\n"
+            f"분류: {session.task_type}\n"
+            f"실행자: {session.executor_role} ({session.executor_runner or '?'})"
+        )
+        if session.write_blocked_reason:
+            summary += f"\n승인 대기: {session.write_blocked_reason}"
+        await _send_message_chunks(
+            interaction,
+            summary,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
     @bot.tree.command(name="checkpoints_now", description="지금 기준으로 다가오는 체크포인트를 보여줍니다.", guild=guild)
     @app_commands.describe(window_minutes="몇 분 앞까지 확인할지 설정합니다.")
     async def checkpoints_now(
@@ -113,6 +210,43 @@ def register_discord_commands(
             allowed_mentions=allowed_mentions,
             discord_module=discord,
         )
+
+
+def _engineer_orchestrator() -> WorkflowOrchestrator:
+    repo_root = Path(os.environ.get("YULE_REPO_ROOT", ".")).resolve()
+    pool = build_participants_pool(repo_root, "engineering-agent")
+    return WorkflowOrchestrator(Dispatcher(pool))
+
+
+def _run_engineer_intake(
+    *,
+    prompt: str,
+    task_type: Optional[str],
+    write_requested: bool,
+    channel_id: Optional[int],
+    user_id: Optional[int],
+):
+    parsed: Optional[TaskType] = None
+    if task_type:
+        try:
+            parsed = TaskType(task_type)
+        except ValueError as exc:
+            raise ValueError(
+                f"task_type must be one of {[t.value for t in TaskType]}, got {task_type!r}"
+            ) from exc
+    orchestrator = _engineer_orchestrator()
+    return orchestrator.intake(
+        prompt=prompt,
+        task_type=parsed,
+        write_requested=write_requested,
+        channel_id=channel_id,
+        user_id=user_id,
+    )
+
+
+def _load_engineer_session(*, session_id: str):
+    orchestrator = _engineer_orchestrator()
+    return orchestrator.get(session_id)
 
 
 def _bind_discord_runtime_globals(*, discord_module: Any, app_commands_module: Any) -> None:

--- a/tests/test_agent_workflow.py
+++ b/tests/test_agent_workflow.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    TaskType,
+    WorkflowError,
+    WorkflowOrchestrator,
+    WorkflowState,
+    build_participants_pool,
+    extract_urls,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _build_orchestrator() -> tuple[WorkflowOrchestrator, list[datetime]]:
+    pool = build_participants_pool(REPO_ROOT, "engineering-agent")
+    timestamps = [datetime(2026, 4, 29, 9, 0, 0)]
+
+    def fake_now() -> datetime:
+        ts = timestamps[-1]
+        timestamps.append(ts.replace(minute=ts.minute + 1) if ts.minute < 59 else ts)
+        return ts
+
+    return WorkflowOrchestrator(Dispatcher(pool), now_fn=fake_now), timestamps
+
+
+class _IsolatedCacheTestCase(unittest.TestCase):
+    """Each test gets its own SQLite cache DB so sessions don't leak across cases."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_root = os.environ.get("YULE_REPO_ROOT")
+        os.environ["YULE_REPO_ROOT"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        if self._prev_root is None:
+            os.environ.pop("YULE_REPO_ROOT", None)
+        else:
+            os.environ["YULE_REPO_ROOT"] = self._prev_root
+
+
+class ExtractUrlsTestCase(unittest.TestCase):
+    def test_finds_multiple_urls(self) -> None:
+        text = "참고 https://stripe.com/pricing 그리고 http://example.com/x?y=1, 끝"
+        self.assertEqual(
+            extract_urls(text),
+            ("https://stripe.com/pricing", "http://example.com/x?y=1"),
+        )
+
+    def test_strips_trailing_punctuation(self) -> None:
+        self.assertEqual(
+            extract_urls("see (https://example.com/foo)."),
+            ("https://example.com/foo",),
+        )
+
+    def test_no_url(self) -> None:
+        self.assertEqual(extract_urls("그냥 평범한 문장"), ())
+
+
+class IntakeTestCase(_IsolatedCacheTestCase):
+    def test_intake_classifies_and_picks_executor(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(
+            prompt="새 랜딩페이지 hero 섹션 정리",
+            write_requested=True,
+        )
+        self.assertEqual(result.session.state, WorkflowState.INTAKE)
+        self.assertEqual(result.plan.task_type, TaskType.LANDING_PAGE)
+        self.assertEqual(result.session.executor_role, "frontend-engineer")
+        self.assertTrue(result.session.write_requested)
+        self.assertIsNotNone(result.session.write_blocked_reason)
+
+    def test_intake_extracts_user_url(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(
+            prompt="이메일 캠페인 https://example.com/ad-creative 참고",
+            write_requested=False,
+        )
+        self.assertIn("https://example.com/ad-creative", result.session.references_user)
+        self.assertIn("Really Good Emails", result.session.references_suggested)
+        # User-provided URL must come first in the message body
+        idx_user = result.message.find("https://example.com/ad-creative")
+        idx_suggested = result.message.find("Really Good Emails")
+        self.assertLess(idx_user, idx_suggested)
+
+    def test_intake_message_omits_references_for_pure_backend(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="users API schema 추가", write_requested=False)
+        self.assertEqual(result.session.references_suggested, ())
+        self.assertIn("이 task_type에는 시각 reference를 강제하지 않습니다", result.message)
+
+
+class TransitionTestCase(_IsolatedCacheTestCase):
+    def test_full_happy_path(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="랜딩 hero 정리", write_requested=True)
+        sid = result.session.session_id
+
+        approved = orch.approve(sid)
+        self.assertEqual(approved.state, WorkflowState.APPROVED)
+        self.assertIsNone(approved.write_blocked_reason)
+
+        progress = orch.progress(sid, note="시안 1차")
+        self.assertEqual(progress.session.state, WorkflowState.IN_PROGRESS)
+        self.assertEqual(progress.session.progress_notes, ("시안 1차",))
+
+        completion = orch.complete(
+            sid,
+            summary="hero 카피 정리 완료",
+            references_used=[
+                {"title": "Stripe", "source": "Mobbin", "url": "https://x", "rationale": "step copy 차용"},
+            ],
+        )
+        self.assertEqual(completion.session.state, WorkflowState.COMPLETED)
+        self.assertIn("Stripe", completion.message)
+        self.assertIn("step copy 차용", completion.message)
+
+    def test_progress_before_approval_rejected(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="x", write_requested=True)
+        with self.assertRaises(WorkflowError):
+            orch.progress(result.session.session_id, note="early")
+
+    def test_complete_before_approval_rejected(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="x", write_requested=True)
+        with self.assertRaises(WorkflowError):
+            orch.complete(result.session.session_id, summary="early")
+
+    def test_double_approve_rejected(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="x", write_requested=True)
+        sid = result.session.session_id
+        orch.approve(sid)
+        with self.assertRaises(WorkflowError):
+            orch.approve(sid)
+
+    def test_reject_blocks_further_transitions(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="x", write_requested=True)
+        sid = result.session.session_id
+        orch.reject(sid, reason="중복 작업")
+        with self.assertRaises(WorkflowError):
+            orch.complete(sid, summary="x")
+        with self.assertRaises(WorkflowError):
+            orch.progress(sid, note="x")
+
+    def test_unknown_session_id(self) -> None:
+        orch, _ = _build_orchestrator()
+        with self.assertRaises(WorkflowError):
+            orch.approve("nonexistent")
+
+
+class WriteGateTestCase(_IsolatedCacheTestCase):
+    def test_write_not_requested_has_no_block(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="시안 정리", write_requested=False)
+        self.assertIsNone(result.session.write_blocked_reason)
+        self.assertIn("승인 없이 진행 가능", result.message)
+
+    def test_write_requested_blocks_until_approve(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="x", write_requested=True)
+        self.assertIn("승인 필요", result.message)
+
+
+class CompletionFormatTestCase(_IsolatedCacheTestCase):
+    def test_completion_includes_used_references_block(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="hero 정리", write_requested=True)
+        sid = result.session.session_id
+        orch.approve(sid)
+        completion = orch.complete(
+            sid,
+            summary="끝",
+            references_used=[
+                {"title": "Awwwards SOTD", "source": "Awwwards", "rationale": "scroll 인터랙션 패턴 차용"},
+            ],
+        )
+        self.assertIn("Awwwards SOTD", completion.message)
+        self.assertIn("scroll 인터랙션 패턴 차용", completion.message)
+
+    def test_completion_marks_no_references_used(self) -> None:
+        orch, _ = _build_orchestrator()
+        result = orch.intake(prompt="새 랜딩페이지 hero 정리", write_requested=True)
+        sid = result.session.session_id
+        orch.approve(sid)
+        completion = orch.complete(sid, summary="끝", references_used=[])
+        # Suggested references existed (landing-page) but none were actually used.
+        self.assertIn("(없음", completion.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- #37

## ✨ 과제 내용
engineering-agent 작업을 Discord와 CLI에서 동일한 흐름으로 위임할 수 있도록
워크플로우 오케스트레이터를 추가했습니다.

이번 PR은 단순히 dispatcher 결과를 출력하는 수준이 아니라,
작업 1건을 `intake → approved → in_progress → completed/rejected` 상태로 추적하고,
사용자 승인 전 write를 막고, 진행 상황과 완료 보고를 표준 메시지 형식으로 회신하는 것이 목표입니다.

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- `src/yule_orchestrator/agents/workflow.py`
- `src/yule_orchestrator/agents/workflow_state.py`
- `src/yule_orchestrator/agents/dispatcher.py`
- `src/yule_orchestrator/discord/commands.py`
- `tests/test_agent_workflow.py`
- 이번 PR은 "Discord 작업 위임 상태 관리"를 다룬 단계이며, 실제 역할별 실행 자동화는 후속 이슈에서 연결함
