### PR TITLE
[Feature] engineering-agent PR 리뷰 피드백 및 외부 코멘트 처리 루프 추가

### DIFF
--- a/policies/runtime/agents/engineering-agent/review-loop.md
+++ b/policies/runtime/agents/engineering-agent/review-loop.md
@@ -1,0 +1,145 @@
+# Engineering-Agent — Review Feedback Loop
+
+PR 리뷰 코멘트, GitHub Copilot 코멘트, 외부 에이전트 의견을 다시 engineering-agent 작업 흐름으로 되돌리는 루프 정책. 단일 executor 원칙과 write 게이트는 그대로 유지하면서 "리뷰 → 재분배 → 회신" 닫힘 회로만 추가한다.
+
+## 입력 포맷 (`ReviewFeedback`)
+
+`src/yule_orchestrator/agents/review_loop.py`의 `ReviewFeedback` 데이터클래스를 단일 입력 형식으로 사용한다. 어떤 출처든 이 형식으로 정규화해서 들어온다.
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `feedback_id` | str | 출처별 고유 ID (PR review id, copilot comment id 등) |
+| `source` | enum | `github_pr_review` / `github_copilot` / `external_agent` / `user` |
+| `submitted_at` | datetime | 피드백 작성 시각 |
+| `summary` | str | 한 줄 요약 (라우팅 키워드 매칭 대상) |
+| `body` | str | 본문 (선택, 라우팅 보조 신호) |
+| `target_session_id` | str? | 연결할 기존 WorkflowSession ID |
+| `target_pr_url` / `target_issue_url` | str? | 원본 위치 |
+| `target_thread_id` | int? | Discord thread 연결용 |
+| `file_paths` | tuple[str] | 영향 파일 (라우팅 보조) |
+| `severity` | enum | `blocking` / `high` / `medium` / `low` / `nit` |
+| `categories` | tuple[str] | `ui`, `test`, `architecture` 등 자유 라벨 |
+| `references_user` | tuple[str] | 사용자가 직접 첨부한 레퍼런스 링크 |
+| `author` | str? | 리뷰어 식별자 |
+
+직렬화/역직렬화는 `to_payload`/`from_payload` 헬퍼로 한다.
+
+## 재분배 규칙 (`route_review_feedback`)
+
+`summary + body + categories`를 하나의 텍스트로 합치고, 아래 우선순위로 매칭해 `primary_role`을 정한다.
+
+1. **`architecture` + 심각도 `blocking`/`high`** → `tech-lead` (지원: backend-engineer, frontend-engineer)
+2. **`ui`, `ux`, `layout`, `copy`, `branding`, `design`, `visual`** → `product-designer` (지원: frontend-engineer)
+3. **`test`, `coverage`, `qa`, `regression`, `edge-case`** → `qa-engineer` (지원: backend-engineer, frontend-engineer)
+4. **`backend`, `api`, `data`, `model`, `auth`, `migration`, `server`** 또는 file_paths가 backend 패턴** → `backend-engineer` (지원: qa-engineer)
+5. **`frontend`, `component`, `page`, `interaction`, `client`, `react`** 또는 file_paths가 `.tsx`/`.jsx`/`.css` 등** → `frontend-engineer` (지원: product-designer, qa-engineer)
+6. **그 외 모호한 경우** → `tech-lead` (혼자 분류 후 재라우팅)
+
+`severity == nit`인 경우 사유에 `nit severity — fix optional` 표시를 붙여, 응답 시 우선순위가 낮음을 알린다.
+
+단일 write executor 원칙은 그대로 유지된다. supporting_roles는 의견을 제출하지만 코드 commit은 primary_role만 한다.
+
+## 레퍼런스 회수 훅
+
+피드백 본문에 다음 키워드가 있으면 `reference_needed=True`로 표시되고 추천 소스가 함께 반환된다.
+
+| 키워드 그룹 | 부족한 측면 | 추천 소스 |
+| --- | --- | --- |
+| `flow`, `흐름`, `단계`, `navigation` | UX 플로우 | Mobbin, Page Flows |
+| `copy`, `카피`, `문구`, `메시지`, `tone`, `헤드라인`, `후크` | 카피 훅 | Really Good Emails, Page Flows |
+| `visual`, `비주얼`, `디자인`, `color`, `typography`, `스타일` | 비주얼 완성도 | Awwwards, Behance, Notefolio, Pinterest Trends |
+| `conversion`, `설득력`, `cta`, `광고`, `ad`, `캠페인` | 설득력 | Meta Ad Library, TikTok Creative Center, Google Trends |
+
+`categories`에 `ui`/`ux`/`design` 계열이 들어오면 키워드 매칭이 없어도 `reference_needed=True`로 잡힌다.
+
+자동 수집 정책은 `reference-pack.md`를 그대로 따른다 — Mobbin, Behance, Notefolio 등은 약관상 자동 스크래핑 금지이며, **소스 이름만 추천**하고 실제 페치는 사용자가 수동으로 하거나 후속 reference_collector 마일스톤에서 처리한다.
+
+## 워크플로 통합 (`WorkflowOrchestrator.record_review_feedback`)
+
+`WorkflowSession`에 두 필드가 추가된다.
+
+- `review_cycle: int` (기본 0) — 누적 리뷰 회차
+- `review_feedbacks: Sequence[Mapping]` — 각 피드백 + 라우팅 결정 누적
+
+`record_review_feedback(session_id, feedback)` 동작:
+
+1. session 로드. `REJECTED` 상태면 `WorkflowError`로 거부.
+2. `route_review_feedback(feedback)`로 라우팅 결정.
+3. `feedback`을 직렬화해 `routing` 결과와 함께 `review_feedbacks`에 append.
+4. `review_cycle += 1`.
+5. 세션이 `COMPLETED`였다면 **`IN_PROGRESS`로 재오픈**한다 — 이후 `progress()` / `complete()` / `respond_to_review()` 호출이 그대로 가능.
+6. `target_thread_id`가 있으면 session.thread_id로 채운다 (기존 thread 유지).
+7. `format_review_intake_message()`로 thread 첫 회신 메시지 생성.
+
+## 회신 (`WorkflowOrchestrator.respond_to_review`)
+
+`respond_to_review(session_id, feedback_id=..., applied=..., proposed=..., remaining=..., references_used=...)` 동작:
+
+1. session에서 해당 `feedback_id` 레코드 조회. 없으면 에러.
+2. 적용/제안/남은 이슈/사용 레퍼런스를 모아 `format_review_reply_message()`로 회신 메시지 생성.
+3. session.progress_notes에 `"review cycle N 회신: 적용 X건, 제안 Y건, 남음 Z건"` 한 줄 추가.
+4. session.references_used에 새 레퍼런스 누적.
+
+상태 전이는 일으키지 않는다 — 별도 `progress()`/`complete()` 흐름과 자유롭게 조합할 수 있다.
+
+## 운영 메시지 양식
+
+### 인테이크 (재분배 안내)
+
+```
+리뷰 피드백 수신 (cycle N)
+- 세션: `<session_id>`
+- 출처: <source> / 심각도: <severity>
+- 작성자: <author>
+
+요약
+<summary>
+
+본문
+<body>
+
+재분배
+- 담당 역할: `<role>`
+- 지원 역할: `<role>`, ...
+- 라우팅 사유: ...
+- 영향 파일: `<path>`, ...
+
+레퍼런스 회수 필요
+- 부족한 측면: <gaps>
+- 추천 소스: <sources>
+```
+
+### 회신
+
+```
+리뷰 회신 (cycle N)
+- 세션: `<session_id>`
+- 담당: `<role>`
+- 원 피드백: <summary>
+
+적용한 수정
+- ...
+
+추가 제안
+- ...
+
+남은 이슈
+- ...
+
+참고한 레퍼런스
+- <title> — <url>
+```
+
+## 건드리지 말아야 할 것
+
+- 단일 executor 계약: supporting_roles는 의견용, write는 primary_role만.
+- `WorkflowState` 다이어그램: `INTAKE → APPROVED → IN_PROGRESS → COMPLETED|REJECTED` 그대로 유지. 리뷰는 새 상태를 넣지 않고 `review_cycle`만 증가시킨다.
+- Write 게이트: review-loop은 write_blocked_reason을 만지지 않는다. 재작업이 새로 write를 요구하면 `approve()` 흐름을 다시 타야 한다.
+- Reference 자동 수집 금지 정책: 소스 이름만 추천, 실제 페치는 사용자/후속 마일스톤.
+
+## 후속 마일스톤
+
+- 피드백 자동 수집: GitHub PR review API / Copilot 코멘트 fetch → ReviewFeedback 변환기.
+- Discord 슬래시 명령: `/engineer-review` 로 thread에 직접 리뷰 입력.
+- 자동 reference_collector 연동: reference_needed=True인 피드백은 실제 사이트에서 추천 카드 가져오기 (약관 검토 후).
+- Multi-feedback batching: 같은 PR에 여러 코멘트가 동시에 들어올 때 묶어서 한 번에 라우팅.

