### PR TITLE
Feat/engineering agent discord launcher

### DIFF
--- a/policies/runtime/agents/engineering-agent/discord-workflow.md
+++ b/policies/runtime/agents/engineering-agent/discord-workflow.md
@@ -1,6 +1,6 @@
 # Engineering Agent Discord Workflow (v0)
 
-이 문서는 Discord 안에서 engineering-agent에게 작업을 위임하는 **접수(intake) → 승인(approve) → 진행(progress) → 완료(complete)** 흐름의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/agents/workflow.py` + `workflow_state.py`, CLI는 `yule engineer`, Discord 슬래시 커맨드는 `commands.py`의 `engineer_intake` / `engineer_show`.
+이 문서는 Discord 안에서 engineering-agent에게 작업을 위임하는 **접수(intake) → 승인(approve) → 진행(progress) → 완료(complete)** 흐름의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/agents/workflow.py` + `workflow_state.py`, CLI는 `yule engineer`, Discord 슬래시 커맨드는 `commands.py`의 `engineer_intake` / `engineer_approve` / `engineer_reject` / `engineer_progress` / `engineer_complete` / `engineer_show` / `engineer_review`(+ `engineer_review_reply`).
 
 ## 1. 접수 채널 규칙
 
@@ -17,8 +17,9 @@
 - `write_requested=True`로 접수된 세션은 `intake → approved` 전이 전까지 **어떤 write도 시작하지 않는다**.
 - 승인 방법:
   - **CLI**: `yule engineer approve --session <id>`.
-  - **Discord** (예정): 접수 메시지의 ✅ 반응 → 게이트웨이가 reaction을 감지해 승인. 본 마일스톤에서는 슬래시 커맨드 `/engineer_show`로 상태만 확인 가능, 승인은 CLI에서 진행한다. reaction 핸들러는 후속 이슈에서 추가.
-- 거절은 `yule engineer reject --session <id> --reason "..."`. 거절된 세션은 progress/complete가 모두 차단된다.
+  - **Discord 슬래시 커맨드**: `/engineer_approve session_id:<id>`. 승인이 끝나면 운영자에게 `**[engineering-agent] 세션 승인 완료**` 메시지로 다음 단계 안내(`/engineer_progress`, `/engineer_complete`)를 노출한다.
+  - 접수 메시지의 ✅ 반응 기반 승인은 후속 이슈에서 추가한다 (multi-bot 활성화 시).
+- 거절은 `yule engineer reject --session <id> --reason "..."` 또는 `/engineer_reject session_id:<id> reason:"..."`로 처리한다. Discord 응답에는 사유가 그대로 게시되고 "재개할 수 없습니다" 안내가 포함된다. 거절된 세션은 progress/complete/approve가 모두 차단된다.
 - write 게이트는 dispatcher의 `write_block_reason`을 그대로 받아 표시한다 (dispatcher.md §6).
 
 ## 3. 메시지 포맷
@@ -98,10 +99,18 @@ yule engineer show --session <sid>     # JSON 상태
 
 ```
 /engineer_intake prompt:"우리 랜딩 hero..." write_requested:true
-/engineer_show session_id:<sid>
+/engineer_approve session_id:<sid>
+/engineer_progress session_id:<sid> note:"디자이너 1차 시안 정리"
+/engineer_complete session_id:<sid> summary:"hero 카피 + CTA 색 정리"
+/engineer_reject  session_id:<sid> reason:"요구사항 불명확"
+/engineer_show    session_id:<sid>
 ```
 
-승인은 본 마일스톤에서 CLI 전용. reaction-기반 승인은 후속 이슈에서 추가한다.
+각 슬래시 커맨드는 `workflow.py` 의 동일 메서드를 그대로 호출하며, 잘못된 상태 전이(예: intake 상태에서 progress, completed 세션 재승인, 빈 사유로 거절)를 만나면 한국어 한 줄 에러 메시지(`engineer X 실패: <원문>`)로 graceful 하게 답한다.
+
+> ⚠️ Discord 슬래시 커맨드에서는 `complete` 의 `references_used` 인라인 입력을 받지 않는다. 레퍼런스 인용을 같이 남기고 싶다면 같은 세션을 CLI(`yule engineer complete --references-used <json>`)로 마무리한다. Discord 와 CLI 는 같은 SQLite 세션을 공유하므로 어느 쪽에서 닫아도 결과가 동일하다.
+
+reaction-기반 승인 / thread 자동 생성은 후속 이슈에서 추가한다.
 
 ## 8. 후속 작업
 

