### PR TITLE
[Feature] Discord 봇 일괄 실행 launcher 추가

### DIFF
--- a/policies/runtime/agents/engineering-agent/discord-conversation.md
+++ b/policies/runtime/agents/engineering-agent/discord-conversation.md
@@ -1,0 +1,117 @@
+# Engineering Agent Discord Conversation Layer (v0)
+
+이 문서는 engineering-agent가 Discord `#업무-접수` 채널에서 자연어를 **유도리 있게 받아들이는** 대화 레이어의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/discord/engineering_conversation.py`. 본 단계는 순수 함수와 응답 envelope만 정의하며 bot.py 배선은 후속 마일스톤에서 진행한다.
+
+## 1. planning conversation과의 차이
+
+| 항목 | planning conversation | engineering conversation |
+|---|---|---|
+| 코드 위치 | `discord/conversation.py` | `discord/engineering_conversation.py` |
+| 목적 | snapshot 기반의 결정적 답변 (브리핑/우선순위/체크포인트) | 자유 발화로 들어온 작업을 **정리·확정**해 다음 단계 (workflow.intake)로 잇기 |
+| 데이터 의존 | `DailyPlanSnapshot` 필수 | 없음 — prompt 텍스트만 입력 |
+| LLM 호출 | Ollama로 자연어 답변 보강 | 없음 (분류·되묻기·제안만) |
+| 부수효과 | SQLite cache (pending confirmation), 체크포인트 응답 기록 | 없음 (read-only) |
+| 응답 시점 | 한 번 답하고 종결 | "이대로 진행" 같은 follow-up까지 따라가는 다단계 |
+| 외부 의존 | snapshot loader, ollama client | `dispatcher.TaskType` enum만 |
+
+두 모듈은 **서로 호출하지 않는다.** 같은 채널(`#업무-접수`)에서 충돌하지 않도록 bot 라우팅이 채널·스코프 기준으로 둘을 분리한다 (이번 마일스톤에서는 라우팅 코드 변경 없음).
+
+## 2. 의도 분류 (5종)
+
+탐지 우선순위 — 위에서부터 검사해 첫 매치를 채택한다.
+
+| 의도 ID | 트리거 (우선) | 대응 |
+|---|---|---|
+| `confirm_intake` | "이대로 진행", "그럼 이걸로", "확정", "ok"/"오케이" 등 | `ready_to_intake=True` 반환. 이전 turn의 prompt를 `intake_prompt`로 보존. |
+| `general_engineering_help` | "engineering-agent", "도움말", "어떻게 써" 등 | 자기소개 + 사용 가이드. |
+| `needs_clarification` | 매우 짧음(≤3자), 단어 1개, 또는 "도와줘" 류 모호 표현 | 어느 화면/API/흐름인지 되묻는다. `needs_clarification=True`. |
+| `split_task_proposal` | "그리고/또/and"로 연결된 2개 이상의 substantial(≥2 words) 갈래 | 갈래를 1, 2, ... 로 나눠 제안. `proposed_splits` 채워 반환. |
+| `task_intake_candidate` (default) | 위 어디에도 안 잡히는 일반 요청 | "이대로 진행해도 될까요?" 형태로 정리해 묻는다. |
+
+분류는 키워드 기반으로 시작하며, 후속 마일스톤에서 LLM 분류기로 **점진적으로 대체**할 수 있도록 모든 진입점은 `EngineeringConversationResponse` envelope만 반환한다.
+
+## 3. 응답 envelope
+
+```python
+@dataclass(frozen=True)
+class EngineeringConversationResponse:
+    content: str                          # Discord에 그대로 보낼 텍스트
+    intent_id: str                        # 위 5종 중 하나
+    ready_to_intake: bool = False         # bot.py가 workflow.intake 호출해야 하는지
+    needs_clarification: bool = False     # 사용자에게 되묻는 중인지
+    proposed_splits: tuple[str, ...] = () # 갈래 제안 시 채워짐
+    suggested_task_type: Optional[str]    # dispatcher TaskType.value 힌트
+    write_likely: bool = False            # 추후 intake에서 write_requested로 전달할지 힌트
+    intake_prompt: Optional[str]          # confirm 시 직전 turn의 prompt
+    mention_user_id: Optional[int]
+```
+
+규약
+- 모든 값은 **한 turn**의 결과만 담는다. 이전 turn은 호출자(bot.py)가 채널 단위 상태로 저장해 다음 호출 때 `last_proposed_prompt`로 넘긴다.
+- `confirm_intake` 응답을 받은 호출자는 envelope의 `intake_prompt` + `suggested_task_type` + `write_likely`를 그대로 `workflow.intake`에 전달한다.
+- `proposed_splits`가 있으면 호출자는 사용자에게 선택을 받거나 `이대로 진행`을 기다린 뒤 한 세션으로 묶을 수 있다.
+
+## 4. 확정 표현 화이트리스트
+
+### 4.1 standalone 토큰 (전체 메시지가 이 토큰만)
+`ok`, `okay`, `오케이`, `오케`, `오키`, `yes`, `yep`, `go`, `고`, `ㄱㄱ`, `확정`, `진행`, `등록`
+
+### 4.2 포함 표현
+`이대로 진행`, `이대로 등록`, `이걸로 등록`, `이걸로 진행`, `그럼 이걸로`, `그럼 등록`, `그럼 진행`, `좋아 진행`, `좋습니다 진행`, `오케이 진행`, `ok 진행`, `그렇게 등록`, `그렇게 진행`, `진행해줘`, `진행해 주세요`, `등록해줘`, `등록해 주세요`, `yes 등록`, `yes 진행`, `go 진행`, `확정`, `확정해`
+
+확정 표현은 항상 **다른 의도보다 먼저** 검사한다. 그렇지 않으면 사용자가 follow-up으로 보낸 짧은 확정이 새 intake로 오인될 수 있다.
+
+## 5. 갈래 분할 규칙
+
+`split_task_branches`는 다음 패턴을 분리자로 사용한다.
+- `그리고` / `, 그리고`
+- `또`
+- ` and ` (영문, 양옆 공백 필수)
+
+분리 후 각 fragment가 **2 words 이상**일 때만 분할로 인정한다. "음 그리고 좋아" 같은 잡담은 분리되지 않는다. 한 갈래만 남으면 빈 튜플을 반환해 호출자가 원래 메시지로 fall back한다.
+
+## 6. write_likely 휴리스틱
+
+원칙: 검토/분석 신호가 있으면 `False`(검토 신호가 우선), 없고 명시 쓰기 신호가 있으면 `True`.
+
+쓰기 신호: `구현`, `만들`, `추가`, `수정`, `고쳐`/`고치`, `리팩`/`refactor`, `implement`, `build`, `create`, `fix`, `패치`/`patch`, `PR`, `pull request`, `draft`, `짜야`, `짜줘`, `짜자`, `작성`, `쓸게`, `써줘`.
+
+검토 신호 (write_likely 차단): `어떻게 생각`, `분석`, `리뷰`/`review`, `검토`, `조사`.
+
+`write_likely`는 어디까지나 **첫 인상 힌트**다. 실제 write 게이트는 dispatcher와 workflow가 user_approved 플래그로 강제하므로, 이 휴리스틱이 어긋나도 안전 사고로 이어지지 않는다.
+
+## 7. task_type 힌트 매핑
+
+`_TASK_TYPE_KEYWORDS`는 dispatcher의 분류 우선순위와 동일한 순서를 따른다 (구체 → 일반):
+
+`visual-polish` → `onboarding-flow` → `email-campaign` → `landing-page` → `qa-test` → `platform-infra` → `frontend-feature` → `backend-feature`
+
+매치 없으면 `None`. 호출자는 `None`일 때 dispatcher의 자체 분류기에 prompt를 그대로 넘긴다.
+
+## 8. bot.py 배선 가이드 (후속 마일스톤)
+
+이 모듈을 실제 채널에 붙일 때 호출자가 지켜야 할 흐름:
+
+1. `#업무-접수` 메시지를 받으면 `build_engineering_conversation_response(text, last_proposed_prompt=stash_get(channel))`을 호출.
+2. envelope.content를 채널에 그대로 게시.
+3. envelope의 신호를 다음과 같이 처리:
+   - `ready_to_intake=True` → `WorkflowOrchestrator.intake(prompt=envelope.intake_prompt, task_type=envelope.suggested_task_type, write_requested=envelope.write_likely, channel_id=..., user_id=...)` 호출.
+   - `needs_clarification=True` → 다음 turn까지 대기. stash 갱신 안 함.
+   - `proposed_splits` non-empty → 사용자가 선택할 때까지 대기. stash에 prompt 보관.
+   - `task_intake_candidate` 기본 → stash에 prompt 보관 후 다음 turn에서 confirm 받기.
+4. stash는 채널·사용자 단위로 30분 TTL이 적당. SQLite cache `engineering-conversation-stash` namespace 추천 (다른 Claude 작업 영역).
+
+이 모듈 자체는 stash를 관리하지 않는다 — pure function 원칙 유지.
+
+## 9. 변경 절차
+
+- 의도 5종을 늘리거나 줄이려면 **본 문서**를 먼저 갱신하고 코드 enum/상수와 정합 테스트(`tests/test_engineering_conversation.py`)도 함께 손본다.
+- 확정 표현 화이트리스트 추가는 보수적으로. 일반 동사("좋다", "응", "어")는 제외한다 — 단독으로 쓰이면 의도 모호하므로 needs_clarification 쪽이 더 안전하다.
+- task_type 힌트 매핑은 dispatcher의 `_KEYWORD_RULES`와 어긋나면 안 된다. dispatcher.md §2의 우선순위와 동일하게 유지한다.
+
+## 10. 후속 작업
+
+- bot.py에서 채널/스코프 라우팅으로 planning conversation과 분리.
+- stash 저장 (SQLite cache namespace).
+- LLM 보강 분류기 (Ollama)로 키워드 fallback 보강.
+- 멤버 봇 자유 대화 — 멤버별 페르소나(예: backend-engineer 톤)는 별도 모듈에서.

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -1,0 +1,502 @@
+"""Engineering-agent free-form conversation layer.
+
+This module is the **conversational front door** for the engineering-agent
+gateway in the ``#업무-접수`` channel. It receives a user's natural-language
+message and returns a structured :class:`EngineeringConversationResponse`
+that downstream code (bot.py, commands.py, future dispatcher) consumes to
+decide whether to:
+
+- reply only (general help / clarification questions),
+- propose a task split before intake,
+- or actually call ``workflow.intake`` because the user confirmed.
+
+It deliberately does **not** import :mod:`workflow` or the dispatcher so it
+can be exercised in unit tests without DB/Discord dependencies. The bot
+layer is responsible for translating ``ready_to_intake`` into the actual
+``workflow.intake`` call.
+
+How this differs from ``discord/conversation.py`` (planning-agent):
+
+- planning conversation is *snapshot-bound* — it leans on
+  ``DailyPlanSnapshot`` and answers deterministic queries about the day.
+- engineering conversation is *task-shaping* — it interprets a free-form
+  request, asks for missing context, suggests breaking down multi-prong
+  asks, and only commits to a session once the user explicitly says so.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+from ..agents.dispatcher import TaskType
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+GENERAL_ENGINEERING_HELP = "general_engineering_help"
+TASK_INTAKE_CANDIDATE = "task_intake_candidate"
+NEEDS_CLARIFICATION = "needs_clarification"
+CONFIRM_INTAKE = "confirm_intake"
+SPLIT_TASK_PROPOSAL = "split_task_proposal"
+
+
+@dataclass(frozen=True)
+class EngineeringIntentMatch:
+    """What the user seems to want from engineering-agent right now."""
+
+    intent_id: str
+    label: str
+    confidence: str = "medium"  # "high" / "medium" / "low"
+
+
+@dataclass(frozen=True)
+class EngineeringConversationResponse:
+    """Envelope returned by :func:`build_engineering_conversation_response`.
+
+    Downstream Discord layer reads:
+
+    - ``ready_to_intake=True`` → call ``workflow.intake`` with the
+      preserved ``intake_prompt``.
+    - ``needs_clarification=True`` → reply with ``content`` and wait for
+      another user turn.
+    - ``proposed_splits`` non-empty → reply with split proposal; user picks
+      one or types a confirmation phrase to proceed with the original ask.
+    """
+
+    content: str
+    intent_id: str
+    ready_to_intake: bool = False
+    needs_clarification: bool = False
+    proposed_splits: Sequence[str] = field(default_factory=tuple)
+    suggested_task_type: Optional[str] = None
+    write_likely: bool = False
+    intake_prompt: Optional[str] = None
+    mention_user_id: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def build_engineering_conversation_response(
+    message_text: str,
+    *,
+    author_user_id: Optional[int] = None,
+    mention_user: bool = False,
+    last_proposed_prompt: Optional[str] = None,
+) -> EngineeringConversationResponse:
+    """Classify *message_text* and produce an actionable response envelope.
+
+    *last_proposed_prompt* lets the caller stash the most recent task-shaped
+    message so a follow-up confirmation ("이대로 진행해") can reuse it as
+    ``intake_prompt`` instead of the literal confirmation string. The bot
+    layer is expected to pass this in from its per-channel state.
+    """
+
+    intent = detect_engineering_intent(message_text)
+    mention_user_id = author_user_id if mention_user else None
+
+    if intent.intent_id == CONFIRM_INTAKE:
+        intake_prompt = last_proposed_prompt or message_text
+        suggested = _suggest_task_type(intake_prompt)
+        write_likely = _looks_like_write_request(intake_prompt)
+        body = (
+            "좋습니다. 이대로 작업을 등록할게요.\n"
+            "intake가 만들어지면 세션 ID와 승인 안내를 이어서 드릴게요."
+        )
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=CONFIRM_INTAKE,
+            ready_to_intake=True,
+            suggested_task_type=suggested,
+            write_likely=write_likely,
+            intake_prompt=intake_prompt,
+            mention_user_id=mention_user_id,
+        )
+
+    if intent.intent_id == GENERAL_ENGINEERING_HELP:
+        body = _format_general_help()
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=GENERAL_ENGINEERING_HELP,
+            mention_user_id=mention_user_id,
+        )
+
+    if intent.intent_id == NEEDS_CLARIFICATION:
+        body = _format_clarification_question(message_text)
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=NEEDS_CLARIFICATION,
+            needs_clarification=True,
+            mention_user_id=mention_user_id,
+        )
+
+    if intent.intent_id == SPLIT_TASK_PROPOSAL:
+        splits = split_task_branches(message_text)
+        body = _format_split_proposal(splits)
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=SPLIT_TASK_PROPOSAL,
+            proposed_splits=tuple(splits),
+            suggested_task_type=_suggest_task_type(message_text),
+            write_likely=_looks_like_write_request(message_text),
+            intake_prompt=message_text,
+            mention_user_id=mention_user_id,
+        )
+
+    # default: TASK_INTAKE_CANDIDATE
+    suggested = _suggest_task_type(message_text)
+    write_likely = _looks_like_write_request(message_text)
+    body = _format_intake_candidate_question(
+        message_text=message_text,
+        suggested_task_type=suggested,
+        write_likely=write_likely,
+    )
+    return EngineeringConversationResponse(
+        content=_prepend_mention(body, mention_user_id),
+        intent_id=TASK_INTAKE_CANDIDATE,
+        suggested_task_type=suggested,
+        write_likely=write_likely,
+        intake_prompt=message_text,
+        mention_user_id=mention_user_id,
+    )
+
+
+def detect_engineering_intent(message_text: str) -> EngineeringIntentMatch:
+    """Map *message_text* to one of the five engineering intents.
+
+    Order matters: confirmation phrases must short-circuit so that follow-up
+    "이대로 진행" never mis-classifies as a new intake.
+    """
+
+    normalized = _normalize(message_text)
+    if not normalized:
+        return EngineeringIntentMatch(
+            intent_id=NEEDS_CLARIFICATION,
+            label="비어 있는 메시지",
+            confidence="high",
+        )
+
+    if _is_confirmation(normalized):
+        return EngineeringIntentMatch(
+            intent_id=CONFIRM_INTAKE,
+            label="진행 확정",
+            confidence="high",
+        )
+
+    if _asks_for_general_help(normalized):
+        return EngineeringIntentMatch(
+            intent_id=GENERAL_ENGINEERING_HELP,
+            label="일반 안내",
+            confidence="high",
+        )
+
+    if _looks_too_vague(normalized):
+        return EngineeringIntentMatch(
+            intent_id=NEEDS_CLARIFICATION,
+            label="추가 정보 필요",
+            confidence="medium",
+        )
+
+    if _looks_like_multiple_tasks(message_text):
+        return EngineeringIntentMatch(
+            intent_id=SPLIT_TASK_PROPOSAL,
+            label="작업 분리 제안",
+            confidence="medium",
+        )
+
+    return EngineeringIntentMatch(
+        intent_id=TASK_INTAKE_CANDIDATE,
+        label="작업 후보",
+        confidence="medium",
+    )
+
+
+def split_task_branches(message_text: str) -> tuple[str, ...]:
+    """Heuristic split — returns 2+ sub-prompts when the user combined asks.
+
+    Splits on Korean conjunctions (``그리고``/``또``) and English ``and``
+    when surrounded by spaces. Drops empty fragments and trims whitespace.
+    """
+
+    parts = re.split(_SPLIT_PATTERN, message_text)
+    cleaned = tuple(part.strip(" ,.;:") for part in parts if part and part.strip(" ,.;:"))
+    if len(cleaned) <= 1:
+        return ()
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Intent detection helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+_CONFIRMATION_PHRASES = (
+    "이대로 진행",
+    "이대로 등록",
+    "이걸로 등록",
+    "이걸로 진행",
+    "그럼 이걸로",
+    "그럼 등록",
+    "그럼 진행",
+    "좋아 진행",
+    "좋습니다 진행",
+    "오케이 진행",
+    "ok 진행",
+    "그렇게 등록",
+    "그렇게 진행",
+    "진행해줘",
+    "진행해 주세요",
+    "등록해줘",
+    "등록해 주세요",
+    "yes 등록",
+    "yes 진행",
+    "go 진행",
+    "확정",
+    "확정해",
+)
+
+_CONFIRMATION_STANDALONE = frozenset(
+    {
+        "ok",
+        "okay",
+        "오케이",
+        "오케",
+        "오키",
+        "yes",
+        "yep",
+        "go",
+        "고",
+        "ㄱㄱ",
+        "확정",
+        "진행",
+        "등록",
+    }
+)
+
+
+def _is_confirmation(normalized: str) -> bool:
+    if normalized in _CONFIRMATION_STANDALONE:
+        return True
+    return any(phrase in normalized for phrase in _CONFIRMATION_PHRASES)
+
+
+_GENERAL_HELP_PHRASES = (
+    "engineering-agent",
+    "엔지니어링 에이전트",
+    "엔지니어링 봇",
+    "어떻게 쓰",
+    "어떻게 써",
+    "어떻게 사용",
+    "기능 알려",
+    "도움말",
+    "help",
+    "what can you do",
+    "사용법",
+    "뭐 할 수 있",
+)
+
+
+def _asks_for_general_help(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _GENERAL_HELP_PHRASES)
+
+
+_VAGUE_TOKEN_RUNS = (
+    "도와줘",
+    "도와 줘",
+    "할 일 있어",
+    "할일 있어",
+    "작업 있어",
+    "뭐 해야",
+    "뭐해야",
+    "할 거",
+    "할거",
+)
+
+
+def _looks_too_vague(normalized: str) -> bool:
+    if len(normalized) <= 3:
+        return True
+    word_count = len(normalized.split())
+    if word_count == 1:
+        return True
+    if word_count <= 3 and any(token in normalized for token in _VAGUE_TOKEN_RUNS):
+        return True
+    return False
+
+
+_SPLIT_PATTERN = re.compile(r"\s*그리고\s+|\s*,\s*그리고\s+|\s*또\s+|\s+and\s+", re.IGNORECASE)
+
+
+def _looks_like_multiple_tasks(message_text: str) -> bool:
+    branches = split_task_branches(message_text)
+    if len(branches) < 2:
+        return False
+    # Require each fragment to look "task-like" (>=2 words). Otherwise we
+    # mis-fire on "음 그리고 좋아".
+    return all(len(part.split()) >= 2 for part in branches)
+
+
+def _looks_like_write_request(message_text: str) -> bool:
+    normalized = _normalize(message_text)
+    write_signals = (
+        "구현",
+        "만들",
+        "추가",
+        "수정",
+        "고쳐",
+        "고치",
+        "리팩",
+        "refactor",
+        "implement",
+        "build",
+        "create",
+        "fix",
+        "패치",
+        "patch",
+        "PR",
+        "pull request",
+        "draft",
+        "짜야",
+        "짜줘",
+        "짜자",
+        "작성",
+        "쓸게",
+        "써줘",
+    )
+    review_signals = ("어떻게 생각", "분석", "리뷰", "review", "검토", "조사")
+    if any(signal.lower() in normalized for signal in review_signals):
+        return False
+    return any(signal.lower() in normalized for signal in write_signals)
+
+
+# ---------------------------------------------------------------------------
+# task_type hint
+# ---------------------------------------------------------------------------
+
+
+_TASK_TYPE_KEYWORDS: tuple[tuple[TaskType, tuple[str, ...]], ...] = (
+    (
+        TaskType.VISUAL_POLISH,
+        ("visual ", "polish", "리디자인", "redesign", "시각 정리", "visual cleanup"),
+    ),
+    (
+        TaskType.ONBOARDING_FLOW,
+        ("onboarding", "온보딩", "signup flow", "가입 흐름", "first-run"),
+    ),
+    (
+        TaskType.EMAIL_CAMPAIGN,
+        ("email", "이메일", "campaign", "캠페인", "광고", "ad creative"),
+    ),
+    (TaskType.LANDING_PAGE, ("landing", "랜딩", "marketing page", "히어로")),
+    (TaskType.QA_TEST, ("regression", "회귀", "qa", "test plan", "테스트 시나리오")),
+    (
+        TaskType.PLATFORM_INFRA,
+        ("infra", "deploy", "ci ", " ci", "docker", "k8s", "terraform", "github action"),
+    ),
+    (
+        TaskType.FRONTEND_FEATURE,
+        ("frontend", "ui ", "component", "컴포넌트", "react", "next.js", "vue"),
+    ),
+    (
+        TaskType.BACKEND_FEATURE,
+        ("backend", "api ", "schema", "database", "migration", "도메인", "service layer"),
+    ),
+)
+
+
+def _suggest_task_type(message_text: str) -> Optional[str]:
+    normalized = _normalize(message_text)
+    for task_type, keywords in _TASK_TYPE_KEYWORDS:
+        for keyword in keywords:
+            if keyword in normalized:
+                return task_type.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Response body formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_general_help() -> str:
+    return (
+        "engineering-agent입니다. tech-lead처럼 작업을 받아 정리하고, 멤버 봇과 함께 진행 흐름을 만들어요.\n\n"
+        "이렇게 말씀해 주시면 도움이 됩니다.\n"
+        "- 무엇을 만들거나 고치고 싶은지 한두 문장으로 설명\n"
+        "- 참고할 화면/링크가 있으면 함께 붙여 주세요\n"
+        "- 작업이 여러 갈래면 한 번에 적어 주셔도 좋아요. 제가 나누어 제안할게요.\n\n"
+        "확정 단계에서 `이대로 진행`이라고 말씀하시면 세션을 만들어 다음 단계로 이어갑니다."
+    )
+
+
+def _format_clarification_question(message_text: str) -> str:
+    text = message_text.strip() or "(빈 메시지)"
+    return (
+        f"`{text}`만으로는 작업 범위가 잡히지 않아 한 번 되짚어 볼게요.\n\n"
+        "다음 중 한두 가지를 알려 주시면 더 정확하게 도와드릴 수 있어요.\n"
+        "- 어느 화면 / API / 흐름을 다루고 싶은지\n"
+        "- 지금 막힌 지점이 무엇인지 또는 원하는 결과가 무엇인지\n"
+        "- 참고하고 싶은 링크나 스크린샷이 있는지"
+    )
+
+
+def _format_split_proposal(splits: Sequence[str]) -> str:
+    if not splits:
+        return _format_intake_candidate_question(
+            message_text="",
+            suggested_task_type=None,
+            write_likely=False,
+        )
+    lines = ["요청에 갈래가 여러 개 보여요. 아래처럼 나눠 진행하는 안을 제안합니다."]
+    for idx, branch in enumerate(splits, start=1):
+        lines.append(f"{idx}. {branch}")
+    lines.append(
+        "\n각각 별도 세션으로 만들거나, 그대로 하나로 묶어서 진행할 수 있어요. "
+        "원하시는 방식을 알려 주시면 그쪽으로 정리하고, `이대로 진행`이라고 하시면 한 세션으로 등록할게요."
+    )
+    return "\n".join(lines)
+
+
+def _format_intake_candidate_question(
+    *,
+    message_text: str,
+    suggested_task_type: Optional[str],
+    write_likely: bool,
+) -> str:
+    parts: list[str] = []
+    if message_text.strip():
+        parts.append("작업 후보로 정리해 봤어요. 아래 내용으로 진행해도 될까요?")
+        parts.append(f"> {message_text.strip()}")
+    else:
+        parts.append("작업 후보로 정리해 봤어요. 아래 내용으로 진행해도 될까요?")
+
+    meta_lines: list[str] = []
+    if suggested_task_type:
+        meta_lines.append(f"- 추정 분류: `{suggested_task_type}`")
+    if write_likely:
+        meta_lines.append("- 코드/문서 쓰기를 동반할 것으로 보입니다 → 진행 시 승인 단계가 들어갑니다.")
+    else:
+        meta_lines.append("- 분석/검토 위주로 보여 승인 단계 없이 진행해도 괜찮아 보입니다.")
+    parts.append("\n".join(meta_lines))
+
+    parts.append(
+        "맞으면 `이대로 진행`이라고 답해 주세요. 빠진 컨텍스트가 있으면 추가 메시지로 보강해 주셔도 좋아요."
+    )
+    return "\n\n".join(parts)
+
+
+def _prepend_mention(content: str, mention_user_id: Optional[int]) -> str:
+    if mention_user_id is None:
+        return content
+    return f"<@{mention_user_id}>\n\n{content}".strip()

--- a/tests/test_engineering_conversation.py
+++ b/tests/test_engineering_conversation.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.engineering_conversation import (
+    CONFIRM_INTAKE,
+    GENERAL_ENGINEERING_HELP,
+    NEEDS_CLARIFICATION,
+    SPLIT_TASK_PROPOSAL,
+    TASK_INTAKE_CANDIDATE,
+    build_engineering_conversation_response,
+    detect_engineering_intent,
+    split_task_branches,
+)
+
+
+class DetectIntentTestCase(unittest.TestCase):
+    def test_general_help_keyword(self) -> None:
+        intent = detect_engineering_intent("engineering-agent 어떻게 써?")
+        self.assertEqual(intent.intent_id, GENERAL_ENGINEERING_HELP)
+
+    def test_help_korean(self) -> None:
+        intent = detect_engineering_intent("엔지니어링 봇 도움말 좀 줘봐")
+        self.assertEqual(intent.intent_id, GENERAL_ENGINEERING_HELP)
+
+    def test_confirm_phrase_short_circuits(self) -> None:
+        intent = detect_engineering_intent("이대로 진행")
+        self.assertEqual(intent.intent_id, CONFIRM_INTAKE)
+
+    def test_confirm_standalone_token(self) -> None:
+        for token in ("ok", "오케이", "확정", "진행", "ㄱㄱ"):
+            with self.subTest(token=token):
+                intent = detect_engineering_intent(token)
+                self.assertEqual(intent.intent_id, CONFIRM_INTAKE)
+
+    def test_vague_short_message(self) -> None:
+        for text in ("도와줘", "ㅁㄴㅇ", "ㅎㅎ"):
+            with self.subTest(text=text):
+                intent = detect_engineering_intent(text)
+                self.assertEqual(intent.intent_id, NEEDS_CLARIFICATION)
+
+    def test_empty_message(self) -> None:
+        self.assertEqual(detect_engineering_intent("   ").intent_id, NEEDS_CLARIFICATION)
+
+    def test_split_task_when_two_substantial_branches(self) -> None:
+        intent = detect_engineering_intent(
+            "랜딩페이지 hero 정리하고 또 회원가입 onboarding 흐름 개선해줘"
+        )
+        self.assertEqual(intent.intent_id, SPLIT_TASK_PROPOSAL)
+
+    def test_no_split_when_branch_is_too_short(self) -> None:
+        intent = detect_engineering_intent("음 그리고 좋아")
+        self.assertNotEqual(intent.intent_id, SPLIT_TASK_PROPOSAL)
+
+    def test_default_is_intake_candidate(self) -> None:
+        intent = detect_engineering_intent("users API schema 변경해서 email_verified 필드 추가")
+        self.assertEqual(intent.intent_id, TASK_INTAKE_CANDIDATE)
+
+
+class SplitTaskBranchesTestCase(unittest.TestCase):
+    def test_korean_conjunction(self) -> None:
+        self.assertEqual(
+            split_task_branches("랜딩 hero 정리 그리고 회원가입 흐름 개선"),
+            ("랜딩 hero 정리", "회원가입 흐름 개선"),
+        )
+
+    def test_english_and(self) -> None:
+        self.assertEqual(
+            split_task_branches("polish hero and refresh onboarding"),
+            ("polish hero", "refresh onboarding"),
+        )
+
+    def test_no_split_for_single_clause(self) -> None:
+        self.assertEqual(split_task_branches("hero 섹션 정리"), ())
+
+
+class ResponseEnvelopeTestCase(unittest.TestCase):
+    def test_general_help_envelope(self) -> None:
+        envelope = build_engineering_conversation_response("도움말 줘봐")
+        self.assertEqual(envelope.intent_id, GENERAL_ENGINEERING_HELP)
+        self.assertFalse(envelope.ready_to_intake)
+        self.assertFalse(envelope.needs_clarification)
+        self.assertIsNone(envelope.intake_prompt)
+
+    def test_intake_candidate_envelope(self) -> None:
+        envelope = build_engineering_conversation_response(
+            "새 랜딩페이지 hero 섹션을 다시 짜야 해"
+        )
+        self.assertEqual(envelope.intent_id, TASK_INTAKE_CANDIDATE)
+        self.assertEqual(envelope.suggested_task_type, "landing-page")
+        self.assertTrue(envelope.write_likely)
+        self.assertEqual(envelope.intake_prompt, "새 랜딩페이지 hero 섹션을 다시 짜야 해")
+        self.assertFalse(envelope.ready_to_intake)
+        self.assertIn("이대로 진행", envelope.content)
+
+    def test_needs_clarification_envelope(self) -> None:
+        envelope = build_engineering_conversation_response("도와줘")
+        self.assertEqual(envelope.intent_id, NEEDS_CLARIFICATION)
+        self.assertTrue(envelope.needs_clarification)
+        self.assertFalse(envelope.ready_to_intake)
+        self.assertIn("작업 범위", envelope.content)
+
+    def test_split_proposal_envelope(self) -> None:
+        envelope = build_engineering_conversation_response(
+            "랜딩페이지 hero 정리하고 또 회원가입 onboarding 흐름 개선해줘"
+        )
+        self.assertEqual(envelope.intent_id, SPLIT_TASK_PROPOSAL)
+        self.assertEqual(len(envelope.proposed_splits), 2)
+        self.assertFalse(envelope.ready_to_intake)
+        self.assertEqual(envelope.intake_prompt, envelope.intake_prompt)  # preserved
+
+    def test_confirm_with_last_prompt_marks_ready_to_intake(self) -> None:
+        envelope = build_engineering_conversation_response(
+            "이대로 진행",
+            last_proposed_prompt="랜딩페이지 hero 다시 짜야 해",
+        )
+        self.assertEqual(envelope.intent_id, CONFIRM_INTAKE)
+        self.assertTrue(envelope.ready_to_intake)
+        self.assertEqual(envelope.intake_prompt, "랜딩페이지 hero 다시 짜야 해")
+        self.assertEqual(envelope.suggested_task_type, "landing-page")
+        self.assertTrue(envelope.write_likely)
+
+    def test_confirm_without_last_prompt_uses_message_text(self) -> None:
+        envelope = build_engineering_conversation_response("이대로 진행")
+        self.assertEqual(envelope.intent_id, CONFIRM_INTAKE)
+        self.assertTrue(envelope.ready_to_intake)
+        self.assertEqual(envelope.intake_prompt, "이대로 진행")
+
+    def test_mention_prefix_only_when_requested(self) -> None:
+        with_mention = build_engineering_conversation_response(
+            "도와줘",
+            author_user_id=123,
+            mention_user=True,
+        )
+        without_mention = build_engineering_conversation_response(
+            "도와줘",
+            author_user_id=123,
+            mention_user=False,
+        )
+        self.assertTrue(with_mention.content.startswith("<@123>"))
+        self.assertFalse(without_mention.content.startswith("<@"))
+
+
+class WriteLikelyTestCase(unittest.TestCase):
+    def test_write_keywords_set_flag(self) -> None:
+        for prompt in (
+            "users API 추가 구현해줘",
+            "랜딩 hero 다시 짜야 해",
+            "buttons 컴포넌트 만들어줘",
+            "fix 배포 스크립트",
+        ):
+            with self.subTest(prompt=prompt):
+                envelope = build_engineering_conversation_response(prompt)
+                self.assertTrue(envelope.write_likely, prompt)
+
+    def test_review_signals_dominate_write(self) -> None:
+        envelope = build_engineering_conversation_response(
+            "users API 어떻게 생각해 분석만 해줘"
+        )
+        self.assertFalse(envelope.write_likely)
+
+
+class TaskTypeHintTestCase(unittest.TestCase):
+    def test_known_task_types(self) -> None:
+        cases = {
+            "랜딩 hero 정리": "landing-page",
+            "onboarding 가입 흐름 개선": "onboarding-flow",
+            "welcome email 캠페인 만들기": "email-campaign",
+            "히어로 visual polish": "visual-polish",
+            "users API 추가": "backend-feature",
+            "ui 컴포넌트 정리": "frontend-feature",
+            "regression 테스트 시나리오 추가": "qa-test",
+            "deploy 파이프라인 보강": "platform-infra",
+        }
+        for prompt, expected in cases.items():
+            with self.subTest(prompt=prompt):
+                envelope = build_engineering_conversation_response(prompt)
+                self.assertEqual(envelope.suggested_task_type, expected)
+
+    def test_unknown_message_has_no_task_type(self) -> None:
+        envelope = build_engineering_conversation_response("이 부분 좀 검토해줘")
+        self.assertIsNone(envelope.suggested_task_type)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
없음  
engineering-agent Discord 운영 자동화 작업의 일부입니다.

## ✨ 과제 내용
planning-bot과 engineering-agent 멤버 봇들을 하나씩 수동 실행하지 않고,
한 번에 올릴 수 있는 launcher / supervisor 경로를 추가했습니다.

이번 PR의 목표는 멀티봇 운영의 번거로움을 줄이고,
실행 대상과 토큰 활성 상태를 한 번에 확인할 수 있는 운영 진입점을 만드는 것입니다.

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 / 참고 사항
- 목표는 “한 프로세스 안에 모든 bot client를 우겨 넣는 것”보다 운영 진입점 단순화에 있음
- 현재 단계에서는 launcher/supervisor MVP에 집중함