--- a/policies/runtime/agents/engineering-agent/review-loop.md
+++ b/policies/runtime/agents/engineering-agent/review-loop.md
@@ -137,9 +137,39 @@ PR 리뷰 코멘트, GitHub Copilot 코멘트, 외부 에이전트 의견을 다
 - Write 게이트: review-loop은 write_blocked_reason을 만지지 않는다. 재작업이 새로 write를 요구하면 `approve()` 흐름을 다시 타야 한다.
 - Reference 자동 수집 금지 정책: 소스 이름만 추천, 실제 페치는 사용자/후속 마일스톤.
 
+## Discord 진입점
+
+`/engineer_review` 와 `/engineer_review_reply` 두 슬래시 명령으로 thread에서 직접 루프를 돌릴 수 있다.
+
+### `/engineer_review`
+
+| 파라미터 | 필수 | 설명 |
+| --- | --- | --- |
+| `session_id` | ✅ | 피드백을 연결할 워크플로 세션 ID |
+| `summary` | ✅ | 한 줄 요약 (라우팅에 사용) |
+| `body` | ⏵ | 피드백 본문 |
+| `severity` | ⏵ | `blocking`/`high`/`medium`/`low`/`nit` (기본 medium) |
+| `categories` | ⏵ | 쉼표로 구분 (예: `ui, copy`) |
+| `source` | ⏵ | `github_pr_review`/`github_copilot`/`external_agent`/`user` (기본 user) |
+| `file_paths` | ⏵ | 쉼표로 구분한 영향 파일 경로 |
+
+실행 결과로 인테이크 메시지와 함께 자동 생성된 `feedback_id`(예: `fb-1a2b3c4d`)를 표시한다. 이 ID를 다음 회신에 사용한다.
+
+### `/engineer_review_reply`
+
+| 파라미터 | 필수 | 설명 |
+| --- | --- | --- |
+| `session_id` | ✅ | 회신 대상 세션 |
+| `feedback_id` | ✅ | 인테이크 시 받은 ID |
+| `applied` | ✅ | 적용한 수정 (개행 또는 `;` 분리, `-`/`•` 글머리 자동 제거) |
+| `proposed` | ⏵ | 추가 제안 |
+| `remaining` | ⏵ | 남은 이슈 |
+
+회신 메시지가 thread에 게시되고 session.progress_notes에 회차 메모가 누적된다.
+
 ## 후속 마일스톤
 
-- 피드백 자동 수집: GitHub PR review API / Copilot 코멘트 fetch → ReviewFeedback 변환기.
-- Discord 슬래시 명령: `/engineer-review` 로 thread에 직접 리뷰 입력.
+- 피드백 자동 수집: GitHub PR review API / Copilot 코멘트 fetch → ReviewFeedback 변환기 (webhook 또는 polling).
 - 자동 reference_collector 연동: reference_needed=True인 피드백은 실제 사이트에서 추천 카드 가져오기 (약관 검토 후).
 - Multi-feedback batching: 같은 PR에 여러 코멘트가 동시에 들어올 때 묶어서 한 번에 라우팅.
+- 라벨 사전 표준화: `categories`를 자유 라벨에서 정해진 사전으로 좁혀 라우팅 정확도 향상.