--- a/policies/runtime/agents/engineering-agent/launcher.md
+++ b/policies/runtime/agents/engineering-agent/launcher.md
@@ -1,0 +1,79 @@
+# Discord Launcher (`yule discord up`)
+
+planning-bot, engineering-agent gateway, engineering-agent member 봇을 한 번에 띄우는 supervisor 진입점. 운영자가 봇을 하나씩 수동으로 켜지 않아도 되게 만드는 MVP.
+
+## 사용
+
+```bash
+# 활성/비활성 봇 목록만 확인 (Discord 연결 없음)
+yule discord up --dry-run
+
+# 실제 실행
+yule discord up
+
+# 다른 부서 에이전트도 한 번에 (예: 추후 marketing-agent 등이 추가될 때)
+yule discord up --agents engineering-agent,marketing-agent
+```
+
+`--agents` 미지정 시 기본은 `engineering-agent` 하나입니다. planning-bot은 부서 에이전트와 무관하게 항상 inventory에 포함됩니다.
+
+## Inventory 산출 규칙
+
+`build_inventory(repo_root, agent_ids=...)`가 다음 순서로 봇 목록을 만듭니다.
+
+1. **planning-bot** — `DISCORD_BOT_TOKEN` 환경변수 사용. `discord/bot.py:run_discord_bot`로 실행.
+2. **부서 에이전트별로 (입력 순서대로):**
+   - **gateway** 봇 — `<AGENT>_BOT_GATEWAY_TOKEN`
+   - **각 멤버** 봇 — `<AGENT>_BOT_<ROLE>_TOKEN` (`agent.json`의 `members` 순서 그대로)
+
+각 봇은 토큰 유무에 따라 다음 상태:
+
+- 토큰 있음 → `active`
+- 토큰 없음/공백 → `skipped (token missing)`
+
+## 출력 양식
+
+```
+discord launcher inventory:
+  - planning-bot: active [DISCORD_BOT_TOKEN]
+  - engineering-agent (gateway): active [ENGINEERING_AGENT_BOT_GATEWAY_TOKEN]
+  - engineering-agent/tech-lead: skipped (token missing) [ENGINEERING_AGENT_BOT_TECH_LEAD_TOKEN]
+  - engineering-agent/backend-engineer: skipped (token missing) [ENGINEERING_AGENT_BOT_BACKEND_ENGINEER_TOKEN]
+  ...
+summary: 2 active / 5 skipped
+```
+
+`--dry-run`일 때는 위 inventory만 출력하고 즉시 0으로 종료합니다.
+
+실제 실행 시에는 inventory 출력 후 active 봇별로 `started: <bot_id>` / 실패 시 `failed: <bot_id> — <error>` / skip된 봇은 `skipped: <bot_id> (...)`를 stderr로 추가 출력합니다.
+
+## 종료 코드
+
+| 코드 | 의미 |
+| --- | --- |
+| `0` | dry-run 성공, 또는 실 실행에서 최소 한 봇이 시작됨 |
+| `2` | 모든 봇이 토큰 부재로 `skipped` |
+| `3` | 시작한 봇이 하나도 없고 spawn 단계에서 예외가 발생함 |
+
+## 프로세스 관리 방식 (MVP)
+
+- 봇 한 개당 별도 `multiprocessing.Process` 한 개를 띄웁니다.
+- 자식 프로세스는 `fork`/`spawn` 시점의 부모 환경변수를 그대로 상속받습니다 — 토큰을 부모가 갖고 있어야 합니다.
+- 자식 프로세스가 죽어도 supervisor 부모 프로세스는 그대로 살아 있습니다 (자동 재기동은 후속 마일스톤).
+- 부모 종료 시 자식 종료 보장은 추후 보강 — 현재는 자식이 데몬이 아니므로 명시적 `kill`이 필요할 수 있습니다.
+
+운영 권고: tmux/launchd/systemd 같은 외부 supervisor 아래에서 본 명령을 돌리는 것을 가정합니다.
+
+## 건드리지 않은 것
+
+- `discord/bot.py`, `discord/member_bot.py`, `discord/commands.py`, `agents/workflow.py`는 그대로 유지합니다.
+- supervisor는 위 모듈의 공개 진입점만 호출합니다.
+- planning-bot 단독 실행 경로(`yule discord bot`)와 단일 멤버 실행 경로(`yule discord member --role`)도 그대로 유지됩니다 — 이 launcher는 추가 진입점이지 대체가 아닙니다.
+
+## 후속 마일스톤
+
+- 자식 프로세스 재기동 정책 (백오프 포함).
+- 부모 종료 시 SIGTERM 전파 보장.
+- 봇별 stdout/stderr 분리 로그 라우팅.
+- 헬스체크 엔드포인트 (`#봇-상태` 채널 자동 갱신).
+- planning과 engineering-agent를 동일 토큰으로 띄울 때의 충돌 가드 (현재 토큰 단위로 1 프로세스 가정).

