### PR TITLE
[Feature] engineering-agent 멤버 간 메시지 프로토콜 추가

### DIFF
--- a/agents/engineering-agent/agent.json
+++ b/agents/engineering-agent/agent.json
@@ -24,6 +24,7 @@
     "policies/runtime/agents/engineering-agent/multi-bot-launcher.md",
     "policies/runtime/agents/engineering-agent/dispatcher.md",
     "policies/runtime/agents/engineering-agent/discord-workflow.md",
+    "policies/runtime/agents/engineering-agent/message-protocol.md",
     "policies/runtime/agents/engineering-agent/version-control.md",
     "policies/runtime/agents/engineering-agent/workflow.md",
     "policies/runtime/agents/engineering-agent/testing.md"

--- a/policies/runtime/agents/engineering-agent/message-protocol.md
+++ b/policies/runtime/agents/engineering-agent/message-protocol.md
@@ -1,0 +1,143 @@
+# Engineering Agent Inter-member Message Protocol (v0)
+
+이 문서는 engineering-agent 부서 안의 멤버들 — 그리고 향후 cto-agent / design-agent / marketing-agent 부서 — 가 주고받는 **표준 메시지 계약**을 정의한다. 코드 진실 소스는 `src/yule_orchestrator/agents/message.py`.
+
+## 1. 목적과 범위
+- 부서 내부 왕복 흐름(tech-lead → 멤버 → tech-lead → gateway)을 한 데이터 모델로 통일한다.
+- 다른 부서가 그대로 재사용할 수 있도록 부서 비종속(`from_role`/`to_role`은 free-form 문자열) 형태로 정의한다.
+- 본 단계는 **계약과 빌더만** 정의한다. 영속화·운반(채널)은 다음 멤버 봇 IPC 마일스톤에서 다룬다.
+
+## 2. 라우팅 주소
+
+`role_address(agent_id, role) -> "<agent>/<role>"` 형식을 표준으로 사용한다.
+
+예시
+- `engineering-agent/tech-lead`
+- `engineering-agent/backend-engineer`
+- `design-agent/product-designer` (분리 시)
+- 게이트웨이 회신은 특수값 `"gateway"`로 표시한다.
+
+## 3. 필수 필드
+
+```
+AgentMessage
+├── 라우팅
+│   ├── from_role: str
+│   └── to_role: str
+├── 작업 컨텍스트
+│   ├── task_type: str  # TaskType enum value 권장
+│   ├── topic: str       # 짧은 제목
+│   ├── content: str     # 본문
+│   ├── requested_action: RequestedAction
+│   └── priority: Priority  # 기본 P2
+├── 스레딩 메타
+│   ├── message_id: str (auto, 12 hex)
+│   ├── parent_message_id: Optional[str]
+│   ├── thread_id: Optional[str]
+│   ├── run_id: Optional[str]   # workflow session id 권장
+│   └── created_at: datetime
+└── 레퍼런스 팩 (UI/UX/마케팅/콘텐츠 작업 시)
+    ├── context_refs: tuple[ContextRef, ...]   # PR/issue/file 포인터
+    ├── reference_links: tuple[str, ...]        # URL (사용자 1순위)
+    ├── reference_notes: tuple[Mapping, ...]    # {title, source, takeaway, avoid}
+    ├── visual_direction: Optional[str]         # 시각 톤 메모
+    ├── copy_tone: Optional[str]                # 카피 톤 메모
+    └── competitive_examples: tuple[Mapping, ...] # {name, url, why}
+```
+
+## 4. RequestedAction
+
+요청용 (tech-lead → 멤버):
+- `analyze` — 검토하고 의견 제시
+- `advise` — 추천안 제시
+- `implement` — 코드/콘텐츠 생산
+- `review` — 기존 산출물 리뷰
+- `test` — 테스트/검증 케이스 생산
+- `design` — 디자인 산출물 생산
+- `investigate` — 디버깅/조사
+- `handoff` — 다른 부서·역할에 인계
+- `acknowledge` — 단순 수신 확인 (close_thread가 사용)
+
+회신용 (멤버 → tech-lead):
+- `in_progress` — 진행 중 상태 보고
+- `completed` — 완료 (terminal)
+- `needs_clarification` — 정보 부족
+- `blocked` — 외부 의존으로 막힘
+- `rejected` — 범위 외/거절 (terminal)
+
+스키마 자체는 방향을 강제하지 않는다. 빌더 헬퍼(`new_request`/`reply_to`/`close_thread`)가 잘못된 짝을 거부한다.
+
+## 5. Priority
+
+- `P0` — 긴급/장애. SLA 즉시.
+- `P1` — 높음. 같은 작업일 안에 회신.
+- `P2` — 일반(기본).
+- `P3` — 낮음. 가용 시간에.
+
+## 6. 왕복 빌더
+
+```python
+from yule_orchestrator.agents import (
+    new_request, reply_to, close_thread,
+    RequestedAction, Priority, ContextRef, role_address,
+)
+
+req = new_request(
+    from_role=role_address("engineering-agent", "tech-lead"),
+    to_role=role_address("engineering-agent", "backend-engineer"),
+    task_type="backend-feature",
+    topic="users API에 email 인증 필드 추가",
+    content="users 테이블에 email_verified column을 추가하고 ...",
+    requested_action=RequestedAction.IMPLEMENT,
+    priority=Priority.P1,
+    run_id="ws-abc123",
+    context_refs=[ContextRef(kind="issue", value="#142")],
+    reference_links=["https://example.com/auth-flow"],
+)
+
+reply = reply_to(
+    req,
+    content="구현 완료. PR #143 열었음.",
+    requested_action=RequestedAction.COMPLETED,
+    context_refs=[ContextRef(kind="pr", value="#143")],
+)
+
+closure = close_thread(
+    reply,
+    summary="email 인증 추가, PR #143 머지 대기",
+    references_used=[{"title": "Auth0", "rationale": "이중 토큰 패턴 차용"}],
+)
+```
+
+규약
+- `reply_to`는 from/to를 자동으로 swap하고 `parent_message_id`를 부모로 설정한다.
+- `task_type`/`topic`/`thread_id`/`run_id`는 부모에서 상속해 체인을 그룹화한다.
+- `close_thread`는 terminal 회신(`COMPLETED`/`REJECTED`)에서만 호출 가능하며, 결과를 `extra.round_trip_outcome`에 기록한다.
+
+## 7. 통합 포인트 (다음 마일스톤)
+
+- **dispatcher**: `DispatchPlan.assignments`를 입력 삼아 tech-lead가 각 멤버에게 `new_request`를 발행한다. role 기반 라우팅이 `role_address(agent_id, role)`로 일치한다.
+- **workflow**: `WorkflowSession.session_id`를 `run_id`에 그대로 사용한다. 멤버 회신은 `WorkflowSession.progress_notes`로 누적, 최종 `completed` 회신은 `format_completion_message`의 입력이 된다.
+- **Discord**: `thread_id`를 Discord thread snowflake로 매핑한다. `with_thread_id`로 후속 할당.
+- **멤버 봇 IPC**: in-process queue (Phase 1) → socket (Phase 2). 메시지 자체는 동일.
+
+## 8. 다른 부서 재사용
+
+본 스키마는 부서 비종속이다. cto-agent / design-agent / marketing-agent가 도입될 때:
+- `from_role` / `to_role` prefix만 자기 부서 id로 바꾼다.
+- RequestedAction enum이 부족하면 본 정책에 추가한 뒤 코드 enum도 함께 갱신한다 (하나의 진실 소스).
+- 레퍼런스 팩 필드(`visual_direction` / `copy_tone` / `competitive_examples`)는 마케팅·디자인 부서가 그대로 사용. 백엔드/QA는 비워둔다.
+
+## 9. 변경 절차
+
+1. RequestedAction 또는 Priority 추가/삭제는 본 문서를 먼저 수정.
+2. 코드(`message.py`)와 정합 테스트 (`tests/test_agent_message.py::ActionPartitionTestCase`)를 함께 갱신.
+3. 다른 부서가 이미 사용 중이면 마이그레이션 노트를 PR 본문에 첨부.
+4. 영속화/운반 채널이 추가되면 직렬화 스키마(JSON shape)는 본 문서의 §3 트리를 그대로 따른다 (필드 이름 보존).
+
+## 10. 후속 작업
+
+- 영속화 (SQLite 테이블 또는 JSON cache namespace `engineering-agent-messages`).
+- in-process queue 기반 멤버 봇 IPC 디스패처.
+- Discord thread bridge (게이트웨이가 thread를 만들고 `thread_id`를 메시지에 주입).
+- close_thread → workflow.complete() 자동 연결.