--- a/src/yule_orchestrator/agents/review_loop.py
+++ b/src/yule_orchestrator/agents/review_loop.py
@@ -1,0 +1,332 @@
+"""Review feedback intake and re-routing for engineering-agent.
+
+PR 리뷰 코멘트, GitHub Copilot 코멘트, 외부 에이전트 의견을 입력으로 받아
+적절한 멤버 역할에 다시 분배하고, 수정 결과를 thread로 회신할 때 쓰는 메시지를
+구성하는 모듈. Dispatcher와 별도 경로로 동작하며, 기존 WorkflowSession과
+같은 thread_id에 연결돼 새 review_cycle만 증가시킨다.
+
+설계 원칙:
+- 입력 source 종류는 source 필드로 평면화 (github_pr_review, github_copilot, external_agent, user)
+- 라우팅은 categories(우선) → file_paths(보조) → fallback tech-lead 순서
+- 단일 executor 원칙은 그대로 유지: 응답하는 역할은 한 번에 하나
+- 레퍼런스 회수가 필요한 카테고리에선 reference_sources를 함께 반환
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Mapping, Optional, Sequence
+
+
+class ReviewSource(str, Enum):
+    GITHUB_PR_REVIEW = "github_pr_review"
+    GITHUB_COPILOT = "github_copilot"
+    EXTERNAL_AGENT = "external_agent"
+    USER = "user"
+
+
+class ReviewSeverity(str, Enum):
+    BLOCKING = "blocking"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    NIT = "nit"
+
+
+REVIEW_CATEGORY_DESIGN = ("ui", "ux", "layout", "copy", "branding", "design", "visual")
+REVIEW_CATEGORY_QA = ("test", "coverage", "qa", "regression", "edge-case")
+REVIEW_CATEGORY_ARCHITECTURE = ("architecture", "system", "scalability", "refactor", "design-system")
+REVIEW_CATEGORY_BACKEND = ("backend", "api", "data", "model", "auth", "migration", "server")
+REVIEW_CATEGORY_FRONTEND = ("frontend", "component", "page", "interaction", "client", "react")
+
+REFERENCE_GAP_KEYWORDS_FLOW = ("flow", "흐름", "단계", "navigation")
+REFERENCE_GAP_KEYWORDS_COPY = ("copy", "카피", "문구", "메시지", "tone", "헤드라인", "후크")
+REFERENCE_GAP_KEYWORDS_VISUAL = ("visual", "비주얼", "디자인", "color", "typography", "스타일")
+REFERENCE_GAP_KEYWORDS_PERSUASION = ("conversion", "설득력", "cta", "광고", "ad", "캠페인")
+
+REFERENCE_SOURCES_FLOW = ("Mobbin", "Page Flows")
+REFERENCE_SOURCES_VISUAL = ("Awwwards", "Behance", "Notefolio", "Pinterest Trends")
+REFERENCE_SOURCES_COPY = ("Really Good Emails", "Page Flows")
+REFERENCE_SOURCES_PERSUASION = ("Meta Ad Library", "TikTok Creative Center", "Google Trends")
+
+
+@dataclass(frozen=True)
+class ReviewFeedback:
+    """Normalized feedback record across PR review / Copilot / external sources."""
+
+    feedback_id: str
+    source: ReviewSource
+    submitted_at: datetime
+    summary: str
+    body: str = ""
+    target_session_id: Optional[str] = None
+    target_pr_url: Optional[str] = None
+    target_issue_url: Optional[str] = None
+    target_thread_id: Optional[int] = None
+    file_paths: Sequence[str] = ()
+    severity: ReviewSeverity = ReviewSeverity.MEDIUM
+    categories: Sequence[str] = ()
+    references_user: Sequence[str] = ()
+    author: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ReviewRouting:
+    """Routing decision for a single ReviewFeedback record."""
+
+    feedback_id: str
+    primary_role: str
+    supporting_roles: Sequence[str]
+    reasons: Sequence[str]
+    reference_needed: bool
+    reference_sources: Sequence[str]
+    reference_gaps: Sequence[str] = ()
+
+
+def to_payload(feedback: ReviewFeedback) -> Mapping[str, object]:
+    """Serialize a ReviewFeedback to a JSON-friendly dict (for workflow state)."""
+
+    return {
+        "feedback_id": feedback.feedback_id,
+        "source": feedback.source.value,
+        "submitted_at": feedback.submitted_at.isoformat(),
+        "summary": feedback.summary,
+        "body": feedback.body,
+        "target_session_id": feedback.target_session_id,
+        "target_pr_url": feedback.target_pr_url,
+        "target_issue_url": feedback.target_issue_url,
+        "target_thread_id": feedback.target_thread_id,
+        "file_paths": list(feedback.file_paths),
+        "severity": feedback.severity.value,
+        "categories": list(feedback.categories),
+        "references_user": list(feedback.references_user),
+        "author": feedback.author,
+    }
+
+
+def from_payload(payload: Mapping[str, object]) -> ReviewFeedback:
+    return ReviewFeedback(
+        feedback_id=str(payload["feedback_id"]),
+        source=ReviewSource(str(payload.get("source") or ReviewSource.USER.value)),
+        submitted_at=datetime.fromisoformat(str(payload["submitted_at"])),
+        summary=str(payload.get("summary") or ""),
+        body=str(payload.get("body") or ""),
+        target_session_id=_optional_str(payload.get("target_session_id")),
+        target_pr_url=_optional_str(payload.get("target_pr_url")),
+        target_issue_url=_optional_str(payload.get("target_issue_url")),
+        target_thread_id=_optional_int(payload.get("target_thread_id")),
+        file_paths=tuple(str(item) for item in payload.get("file_paths") or ()),
+        severity=ReviewSeverity(str(payload.get("severity") or ReviewSeverity.MEDIUM.value)),
+        categories=tuple(str(item) for item in payload.get("categories") or ()),
+        references_user=tuple(str(item) for item in payload.get("references_user") or ()),
+        author=_optional_str(payload.get("author")),
+    )
+
+
+def route_review_feedback(feedback: ReviewFeedback) -> ReviewRouting:
+    """Decide which role addresses this feedback, with optional reference fetch."""
+
+    haystack = " ".join([feedback.summary, feedback.body, *feedback.categories]).lower()
+    paths_haystack = " ".join(feedback.file_paths).lower()
+
+    primary_role = "tech-lead"
+    reasons: list[str] = []
+    supporting: list[str] = []
+
+    has_design = _matches(haystack, REVIEW_CATEGORY_DESIGN)
+    has_qa = _matches(haystack, REVIEW_CATEGORY_QA)
+    has_architecture = _matches(haystack, REVIEW_CATEGORY_ARCHITECTURE)
+    has_backend = _matches(haystack, REVIEW_CATEGORY_BACKEND)
+    has_frontend = _matches(haystack, REVIEW_CATEGORY_FRONTEND)
+
+    paths_match_frontend = _matches(paths_haystack, REVIEW_CATEGORY_FRONTEND + ("css", "tsx", "jsx", "html"))
+    paths_match_backend = _matches(paths_haystack, REVIEW_CATEGORY_BACKEND + ("/api/", "service", "controller"))
+
+    if has_architecture and feedback.severity in (ReviewSeverity.BLOCKING, ReviewSeverity.HIGH):
+        primary_role = "tech-lead"
+        reasons.append("architecture/system level concern")
+        supporting = ["backend-engineer", "frontend-engineer"]
+    elif has_design:
+        primary_role = "product-designer"
+        reasons.append("design/copy/UX feedback")
+        supporting = ["frontend-engineer"]
+    elif has_qa:
+        primary_role = "qa-engineer"
+        reasons.append("test/coverage gap")
+        supporting = ["backend-engineer", "frontend-engineer"]
+    elif has_backend or paths_match_backend:
+        primary_role = "backend-engineer"
+        reasons.append("backend/data/api signal")
+        supporting = ["qa-engineer"]
+    elif has_frontend or paths_match_frontend:
+        primary_role = "frontend-engineer"
+        reasons.append("frontend/component signal")
+        supporting = ["product-designer", "qa-engineer"]
+    else:
+        primary_role = "tech-lead"
+        reasons.append("ambiguous feedback — tech-lead triage")
+
+    reference_gaps, reference_sources = _detect_reference_gaps(haystack)
+    reference_needed = bool(reference_gaps) or has_design
+
+    if reference_needed and not reference_sources:
+        reference_sources = REFERENCE_SOURCES_VISUAL
+
+    if feedback.severity == ReviewSeverity.NIT and primary_role != "tech-lead":
+        reasons.append("nit severity — fix optional")
+
+    return ReviewRouting(
+        feedback_id=feedback.feedback_id,
+        primary_role=primary_role,
+        supporting_roles=tuple(supporting),
+        reasons=tuple(reasons),
+        reference_needed=reference_needed,
+        reference_sources=tuple(reference_sources),
+        reference_gaps=tuple(reference_gaps),
+    )
+
+
+def format_review_intake_message(
+    feedback: ReviewFeedback,
+    routing: ReviewRouting,
+    *,
+    session_id: str,
+    review_cycle: int,
+) -> str:
+    """Discord/PR thread 첫 회신: 누가 받고 무엇을 볼지 안내."""
+
+    lines: list[str] = []
+    lines.append(f"**리뷰 피드백 수신 (cycle {review_cycle})**")
+    lines.append(f"- 세션: `{session_id}`")
+    lines.append(f"- 출처: {feedback.source.value} / 심각도: {feedback.severity.value}")
+    if feedback.author:
+        lines.append(f"- 작성자: {feedback.author}")
+    lines.append("")
+    lines.append(f"**요약**\n{feedback.summary}")
+    if feedback.body:
+        lines.append("")
+        lines.append("**본문**")
+        lines.append(feedback.body)
+    lines.append("")
+    lines.append("**재분배**")
+    lines.append(f"- 담당 역할: `{routing.primary_role}`")
+    if routing.supporting_roles:
+        lines.append(f"- 지원 역할: {', '.join(f'`{role}`' for role in routing.supporting_roles)}")
+    if routing.reasons:
+        lines.append(f"- 라우팅 사유: {'; '.join(routing.reasons)}")
+    if feedback.file_paths:
+        lines.append(f"- 영향 파일: {', '.join(f'`{path}`' for path in list(feedback.file_paths)[:5])}")
+    if routing.reference_needed:
+        lines.append("")
+        lines.append("**레퍼런스 회수 필요**")
+        if routing.reference_gaps:
+            lines.append(f"- 부족한 측면: {', '.join(routing.reference_gaps)}")
+        if routing.reference_sources:
+            lines.append(
+                f"- 추천 소스: {', '.join(routing.reference_sources)}"
+            )
+    return "\n".join(lines)
+
+
+def format_review_reply_message(
+    feedback: ReviewFeedback,
+    routing: ReviewRouting,
+    *,
+    session_id: str,
+    review_cycle: int,
+    applied: Sequence[str],
+    proposed: Sequence[str] = (),
+    remaining: Sequence[str] = (),
+    references_used: Sequence[Mapping[str, str]] = (),
+) -> str:
+    """피드백 처리 후 thread에 올릴 회신 — 적용/제안/남은 이슈/레퍼런스."""
+
+    lines: list[str] = []
+    lines.append(f"**리뷰 회신 (cycle {review_cycle})**")
+    lines.append(f"- 세션: `{session_id}`")
+    lines.append(f"- 담당: `{routing.primary_role}`")
+    lines.append(f"- 원 피드백: {feedback.summary}")
+
+    lines.append("")
+    if applied:
+        lines.append("**적용한 수정**")
+        for item in applied:
+            lines.append(f"- {item}")
+    else:
+        lines.append("**적용한 수정**: 없음 (제안만 정리)")
+
+    if proposed:
+        lines.append("")
+        lines.append("**추가 제안**")
+        for item in proposed:
+            lines.append(f"- {item}")
+
+    if remaining:
+        lines.append("")
+        lines.append("**남은 이슈**")
+        for item in remaining:
+            lines.append(f"- {item}")
+
+    if references_used:
+        lines.append("")
+        lines.append("**참고한 레퍼런스**")
+        for ref in references_used:
+            label = ref.get("title") or ref.get("source") or ""
+            url = ref.get("url") or ""
+            if url:
+                lines.append(f"- {label} — {url}")
+            else:
+                lines.append(f"- {label}")
+    elif routing.reference_needed and routing.reference_sources:
+        lines.append("")
+        lines.append(
+            f"**참고 권장 소스**: {', '.join(routing.reference_sources)} "
+            "(약관상 자동 수집 금지 — 사용자 제공 또는 수동 참고)"
+        )
+
+    return "\n".join(lines)
+
+
+def _matches(haystack: str, keywords: Sequence[str]) -> bool:
+    return any(keyword in haystack for keyword in keywords)
+
+
+def _detect_reference_gaps(haystack: str) -> tuple[list[str], list[str]]:
+    gaps: list[str] = []
+    sources: list[str] = []
+    if _matches(haystack, REFERENCE_GAP_KEYWORDS_FLOW):
+        gaps.append("UX 플로우")
+        sources.extend(REFERENCE_SOURCES_FLOW)
+    if _matches(haystack, REFERENCE_GAP_KEYWORDS_COPY):
+        gaps.append("카피 훅")
+        sources.extend(REFERENCE_SOURCES_COPY)
+    if _matches(haystack, REFERENCE_GAP_KEYWORDS_VISUAL):
+        gaps.append("비주얼 완성도")
+        sources.extend(REFERENCE_SOURCES_VISUAL)
+    if _matches(haystack, REFERENCE_GAP_KEYWORDS_PERSUASION):
+        gaps.append("설득력")
+        sources.extend(REFERENCE_SOURCES_PERSUASION)
+
+    seen: list[str] = []
+    for source in sources:
+        if source not in seen:
+            seen.append(source)
+    return gaps, seen
+
+
+def _optional_str(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: object) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/yule_orchestrator/agents/workflow.py
+++ b/src/yule_orchestrator/agents/workflow.py
@@ -17,6 +17,15 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
 from .dispatcher import Dispatcher, DispatchPlan, DispatchRequest, TaskType
+from .review_loop import (
+    ReviewFeedback,
+    ReviewRouting,
+    format_review_intake_message,
+    format_review_reply_message,
+    from_payload as review_feedback_from_payload,
+    route_review_feedback,
+    to_payload as review_feedback_to_payload,
+)
 from .workflow_state import (
     WorkflowSession,
     WorkflowState,
@@ -49,6 +58,20 @@ class ProgressResult:
 
 @dataclass(frozen=True)
 class CompletionResult:
+    session: WorkflowSession
+    message: str
+
+
+@dataclass(frozen=True)
+class ReviewIntakeResult:
+    session: WorkflowSession
+    feedback: ReviewFeedback
+    routing: ReviewRouting
+    message: str
+
+
+@dataclass(frozen=True)
+class ReviewReplyResult:
     session: WorkflowSession
     message: str
 
@@ -184,6 +207,116 @@ class WorkflowOrchestrator:
         updated = update_session(completed, now=self.now_fn())
         return CompletionResult(session=updated, message=format_completion_message(updated))
 
+    def record_review_feedback(
+        self,
+        session_id: str,
+        feedback: ReviewFeedback,
+    ) -> ReviewIntakeResult:
+        """Append a review feedback record and re-route to the right role.
+
+        Allowed from any state except ``REJECTED``. If the session was
+        ``COMPLETED``, the session re-opens to ``IN_PROGRESS`` so subsequent
+        ``progress()`` / ``complete()`` / ``respond_to_review()`` calls work.
+        """
+
+        session = self._require_session(session_id)
+        if session.state == WorkflowState.REJECTED:
+            raise WorkflowError(
+                f"session {session_id} is rejected; review feedback is not accepted"
+            )
+
+        routing = route_review_feedback(feedback)
+        feedback_record = dict(review_feedback_to_payload(feedback))
+        feedback_record["routing"] = {
+            "primary_role": routing.primary_role,
+            "supporting_roles": list(routing.supporting_roles),
+            "reasons": list(routing.reasons),
+            "reference_needed": routing.reference_needed,
+            "reference_sources": list(routing.reference_sources),
+            "reference_gaps": list(routing.reference_gaps),
+        }
+
+        new_state = (
+            WorkflowState.IN_PROGRESS
+            if session.state == WorkflowState.COMPLETED
+            else session.state
+        )
+        new_cycle = session.review_cycle + 1
+        new_feedbacks = tuple(session.review_feedbacks) + (feedback_record,)
+        thread_id = feedback.target_thread_id or session.thread_id
+
+        updated = replace(
+            session,
+            state=new_state,
+            review_cycle=new_cycle,
+            review_feedbacks=new_feedbacks,
+            thread_id=thread_id,
+        )
+        updated = update_session(updated, now=self.now_fn())
+
+        message = format_review_intake_message(
+            feedback,
+            routing,
+            session_id=updated.session_id,
+            review_cycle=new_cycle,
+        )
+        return ReviewIntakeResult(
+            session=updated,
+            feedback=feedback,
+            routing=routing,
+            message=message,
+        )
+
+    def respond_to_review(
+        self,
+        session_id: str,
+        *,
+        feedback_id: str,
+        applied: Sequence[str],
+        proposed: Sequence[str] = (),
+        remaining: Sequence[str] = (),
+        references_used: Sequence[Mapping[str, Any]] = (),
+    ) -> ReviewReplyResult:
+        session = self._require_session(session_id)
+        if session.state == WorkflowState.REJECTED:
+            raise WorkflowError(
+                f"session {session_id} is rejected; review reply is not allowed"
+            )
+
+        target_record: Optional[Mapping[str, Any]] = None
+        for record in session.review_feedbacks:
+            if record.get("feedback_id") == feedback_id:
+                target_record = record
+                break
+        if target_record is None:
+            raise WorkflowError(
+                f"feedback {feedback_id} not found in session {session_id}"
+            )
+
+        feedback = _feedback_from_record(target_record)
+        routing = _routing_from_record(target_record, fallback=feedback)
+        message = format_review_reply_message(
+            feedback,
+            routing,
+            session_id=session.session_id,
+            review_cycle=session.review_cycle,
+            applied=applied,
+            proposed=proposed,
+            remaining=remaining,
+            references_used=references_used,
+        )
+        note = (
+            f"review cycle {session.review_cycle} 회신: "
+            f"적용 {len(applied)}건, 제안 {len(proposed)}건, 남음 {len(remaining)}건"
+        )
+        notes = tuple(session.progress_notes) + (note,)
+        used = tuple(dict(item) for item in session.references_used) + tuple(
+            dict(item) for item in references_used
+        )
+        updated = replace(session, progress_notes=notes, references_used=used)
+        updated = update_session(updated, now=self.now_fn())
+        return ReviewReplyResult(session=updated, message=message)
+
     def get(self, session_id: str) -> Optional[WorkflowSession]:
         return load_session(session_id)
 
@@ -192,6 +325,32 @@ class WorkflowOrchestrator:
         if session is None:
             raise WorkflowError(f"session {session_id} not found")
         return session
+
+
+def _feedback_from_record(record: Mapping[str, Any]) -> ReviewFeedback:
+    payload = {key: value for key, value in record.items() if key != "routing"}
+    return review_feedback_from_payload(payload)
+
+
+def _routing_from_record(record: Mapping[str, Any], *, fallback: ReviewFeedback) -> ReviewRouting:
+    routing_data = record.get("routing")
+    if isinstance(routing_data, Mapping):
+        return ReviewRouting(
+            feedback_id=fallback.feedback_id,
+            primary_role=str(routing_data.get("primary_role") or "tech-lead"),
+            supporting_roles=tuple(
+                str(item) for item in routing_data.get("supporting_roles") or ()
+            ),
+            reasons=tuple(str(item) for item in routing_data.get("reasons") or ()),
+            reference_needed=bool(routing_data.get("reference_needed")),
+            reference_sources=tuple(
+                str(item) for item in routing_data.get("reference_sources") or ()
+            ),
+            reference_gaps=tuple(
+                str(item) for item in routing_data.get("reference_gaps") or ()
+            ),
+        )
+    return route_review_feedback(fallback)
 
 
 def extract_urls(text: str) -> tuple[str, ...]:

--- a/src/yule_orchestrator/agents/workflow_state.py
+++ b/src/yule_orchestrator/agents/workflow_state.py
@@ -54,6 +54,8 @@ class WorkflowSession:
     thread_id: Optional[int] = None
     write_requested: bool = False
     write_blocked_reason: Optional[str] = None
+    review_cycle: int = 0
+    review_feedbacks: Sequence[Mapping[str, Any]] = ()
     extra: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -117,6 +119,8 @@ def _to_payload(session: WorkflowSession) -> Mapping[str, Any]:
         "thread_id": session.thread_id,
         "write_requested": session.write_requested,
         "write_blocked_reason": session.write_blocked_reason,
+        "review_cycle": session.review_cycle,
+        "review_feedbacks": [dict(item) for item in session.review_feedbacks],
         "extra": dict(session.extra),
     }
 
@@ -146,6 +150,11 @@ def _from_payload(payload: Mapping[str, Any]) -> WorkflowSession:
         thread_id=_optional_int(payload.get("thread_id")),
         write_requested=bool(payload.get("write_requested", False)),
         write_blocked_reason=_optional_str(payload.get("write_blocked_reason")),
+        review_cycle=int(payload.get("review_cycle") or 0),
+        review_feedbacks=tuple(
+            dict(item) if isinstance(item, dict) else {}
+            for item in payload.get("review_feedbacks") or ()
+        ),
         extra=dict(payload.get("extra") or {}),
     )
 

--- a/src/yule_orchestrator/discord/commands.py
+++ b/src/yule_orchestrator/discord/commands.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from ..agents import (
     Dispatcher,
@@ -12,6 +13,11 @@ from ..agents import (
     WorkflowError,
     WorkflowOrchestrator,
     build_participants_pool,
+)
+from ..agents.review_loop import (
+    ReviewFeedback,
+    ReviewSeverity,
+    ReviewSource,
 )
 from .formatter import (
     format_checkpoints_message,
@@ -185,6 +191,108 @@ def register_discord_commands(
             discord_module=discord,
         )
 
+    @bot.tree.command(
+        name="engineer_review",
+        description="기존 세션에 PR 리뷰/Copilot/외부 피드백을 입력합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="피드백을 연결할 워크플로 세션 ID.",
+        summary="한 줄 요약 (라우팅에 사용).",
+        body="피드백 본문 (선택).",
+        severity="blocking / high / medium / low / nit (기본: medium).",
+        categories="쉼표로 구분한 카테고리 라벨 (예: ui, copy).",
+        source="github_pr_review / github_copilot / external_agent / user (기본: user).",
+        file_paths="쉼표로 구분한 영향 파일 경로 (선택).",
+    )
+    async def engineer_review(
+        interaction: "discord.Interaction",
+        session_id: str,
+        summary: str,
+        body: Optional[str] = None,
+        severity: Optional[str] = None,
+        categories: Optional[str] = None,
+        source: Optional[str] = None,
+        file_paths: Optional[str] = None,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            result = await asyncio.to_thread(
+                _run_engineer_review,
+                session_id=session_id,
+                summary=summary,
+                body=body,
+                severity=severity,
+                categories=categories,
+                source=source,
+                file_paths=file_paths,
+                channel_id=interaction.channel_id,
+                thread_id=getattr(interaction.channel, "id", None),
+                user_id=interaction.user.id,
+                author_name=str(interaction.user),
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer review 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            result.message + f"\n\n_피드백 ID_: `{result.feedback.feedback_id}`",
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
+    @bot.tree.command(
+        name="engineer_review_reply",
+        description="리뷰 피드백에 적용/제안/남은 이슈 회신을 게시합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="회신 대상 워크플로 세션 ID.",
+        feedback_id="회신 대상 feedback ID.",
+        applied="적용한 수정 (개행 또는 ; 으로 분리).",
+        proposed="추가 제안 (선택, 개행 또는 ; 분리).",
+        remaining="남은 이슈 (선택, 개행 또는 ; 분리).",
+    )
+    async def engineer_review_reply(
+        interaction: "discord.Interaction",
+        session_id: str,
+        feedback_id: str,
+        applied: str,
+        proposed: Optional[str] = None,
+        remaining: Optional[str] = None,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            result = await asyncio.to_thread(
+                _run_engineer_review_reply,
+                session_id=session_id,
+                feedback_id=feedback_id,
+                applied=applied,
+                proposed=proposed,
+                remaining=remaining,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer review reply 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            result.message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
     @bot.tree.command(name="checkpoints_now", description="지금 기준으로 다가오는 체크포인트를 보여줍니다.", guild=guild)
     @app_commands.describe(window_minutes="몇 분 앞까지 확인할지 설정합니다.")
     async def checkpoints_now(
@@ -247,6 +355,109 @@ def _run_engineer_intake(
 def _load_engineer_session(*, session_id: str):
     orchestrator = _engineer_orchestrator()
     return orchestrator.get(session_id)
+
+
+def _run_engineer_review(
+    *,
+    session_id: str,
+    summary: str,
+    body: Optional[str],
+    severity: Optional[str],
+    categories: Optional[str],
+    source: Optional[str],
+    file_paths: Optional[str],
+    channel_id: Optional[int],
+    thread_id: Optional[int],
+    user_id: Optional[int],
+    author_name: Optional[str],
+):
+    if not summary or not summary.strip():
+        raise ValueError("summary must not be empty")
+
+    parsed_severity = _parse_review_severity(severity)
+    parsed_source = _parse_review_source(source)
+
+    feedback = ReviewFeedback(
+        feedback_id=_generate_feedback_id(),
+        source=parsed_source,
+        submitted_at=datetime.now(),
+        summary=summary.strip(),
+        body=(body or "").strip(),
+        target_session_id=session_id,
+        target_thread_id=thread_id,
+        file_paths=_split_csv(file_paths),
+        severity=parsed_severity,
+        categories=_split_csv(categories),
+        author=author_name,
+    )
+    orchestrator = _engineer_orchestrator()
+    return orchestrator.record_review_feedback(session_id, feedback)
+
+
+def _run_engineer_review_reply(
+    *,
+    session_id: str,
+    feedback_id: str,
+    applied: str,
+    proposed: Optional[str],
+    remaining: Optional[str],
+):
+    applied_items = _split_lines_or_semicolons(applied)
+    if not applied_items:
+        raise ValueError("applied must include at least one item")
+    proposed_items = _split_lines_or_semicolons(proposed)
+    remaining_items = _split_lines_or_semicolons(remaining)
+    orchestrator = _engineer_orchestrator()
+    return orchestrator.respond_to_review(
+        session_id,
+        feedback_id=feedback_id,
+        applied=applied_items,
+        proposed=proposed_items,
+        remaining=remaining_items,
+    )
+
+
+def _parse_review_severity(value: Optional[str]) -> ReviewSeverity:
+    if not value:
+        return ReviewSeverity.MEDIUM
+    try:
+        return ReviewSeverity(value.strip().lower())
+    except ValueError as exc:
+        raise ValueError(
+            f"severity must be one of {[s.value for s in ReviewSeverity]}, got {value!r}"
+        ) from exc
+
+
+def _parse_review_source(value: Optional[str]) -> ReviewSource:
+    if not value:
+        return ReviewSource.USER
+    try:
+        return ReviewSource(value.strip().lower())
+    except ValueError as exc:
+        raise ValueError(
+            f"source must be one of {[s.value for s in ReviewSource]}, got {value!r}"
+        ) from exc
+
+
+def _split_csv(value: Optional[str]) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _split_lines_or_semicolons(value: Optional[str]) -> tuple[str, ...]:
+    if not value:
+        return ()
+    parts: list[str] = []
+    for chunk in value.replace(";", "\n").splitlines():
+        stripped = chunk.strip().lstrip("-• ").strip()
+        if stripped:
+            parts.append(stripped)
+    return tuple(parts)
+
+
+def _generate_feedback_id() -> str:
+    return f"fb-{uuid.uuid4().hex[:8]}"
 
 
 def _bind_discord_runtime_globals(*, discord_module: Any, app_commands_module: Any) -> None:

--- a/tests/test_discord_commands.py
+++ b/tests/test_discord_commands.py
@@ -5,9 +5,12 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
+import os
+import tempfile
 import unittest
 
 import yule_orchestrator.discord.commands as discord_commands
+from yule_orchestrator.agents.review_loop import ReviewSeverity, ReviewSource
 
 
 class DiscordCommandsTestCase(unittest.TestCase):
@@ -36,3 +39,146 @@ class DiscordCommandsTestCase(unittest.TestCase):
                 discord_commands.__dict__.pop("app_commands", None)
             else:
                 discord_commands.__dict__["app_commands"] = previous_app_commands
+
+    def test_split_lines_or_semicolons_strips_bullets_and_separators(self) -> None:
+        result = discord_commands._split_lines_or_semicolons(
+            "- 카피 교체\n- CTA 색상\n;final consult"
+        )
+        self.assertEqual(result, ("카피 교체", "CTA 색상", "final consult"))
+
+    def test_split_csv_drops_blanks(self) -> None:
+        self.assertEqual(
+            discord_commands._split_csv(" ui , copy ,, ux "),
+            ("ui", "copy", "ux"),
+        )
+
+    def test_parse_review_severity_defaults_to_medium(self) -> None:
+        self.assertEqual(
+            discord_commands._parse_review_severity(None),
+            ReviewSeverity.MEDIUM,
+        )
+
+    def test_parse_review_severity_rejects_unknown_value(self) -> None:
+        with self.assertRaises(ValueError):
+            discord_commands._parse_review_severity("urgent")
+
+    def test_parse_review_source_defaults_to_user(self) -> None:
+        self.assertEqual(
+            discord_commands._parse_review_source(None),
+            ReviewSource.USER,
+        )
+
+    def test_generate_feedback_id_has_expected_prefix(self) -> None:
+        identifier = discord_commands._generate_feedback_id()
+        self.assertTrue(identifier.startswith("fb-"))
+        self.assertEqual(len(identifier), len("fb-") + 8)
+
+
+class EngineerReviewSlashHelpersTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_db = os.environ.get("YULE_CACHE_DB_PATH")
+        os.environ["YULE_CACHE_DB_PATH"] = os.path.join(self._tmp.name, "cache.sqlite3")
+
+    def tearDown(self) -> None:
+        if self._prev_db is None:
+            os.environ.pop("YULE_CACHE_DB_PATH", None)
+        else:
+            os.environ["YULE_CACHE_DB_PATH"] = self._prev_db
+
+    def _intake_session(self) -> str:
+        orchestrator = discord_commands._engineer_orchestrator()
+        result = orchestrator.intake(prompt="새 랜딩 hero 정리", write_requested=False)
+        return result.session.session_id
+
+    def test_run_engineer_review_records_feedback_and_returns_routing(self) -> None:
+        session_id = self._intake_session()
+
+        result = discord_commands._run_engineer_review(
+            session_id=session_id,
+            summary="hero 카피가 약하고 비주얼이 평이합니다",
+            body=None,
+            severity="high",
+            categories="copy, visual",
+            source="github_pr_review",
+            file_paths="web/Hero.tsx",
+            channel_id=42,
+            thread_id=42,
+            user_id=777,
+            author_name="reviewer-1",
+        )
+
+        self.assertEqual(result.session.review_cycle, 1)
+        self.assertEqual(result.routing.primary_role, "product-designer")
+        self.assertTrue(result.feedback.feedback_id.startswith("fb-"))
+        self.assertIn("리뷰 피드백 수신", result.message)
+
+    def test_run_engineer_review_rejects_blank_summary(self) -> None:
+        session_id = self._intake_session()
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_review(
+                session_id=session_id,
+                summary="   ",
+                body=None,
+                severity=None,
+                categories=None,
+                source=None,
+                file_paths=None,
+                channel_id=None,
+                thread_id=None,
+                user_id=None,
+                author_name=None,
+            )
+
+    def test_run_engineer_review_reply_writes_progress_note(self) -> None:
+        session_id = self._intake_session()
+        intake = discord_commands._run_engineer_review(
+            session_id=session_id,
+            summary="copy 부족",
+            body=None,
+            severity=None,
+            categories="copy",
+            source=None,
+            file_paths=None,
+            channel_id=None,
+            thread_id=None,
+            user_id=777,
+            author_name="reviewer-1",
+        )
+
+        reply = discord_commands._run_engineer_review_reply(
+            session_id=session_id,
+            feedback_id=intake.feedback.feedback_id,
+            applied="- 헤드라인 카피 교체\n- CTA 문구 강화",
+            proposed=None,
+            remaining="A/B 테스트",
+        )
+
+        self.assertIn("리뷰 회신", reply.message)
+        self.assertIn("헤드라인 카피 교체", reply.message)
+        self.assertEqual(len(reply.session.progress_notes), 1)
+
+    def test_run_engineer_review_reply_requires_applied(self) -> None:
+        session_id = self._intake_session()
+        intake = discord_commands._run_engineer_review(
+            session_id=session_id,
+            summary="copy 부족",
+            body=None,
+            severity=None,
+            categories="copy",
+            source=None,
+            file_paths=None,
+            channel_id=None,
+            thread_id=None,
+            user_id=777,
+            author_name="reviewer-1",
+        )
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_review_reply(
+                session_id=session_id,
+                feedback_id=intake.feedback.feedback_id,
+                applied="",
+                proposed=None,
+                remaining=None,
+            )

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    WorkflowError,
+    WorkflowOrchestrator,
+    WorkflowState,
+    build_participants_pool,
+)
+from yule_orchestrator.agents.review_loop import (
+    ReviewFeedback,
+    ReviewSeverity,
+    ReviewSource,
+    format_review_intake_message,
+    format_review_reply_message,
+    from_payload,
+    route_review_feedback,
+    to_payload,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _feedback(
+    *,
+    summary: str,
+    body: str = "",
+    categories: tuple[str, ...] = (),
+    file_paths: tuple[str, ...] = (),
+    severity: ReviewSeverity = ReviewSeverity.MEDIUM,
+    source: ReviewSource = ReviewSource.GITHUB_PR_REVIEW,
+    target_session_id: str | None = None,
+    target_thread_id: int | None = None,
+) -> ReviewFeedback:
+    return ReviewFeedback(
+        feedback_id="fb-1",
+        source=source,
+        submitted_at=datetime(2026, 4, 29, 10, 0, 0),
+        summary=summary,
+        body=body,
+        target_session_id=target_session_id,
+        target_thread_id=target_thread_id,
+        file_paths=file_paths,
+        severity=severity,
+        categories=categories,
+        author="reviewer-1",
+    )
+
+
+class RouteReviewFeedbackTestCase(unittest.TestCase):
+    def test_design_feedback_routes_to_product_designer_with_reference_needed(self) -> None:
+        feedback = _feedback(
+            summary="hero copy too generic; layout feels flat",
+            categories=("ui", "copy"),
+        )
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "product-designer")
+        self.assertIn("frontend-engineer", routing.supporting_roles)
+        self.assertTrue(routing.reference_needed)
+        self.assertIn("Really Good Emails", routing.reference_sources + ("",) * 0)
+
+    def test_qa_feedback_routes_to_qa_engineer(self) -> None:
+        feedback = _feedback(
+            summary="missing regression test for login redirect",
+            categories=("test",),
+        )
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "qa-engineer")
+        self.assertFalse(routing.reference_needed)
+
+    def test_backend_path_routes_to_backend_engineer(self) -> None:
+        feedback = _feedback(
+            summary="auth token validation off",
+            file_paths=("src/api/auth_service.py",),
+        )
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "backend-engineer")
+
+    def test_frontend_path_routes_to_frontend_engineer(self) -> None:
+        feedback = _feedback(
+            summary="button alignment broken on mobile",
+            file_paths=("web/components/Button.tsx",),
+        )
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "frontend-engineer")
+
+    def test_blocking_architecture_feedback_routes_to_tech_lead(self) -> None:
+        feedback = _feedback(
+            summary="this introduces a circular dependency in the domain layer",
+            categories=("architecture",),
+            severity=ReviewSeverity.BLOCKING,
+        )
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "tech-lead")
+        self.assertIn("backend-engineer", routing.supporting_roles)
+
+    def test_ambiguous_feedback_falls_back_to_tech_lead(self) -> None:
+        feedback = _feedback(summary="not sure if this is the right approach")
+        routing = route_review_feedback(feedback)
+        self.assertEqual(routing.primary_role, "tech-lead")
+
+    def test_reference_gap_keywords_surface_correct_sources(self) -> None:
+        feedback = _feedback(
+            summary="UX 플로우 단계가 너무 깊고 카피 훅이 약합니다",
+            categories=("ui",),
+        )
+        routing = route_review_feedback(feedback)
+        self.assertTrue(routing.reference_needed)
+        self.assertIn("UX 플로우", routing.reference_gaps)
+        self.assertIn("카피 훅", routing.reference_gaps)
+        self.assertIn("Mobbin", routing.reference_sources)
+
+
+class ReviewFeedbackPayloadTestCase(unittest.TestCase):
+    def test_round_trip_serialization(self) -> None:
+        original = _feedback(
+            summary="add a11y label to button",
+            body="aria-label missing",
+            categories=("ui", "accessibility"),
+            file_paths=("web/Button.tsx",),
+            severity=ReviewSeverity.HIGH,
+            source=ReviewSource.GITHUB_COPILOT,
+            target_session_id="abcd1234",
+            target_thread_id=999,
+        )
+        roundtrip = from_payload(to_payload(original))
+        self.assertEqual(roundtrip.feedback_id, original.feedback_id)
+        self.assertEqual(roundtrip.source, original.source)
+        self.assertEqual(roundtrip.severity, original.severity)
+        self.assertEqual(roundtrip.categories, original.categories)
+        self.assertEqual(roundtrip.target_thread_id, 999)
+
+
+class FormatReviewMessagesTestCase(unittest.TestCase):
+    def test_intake_message_lists_role_and_reference_sources(self) -> None:
+        feedback = _feedback(
+            summary="onboarding flow drops user at step 3",
+            categories=("ux",),
+        )
+        routing = route_review_feedback(feedback)
+        message = format_review_intake_message(
+            feedback,
+            routing,
+            session_id="sess-1",
+            review_cycle=1,
+        )
+        self.assertIn("리뷰 피드백 수신", message)
+        self.assertIn("`product-designer`", message)
+        self.assertIn("Mobbin", message)
+
+    def test_reply_message_lists_applied_proposed_remaining(self) -> None:
+        feedback = _feedback(summary="hero CTA copy weak", categories=("copy",))
+        routing = route_review_feedback(feedback)
+        message = format_review_reply_message(
+            feedback,
+            routing,
+            session_id="sess-1",
+            review_cycle=2,
+            applied=("CTA copy를 'Start free' 로 교체",),
+            proposed=("Hero subheadline에 social proof 추가",),
+            remaining=("A/B 테스트 셋업",),
+        )
+        self.assertIn("적용한 수정", message)
+        self.assertIn("Start free", message)
+        self.assertIn("추가 제안", message)
+        self.assertIn("남은 이슈", message)
+
+
+class _IsolatedCacheTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_root = os.environ.get("YULE_REPO_ROOT")
+        os.environ["YULE_REPO_ROOT"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        if self._prev_root is None:
+            os.environ.pop("YULE_REPO_ROOT", None)
+        else:
+            os.environ["YULE_REPO_ROOT"] = self._prev_root
+
+
+def _build_orchestrator() -> WorkflowOrchestrator:
+    pool = build_participants_pool(REPO_ROOT, "engineering-agent")
+    return WorkflowOrchestrator(Dispatcher(pool), now_fn=lambda: datetime(2026, 4, 29, 10, 0, 0))
+
+
+class ReviewWorkflowIntegrationTestCase(_IsolatedCacheTestCase):
+    def test_record_review_increments_cycle_and_appends_record(self) -> None:
+        orch = _build_orchestrator()
+        intake = orch.intake(prompt="기존 랜딩 hero 섹션 보강", write_requested=True)
+        orch.approve(intake.session.session_id)
+
+        feedback = _feedback(
+            summary="hero copy too long; layout dense",
+            categories=("ui", "copy"),
+            target_session_id=intake.session.session_id,
+            target_thread_id=intake.session.thread_id,
+        )
+        result = orch.record_review_feedback(intake.session.session_id, feedback)
+
+        self.assertEqual(result.session.review_cycle, 1)
+        self.assertEqual(len(result.session.review_feedbacks), 1)
+        self.assertEqual(result.routing.primary_role, "product-designer")
+        self.assertIn("리뷰 피드백 수신", result.message)
+
+    def test_record_review_reopens_completed_session(self) -> None:
+        orch = _build_orchestrator()
+        intake = orch.intake(prompt="새 결제 API 스켈레톤")
+        orch.approve(intake.session.session_id)
+        orch.complete(intake.session.session_id, summary="merged PR #42")
+
+        feedback = _feedback(
+            summary="missing regression test for refund path",
+            categories=("test",),
+        )
+        result = orch.record_review_feedback(intake.session.session_id, feedback)
+
+        self.assertEqual(result.session.state, WorkflowState.IN_PROGRESS)
+        self.assertEqual(result.routing.primary_role, "qa-engineer")
+
+    def test_record_review_rejected_session_raises(self) -> None:
+        orch = _build_orchestrator()
+        intake = orch.intake(prompt="잘못된 작업")
+        orch.reject(intake.session.session_id, reason="duplicate")
+
+        with self.assertRaises(WorkflowError):
+            orch.record_review_feedback(
+                intake.session.session_id,
+                _feedback(summary="trivial nit"),
+            )
+
+    def test_respond_to_review_writes_progress_note(self) -> None:
+        orch = _build_orchestrator()
+        intake = orch.intake(prompt="이메일 캠페인 카피 정리")
+        orch.approve(intake.session.session_id)
+        feedback = _feedback(
+            summary="후크가 약하고 비주얼이 평이합니다",
+            categories=("copy", "visual"),
+        )
+        orch.record_review_feedback(intake.session.session_id, feedback)
+
+        reply = orch.respond_to_review(
+            intake.session.session_id,
+            feedback_id=feedback.feedback_id,
+            applied=("후크 카피 교체",),
+            proposed=("CTA 버튼 색상 시안 변경",),
+            remaining=("최종 디자이너 컨펌",),
+        )
+
+        self.assertIn("리뷰 회신", reply.message)
+        self.assertIn("후크 카피 교체", reply.message)
+        self.assertEqual(len(reply.session.progress_notes), 1)
+        self.assertIn("review cycle 1 회신", reply.session.progress_notes[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- #39

## ✨ 과제 내용
PR 리뷰 코멘트, GitHub Copilot 코멘트, 외부 에이전트 의견, 사용자 피드백을
engineering-agent의 기존 작업 세션으로 다시 되돌려 보내는 review loop를 추가했습니다.

이번 PR의 목표는 새로운 workflow state를 만드는 것이 아니라,
기존 `WorkflowSession` 위에 `review_cycle`과 `review_feedbacks`를 누적해
"리뷰 → 재분배 → 회신" 닫힘 회로를 만드는 것입니다.

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- `src/yule_orchestrator/agents/review_loop.py`
- `src/yule_orchestrator/agents/workflow.py`
- `tests/test_review_loop.py`
- `policies/runtime/agents/engineering-agent/review-loop.md`
- 이번 PR은 "리뷰 입력을 다시 작업 흐름으로 연결"한 단계이며, 외부 시스템 자동 수집/자동 게시까지는 아직 포함하지 않음