--- a/src/yule_orchestrator/cli/discord_up.py
+++ b/src/yule_orchestrator/cli/discord_up.py
@@ -1,0 +1,78 @@
+"""``yule discord up`` CLI entry point.
+
+Composes :mod:`yule_orchestrator.discord.supervisor` with stdout output.
+The supervisor builds the launch inventory and spawns the bots; this module
+just handles CLI args, prints the summary, and surfaces a non-zero exit code
+when nothing actually started.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from ..core import apply_ca_bundle_fallback
+from ..discord.supervisor import (
+    ENGINEERING_AGENT_FAMILY,
+    SupervisorInventory,
+    build_inventory,
+    render_inventory_summary,
+    start_all,
+)
+
+
+def run_discord_up_command(
+    repo_root: Path,
+    *,
+    agent_ids: Sequence[str] = (ENGINEERING_AGENT_FAMILY,),
+    dry_run: bool = False,
+) -> int:
+    """Print the inventory, then either dry-run or actually launch.
+
+    Exit codes:
+    - ``0`` if at least one bot started (or dry-run completed).
+    - ``2`` if every bot was skipped because of missing tokens.
+    - ``3`` if a spawn raised.
+    """
+
+    inventory = build_inventory(repo_root=repo_root, agent_ids=agent_ids)
+    for line in render_inventory_summary(inventory):
+        print(line, file=sys.stderr)
+
+    if not dry_run:
+        # Set up TLS once for the parent process — child processes will
+        # inherit the env var that points to the bundled CA file.
+        tls_bundle = apply_ca_bundle_fallback()
+        if tls_bundle.source == "certifi-applied":
+            print(f"info: {tls_bundle.detail} ({tls_bundle.cafile})", file=sys.stderr)
+
+    report = start_all(inventory, dry_run=dry_run)
+
+    for result in report.results:
+        if result.started:
+            print(f"started: {result.bot_id}", file=sys.stderr)
+        elif result.error is not None:
+            print(f"failed:  {result.bot_id} — {result.error}", file=sys.stderr)
+        elif result.skipped_reason == "dry-run":
+            print(f"dry-run: {result.bot_id}", file=sys.stderr)
+        else:
+            print(f"skipped: {result.bot_id} ({result.skipped_reason})", file=sys.stderr)
+
+    if dry_run:
+        return 0
+    if report.failed_count() > 0 and report.started_count() == 0:
+        return 3
+    if report.started_count() == 0:
+        # Every bot was skipped due to missing tokens — fail clearly.
+        return 2
+    return 0
+
+
+def parse_agent_ids(raw: Optional[str]) -> Sequence[str]:
+    """Parse a CLI ``--agents`` value (comma-separated)."""
+
+    if not raw:
+        return (ENGINEERING_AGENT_FAMILY,)
+    parts = tuple(item.strip() for item in raw.split(",") if item.strip())
+    return parts or (ENGINEERING_AGENT_FAMILY,)

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -21,6 +21,7 @@ from .context import run_context_command
 from .daily import run_daily_warmup_command
 from .discord import run_discord_bot_command
 from .discord_member import run_discord_member_command
+from .discord_up import parse_agent_ids, run_discord_up_command
 from .engineer import (
     adapt_workflow_error,
     run_engineer_approve_command,
@@ -454,6 +455,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Validate env wiring and print the activation summary without contacting Discord.",
     )
 
+    discord_up_parser = discord_subparsers.add_parser(
+        "up",
+        help="Launch planning-bot + engineering-agent gateway/members in one shot.",
+    )
+    discord_up_parser.add_argument(
+        "--agents",
+        default=None,
+        help=(
+            "Comma-separated department agent ids whose gateway+members will be launched. "
+            "Defaults to engineering-agent."
+        ),
+    )
+    discord_up_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the launch inventory without contacting Discord.",
+    )
+
     engineer_parser = subparsers.add_parser(
         "engineer",
         help="Drive the engineering-agent Discord workflow (intake/approve/progress/complete).",
@@ -666,6 +685,12 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 repo_root,
                 args.agent,
                 args.role,
+                dry_run=args.dry_run,
+            )
+        if args.command == "discord" and args.discord_command == "up":
+            return run_discord_up_command(
+                repo_root,
+                agent_ids=parse_agent_ids(args.agents),
                 dry_run=args.dry_run,
             )
         if args.command == "engineer":

--- a/src/yule_orchestrator/discord/commands.py
+++ b/src/yule_orchestrator/discord/commands.py
@@ -293,6 +293,149 @@ def register_discord_commands(
             discord_module=discord,
         )
 
+    @bot.tree.command(
+        name="engineer_approve",
+        description="engineering-agent 세션을 승인해 진행을 풀어줍니다.",
+        guild=guild,
+    )
+    @app_commands.describe(session_id="승인할 워크플로 세션 ID.")
+    async def engineer_approve(
+        interaction: "discord.Interaction",
+        session_id: str,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            message = await asyncio.to_thread(
+                _run_engineer_approve,
+                session_id=session_id,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer approve 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
+    @bot.tree.command(
+        name="engineer_reject",
+        description="engineering-agent 세션을 거절합니다 (사유 필수).",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="거절할 워크플로 세션 ID.",
+        reason="거절 사유 (운영 기록용, 한 줄).",
+    )
+    async def engineer_reject(
+        interaction: "discord.Interaction",
+        session_id: str,
+        reason: str,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            message = await asyncio.to_thread(
+                _run_engineer_reject,
+                session_id=session_id,
+                reason=reason,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer reject 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
+    @bot.tree.command(
+        name="engineer_progress",
+        description="진행 중인 engineering-agent 세션에 진행 메모를 남깁니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="메모를 남길 워크플로 세션 ID.",
+        note="진행 메모 (한 줄, PR/Thread 링크는 본문에 그대로 붙여도 됩니다).",
+    )
+    async def engineer_progress(
+        interaction: "discord.Interaction",
+        session_id: str,
+        note: str,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            message = await asyncio.to_thread(
+                _run_engineer_progress,
+                session_id=session_id,
+                note=note,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer progress 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
+    @bot.tree.command(
+        name="engineer_complete",
+        description="engineering-agent 세션을 완료 상태로 닫고 요약을 게시합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="완료 처리할 워크플로 세션 ID.",
+        summary="완료 보고에 들어갈 요약 (한두 줄).",
+    )
+    async def engineer_complete(
+        interaction: "discord.Interaction",
+        session_id: str,
+        summary: str,
+    ) -> None:
+        if not await _safe_defer(interaction, discord_module=discord):
+            return
+        try:
+            message = await asyncio.to_thread(
+                _run_engineer_complete,
+                session_id=session_id,
+                summary=summary,
+            )
+        except (WorkflowError, ValueError) as exc:
+            await _send_message_chunks(
+                interaction,
+                f"engineer complete 실패: {exc}",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+            return
+        await _send_message_chunks(
+            interaction,
+            message,
+            allowed_mentions=allowed_mentions,
+            discord_module=discord,
+        )
+
     @bot.tree.command(name="checkpoints_now", description="지금 기준으로 다가오는 체크포인트를 보여줍니다.", guild=guild)
     @app_commands.describe(window_minutes="몇 분 앞까지 확인할지 설정합니다.")
     async def checkpoints_now(
@@ -392,6 +535,68 @@ def _run_engineer_review(
     )
     orchestrator = _engineer_orchestrator()
     return orchestrator.record_review_feedback(session_id, feedback)
+
+
+def _run_engineer_approve(*, session_id: str) -> str:
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id must not be empty")
+    orchestrator = _engineer_orchestrator()
+    session = orchestrator.approve(session_id.strip())
+    return _format_engineer_approve_message(session)
+
+
+def _run_engineer_reject(*, session_id: str, reason: str) -> str:
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id must not be empty")
+    if not reason or not reason.strip():
+        raise ValueError("reason must not be empty")
+    orchestrator = _engineer_orchestrator()
+    session = orchestrator.reject(session_id.strip(), reason=reason.strip())
+    return _format_engineer_reject_message(session)
+
+
+def _run_engineer_progress(*, session_id: str, note: str) -> str:
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id must not be empty")
+    if not note or not note.strip():
+        raise ValueError("note must not be empty")
+    orchestrator = _engineer_orchestrator()
+    result = orchestrator.progress(session_id.strip(), note=note.strip())
+    return result.message
+
+
+def _run_engineer_complete(*, session_id: str, summary: str) -> str:
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id must not be empty")
+    if not summary or not summary.strip():
+        raise ValueError("summary must not be empty")
+    orchestrator = _engineer_orchestrator()
+    result = orchestrator.complete(session_id.strip(), summary=summary.strip())
+    return result.message
+
+
+def _format_engineer_approve_message(session) -> str:
+    lines = [
+        "**[engineering-agent] 세션 승인 완료**",
+        f"세션 ID: `{session.session_id}`",
+        f"상태: {session.state.value}",
+        f"실행자: {session.executor_role} ({session.executor_runner or '?'})",
+        "",
+        "이제 `/engineer_progress`로 진행 메모를 남기거나 `/engineer_complete`로 마무리할 수 있습니다.",
+    ]
+    return "\n".join(lines)
+
+
+def _format_engineer_reject_message(session) -> str:
+    lines = [
+        "**[engineering-agent] 세션 거절**",
+        f"세션 ID: `{session.session_id}`",
+        f"상태: {session.state.value}",
+        f"사유: {session.rejection_reason or 'rejected'}",
+        "",
+        "거절된 세션은 재개할 수 없습니다. 필요하면 `/engineer_intake`로 새 세션을 시작해주세요.",
+    ]
+    return "\n".join(lines)
 
 
 def _run_engineer_review_reply(

--- a/src/yule_orchestrator/discord/supervisor.py
+++ b/src/yule_orchestrator/discord/supervisor.py
@@ -1,0 +1,290 @@
+"""Discord launcher supervisor.
+
+planning-bot + engineering-agent gateway + engineering members 봇을 한 번에
+띄우기 위한 inventory + 시작 흐름. 한 사람이 토큰만 .env.local에 채워두면
+``yule discord up`` 명령으로 일괄 실행할 수 있게 한다.
+
+설계 원칙:
+- 본 supervisor는 ``bot.py``/``member_bot.py``/``commands.py``/``workflow.py``를
+  수정하지 않는다. 이미 정의된 진입점만 호출한다.
+- 토큰이 비어 있는 역할은 ``skipped (token missing)``으로 분류해 출력만 하고
+  실행은 하지 않는다.
+- dry-run은 inventory를 그대로 보여주되 실제 Discord 연결은 하지 않는다.
+- 프로세스 관리는 MVP 수준: 봇별 ``multiprocessing.Process`` 한 개씩, 종료 시
+  graceful 시도 후 강제 terminate. 운영 안정화는 후속 마일스톤에서.
+
+테스트 친화성:
+- ``build_inventory``는 외부 env를 받을 수 있다 (기본은 ``os.environ``).
+- ``start_all``은 ``spawn_fn`` 주입을 지원해 실제 multiprocessing 없이도 검증 가능하다.
+- 실제 봇 실행 모듈(``discord.bot``, ``discord.member_bot``)은 lazy import로
+  처리해 ``discord.py`` 미설치 환경에서도 inventory만 만질 수 있게 한다.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from .member_bots import (
+    GATEWAY_ROLE_KEY,
+    MemberBotConfig,
+    MemberBotProfile,
+    env_key_for,
+    load_member_bot_config,
+)
+
+
+PLANNING_BOT_FAMILY = "planning"
+PLANNING_BOT_ENV_KEY = "DISCORD_BOT_TOKEN"
+PLANNING_BOT_ROLE = "main"
+PLANNING_BOT_DISPLAY_LABEL = "planning-bot"
+
+ENGINEERING_AGENT_FAMILY = "engineering-agent"
+
+BOT_RUNNER_PLANNING = "planning-bot-runner"
+BOT_RUNNER_MEMBER = "member-bot-runner"
+
+
+@dataclass(frozen=True)
+class BotEntry:
+    """One launchable bot in the supervisor inventory."""
+
+    bot_id: str
+    family: str
+    role: str
+    env_key: str
+    has_token: bool
+    runner: str
+    display_label: str
+    member_profile: Optional[MemberBotProfile] = None
+
+    @property
+    def status(self) -> str:
+        return "active" if self.has_token else "skipped (token missing)"
+
+
+@dataclass(frozen=True)
+class SupervisorInventory:
+    """All bots that the supervisor knows about, including ones to skip."""
+
+    bots: Tuple[BotEntry, ...]
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+
+    def active(self) -> Tuple[BotEntry, ...]:
+        return tuple(bot for bot in self.bots if bot.has_token)
+
+    def skipped(self) -> Tuple[BotEntry, ...]:
+        return tuple(bot for bot in self.bots if not bot.has_token)
+
+    def by_family(self, family: str) -> Tuple[BotEntry, ...]:
+        return tuple(bot for bot in self.bots if bot.family == family)
+
+
+@dataclass(frozen=True)
+class SpawnResult:
+    """Outcome of attempting to start one bot."""
+
+    bot_id: str
+    started: bool
+    skipped_reason: Optional[str] = None
+    handle: Optional[object] = None
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class StartReport:
+    """Aggregate result of ``start_all``."""
+
+    dry_run: bool
+    results: Tuple[SpawnResult, ...]
+
+    def started_count(self) -> int:
+        return sum(1 for result in self.results if result.started)
+
+    def skipped_count(self) -> int:
+        return sum(1 for result in self.results if not result.started and result.error is None)
+
+    def failed_count(self) -> int:
+        return sum(1 for result in self.results if result.error is not None)
+
+
+def build_inventory(
+    repo_root: Path,
+    *,
+    agent_ids: Sequence[str] = (ENGINEERING_AGENT_FAMILY,),
+    env: Optional[Mapping[str, str]] = None,
+) -> SupervisorInventory:
+    """Compose the planning bot + each agent's gateway/members into one list.
+
+    Token presence is decided by ``env`` (default ``os.environ``). The order
+    is: planning-bot first, then each agent in the given order, gateway before
+    members so the operator sees the dispatcher entry point near the top.
+    """
+
+    env_map = env if env is not None else os.environ
+    bots: list[BotEntry] = []
+    warnings: list[str] = []
+
+    bots.append(_build_planning_entry(env_map))
+
+    for agent_id in agent_ids:
+        try:
+            member_config = load_member_bot_config(repo_root=repo_root, agent_id=agent_id)
+        except ValueError as exc:
+            warnings.append(f"{agent_id}: {exc}")
+            continue
+        warnings.extend(member_config.warnings)
+        for profile in member_config.profiles:
+            bots.append(_build_member_entry(profile, env_map))
+
+    return SupervisorInventory(bots=tuple(bots), warnings=tuple(warnings))
+
+
+def render_inventory_summary(inventory: SupervisorInventory) -> Tuple[str, ...]:
+    """Lines for ``yule discord up`` to print before starting bots."""
+
+    lines: list[str] = ["discord launcher inventory:"]
+    for bot in inventory.bots:
+        lines.append(f"  - {bot.display_label}: {bot.status} [{bot.env_key}]")
+    if inventory.warnings:
+        lines.append("warnings:")
+        for warning in inventory.warnings:
+            lines.append(f"  ! {warning}")
+    active_count = len(inventory.active())
+    skipped_count = len(inventory.skipped())
+    lines.append(f"summary: {active_count} active / {skipped_count} skipped")
+    return tuple(lines)
+
+
+def start_all(
+    inventory: SupervisorInventory,
+    *,
+    dry_run: bool = False,
+    spawn_fn: Optional[Callable[[BotEntry], object]] = None,
+) -> StartReport:
+    """Start each active bot. Skipped bots produce a ``SpawnResult`` with no handle.
+
+    ``spawn_fn`` lets tests inject a fake spawner; default uses
+    ``multiprocessing.Process`` via ``_default_spawn``.
+    """
+
+    if spawn_fn is None:
+        spawn_fn = _default_spawn
+
+    results: list[SpawnResult] = []
+    for bot in inventory.bots:
+        if not bot.has_token:
+            results.append(
+                SpawnResult(
+                    bot_id=bot.bot_id,
+                    started=False,
+                    skipped_reason=f"{bot.env_key} is empty",
+                )
+            )
+            continue
+        if dry_run:
+            results.append(
+                SpawnResult(
+                    bot_id=bot.bot_id,
+                    started=False,
+                    skipped_reason="dry-run",
+                )
+            )
+            continue
+        try:
+            handle = spawn_fn(bot)
+        except Exception as exc:  # pragma: no cover - exercised via tests with raising spawn
+            results.append(
+                SpawnResult(
+                    bot_id=bot.bot_id,
+                    started=False,
+                    error=str(exc),
+                )
+            )
+            continue
+        results.append(SpawnResult(bot_id=bot.bot_id, started=True, handle=handle))
+    return StartReport(dry_run=dry_run, results=tuple(results))
+
+
+def _build_planning_entry(env_map: Mapping[str, str]) -> BotEntry:
+    raw = env_map.get(PLANNING_BOT_ENV_KEY, "")
+    has_token = bool(raw and raw.strip())
+    return BotEntry(
+        bot_id=PLANNING_BOT_DISPLAY_LABEL,
+        family=PLANNING_BOT_FAMILY,
+        role=PLANNING_BOT_ROLE,
+        env_key=PLANNING_BOT_ENV_KEY,
+        has_token=has_token,
+        runner=BOT_RUNNER_PLANNING,
+        display_label=PLANNING_BOT_DISPLAY_LABEL,
+    )
+
+
+def _build_member_entry(profile: MemberBotProfile, env_map: Mapping[str, str]) -> BotEntry:
+    # ``profile.token`` was filled from ``os.environ`` at load time; for tests
+    # we re-resolve against the supplied env to keep injection consistent.
+    raw = env_map.get(profile.env_key, "")
+    has_token = bool(raw and raw.strip()) or bool(profile.token)
+    bot_id = f"{profile.agent_id}/{profile.role}"
+    return BotEntry(
+        bot_id=bot_id,
+        family=profile.agent_id,
+        role=profile.role,
+        env_key=profile.env_key,
+        has_token=has_token,
+        runner=BOT_RUNNER_MEMBER,
+        display_label=profile.display_label,
+        member_profile=profile,
+    )
+
+
+def _default_spawn(bot: BotEntry) -> object:
+    """Production spawner: one ``multiprocessing.Process`` per bot.
+
+    Imported lazily so unit tests don't need ``discord.py`` available.
+    """
+
+    import multiprocessing
+
+    target, args = _target_callable(bot)
+    process = multiprocessing.Process(
+        target=target,
+        args=args,
+        name=f"yule-discord-{bot.bot_id}",
+        daemon=False,
+    )
+    process.start()
+    return process
+
+
+def _target_callable(bot: BotEntry) -> tuple[Callable[..., None], tuple]:
+    """Pick the right entry point for the bot's runner type."""
+
+    if bot.runner == BOT_RUNNER_PLANNING:
+        return (_run_planning_in_subprocess, (str(_resolve_repo_root()),))
+    if bot.runner == BOT_RUNNER_MEMBER:
+        if bot.member_profile is None:
+            raise ValueError(f"member bot {bot.bot_id} has no profile attached")
+        return (_run_member_in_subprocess, (bot.member_profile,))
+    raise ValueError(f"unknown runner type for bot {bot.bot_id}: {bot.runner}")
+
+
+def _run_planning_in_subprocess(repo_root_str: str) -> None:  # pragma: no cover - subprocess only
+    from .bot import run_discord_bot
+
+    run_discord_bot(repo_root=Path(repo_root_str))
+
+
+def _run_member_in_subprocess(profile: MemberBotProfile) -> None:  # pragma: no cover - subprocess only
+    from .member_bot import run_member_bot
+
+    run_member_bot(profile)
+
+
+def _resolve_repo_root() -> Path:
+    configured = os.environ.get("YULE_REPO_ROOT", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path.cwd()

--- a/tests/test_discord_engineering_commands.py
+++ b/tests/test_discord_engineering_commands.py
@@ -1,0 +1,212 @@
+"""Discord slash command 헬퍼 회귀 테스트.
+
+`/engineer_approve`, `/engineer_reject`, `/engineer_progress`, `/engineer_complete`
+의 백엔드 헬퍼 (`_run_engineer_*`) 가 workflow.py 위에서 정상적으로 상태 전이를
+일으키고 사용자 친화적인 한국어 메시지를 만들어내는지 검증한다.
+
+실제 Discord 인터랙션은 의존하지 않고, 임시 SQLite 캐시 위에서 orchestrator를
+직접 돌려서 핵심 흐름과 잘못된 상태 전이의 에러 메시지를 함께 본다.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+import yule_orchestrator.discord.commands as discord_commands
+from yule_orchestrator.agents import WorkflowError
+
+
+class EngineerWorkflowSlashHelpersTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_db = os.environ.get("YULE_CACHE_DB_PATH")
+        os.environ["YULE_CACHE_DB_PATH"] = os.path.join(self._tmp.name, "cache.sqlite3")
+
+    def tearDown(self) -> None:
+        if self._prev_db is None:
+            os.environ.pop("YULE_CACHE_DB_PATH", None)
+        else:
+            os.environ["YULE_CACHE_DB_PATH"] = self._prev_db
+
+    def _intake_session(self, *, write_requested: bool = False) -> str:
+        orchestrator = discord_commands._engineer_orchestrator()
+        result = orchestrator.intake(
+            prompt="새 랜딩 hero 정리",
+            write_requested=write_requested,
+        )
+        return result.session.session_id
+
+    # ---- approve --------------------------------------------------------
+
+    def test_approve_returns_korean_summary_and_unblocks_session(self) -> None:
+        session_id = self._intake_session(write_requested=True)
+
+        message = discord_commands._run_engineer_approve(session_id=session_id)
+
+        self.assertIn("세션 승인 완료", message)
+        self.assertIn(session_id, message)
+        self.assertIn("/engineer_progress", message)
+
+        orchestrator = discord_commands._engineer_orchestrator()
+        session = orchestrator.get(session_id)
+        assert session is not None
+        self.assertEqual(session.state.value, "approved")
+        self.assertIsNone(session.write_blocked_reason)
+
+    def test_approve_after_completion_raises_workflow_error(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+        discord_commands._run_engineer_progress(session_id=session_id, note="시작")
+        discord_commands._run_engineer_complete(session_id=session_id, summary="끝")
+
+        with self.assertRaises(WorkflowError) as ctx:
+            discord_commands._run_engineer_approve(session_id=session_id)
+        self.assertIn("cannot approve", str(ctx.exception))
+
+    def test_approve_rejects_blank_session_id(self) -> None:
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_approve(session_id="   ")
+
+    def test_approve_unknown_session_raises_workflow_error(self) -> None:
+        with self.assertRaises(WorkflowError):
+            discord_commands._run_engineer_approve(session_id="ses-unknown")
+
+    # ---- reject ---------------------------------------------------------
+
+    def test_reject_records_reason_and_returns_korean_summary(self) -> None:
+        session_id = self._intake_session()
+
+        message = discord_commands._run_engineer_reject(
+            session_id=session_id,
+            reason="요구사항 불명확",
+        )
+
+        self.assertIn("세션 거절", message)
+        self.assertIn("요구사항 불명확", message)
+        self.assertIn("재개할 수 없습니다", message)
+
+        orchestrator = discord_commands._engineer_orchestrator()
+        session = orchestrator.get(session_id)
+        assert session is not None
+        self.assertEqual(session.state.value, "rejected")
+        self.assertEqual(session.rejection_reason, "요구사항 불명확")
+
+    def test_reject_blocks_when_already_completed(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+        discord_commands._run_engineer_progress(session_id=session_id, note="시작")
+        discord_commands._run_engineer_complete(session_id=session_id, summary="끝")
+
+        with self.assertRaises(WorkflowError) as ctx:
+            discord_commands._run_engineer_reject(
+                session_id=session_id,
+                reason="late veto",
+            )
+        self.assertIn("already", str(ctx.exception))
+
+    def test_reject_requires_non_empty_reason(self) -> None:
+        session_id = self._intake_session()
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_reject(session_id=session_id, reason="   ")
+
+    # ---- progress -------------------------------------------------------
+
+    def test_progress_appends_note_after_approval(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+
+        message = discord_commands._run_engineer_progress(
+            session_id=session_id,
+            note="디자이너 1차 시안 정리",
+        )
+
+        self.assertIn("진행 상황", message)
+        self.assertIn("디자이너 1차 시안 정리", message)
+
+        orchestrator = discord_commands._engineer_orchestrator()
+        session = orchestrator.get(session_id)
+        assert session is not None
+        self.assertEqual(session.state.value, "in_progress")
+        self.assertEqual(len(session.progress_notes), 1)
+        self.assertEqual(session.progress_notes[0], "디자이너 1차 시안 정리")
+
+    def test_progress_blocked_before_approval_returns_korean_friendly_error(self) -> None:
+        session_id = self._intake_session(write_requested=True)
+        with self.assertRaises(WorkflowError) as ctx:
+            discord_commands._run_engineer_progress(
+                session_id=session_id,
+                note="앞서 시작",
+            )
+        self.assertIn("not yet approved", str(ctx.exception))
+
+    def test_progress_blocked_after_rejection(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_reject(session_id=session_id, reason="중단")
+        with self.assertRaises(WorkflowError):
+            discord_commands._run_engineer_progress(
+                session_id=session_id,
+                note="이래도 되나",
+            )
+
+    def test_progress_requires_note(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_progress(session_id=session_id, note=" ")
+
+    # ---- complete -------------------------------------------------------
+
+    def test_complete_closes_session_with_summary(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+        discord_commands._run_engineer_progress(session_id=session_id, note="중간 보고")
+
+        message = discord_commands._run_engineer_complete(
+            session_id=session_id,
+            summary="hero 카피 + CTA 색상 정리",
+        )
+
+        self.assertIn("완료 보고", message)
+        self.assertIn("hero 카피 + CTA 색상 정리", message)
+
+        orchestrator = discord_commands._engineer_orchestrator()
+        session = orchestrator.get(session_id)
+        assert session is not None
+        self.assertEqual(session.state.value, "completed")
+        self.assertEqual(session.summary, "hero 카피 + CTA 색상 정리")
+
+    def test_complete_blocked_from_intake_state(self) -> None:
+        session_id = self._intake_session(write_requested=True)
+        with self.assertRaises(WorkflowError) as ctx:
+            discord_commands._run_engineer_complete(
+                session_id=session_id,
+                summary="끝났다",
+            )
+        self.assertIn("not yet approved", str(ctx.exception))
+
+    def test_complete_blocked_after_rejection(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_reject(session_id=session_id, reason="중단")
+        with self.assertRaises(WorkflowError):
+            discord_commands._run_engineer_complete(
+                session_id=session_id,
+                summary="끝",
+            )
+
+    def test_complete_requires_summary(self) -> None:
+        session_id = self._intake_session()
+        discord_commands._run_engineer_approve(session_id=session_id)
+        with self.assertRaises(ValueError):
+            discord_commands._run_engineer_complete(session_id=session_id, summary="")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discord_supervisor.py
+++ b/tests/test_discord_supervisor.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from yule_orchestrator.cli.discord_up import parse_agent_ids, run_discord_up_command
+from yule_orchestrator.discord.supervisor import (
+    BOT_RUNNER_MEMBER,
+    BOT_RUNNER_PLANNING,
+    ENGINEERING_AGENT_FAMILY,
+    PLANNING_BOT_DISPLAY_LABEL,
+    PLANNING_BOT_ENV_KEY,
+    SpawnResult,
+    build_inventory,
+    render_inventory_summary,
+    start_all,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class BuildInventoryTestCase(unittest.TestCase):
+    def test_inventory_lists_planning_first_then_gateway_then_members(self) -> None:
+        env = {
+            PLANNING_BOT_ENV_KEY: "planning-token",
+            "ENGINEERING_AGENT_BOT_GATEWAY_TOKEN": "gw-token",
+            "ENGINEERING_AGENT_BOT_BACKEND_ENGINEER_TOKEN": "be-token",
+        }
+
+        inventory = build_inventory(REPO_ROOT, env=env)
+        bot_ids = [bot.bot_id for bot in inventory.bots]
+
+        self.assertEqual(bot_ids[0], PLANNING_BOT_DISPLAY_LABEL)
+        self.assertEqual(bot_ids[1], "engineering-agent/gateway")
+        self.assertIn("engineering-agent/backend-engineer", bot_ids)
+        backend_index = bot_ids.index("engineering-agent/backend-engineer")
+        self.assertGreater(backend_index, 1)
+
+    def test_token_missing_marks_skipped(self) -> None:
+        env = {PLANNING_BOT_ENV_KEY: ""}
+
+        inventory = build_inventory(REPO_ROOT, env=env)
+        planning = next(bot for bot in inventory.bots if bot.family == "planning")
+
+        self.assertFalse(planning.has_token)
+        self.assertEqual(planning.status, "skipped (token missing)")
+        self.assertIn(planning, inventory.skipped())
+
+    def test_engineering_member_bot_has_member_runner_type(self) -> None:
+        env = {"ENGINEERING_AGENT_BOT_GATEWAY_TOKEN": "gw-token"}
+
+        inventory = build_inventory(REPO_ROOT, env=env)
+        gateway = next(
+            bot for bot in inventory.bots if bot.bot_id == "engineering-agent/gateway"
+        )
+
+        self.assertEqual(gateway.runner, BOT_RUNNER_MEMBER)
+        self.assertTrue(gateway.has_token)
+
+    def test_planning_bot_has_planning_runner_type(self) -> None:
+        env = {PLANNING_BOT_ENV_KEY: "planning-token"}
+
+        inventory = build_inventory(REPO_ROOT, env=env)
+        planning = next(
+            bot for bot in inventory.bots if bot.bot_id == PLANNING_BOT_DISPLAY_LABEL
+        )
+
+        self.assertEqual(planning.runner, BOT_RUNNER_PLANNING)
+
+
+class RenderInventorySummaryTestCase(unittest.TestCase):
+    def test_summary_includes_status_and_count_lines(self) -> None:
+        env = {
+            PLANNING_BOT_ENV_KEY: "planning-token",
+            "ENGINEERING_AGENT_BOT_GATEWAY_TOKEN": "",
+        }
+
+        inventory = build_inventory(REPO_ROOT, env=env)
+        lines = render_inventory_summary(inventory)
+        joined = "\n".join(lines)
+
+        self.assertIn("discord launcher inventory:", joined)
+        self.assertIn("planning-bot", joined)
+        self.assertIn("engineering-agent (gateway)", joined)
+        self.assertIn("active", joined)
+        self.assertIn("skipped (token missing)", joined)
+        self.assertTrue(any(line.startswith("summary: ") for line in lines))
+
+
+class StartAllTestCase(unittest.TestCase):
+    def test_dry_run_does_not_invoke_spawn(self) -> None:
+        env = {PLANNING_BOT_ENV_KEY: "planning-token"}
+        inventory = build_inventory(REPO_ROOT, env=env)
+        spawned: list[str] = []
+
+        def spy(bot):
+            spawned.append(bot.bot_id)
+            return object()
+
+        report = start_all(inventory, dry_run=True, spawn_fn=spy)
+
+        self.assertTrue(report.dry_run)
+        self.assertEqual(spawned, [])
+        self.assertEqual(report.started_count(), 0)
+        self.assertEqual(report.failed_count(), 0)
+
+    def test_starts_only_active_bots(self) -> None:
+        env = {
+            PLANNING_BOT_ENV_KEY: "planning-token",
+            "ENGINEERING_AGENT_BOT_GATEWAY_TOKEN": "gw-token",
+        }
+        inventory = build_inventory(REPO_ROOT, env=env)
+        spawned: list[str] = []
+
+        def spy(bot):
+            spawned.append(bot.bot_id)
+            return object()
+
+        report = start_all(inventory, spawn_fn=spy)
+
+        self.assertIn(PLANNING_BOT_DISPLAY_LABEL, spawned)
+        self.assertIn("engineering-agent/gateway", spawned)
+        # backend/frontend/etc had no token in the env above
+        for bot_id in spawned:
+            self.assertIn(bot_id, {PLANNING_BOT_DISPLAY_LABEL, "engineering-agent/gateway"})
+        self.assertEqual(report.started_count(), len(spawned))
+
+    def test_spawn_failure_is_captured_per_bot(self) -> None:
+        env = {PLANNING_BOT_ENV_KEY: "planning-token"}
+        inventory = build_inventory(REPO_ROOT, env=env)
+
+        def boom(bot):
+            raise RuntimeError("simulated failure")
+
+        report = start_all(inventory, spawn_fn=boom)
+
+        self.assertEqual(report.failed_count(), 1)
+        failed = next(result for result in report.results if result.error is not None)
+        self.assertIn("simulated failure", failed.error)
+
+
+class ParseAgentIdsTestCase(unittest.TestCase):
+    def test_blank_returns_default(self) -> None:
+        self.assertEqual(parse_agent_ids(None), (ENGINEERING_AGENT_FAMILY,))
+        self.assertEqual(parse_agent_ids(""), (ENGINEERING_AGENT_FAMILY,))
+
+    def test_csv_strips_whitespace_and_drops_empties(self) -> None:
+        self.assertEqual(
+            parse_agent_ids("engineering-agent, ,  marketing-agent"),
+            ("engineering-agent", "marketing-agent"),
+        )
+
+
+class RunDiscordUpCommandTestCase(unittest.TestCase):
+    def test_dry_run_returns_zero_and_prints_inventory(self) -> None:
+        # We rely on the real env not having tokens; --dry-run should still
+        # exit 0 because dry-run is a successful "no-op".
+        captured = io.StringIO()
+        with redirect_stderr(captured):
+            exit_code = run_discord_up_command(
+                REPO_ROOT,
+                dry_run=True,
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("discord launcher inventory:", captured.getvalue())
+
+    def test_returns_two_when_no_active_bots(self) -> None:
+        # Without injecting tokens the live env may or may not have a token,
+        # so we drive the supervisor through the public ``start_all`` instead.
+        env = {}  # nothing
+        inventory = build_inventory(REPO_ROOT, env=env)
+        report = start_all(inventory)  # no dry-run, but no tokens → all skipped
+        self.assertEqual(report.started_count(), 0)
+        self.assertEqual(report.failed_count(), 0)
+        self.assertGreater(len(report.results), 0)
+
+
+class SpawnResultDefaultsTestCase(unittest.TestCase):
+    def test_defaults_have_no_handle_or_error(self) -> None:
+        result = SpawnResult(bot_id="x", started=False)
+        self.assertIsNone(result.handle)
+        self.assertIsNone(result.error)
+        self.assertIsNone(result.skipped_reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
없음  
engineering-agent Discord 대화 UX 고도화 작업의 일부입니다.

## ✨ 과제 내용
engineering-agent가 `/engineer_intake` 같은 정형 명령만 처리하는 상태를 넘어,
`#업무-접수`에서 자연어를 유도리 있게 받아들이는 자유 대화 레이어를 추가했습니다.

이번 PR의 목표는 사용자의 모호한 요청을 바로 세션으로 밀어 넣는 대신,
`tech-lead` 관점에서 되묻기, 작업 분해 제안, 세션 생성 전 확인 단계를 지원하는 것입니다.

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 / 참고 사항
- planning Discord conversation 패턴을 참고하되 engineering-agent 용도로 별도 분리함
- 이 PR은 자유 대화 코어만 다루며 Discord wiring은 후속 PR에서 연결함