--- a/src/yule_orchestrator/agents/__init__.py
+++ b/src/yule_orchestrator/agents/__init__.py
@@ -8,6 +8,17 @@ from .dispatcher import (
     TaskType,
     render_plan_summary,
 )
+from .message import (
+    AgentMessage,
+    ContextRef,
+    Priority,
+    RequestedAction,
+    close_thread,
+    new_request,
+    reply_to,
+    role_address,
+    with_thread_id,
+)
 from .registry import (
     DEFAULT_RUNNER_FACTORIES,
     ParticipantsPool,
@@ -29,15 +40,19 @@ from .workflow import (
 from .workflow_state import WorkflowSession, WorkflowState
 
 __all__ = [
+    "AgentMessage",
     "CompletionResult",
+    "ContextRef",
     "DEFAULT_RUNNER_FACTORIES",
     "DispatchPlan",
     "DispatchRequest",
     "Dispatcher",
     "IntakeResult",
     "ParticipantsPool",
+    "Priority",
     "ProgressResult",
     "RegistryError",
+    "RequestedAction",
     "RoleAssignment",
     "RunnerFactory",
     "TaskType",
@@ -46,9 +61,14 @@ __all__ = [
     "WorkflowSession",
     "WorkflowState",
     "build_participants_pool",
+    "close_thread",
     "extract_urls",
     "format_completion_message",
     "format_intake_message",
     "format_progress_message",
+    "new_request",
     "render_plan_summary",
+    "reply_to",
+    "role_address",
+    "with_thread_id",
 ]

--- a/src/yule_orchestrator/agents/message.py
+++ b/src/yule_orchestrator/agents/message.py
@@ -1,0 +1,312 @@
+"""Inter-member message protocol for engineering-agent (and future departments).
+
+The schema is intentionally department-agnostic: ``from_role`` / ``to_role``
+are free-form strings shaped as ``"<agent>/<role>"`` (e.g.
+``"engineering-agent/tech-lead"``). When cto-agent, design-agent, and
+marketing-agent come online they use the same dataclass without changes.
+
+Round-trip pattern:
+
+    tech-lead --new_request--> backend-engineer
+                                   │
+                                   └── reply_to(parent) ──> tech-lead
+                                                              │
+                                                              └── close_thread(parent_chain) ──▶ session
+
+Persistence and transport (in-process queue / Discord thread / socket) are
+out of scope for this module. Consumers are expected to wrap these
+dataclasses into whichever channel they own.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+
+class RequestedAction(str, Enum):
+    """Verbs that say what the recipient is being asked to do (or did).
+
+    Outgoing intent (tech-lead → role): ANALYZE / ADVISE / IMPLEMENT /
+    REVIEW / TEST / DESIGN / INVESTIGATE / HANDOFF.
+    Replies (role → tech-lead): COMPLETED / IN_PROGRESS / NEEDS_CLARIFICATION
+    / BLOCKED / REJECTED.
+    The schema does not enforce direction; helpers in this module produce
+    well-formed pairs.
+    """
+
+    ANALYZE = "analyze"
+    ADVISE = "advise"
+    IMPLEMENT = "implement"
+    REVIEW = "review"
+    TEST = "test"
+    DESIGN = "design"
+    INVESTIGATE = "investigate"
+    HANDOFF = "handoff"
+    ACKNOWLEDGE = "acknowledge"
+
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    NEEDS_CLARIFICATION = "needs_clarification"
+    BLOCKED = "blocked"
+    REJECTED = "rejected"
+
+
+REQUEST_ACTIONS = frozenset(
+    {
+        RequestedAction.ANALYZE,
+        RequestedAction.ADVISE,
+        RequestedAction.IMPLEMENT,
+        RequestedAction.REVIEW,
+        RequestedAction.TEST,
+        RequestedAction.DESIGN,
+        RequestedAction.INVESTIGATE,
+        RequestedAction.HANDOFF,
+        RequestedAction.ACKNOWLEDGE,
+    }
+)
+
+REPLY_ACTIONS = frozenset(
+    {
+        RequestedAction.IN_PROGRESS,
+        RequestedAction.COMPLETED,
+        RequestedAction.NEEDS_CLARIFICATION,
+        RequestedAction.BLOCKED,
+        RequestedAction.REJECTED,
+    }
+)
+
+TERMINAL_REPLY_ACTIONS = frozenset(
+    {RequestedAction.COMPLETED, RequestedAction.REJECTED}
+)
+
+
+class Priority(str, Enum):
+    P0 = "P0"  # urgent / blocker
+    P1 = "P1"  # high
+    P2 = "P2"  # normal — default
+    P3 = "P3"  # low
+
+
+@dataclass(frozen=True)
+class ContextRef:
+    """Pointer to an external artifact (PR / issue / file / discord message)."""
+
+    kind: str
+    value: str
+    label: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AgentMessage:
+    """One message between two agent/role pairs.
+
+    Fields fall into four groups:
+
+    - **Routing**: ``from_role``, ``to_role``.
+    - **Task framing**: ``task_type``, ``topic``, ``content``,
+      ``requested_action``, ``priority``.
+    - **Threading**: ``thread_id``, ``run_id``, ``parent_message_id``,
+      ``message_id``, ``created_at``.
+    - **Reference pack** (UI/UX/marketing/content work): ``context_refs``,
+      ``reference_links``, ``reference_notes``, ``visual_direction``,
+      ``copy_tone``, ``competitive_examples``.
+
+    The pack fields use neutral types so cto-agent / design-agent /
+    marketing-agent can reuse them without subclassing.
+    """
+
+    # routing
+    from_role: str
+    to_role: str
+
+    # task framing
+    task_type: str
+    topic: str
+    content: str
+    requested_action: RequestedAction
+    priority: Priority = Priority.P2
+
+    # threading metadata
+    thread_id: Optional[str] = None
+    run_id: Optional[str] = None
+    parent_message_id: Optional[str] = None
+    message_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    # reference pack (optional, used when task touches UI/UX/marketing/content)
+    context_refs: Sequence[ContextRef] = ()
+    reference_links: Sequence[str] = ()
+    reference_notes: Sequence[Mapping[str, Any]] = ()
+    visual_direction: Optional[str] = None
+    copy_tone: Optional[str] = None
+    competitive_examples: Sequence[Mapping[str, Any]] = ()
+
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def is_request(self) -> bool:
+        return self.requested_action in REQUEST_ACTIONS
+
+    def is_reply(self) -> bool:
+        return self.requested_action in REPLY_ACTIONS
+
+    def is_terminal_reply(self) -> bool:
+        return self.requested_action in TERMINAL_REPLY_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Round-trip helpers
+# ---------------------------------------------------------------------------
+
+
+def new_request(
+    *,
+    from_role: str,
+    to_role: str,
+    task_type: str,
+    topic: str,
+    content: str,
+    requested_action: RequestedAction,
+    priority: Priority = Priority.P2,
+    run_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    context_refs: Sequence[ContextRef] = (),
+    reference_links: Sequence[str] = (),
+    reference_notes: Sequence[Mapping[str, Any]] = (),
+    visual_direction: Optional[str] = None,
+    copy_tone: Optional[str] = None,
+    competitive_examples: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """Build a request message (e.g. tech-lead → backend-engineer)."""
+
+    if requested_action not in REQUEST_ACTIONS:
+        raise ValueError(
+            f"new_request expects a request action; got {requested_action.value}. "
+            f"Use reply_to for {requested_action.value}."
+        )
+    return AgentMessage(
+        from_role=from_role,
+        to_role=to_role,
+        task_type=task_type,
+        topic=topic,
+        content=content,
+        requested_action=requested_action,
+        priority=priority,
+        run_id=run_id,
+        thread_id=thread_id,
+        context_refs=tuple(context_refs),
+        reference_links=tuple(reference_links),
+        reference_notes=tuple(dict(item) for item in reference_notes),
+        visual_direction=visual_direction,
+        copy_tone=copy_tone,
+        competitive_examples=tuple(dict(item) for item in competitive_examples),
+        extra=dict(extra or {}),
+    )
+
+
+def reply_to(
+    parent: AgentMessage,
+    *,
+    content: str,
+    requested_action: RequestedAction,
+    priority: Optional[Priority] = None,
+    context_refs: Sequence[ContextRef] = (),
+    reference_links: Sequence[str] = (),
+    reference_notes: Sequence[Mapping[str, Any]] = (),
+    visual_direction: Optional[str] = None,
+    copy_tone: Optional[str] = None,
+    competitive_examples: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """Build a reply message that swaps from/to and chains parent_message_id.
+
+    Inherits ``thread_id``, ``run_id``, ``task_type``, and ``topic`` from
+    *parent* so the chain stays grouped without callers having to repeat them.
+    """
+
+    if requested_action not in REPLY_ACTIONS:
+        raise ValueError(
+            f"reply_to expects a reply action; got {requested_action.value}. "
+            f"Use new_request for {requested_action.value}."
+        )
+    return AgentMessage(
+        from_role=parent.to_role,
+        to_role=parent.from_role,
+        task_type=parent.task_type,
+        topic=parent.topic,
+        content=content,
+        requested_action=requested_action,
+        priority=priority or parent.priority,
+        thread_id=parent.thread_id,
+        run_id=parent.run_id,
+        parent_message_id=parent.message_id,
+        context_refs=tuple(context_refs),
+        reference_links=tuple(reference_links),
+        reference_notes=tuple(dict(item) for item in reference_notes),
+        visual_direction=visual_direction,
+        copy_tone=copy_tone,
+        competitive_examples=tuple(dict(item) for item in competitive_examples),
+        extra=dict(extra or {}),
+    )
+
+
+def close_thread(
+    final_reply: AgentMessage,
+    *,
+    summary: str,
+    references_used: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """tech-lead's outward-facing summary message that closes the round-trip.
+
+    Sent from the role that *received* the final reply (typically tech-lead)
+    back to the upstream caller (workflow gateway / discord channel /
+    cto-agent). The schema reuses AgentMessage so the same transport works.
+    """
+
+    if final_reply.requested_action not in TERMINAL_REPLY_ACTIONS:
+        raise ValueError(
+            "close_thread expects the final reply to be COMPLETED or REJECTED; "
+            f"got {final_reply.requested_action.value}."
+        )
+    closure_extra = {
+        **dict(extra or {}),
+        "round_trip_outcome": final_reply.requested_action.value,
+        "references_used": [dict(item) for item in references_used],
+    }
+    return AgentMessage(
+        from_role=final_reply.to_role,
+        to_role="gateway",
+        task_type=final_reply.task_type,
+        topic=final_reply.topic,
+        content=summary,
+        requested_action=RequestedAction.ACKNOWLEDGE,
+        priority=final_reply.priority,
+        thread_id=final_reply.thread_id,
+        run_id=final_reply.run_id,
+        parent_message_id=final_reply.message_id,
+        extra=closure_extra,
+    )
+
+
+def with_thread_id(message: AgentMessage, thread_id: str) -> AgentMessage:
+    """Return a copy of *message* with ``thread_id`` set.
+
+    Useful when transport assigns the thread id after the message is built
+    (e.g. Discord creates the thread, then we pin the assignment back).
+    """
+
+    return replace(message, thread_id=thread_id)
+
+
+def role_address(agent_id: str, role: str) -> str:
+    """Build a normalized ``<agent>/<role>`` address string.
+
+    Centralized so future cto-agent/design-agent code uses the same shape.
+    """
+
+    return f"{agent_id}/{role}"

--- a/tests/test_agent_message.py
+++ b/tests/test_agent_message.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.message import (
+    AgentMessage,
+    ContextRef,
+    Priority,
+    REPLY_ACTIONS,
+    REQUEST_ACTIONS,
+    RequestedAction,
+    close_thread,
+    new_request,
+    reply_to,
+    role_address,
+    with_thread_id,
+)
+
+
+def _make_request(**overrides) -> AgentMessage:
+    base = dict(
+        from_role="engineering-agent/tech-lead",
+        to_role="engineering-agent/backend-engineer",
+        task_type="backend-feature",
+        topic="users API에 email 인증 필드 추가",
+        content="users 테이블에 email_verified column을 추가",
+        requested_action=RequestedAction.IMPLEMENT,
+        priority=Priority.P1,
+        run_id="ws-abc",
+    )
+    base.update(overrides)
+    return new_request(**base)
+
+
+class RoleAddressTestCase(unittest.TestCase):
+    def test_format(self) -> None:
+        self.assertEqual(role_address("engineering-agent", "tech-lead"), "engineering-agent/tech-lead")
+        self.assertEqual(role_address("design-agent", "product-designer"), "design-agent/product-designer")
+
+
+class ActionPartitionTestCase(unittest.TestCase):
+    def test_request_and_reply_actions_disjoint(self) -> None:
+        self.assertEqual(REQUEST_ACTIONS & REPLY_ACTIONS, frozenset())
+
+    def test_every_action_is_classified(self) -> None:
+        all_actions = set(RequestedAction)
+        self.assertTrue(all_actions.issuperset(REQUEST_ACTIONS | REPLY_ACTIONS))
+
+
+class NewRequestTestCase(unittest.TestCase):
+    def test_basic_fields_round_trip(self) -> None:
+        req = _make_request()
+        self.assertEqual(req.from_role, "engineering-agent/tech-lead")
+        self.assertEqual(req.to_role, "engineering-agent/backend-engineer")
+        self.assertEqual(req.requested_action, RequestedAction.IMPLEMENT)
+        self.assertEqual(req.priority, Priority.P1)
+        self.assertTrue(req.is_request())
+        self.assertFalse(req.is_reply())
+        self.assertIsNone(req.parent_message_id)
+        self.assertEqual(len(req.message_id), 12)
+
+    def test_default_priority_is_p2(self) -> None:
+        req = _make_request(priority=None)
+        # passing priority=None falls back to default Priority.P2 in the dataclass
+        # via new_request default. Recreate without priority:
+        req = new_request(
+            from_role="x", to_role="y", task_type="t",
+            topic="t", content="c", requested_action=RequestedAction.ANALYZE,
+        )
+        self.assertEqual(req.priority, Priority.P2)
+
+    def test_reply_action_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            new_request(
+                from_role="a", to_role="b", task_type="t",
+                topic="t", content="c",
+                requested_action=RequestedAction.COMPLETED,
+            )
+
+    def test_reference_pack_fields_round_trip(self) -> None:
+        req = _make_request(
+            reference_links=["https://example.com/a"],
+            reference_notes=[{"title": "A", "takeaway": "차용"}],
+            visual_direction="모노톤 + accent 1색",
+            copy_tone="짧고 단정",
+            competitive_examples=[{"name": "Stripe", "url": "https://stripe.com"}],
+            context_refs=[ContextRef(kind="issue", value="#142")],
+        )
+        self.assertEqual(req.reference_links, ("https://example.com/a",))
+        self.assertEqual(req.reference_notes[0]["title"], "A")
+        self.assertEqual(req.visual_direction, "모노톤 + accent 1색")
+        self.assertEqual(req.copy_tone, "짧고 단정")
+        self.assertEqual(req.competitive_examples[0]["name"], "Stripe")
+        self.assertEqual(req.context_refs[0].kind, "issue")
+
+
+class ReplyToTestCase(unittest.TestCase):
+    def test_swaps_routing_and_chains_parent(self) -> None:
+        req = _make_request()
+        rep = reply_to(req, content="구현 완료", requested_action=RequestedAction.COMPLETED)
+        self.assertEqual(rep.from_role, req.to_role)
+        self.assertEqual(rep.to_role, req.from_role)
+        self.assertEqual(rep.parent_message_id, req.message_id)
+        self.assertEqual(rep.task_type, req.task_type)
+        self.assertEqual(rep.topic, req.topic)
+        self.assertEqual(rep.thread_id, req.thread_id)
+        self.assertEqual(rep.run_id, req.run_id)
+        self.assertTrue(rep.is_reply())
+        self.assertTrue(rep.is_terminal_reply())
+
+    def test_inherits_priority_when_not_overridden(self) -> None:
+        req = _make_request(priority=Priority.P0)
+        rep = reply_to(req, content="x", requested_action=RequestedAction.IN_PROGRESS)
+        self.assertEqual(rep.priority, Priority.P0)
+
+    def test_overrides_priority_when_provided(self) -> None:
+        req = _make_request(priority=Priority.P0)
+        rep = reply_to(
+            req,
+            content="x",
+            requested_action=RequestedAction.IN_PROGRESS,
+            priority=Priority.P2,
+        )
+        self.assertEqual(rep.priority, Priority.P2)
+
+    def test_request_action_rejected(self) -> None:
+        req = _make_request()
+        with self.assertRaises(ValueError):
+            reply_to(req, content="x", requested_action=RequestedAction.IMPLEMENT)
+
+    def test_needs_clarification_is_non_terminal(self) -> None:
+        req = _make_request()
+        rep = reply_to(
+            req,
+            content="요청에 user_role 정보가 빠져 있습니다",
+            requested_action=RequestedAction.NEEDS_CLARIFICATION,
+        )
+        self.assertTrue(rep.is_reply())
+        self.assertFalse(rep.is_terminal_reply())
+
+
+class CloseThreadTestCase(unittest.TestCase):
+    def test_close_after_completed(self) -> None:
+        req = _make_request()
+        rep = reply_to(req, content="구현 완료", requested_action=RequestedAction.COMPLETED)
+        closure = close_thread(
+            rep,
+            summary="email 인증 추가, PR #143 작성",
+            references_used=[{"title": "Auth0", "rationale": "이중 토큰 패턴"}],
+        )
+        self.assertEqual(closure.from_role, rep.to_role)
+        self.assertEqual(closure.to_role, "gateway")
+        self.assertEqual(closure.parent_message_id, rep.message_id)
+        self.assertEqual(closure.requested_action, RequestedAction.ACKNOWLEDGE)
+        self.assertEqual(closure.extra["round_trip_outcome"], "completed")
+        self.assertEqual(closure.extra["references_used"][0]["title"], "Auth0")
+
+    def test_close_rejected_outcome(self) -> None:
+        req = _make_request()
+        rep = reply_to(req, content="범위 밖", requested_action=RequestedAction.REJECTED)
+        closure = close_thread(rep, summary="범위 외 요청 — 거절")
+        self.assertEqual(closure.extra["round_trip_outcome"], "rejected")
+
+    def test_non_terminal_reply_rejected(self) -> None:
+        req = _make_request()
+        rep = reply_to(req, content="x", requested_action=RequestedAction.IN_PROGRESS)
+        with self.assertRaises(ValueError):
+            close_thread(rep, summary="early")
+
+
+class WithThreadIdTestCase(unittest.TestCase):
+    def test_assigns_thread_id_without_mutating_original(self) -> None:
+        req = _make_request()
+        self.assertIsNone(req.thread_id)
+        bound = with_thread_id(req, "discord-thread-12345")
+        self.assertEqual(bound.thread_id, "discord-thread-12345")
+        self.assertIsNone(req.thread_id)
+        self.assertEqual(bound.message_id, req.message_id)
+
+
+class GeneralizationTestCase(unittest.TestCase):
+    def test_works_for_design_agent_address(self) -> None:
+        req = new_request(
+            from_role=role_address("design-agent", "product-designer"),
+            to_role=role_address("engineering-agent", "frontend-engineer"),
+            task_type="visual-polish",
+            topic="히어로 컬러 팔레트 합의",
+            content="디자인 토큰 v2를 적용해줘",
+            requested_action=RequestedAction.HANDOFF,
+        )
+        self.assertEqual(req.from_role, "design-agent/product-designer")
+        self.assertEqual(req.to_role, "engineering-agent/frontend-engineer")
+        self.assertEqual(req.requested_action, RequestedAction.HANDOFF)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- #38

## ✨ 과제 내용
engineering-agent 내부 멤버들이 주고받는 표준 메시지 계약을 정의했습니다.

이번 PR은 실제 멤버 봇 IPC나 Discord thread 전달 자체를 구현하는 단계가 아니라,
그 전에 필요한 공통 데이터 모델과 왕복 규약, 레퍼런스 팩 필드, 후속 통합 기준선을 코드와 문서로 고정하는 것이 목표입니다.

## :camera_with_flash: 스크린샷(선택)
해당 없음  
데이터 계약 / 정책 / 테스트 중심 PR이므로 생략 가능

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- `src/yule_orchestrator/agents/message.py`
- `tests/test_agent_message.py`
- `policies/runtime/agents/engineering-agent/message-protocol.md`
- 이번 PR은 "메시지 전달 규약"을 고정한 단계이며, 실제 transport와 orchestration 연결은 후속 이슈에서 담당함
