### PR TITLE
[Feature] engineering-agent 팀 대화 runtime 추가

### DIFF
--- a/policies/runtime/agents/engineering-agent/team-conversation.md
+++ b/policies/runtime/agents/engineering-agent/team-conversation.md
@@ -1,0 +1,74 @@
+# Engineering Agent Team Conversation (v0, sequential MVP)
+
+이 문서는 engineering-agent member 봇들이 같은 Discord thread 안에서 **순차 발화**하도록 하는 MVP의 정책 기준선이다. 코드 진실 소스는 `src/yule_orchestrator/discord/engineering_team_runtime.py` 와 `member_bot.py`. 자유 토론 / 다회 ping-pong 은 본 마일스톤 범위 밖이다.
+
+## 1. 범위
+
+- **포함**: thread 안에서 `tech-lead → product-designer → backend-engineer / frontend-engineer → qa-engineer` 처럼 dispatcher가 정한 `role_sequence`를 한 번씩 발화한다.
+- **포함**: 각 발화는 세션 메타데이터(분류, 실행자, 승인 상태, reference)를 반영한 1차 요약이다. 실제 runner(claude/gemini/codex/ollama)를 깊게 호출하지 않는다.
+- **제외**: 자유 토론, 역할 간 자율 reply, 사용자와의 직접 대화. 이 단계의 member 봇은 dispatch 마커가 본인을 지목할 때만 발화한다.
+
+## 2. 사전 조건
+
+- `WorkflowSession` 이 다음을 채워야 한다:
+  - `thread_id` (게이트웨이가 thread를 만든 뒤 세션에 기입; D 마일스톤에서 wiring).
+  - `role_sequence` (dispatcher가 채움).
+  - `executor_role` (단일 실행자, dispatcher 결정).
+- 각 역할의 토큰(`ENGINEERING_AGENT_BOT_<ROLE>_TOKEN`)이 활성화되어 member 봇이 기동되어 있어야 한다 (`multi-bot-launcher.md` §2 참조). 비활성 토큰은 해당 역할의 발화를 건너뛰고 chain이 끊긴다 — 운영자가 다음 directive 를 수동으로 다시 발사해 복구한다.
+
+## 3. Dispatch 프로토콜
+
+발화 chain 은 thread 안 메시지 본문에 다음 마커를 포함하는 방식으로 흘러간다:
+
+```
+[team-turn:<session_id> <role>]
+```
+
+- `<session_id>` 는 `WorkflowSession.session_id` 12자 hex.
+- `<role>` 는 `tech-lead` / `product-designer` / `frontend-engineer` / `backend-engineer` / `qa-engineer` 중 하나. 없으면 plan 의 첫 역할(보통 `tech-lead`)이 응답한다 — kickoff 1회용.
+- 정규식: `\[team-turn:(?P<sid>[A-Za-z0-9_\-]+)(?:\s+(?P<role>[A-Za-z0-9_\-]+))?\]` (`engineering_team_runtime.DISPATCH_MARKER_RE`).
+
+흐름:
+
+1. 게이트웨이가 thread 를 만들고 `kickoff_directive(session)` 결과를 thread 에 게시한다 (예: `[team-turn:abc123 tech-lead]`).
+2. tech-lead 봇의 `on_message` 가 마커를 감지 → `engineering_team_runtime.handle_team_turn_message` 호출 → 본인의 발화 + 다음 role 의 directive 를 한 메시지로 thread 에 게시.
+3. 다음 봇이 동일하게 동작. 마지막 role 은 directive 를 붙이지 않고 `closing_message(session)` 을 덧붙여 chain 을 닫는다.
+4. 게이트웨이는 각 발화 직후 `mark_turn_played(session, role)` 으로 세션 상태를 갱신한다 — 봇이 같은 thread 에 두 번 발화하지 못하도록 막는 단일 진실 소스.
+
+## 4. 메시지 포맷
+
+각 turn 메시지 본문:
+
+```
+**[<role>]** <header>
+<body>
+[team-turn:<session_id> <next-role>]   ← 마지막 turn 이면 생략
+```
+
+- `header` 는 역할별 한 줄 인사 (`engineering_team_runtime._ROLE_HEADERS`).
+- `body` 는 task_type / executor / write_blocked / reference 4가지를 짧게 요약한 1차 의견. 영문 약어와 한국어를 섞어도 좋지만 한 turn 당 4줄을 넘지 않는다.
+- 사용자 멘션은 사용하지 않는다. role 식별은 `**[role]**` 헤더로만 한다.
+
+기본 템플릿이 다루는 역할: `tech-lead`, `product-designer`, `frontend-engineer`, `backend-engineer`, `qa-engineer`. 그 외는 generic 템플릿으로 fallback (역할 이름이 본문에 그대로 노출).
+
+## 5. 실패 모드 / 운영 가이드
+
+| 증상 | 원인 후보 | 대응 |
+|---|---|---|
+| chain 이 도중에 멈춤 | 다음 role 봇이 비활성(토큰 미발급) | 운영자가 thread 에 `[team-turn:<sid> <next-role>]` 를 직접 게시하거나, `--dry-run` 으로 활성 상태 확인 |
+| 동일 role 이 두 번 발화 | `mark_turn_played` 가 호출되지 않음 (게이트웨이 wiring 누락) | 게이트웨이 hook 점검; 재현되면 `extra.team_conversation.played_roles` 수동 보정 |
+| kickoff 마커에 role 미지정 시 여러 봇이 동시 답변 | role-less 마커는 plan 에 든 모든 활성 봇이 응답 가능 | 운영 규약: 게이트웨이는 항상 role 지정 directive 를 게시한다 (`kickoff_directive` 가 자동으로 해줌) |
+| thread 가 없는 세션에 chain 시도 | dispatcher 만 끝나고 thread 가 아직 생성되지 않은 상태 | `build_turn_plan` 이 `ValueError` 로 차단; 게이트웨이가 thread 생성 → `session.thread_id` 기입 후 재시도 |
+
+## 6. 다음 마일스톤
+
+1. **자유 회신** — 각 role 이 다른 role 의 발화에 멘션 응답. 본 MVP 완료 후 도입.
+2. **runner 통합** — turn 본문을 templated 문자열 대신 실제 runner 출력(요약 1단락)으로 교체. role × runner 매트릭스는 `role-weights-v0.md`.
+3. **재진입** — 같은 thread 에 review 피드백이 들어오면 `played_roles` 를 reset 하고 chain 재시작 (review-loop.md 와 합치기).
+4. **IPC** — 현재는 Discord 본문에 마커를 박아 흐르지만, 같은 호스트 안에서 zmq/queue 로 직접 dispatch 하는 채널을 추가해 latency 개선.
+
+## 7. 참고
+
+- 코드 진실 소스: `src/yule_orchestrator/discord/engineering_team_runtime.py` (TeamTurn / TeamTurnOutcome / handle_team_turn_message).
+- 테스트: `tests/test_engineering_team_runtime.py`.
+- 관련 정책: `discord-workflow.md` §7, `multi-bot-launcher.md` §1, `dispatcher.md` (role_sequence/executor_role 결정).

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import os
 import time as time_module
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
 
+from ..agents import (
+    Dispatcher,
+    WorkflowOrchestrator,
+    build_participants_pool,
+)
 from ..integrations.calendar import list_naver_calendar_items
 from ..integrations.calendar.models import build_fallback_item_uid
 from ..integrations.github.issues import list_open_issues
@@ -23,6 +29,12 @@ from .checkpoint_state import (
 from .commands import register_discord_commands
 from .conversation import build_conversation_response_envelope
 from .config import DiscordBotConfig
+from .engineering_channel_router import (
+    EngineeringConversationOutcome,
+    EngineeringRouteContext,
+    EngineeringThreadKickoff,
+    route_engineering_message,
+)
 from .formatter import (
     format_checkpoints_message,
     format_plan_today_message,
@@ -117,6 +129,27 @@ def run_discord_bot(repo_root: Path) -> None:
                 return
             if self.user is None:
                 return
+
+            content_text = str(getattr(message, "content", "") or "").strip()
+            if content_text.startswith("/"):
+                return
+
+            engineering_context = EngineeringRouteContext.from_env()
+            if engineering_context.configured:
+                send_chunks = _make_engineering_send_chunks(discord)
+                engineering_result = await route_engineering_message(
+                    message=message,
+                    bot_user=self.user,
+                    route_context=engineering_context,
+                    extract_prompt=_extract_conversation_prompt,
+                    conversation_fn=_default_engineering_conversation_fn,
+                    intake_fn=_default_engineering_intake_fn,
+                    thread_kickoff_fn=_make_default_thread_kickoff_fn(discord),
+                    send_chunks=send_chunks,
+                )
+                if engineering_result.handled:
+                    return
+
             if not _should_handle_message(
                 message=message,
                 bot_user=self.user,
@@ -1346,6 +1379,208 @@ def _build_allowed_mentions(discord_module: "discord") -> "discord.AllowedMentio
         everyone=False,
         replied_user=False,
     )
+
+
+def _make_engineering_send_chunks(discord_module: "discord"):
+    allowed_mentions = _build_allowed_mentions(discord_module)
+
+    async def _send(channel, text: str) -> None:
+        if not text:
+            return
+        await _send_channel_message_chunks(
+            channel,
+            text,
+            allowed_mentions=allowed_mentions,
+        )
+
+    return _send
+
+
+_ENGINEERING_LAST_PROPOSED: dict[int, str] = {}
+
+
+def _default_engineering_conversation_fn(
+    *,
+    message_text: str,
+    author_user_id: int | None,
+    channel_id: int | None,
+    bot_user: object,
+):
+    """Bridge to the engineering free-conversation layer.
+
+    The conversation module is being landed in parallel; if it is not yet
+    importable we degrade to a short fallback that points the user at the
+    manual ``/engineer_intake`` slash command instead of crashing.
+    """
+
+    try:
+        from . import engineering_conversation  # type: ignore
+    except ImportError:
+        return EngineeringConversationOutcome(
+            content=(
+                "엔지니어링 자유 대화 레이어가 아직 준비되지 않았습니다.\n"
+                "지금은 `/engineer_intake` 슬래시 명령으로 작업을 등록해주세요."
+            ),
+        )
+
+    builder = getattr(
+        engineering_conversation,
+        "build_engineering_conversation_response",
+        None,
+    )
+    if builder is None:
+        return EngineeringConversationOutcome(
+            content=(
+                "엔지니어링 대화 모듈이 응답 빌더를 노출하지 않았습니다.\n"
+                "지금은 `/engineer_intake` 로 작업을 등록해주세요."
+            ),
+        )
+
+    last_proposed = (
+        _ENGINEERING_LAST_PROPOSED.get(channel_id) if channel_id is not None else None
+    )
+    response = builder(
+        message_text,
+        author_user_id=author_user_id,
+        mention_user=author_user_id is not None,
+        last_proposed_prompt=last_proposed,
+    )
+
+    intent_id = getattr(response, "intent_id", "")
+    intake_prompt = getattr(response, "intake_prompt", None)
+    ready_to_intake = bool(getattr(response, "ready_to_intake", False))
+    if channel_id is not None:
+        if ready_to_intake:
+            _ENGINEERING_LAST_PROPOSED.pop(channel_id, None)
+        elif intent_id in {
+            "task_intake_candidate",
+            "split_task_proposal",
+            "needs_clarification",
+        } and intake_prompt:
+            _ENGINEERING_LAST_PROPOSED[channel_id] = str(intake_prompt)
+
+    return EngineeringConversationOutcome(
+        content=str(getattr(response, "content", "") or ""),
+        confirmed=ready_to_intake,
+        intake_prompt=str(intake_prompt) if intake_prompt else None,
+        write_requested=bool(getattr(response, "write_likely", False)),
+    )
+
+
+def _default_engineering_intake_fn(
+    *,
+    prompt: str,
+    write_requested: bool,
+    channel_id: int | None,
+    user_id: int | None,
+):
+    repo_root = Path(os.environ.get("YULE_REPO_ROOT", ".")).resolve()
+    pool = build_participants_pool(repo_root, "engineering-agent")
+    orchestrator = WorkflowOrchestrator(Dispatcher(pool))
+    return orchestrator.intake(
+        prompt=prompt,
+        write_requested=write_requested,
+        channel_id=channel_id,
+        user_id=user_id,
+    )
+
+
+def _make_default_thread_kickoff_fn(discord_module: "discord"):
+    async def _kickoff(*, channel, session, plan, topic):
+        kickoff_text = _format_engineering_kickoff_message(session, plan)
+        thread_topic = (topic or "").strip() or _default_engineering_thread_topic(session)
+
+        thread_cls = getattr(discord_module, "Thread", None)
+        if thread_cls is not None and isinstance(channel, thread_cls):
+            await channel.send(kickoff_text)
+            return EngineeringThreadKickoff(
+                thread_id=getattr(channel, "id", None),
+                message=kickoff_text,
+            )
+
+        thread = await _create_engineering_thread(
+            channel=channel,
+            name=thread_topic,
+            discord_module=discord_module,
+        )
+        if thread is None:
+            await channel.send(kickoff_text)
+            return EngineeringThreadKickoff(thread_id=None, message=kickoff_text)
+
+        try:
+            await thread.send(kickoff_text)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            print(f"warning: engineering thread kickoff send failed: {exc}")
+
+        return EngineeringThreadKickoff(
+            thread_id=getattr(thread, "id", None),
+            message=kickoff_text,
+        )
+
+    return _kickoff
+
+
+async def _create_engineering_thread(
+    *,
+    channel,
+    name: str,
+    discord_module: "discord",
+):
+    create_thread = getattr(channel, "create_thread", None)
+    if not callable(create_thread):
+        return None
+
+    channel_type = getattr(discord_module, "ChannelType", None)
+    public_thread_type = getattr(channel_type, "public_thread", None) if channel_type else None
+    auto_archive_minutes = 60 * 24
+
+    try:
+        if public_thread_type is not None:
+            return await create_thread(
+                name=name,
+                type=public_thread_type,
+                auto_archive_duration=auto_archive_minutes,
+            )
+        return await create_thread(name=name, auto_archive_duration=auto_archive_minutes)
+    except TypeError:
+        try:
+            return await create_thread(name=name)
+        except Exception as exc:  # noqa: BLE001
+            print(f"warning: engineering thread creation failed: {exc}")
+            return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"warning: engineering thread creation failed: {exc}")
+        return None
+
+
+def _default_engineering_thread_topic(session) -> str:
+    if session is None:
+        return "engineering-agent 작업"
+    session_id = getattr(session, "session_id", None) or "?"
+    task_type = getattr(session, "task_type", None) or "task"
+    return f"engineer-{task_type}-{session_id}"[:90]
+
+
+def _format_engineering_kickoff_message(session, plan) -> str:
+    lines: list[str] = ["**[engineering-agent] 작업 thread 시작**"]
+    if session is not None:
+        session_id = getattr(session, "session_id", None)
+        if session_id:
+            lines.append(f"세션 ID: `{session_id}`")
+        task_type = getattr(session, "task_type", None)
+        if task_type:
+            lines.append(f"분류: {task_type}")
+        executor_role = getattr(session, "executor_role", None)
+        executor_runner = getattr(session, "executor_runner", None)
+        if executor_role:
+            lines.append(f"실행자: {executor_role} ({executor_runner or '?'})")
+    if plan is not None:
+        role_sequence = getattr(plan, "role_sequence", None)
+        if role_sequence:
+            lines.append(f"역할 순서: {' → '.join(role_sequence)}")
+    lines.append("")
+    lines.append("이 thread에서 진행 메모와 결과 회신을 이어 가겠습니다.")
+    return "\n".join(lines)
 
 
 def _checkpoint_window_minutes(window_start: datetime, window_end: datetime) -> int:

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -1,0 +1,355 @@
+"""Routing logic for the engineering #업무-접수 channel.
+
+The Discord bot's planning conversation layer is preserved as-is; this
+router handles the *engineering* path: free conversation in the intake
+channel (or a thread under it), and — when the user signals confirmation
+— a workflow intake plus a thread kickoff message.
+
+The module is pure-Python: all I/O dependencies (engineering conversation
+provider, workflow intake, thread kickoff, message sender) are injected
+as callables so unit tests can drive the router without spinning up
+discord.py. ``bot.py`` wires the production callables.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional, Union
+
+
+# Single-source confirmation lexicon; the engineering conversation layer
+# may also detect intent and pre-set ``confirmed=True`` itself, in which
+# case the router trusts that signal.
+_CONFIRMATION_KEYWORDS: tuple[str, ...] = (
+    "확정",
+    "진행",
+    "시작해",
+    "시작하자",
+    "시작할게",
+    "시작합시다",
+    "고고",
+    "ㄱㄱ",
+    "ㄱㄱㄱ",
+    "맞아 진행",
+    "그대로 진행",
+    "그대로 가",
+    "오케이 진행",
+    "오케 진행",
+    "go ahead",
+    "let's go",
+    "lets go",
+    "kick off",
+    "kickoff",
+    "proceed",
+    "approve and start",
+)
+
+
+@dataclass(frozen=True)
+class EngineeringRouteContext:
+    """Where the engineering intake channel lives.
+
+    Both ``intake_channel_id`` and ``intake_channel_name`` are optional
+    individually — if either one matches the message channel (or its
+    parent, for a thread), the message is treated as engineering.
+    """
+
+    intake_channel_id: Optional[int] = None
+    intake_channel_name: Optional[str] = None
+
+    @property
+    def configured(self) -> bool:
+        return self.intake_channel_id is not None or bool(
+            _normalize_channel_name(self.intake_channel_name)
+        )
+
+    @classmethod
+    def from_env(cls) -> "EngineeringRouteContext":
+        return cls(
+            intake_channel_id=_optional_int_env("DISCORD_ENGINEERING_INTAKE_CHANNEL_ID"),
+            intake_channel_name=_optional_string_env(
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class EngineeringConversationOutcome:
+    """The shape returned by the engineering free-conversation layer.
+
+    ``confirmed=True`` means the user just expressed intent to start
+    a real intake; ``intake_prompt`` is the canonicalised request for
+    the workflow.  The conversation layer is free to omit those fields
+    — the router falls back to a keyword-based confirmation check on
+    the original user text.
+    """
+
+    content: str
+    confirmed: bool = False
+    intake_prompt: Optional[str] = None
+    write_requested: bool = False
+    thread_topic: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EngineeringThreadKickoff:
+    """Result of creating a working thread and posting kickoff."""
+
+    thread_id: Optional[int] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EngineeringRouteResult:
+    """What the router did with one Discord message.
+
+    ``handled=False`` means this message is *not* an engineering channel
+    message; the bot should fall through to its planning conversation
+    path.  ``handled=True`` means the router has already replied (and
+    optionally created an intake/thread), so the bot must not double-reply.
+    """
+
+    handled: bool
+    conversation_message: Optional[str] = None
+    intake_message: Optional[str] = None
+    kickoff_message: Optional[str] = None
+    session_id: Optional[str] = None
+    thread_id: Optional[int] = None
+    error: Optional[str] = None
+
+
+SendChunksFn = Callable[[Any, str], Awaitable[None]]
+ExtractPromptFn = Callable[..., str]
+ConversationFn = Callable[..., Union[
+    EngineeringConversationOutcome,
+    Awaitable[EngineeringConversationOutcome],
+    str,
+    Awaitable[str],
+]]
+IntakeFn = Callable[..., Any]
+ThreadKickoffFn = Callable[..., Awaitable[EngineeringThreadKickoff]]
+
+
+def is_engineering_channel(
+    *,
+    message: Any,
+    route_context: EngineeringRouteContext,
+) -> bool:
+    if not route_context.configured:
+        return False
+
+    channel = getattr(message, "channel", None)
+    if channel is None:
+        return False
+
+    channel_id = getattr(channel, "id", None)
+    parent = getattr(channel, "parent", None)
+    parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
+    channel_name = _normalize_channel_name(getattr(channel, "name", None))
+    parent_name = _normalize_channel_name(getattr(parent, "name", None))
+
+    target_id = route_context.intake_channel_id
+    target_name = _normalize_channel_name(route_context.intake_channel_name)
+
+    if target_id is not None:
+        if channel_id is not None and channel_id == target_id:
+            return True
+        if parent_id is not None and parent_id == target_id:
+            return True
+    if target_name:
+        if channel_name == target_name:
+            return True
+        if parent_name == target_name:
+            return True
+    return False
+
+
+def detect_confirmation_signal(text: str) -> bool:
+    """Heuristic confirmation detector used when the conversation layer
+    does not pre-classify intent.  Matches Korean and English go-ahead
+    phrases conservatively — short ack words like ``yes``/``네`` are
+    excluded so casual chat isn't promoted to a workflow intake."""
+
+    if not text:
+        return False
+    normalized = " ".join(text.lower().split())
+    if not normalized:
+        return False
+    return any(keyword in normalized for keyword in _CONFIRMATION_KEYWORDS)
+
+
+async def route_engineering_message(
+    *,
+    message: Any,
+    bot_user: Any,
+    route_context: EngineeringRouteContext,
+    extract_prompt: ExtractPromptFn,
+    conversation_fn: ConversationFn,
+    intake_fn: IntakeFn,
+    thread_kickoff_fn: ThreadKickoffFn,
+    send_chunks: SendChunksFn,
+) -> EngineeringRouteResult:
+    """Drive the engineering channel response.
+
+    Order:
+      1. If the message is not in an engineering channel, return ``handled=False``.
+      2. Call the conversation layer; reply with whatever it produced.
+      3. If the conversation (or fallback heuristic) says the user just
+         confirmed, call ``intake_fn`` to create a workflow session.
+      4. Post the intake summary, then kick off a thread.
+    """
+
+    if not is_engineering_channel(message=message, route_context=route_context):
+        return EngineeringRouteResult(handled=False)
+
+    prompt_text = extract_prompt(message=message, bot_user=bot_user)
+    prompt_text = (prompt_text or "").strip()
+    if not prompt_text:
+        return EngineeringRouteResult(handled=False)
+
+    raw_outcome = await _maybe_await(
+        conversation_fn(
+            message_text=prompt_text,
+            author_user_id=getattr(message.author, "id", None),
+            channel_id=getattr(getattr(message, "channel", None), "id", None),
+            bot_user=bot_user,
+        )
+    )
+    outcome = _coerce_outcome(raw_outcome, prompt_text=prompt_text)
+
+    if outcome.content:
+        await send_chunks(message.channel, outcome.content)
+
+    confirmed = outcome.confirmed or detect_confirmation_signal(prompt_text)
+    intake_prompt = (outcome.intake_prompt or prompt_text).strip()
+    if not confirmed or not intake_prompt:
+        return EngineeringRouteResult(
+            handled=True,
+            conversation_message=outcome.content or None,
+        )
+
+    try:
+        intake = intake_fn(
+            prompt=intake_prompt,
+            write_requested=outcome.write_requested,
+            channel_id=getattr(getattr(message, "channel", None), "id", None),
+            user_id=getattr(getattr(message, "author", None), "id", None),
+        )
+        intake = await _maybe_await(intake)
+    except Exception as exc:  # noqa: BLE001 - surface error to user, do not crash bot
+        error_text = f"⚠️ engineer intake 실패: {exc}"
+        await send_chunks(message.channel, error_text)
+        return EngineeringRouteResult(
+            handled=True,
+            conversation_message=outcome.content or None,
+            error=str(exc),
+        )
+
+    intake_message = getattr(intake, "message", None)
+    session = getattr(intake, "session", None)
+    plan = getattr(intake, "plan", None)
+    session_id = getattr(session, "session_id", None)
+
+    if intake_message:
+        await send_chunks(message.channel, intake_message)
+
+    kickoff_message: Optional[str] = None
+    thread_id: Optional[int] = None
+    kickoff_error: Optional[str] = None
+    try:
+        kickoff = await thread_kickoff_fn(
+            channel=message.channel,
+            session=session,
+            plan=plan,
+            topic=outcome.thread_topic,
+        )
+    except Exception as exc:  # noqa: BLE001 - intake already saved, just note kickoff issue
+        kickoff_error = str(exc)
+        await send_chunks(
+            message.channel,
+            f"⚠️ thread kickoff 실패: {exc}\n세션 `{session_id or '?'}` 은 이미 생성되어 있습니다.",
+        )
+    else:
+        if kickoff is not None:
+            thread_id = kickoff.thread_id
+            kickoff_message = kickoff.message
+
+    return EngineeringRouteResult(
+        handled=True,
+        conversation_message=outcome.content or None,
+        intake_message=intake_message,
+        kickoff_message=kickoff_message,
+        session_id=session_id,
+        thread_id=thread_id,
+        error=kickoff_error,
+    )
+
+
+def _coerce_outcome(
+    raw: Any,
+    *,
+    prompt_text: str,
+) -> EngineeringConversationOutcome:
+    if isinstance(raw, EngineeringConversationOutcome):
+        return raw
+    if isinstance(raw, str):
+        return EngineeringConversationOutcome(content=raw)
+    # Allow the conversation layer to ship a custom dataclass with a
+    # compatible ``content`` attribute.  We extract the optional fields
+    # defensively so tomorrow's API additions don't break us today.
+    content = str(getattr(raw, "content", "") or "")
+    confirmed = bool(getattr(raw, "confirmed", False))
+    intake_prompt_raw = getattr(raw, "intake_prompt", None)
+    intake_prompt = (
+        str(intake_prompt_raw).strip()
+        if intake_prompt_raw is not None
+        else None
+    )
+    write_requested = bool(getattr(raw, "write_requested", False))
+    thread_topic_raw = getattr(raw, "thread_topic", None)
+    thread_topic = (
+        str(thread_topic_raw).strip()
+        if thread_topic_raw is not None
+        else None
+    )
+    return EngineeringConversationOutcome(
+        content=content,
+        confirmed=confirmed,
+        intake_prompt=intake_prompt or None,
+        write_requested=write_requested,
+        thread_topic=thread_topic or None,
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+def _normalize_channel_name(value: object | None) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lstrip("#").lower()
+
+
+def _optional_int_env(name: str) -> Optional[int]:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    value = raw.strip()
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be an integer value, got: {value!r}"
+        ) from exc
+
+
+def _optional_string_env(name: str) -> Optional[str]:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None

--- a/src/yule_orchestrator/discord/engineering_team_runtime.py
+++ b/src/yule_orchestrator/discord/engineering_team_runtime.py
@@ -1,0 +1,415 @@
+"""Sequential team conversation runtime for engineering-agent member bots.
+
+MVP scope: once a workflow session has a Discord ``thread_id``, walk the
+``role_sequence`` in order and let each role bot post one short, role-shaped
+message in that thread. tech-lead opens, then product-designer / backend-engineer
+/ frontend-engineer / qa-engineer follow whichever order the dispatcher picked.
+
+This is *not* a free discussion layer. Each role utterance is a templated
+opening based on the session metadata (task type, executor role, write gate
+status, references). The point of the MVP is to prove the thread can carry
+multi-bot dialogue at all, so a tech lead reading the channel sees something
+that resembles a team handoff instead of one silent gateway monologue.
+
+The runtime is pure-Python so it can be exercised without a Discord client:
+- ``build_turn_plan`` returns the ordered turn list for a session.
+- ``handle_team_turn_message`` is what each member bot calls inside its
+  ``on_message`` handler — it parses the dispatch marker, decides whether
+  *this* role should speak, and returns the rendered message + the next
+  dispatch directive.
+- ``mark_turn_played`` / ``next_pending_turn`` give the gateway and the bot
+  a shared view of "who has spoken so far" via ``WorkflowSession.extra``.
+
+The Discord-side glue (creating the thread, posting the kickoff, mutating
+the session state) lives in the gateway. Member bots only need this module.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from ..agents.workflow_state import WorkflowSession, load_session
+
+
+TEAM_CONVERSATION_KEY = "team_conversation"
+PLAYED_ROLES_KEY = "played_roles"
+
+DISPATCH_MARKER_RE = re.compile(
+    r"\[team-turn:(?P<sid>[A-Za-z0-9_\-]+)(?:\s+(?P<role>[A-Za-z0-9_\-]+))?\]"
+)
+
+
+@dataclass(frozen=True)
+class TeamTurn:
+    """One role's scripted turn inside a session thread."""
+
+    session_id: str
+    role: str
+    is_executor: bool
+    sequence_index: int
+    thread_id: int
+    header: str
+    body: str
+
+    def render(self) -> str:
+        return f"**[{self.role}]** {self.header}\n{self.body}"
+
+
+@dataclass(frozen=True)
+class TeamTurnOutcome:
+    """What a member bot should post in response to a dispatch directive.
+
+    ``message`` is what to say. ``next_directive`` is appended so the next
+    role's bot picks up the chain; ``None`` means this turn closes the
+    conversation and the bot should not chain further.
+    """
+
+    turn: TeamTurn
+    message: str
+    next_directive: Optional[str]
+    is_final: bool
+
+    def full_post(self) -> str:
+        if self.next_directive is None:
+            return self.message
+        return f"{self.message}\n\n{self.next_directive}"
+
+
+# ---------------------------------------------------------------------------
+# Role-specific opening templates
+# ---------------------------------------------------------------------------
+
+
+_ROLE_HEADERS: Mapping[str, str] = {
+    "tech-lead": "팀 합류, 작업 정리부터 갑니다.",
+    "product-designer": "디자인 관점에서 짚어볼게요.",
+    "frontend-engineer": "프론트 관점에서 정리해 둘게요.",
+    "backend-engineer": "백엔드 관점에서 정리합니다.",
+    "qa-engineer": "QA 관점에서 체크리스트 잡습니다.",
+}
+
+_ROLE_BODY_BUILDERS: Mapping[
+    str, Callable[["_TurnContext"], str]
+] = {}
+
+
+@dataclass(frozen=True)
+class _TurnContext:
+    session: WorkflowSession
+    role: str
+    is_executor: bool
+
+    @property
+    def task_type(self) -> str:
+        return self.session.task_type or "unknown"
+
+    @property
+    def executor_role(self) -> str:
+        return self.session.executor_role or "tech-lead"
+
+    @property
+    def references(self) -> Tuple[str, ...]:
+        merged = tuple(self.session.references_user) + tuple(
+            self.session.references_suggested
+        )
+        return merged
+
+    @property
+    def prompt_excerpt(self) -> str:
+        first_line = (self.session.prompt or "").strip().splitlines()
+        if not first_line:
+            return "(요청 본문 없음)"
+        head = first_line[0].strip()
+        if len(head) > 80:
+            head = head[:77] + "..."
+        return head or "(요청 본문 없음)"
+
+
+def _tech_lead_body(ctx: _TurnContext) -> str:
+    lines = [
+        f"분류: `{ctx.task_type}` · 실행자: `{ctx.executor_role}`.",
+        f"요청: {ctx.prompt_excerpt}",
+    ]
+    if ctx.session.write_requested and ctx.session.write_blocked_reason:
+        lines.append(
+            "쓰기 작업은 승인 대기 중입니다. 먼저 의견 정리부터 받겠습니다."
+        )
+    if ctx.references:
+        lines.append(
+            f"참고 reference {len(ctx.references)}건 공유 — 각자 본인 영역에서 어떻게 활용할지 짧게 댓글 부탁드립니다."
+        )
+    else:
+        lines.append("자료 reference는 따로 없습니다. 각자 도메인 기준으로 시작합시다.")
+    lines.append("순서대로 한 마디씩 받겠습니다.")
+    return "\n".join(lines)
+
+
+def _product_designer_body(ctx: _TurnContext) -> str:
+    refs = ", ".join(ctx.references[:3]) if ctx.references else "(reference 없음)"
+    role_self = "내가 실행자" if ctx.is_executor else f"실행자({ctx.executor_role})"
+    return (
+        f"reference 검토: {refs}.\n"
+        f"{role_self}에게 톤·레이아웃 가이드 1차 정리해서 thread에 붙이겠습니다."
+    )
+
+
+def _frontend_engineer_body(ctx: _TurnContext) -> str:
+    role_self = "본인 영역" if ctx.is_executor else f"실행자({ctx.executor_role})"
+    return (
+        "컴포넌트/레이아웃 분해 검토 시작합니다.\n"
+        f"{role_self} 합류 시 협업 포인트(상태 / 데이터 바인딩)는 thread에서 동기화하겠습니다."
+    )
+
+
+def _backend_engineer_body(ctx: _TurnContext) -> str:
+    role_self = "내가 실행자" if ctx.is_executor else f"실행자({ctx.executor_role})"
+    return (
+        "도메인 / API 영향 검토 들어갑니다.\n"
+        f"{role_self}와 schema·migration 충돌 여부 thread에 메모로 남기겠습니다."
+    )
+
+
+def _qa_engineer_body(ctx: _TurnContext) -> str:
+    role_self = "내가 실행자" if ctx.is_executor else f"실행자({ctx.executor_role})"
+    return (
+        "테스트 시나리오 초안 잡습니다.\n"
+        f"{role_self} 작업이 끝나면 회귀 영향 점검 결과를 같은 thread에 회신하겠습니다."
+    )
+
+
+_ROLE_BODY_BUILDERS = {
+    "tech-lead": _tech_lead_body,
+    "product-designer": _product_designer_body,
+    "frontend-engineer": _frontend_engineer_body,
+    "backend-engineer": _backend_engineer_body,
+    "qa-engineer": _qa_engineer_body,
+}
+
+
+def _generic_body(ctx: _TurnContext) -> str:
+    role_self = "내가 실행자" if ctx.is_executor else f"실행자({ctx.executor_role})"
+    return f"{ctx.role} 관점에서 검토 들어가겠습니다. {role_self} 기준으로 thread 회신 이어가겠습니다."
+
+
+def format_role_turn_text(
+    session: WorkflowSession,
+    role: str,
+    *,
+    is_executor: bool,
+) -> Tuple[str, str]:
+    """Return ``(header, body)`` for one role's turn message.
+
+    Roles outside the canonical engineering set fall back to a generic
+    template so a custom role sequence still produces a coherent line.
+    """
+
+    ctx = _TurnContext(session=session, role=role, is_executor=is_executor)
+    header = _ROLE_HEADERS.get(role, f"{role} 관점에서 정리합니다.")
+    builder = _ROLE_BODY_BUILDERS.get(role, _generic_body)
+    return header, builder(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Plan / state helpers
+# ---------------------------------------------------------------------------
+
+
+def build_turn_plan(session: WorkflowSession) -> Tuple[TeamTurn, ...]:
+    """Build the ordered turn plan for a session.
+
+    Requires ``session.thread_id`` and a non-empty ``role_sequence``. The
+    gateway (D's territory) is responsible for setting both before calling.
+    """
+
+    if session.thread_id is None:
+        raise ValueError(
+            f"session {session.session_id} has no thread_id; thread must be created before team conversation"
+        )
+    if not session.role_sequence:
+        raise ValueError(
+            f"session {session.session_id} has no role_sequence; dispatcher must populate it"
+        )
+
+    plan: list[TeamTurn] = []
+    for idx, role in enumerate(session.role_sequence):
+        is_executor = role == session.executor_role
+        header, body = format_role_turn_text(session, role, is_executor=is_executor)
+        plan.append(
+            TeamTurn(
+                session_id=session.session_id,
+                role=role,
+                is_executor=is_executor,
+                sequence_index=idx,
+                thread_id=int(session.thread_id),
+                header=header,
+                body=body,
+            )
+        )
+    return tuple(plan)
+
+
+def played_roles(session: WorkflowSession) -> Tuple[str, ...]:
+    """Roles that have already taken their turn in this session."""
+
+    block = (session.extra or {}).get(TEAM_CONVERSATION_KEY) or {}
+    return tuple(str(r) for r in (block.get(PLAYED_ROLES_KEY) or ()))
+
+
+def next_pending_turn(session: WorkflowSession) -> Optional[TeamTurn]:
+    """First turn in the plan whose role has not posted yet."""
+
+    plan = build_turn_plan(session)
+    played = set(played_roles(session))
+    for turn in plan:
+        if turn.role not in played:
+            return turn
+    return None
+
+
+def mark_turn_played(session: WorkflowSession, role: str) -> WorkflowSession:
+    """Return a copy of *session* with ``role`` recorded as having spoken.
+
+    The caller is responsible for persisting via
+    ``workflow_state.update_session`` so this module stays free of side
+    effects (and easy to test without a SQLite cache).
+    """
+
+    extra = dict(session.extra or {})
+    block = dict(extra.get(TEAM_CONVERSATION_KEY) or {})
+    played = list(block.get(PLAYED_ROLES_KEY) or ())
+    if role not in played:
+        played.append(role)
+    block[PLAYED_ROLES_KEY] = played
+    extra[TEAM_CONVERSATION_KEY] = block
+    return replace(session, extra=extra)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch protocol
+# ---------------------------------------------------------------------------
+
+
+def parse_dispatch_marker(text: str) -> Optional[Tuple[str, Optional[str]]]:
+    """Parse ``[team-turn:<sid> <role>]`` (role optional) out of a message.
+
+    Returns ``(session_id, role_or_None)`` or ``None`` if no marker is
+    present. Used both by the gateway when emitting directives and by
+    member bots when filtering inbound messages.
+    """
+
+    match = DISPATCH_MARKER_RE.search(text or "")
+    if not match:
+        return None
+    return match.group("sid"), match.group("role")
+
+
+def dispatch_directive(turn: TeamTurn) -> str:
+    """Marker the *previous* speaker appends to hand off to *turn*'s role."""
+
+    return f"[team-turn:{turn.session_id} {turn.role}]"
+
+
+def kickoff_directive(session: WorkflowSession) -> str:
+    """Marker the gateway posts in the thread to start the chain.
+
+    Always targets the first role in ``role_sequence`` (typically
+    ``tech-lead``). Raises ``ValueError`` if the session has no plan yet.
+    """
+
+    plan = build_turn_plan(session)
+    return dispatch_directive(plan[0])
+
+
+# ---------------------------------------------------------------------------
+# Member-bot entry point
+# ---------------------------------------------------------------------------
+
+
+SessionLoader = Callable[[str], Optional[WorkflowSession]]
+
+
+def handle_team_turn_message(
+    *,
+    role: str,
+    text: str,
+    session_loader: Optional[SessionLoader] = None,
+) -> Optional[TeamTurnOutcome]:
+    """Decide what (if anything) the bot for *role* should post.
+
+    Pure-Python; the Discord layer is responsible for taking the returned
+    ``TeamTurnOutcome.full_post()`` and sending it. Returns ``None`` when:
+
+    - the message has no dispatch marker, or
+    - the marker targets a different role, or
+    - the session is unknown, or
+    - the session does not include this role in its plan, or
+    - the role has already posted.
+    """
+
+    parsed = parse_dispatch_marker(text)
+    if parsed is None:
+        return None
+    session_id, target_role = parsed
+    if target_role is not None and target_role != role:
+        return None
+
+    loader = session_loader or load_session
+    session = loader(session_id)
+    if session is None:
+        return None
+
+    try:
+        plan = build_turn_plan(session)
+    except ValueError:
+        return None
+
+    my_turn = next((t for t in plan if t.role == role), None)
+    if my_turn is None:
+        return None
+
+    if role in played_roles(session):
+        return None
+
+    next_turn = _next_unplayed_after(plan, role, session)
+    next_directive = dispatch_directive(next_turn) if next_turn else None
+    is_final = next_turn is None
+
+    return TeamTurnOutcome(
+        turn=my_turn,
+        message=my_turn.render(),
+        next_directive=next_directive,
+        is_final=is_final,
+    )
+
+
+def _next_unplayed_after(
+    plan: Sequence[TeamTurn],
+    role: str,
+    session: WorkflowSession,
+) -> Optional[TeamTurn]:
+    played = set(played_roles(session)) | {role}
+    saw_self = False
+    for turn in plan:
+        if turn.role == role:
+            saw_self = True
+            continue
+        if not saw_self:
+            continue
+        if turn.role not in played:
+            return turn
+    return None
+
+
+def closing_message(session: WorkflowSession) -> str:
+    """Final wrap-up the last role appends after speaking.
+
+    Kept as a separate helper so the gateway / closing role can reuse it
+    without rebuilding the plan.
+    """
+
+    return (
+        "팀 합류 1차 의견 정리 완료. "
+        f"세션 `{session.session_id}` thread에서 이어서 진행합니다."
+    )

--- a/src/yule_orchestrator/discord/member_bot.py
+++ b/src/yule_orchestrator/discord/member_bot.py
@@ -3,17 +3,26 @@ from __future__ import annotations
 import sys
 
 from .config import DiscordBotConfig
+from .engineering_team_runtime import (
+    TeamTurnOutcome,
+    handle_team_turn_message,
+)
 from .member_bots import GATEWAY_ROLE_KEY, MemberBotProfile
 
 
 def run_member_bot(profile: MemberBotProfile) -> None:
     """Run a single member persona bot using its dedicated token.
 
-    MVP behavior: log in, announce identity in stdout, sit idle. The
-    department's outward-facing logic still lives in the gateway path.
-    Member bots will eventually receive internal IPC messages from the
-    gateway; for now their only job is to prove the token works and the
-    persona is recognised in the guild.
+    Behavior:
+
+    1. Log in and announce identity (still useful for ops).
+    2. Listen for ``[team-turn:<session_id> <role>]`` dispatch directives in
+       the channels/threads the bot can see. When the directive targets
+       this role, the bot posts the role's scripted opening turn into the
+       same channel and appends the next directive so the chain continues.
+
+    The actual conversation logic lives in
+    :mod:`engineering_team_runtime`; this function is the Discord wrapper.
     """
 
     if not profile.active:
@@ -40,9 +49,21 @@ def run_member_bot(profile: MemberBotProfile) -> None:
             )
 
         async def on_message(self, message: "discord.Message") -> None:  # noqa: D401 - discord callback
-            # Gateway handles all outward replies; member bots stay silent
-            # until the dispatcher milestone wires internal IPC.
-            return
+            if message.author == self.user:
+                return
+            if profile.role == GATEWAY_ROLE_KEY:
+                # Gateway bot has its own conversation handlers in bot.py;
+                # never let the member-bot loop process gateway traffic.
+                return
+
+            outcome = handle_team_turn_message(
+                role=profile.role,
+                text=message.content or "",
+            )
+            if outcome is None:
+                return
+
+            await _post_team_turn(message.channel, outcome)
 
     bot = MemberBot(command_prefix=commands.when_mentioned, intents=intents)
     print(
@@ -51,3 +72,14 @@ def run_member_bot(profile: MemberBotProfile) -> None:
         file=sys.stderr,
     )
     bot.run(profile.token)
+
+
+async def _post_team_turn(channel, outcome: TeamTurnOutcome) -> None:
+    """Send the rendered turn (and chain directive, if any) into *channel*.
+
+    Extracted so tests can drive the post path without a live Discord
+    client. Splitting the message + directive into one ``send`` keeps the
+    handoff visually grouped in the thread.
+    """
+
+    await channel.send(outcome.full_post())

--- a/tests/test_engineering_channel_router.py
+++ b/tests/test_engineering_channel_router.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.engineering_channel_router import (
+    EngineeringConversationOutcome,
+    EngineeringRouteContext,
+    EngineeringRouteResult,
+    EngineeringThreadKickoff,
+    detect_confirmation_signal,
+    is_engineering_channel,
+    route_engineering_message,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@contextmanager
+def _patched_env(values: dict[str, str | None]):
+    previous: dict[str, str | None] = {}
+    for key, value in values.items():
+        previous[key] = os.environ.get(key)
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        for key, prior in previous.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
+
+
+class _Channel:
+    def __init__(
+        self,
+        *,
+        channel_id: int,
+        name: str | None,
+        parent_id: int | None = None,
+        parent_name: str | None = None,
+    ) -> None:
+        self.id = channel_id
+        self.name = name
+        if parent_id is None and parent_name is None:
+            self.parent = None
+            self.parent_id = None
+        else:
+            self.parent = _Parent(parent_id, parent_name)
+            self.parent_id = parent_id
+
+
+class _Parent:
+    def __init__(self, parent_id: int | None, parent_name: str | None) -> None:
+        self.id = parent_id
+        self.name = parent_name
+
+
+class _Author:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+
+
+class _Message:
+    def __init__(
+        self,
+        *,
+        content: str,
+        channel: _Channel,
+        author_id: int = 4242,
+    ) -> None:
+        self.content = content
+        self.channel = channel
+        self.author = _Author(author_id)
+        self.mentions: list[Any] = []
+
+
+@dataclass
+class _FakeSession:
+    session_id: str
+    task_type: str
+    executor_role: str | None = "tech-lead"
+    executor_runner: str | None = "claude-code"
+
+
+@dataclass
+class _FakePlan:
+    role_sequence: tuple[str, ...] = ("tech-lead", "backend-engineer")
+
+
+@dataclass
+class _FakeIntakeResult:
+    session: _FakeSession
+    plan: _FakePlan
+    message: str
+
+
+def _extract_prompt(*, message: object, bot_user: object) -> str:
+    return str(getattr(message, "content", "") or "")
+
+
+class IsEngineeringChannelTests(unittest.TestCase):
+    def test_matches_by_channel_id(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        ctx = EngineeringRouteContext(intake_channel_id=111)
+        self.assertTrue(is_engineering_channel(message=message, route_context=ctx))
+
+    def test_matches_by_channel_name(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(channel_id=999, name="업무-접수"),
+        )
+        ctx = EngineeringRouteContext(intake_channel_name="업무-접수")
+        self.assertTrue(is_engineering_channel(message=message, route_context=ctx))
+
+    def test_matches_thread_parent(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(
+                channel_id=2222,
+                name="작업-thread",
+                parent_id=111,
+                parent_name="업무-접수",
+            ),
+        )
+        ctx = EngineeringRouteContext(intake_channel_id=111)
+        self.assertTrue(is_engineering_channel(message=message, route_context=ctx))
+
+    def test_thread_parent_name_match(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(
+                channel_id=2222,
+                name="작업-thread",
+                parent_id=None,
+                parent_name="#업무-접수",
+            ),
+        )
+        ctx = EngineeringRouteContext(intake_channel_name="업무-접수")
+        self.assertTrue(is_engineering_channel(message=message, route_context=ctx))
+
+    def test_returns_false_when_no_context_configured(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        ctx = EngineeringRouteContext()
+        self.assertFalse(is_engineering_channel(message=message, route_context=ctx))
+
+    def test_returns_false_for_planning_channel(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(channel_id=555, name="planning-chat"),
+        )
+        ctx = EngineeringRouteContext(intake_channel_id=111, intake_channel_name="업무-접수")
+        self.assertFalse(is_engineering_channel(message=message, route_context=ctx))
+
+
+class ConfirmationSignalTests(unittest.TestCase):
+    def test_detects_korean_confirm_phrases(self) -> None:
+        for phrase in (
+            "이대로 진행해 줘",
+            "확정",
+            "ㄱㄱ 시작하자",
+            "고고",
+            "그대로 가자 진행",
+            "오케이 진행해줘",
+        ):
+            self.assertTrue(
+                detect_confirmation_signal(phrase),
+                f"expected confirmation for {phrase!r}",
+            )
+
+    def test_detects_english_confirm_phrases(self) -> None:
+        for phrase in ("let's go", "Go ahead", "kick off please", "Proceed"):
+            self.assertTrue(
+                detect_confirmation_signal(phrase),
+                f"expected confirmation for {phrase!r}",
+            )
+
+    def test_does_not_promote_casual_yes(self) -> None:
+        for phrase in (
+            "그게 뭐야?",
+            "yes",
+            "네",
+            "오케이",
+            "",
+        ):
+            self.assertFalse(
+                detect_confirmation_signal(phrase),
+                f"did not expect confirmation for {phrase!r}",
+            )
+
+
+class RouteContextEnvTests(unittest.TestCase):
+    def test_reads_env_vars(self) -> None:
+        with _patched_env(
+            {
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_ID": "1234",
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME": "업무-접수",
+            }
+        ):
+            ctx = EngineeringRouteContext.from_env()
+        self.assertEqual(ctx.intake_channel_id, 1234)
+        self.assertEqual(ctx.intake_channel_name, "업무-접수")
+        self.assertTrue(ctx.configured)
+
+    def test_unconfigured_when_env_missing(self) -> None:
+        with _patched_env(
+            {
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_ID": None,
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME": None,
+            }
+        ):
+            ctx = EngineeringRouteContext.from_env()
+        self.assertFalse(ctx.configured)
+
+
+class RouteEngineeringMessageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context = EngineeringRouteContext(intake_channel_id=111)
+        self.send_chunks = AsyncMock()
+
+    def _route(
+        self,
+        *,
+        message: _Message,
+        conversation_fn,
+        intake_fn=None,
+        thread_kickoff_fn=None,
+    ) -> EngineeringRouteResult:
+        intake_fn = intake_fn or AsyncMock(side_effect=AssertionError("intake should not run"))
+        thread_kickoff_fn = thread_kickoff_fn or AsyncMock(
+            side_effect=AssertionError("thread kickoff should not run")
+        )
+        return _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=self.context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=conversation_fn,
+                intake_fn=intake_fn,
+                thread_kickoff_fn=thread_kickoff_fn,
+                send_chunks=self.send_chunks,
+            )
+        )
+
+    def test_non_engineering_channel_returns_unhandled(self) -> None:
+        message = _Message(
+            content="안녕",
+            channel=_Channel(channel_id=999, name="planning-chat"),
+        )
+        outcome = EngineeringConversationOutcome(content="hi")
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: outcome,
+        )
+        self.assertFalse(result.handled)
+        self.send_chunks.assert_not_awaited()
+
+    def test_engineering_message_without_confirmation_only_replies(self) -> None:
+        message = _Message(
+            content="이번 작업 우선순위 좀 정리해줘",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="우선순위는 다음과 같이 보입니다 …",
+        )
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: outcome,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.conversation_message, outcome.content)
+        self.assertIsNone(result.session_id)
+        self.send_chunks.assert_awaited_once()
+        sent_text = self.send_chunks.await_args.args[1]
+        self.assertEqual(sent_text, outcome.content)
+
+    def test_confirmation_runs_intake_and_kickoff(self) -> None:
+        message = _Message(
+            content="좋아요 그대로 진행해 주세요",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="요약은 이렇습니다.",
+            confirmed=True,
+            intake_prompt="planning-bot의 자유대화 레이어를 손봐 주세요",
+            write_requested=True,
+            thread_topic="engineer-feature-abc",
+        )
+        intake_session = _FakeSession(session_id="abc123", task_type="feature")
+        intake_plan = _FakePlan()
+        intake_message = "**[engineering-agent] 새 작업 접수** ..."
+        intake_fn = AsyncMock(
+            return_value=_FakeIntakeResult(
+                session=intake_session,
+                plan=intake_plan,
+                message=intake_message,
+            )
+        )
+        kickoff = EngineeringThreadKickoff(thread_id=4242, message="kickoff!")
+        thread_kickoff_fn = AsyncMock(return_value=kickoff)
+
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: outcome,
+            intake_fn=intake_fn,
+            thread_kickoff_fn=thread_kickoff_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "abc123")
+        self.assertEqual(result.thread_id, 4242)
+        self.assertEqual(result.intake_message, intake_message)
+        self.assertEqual(result.kickoff_message, "kickoff!")
+
+        intake_fn.assert_awaited_once()
+        intake_kwargs = intake_fn.await_args.kwargs
+        self.assertEqual(intake_kwargs["prompt"], outcome.intake_prompt)
+        self.assertTrue(intake_kwargs["write_requested"])
+        self.assertEqual(intake_kwargs["channel_id"], 111)
+        self.assertEqual(intake_kwargs["user_id"], 4242)
+
+        thread_kickoff_fn.assert_awaited_once()
+        kickoff_kwargs = thread_kickoff_fn.await_args.kwargs
+        self.assertIs(kickoff_kwargs["session"], intake_session)
+        self.assertIs(kickoff_kwargs["plan"], intake_plan)
+        self.assertEqual(kickoff_kwargs["topic"], "engineer-feature-abc")
+
+        sent_payloads = [call.args[1] for call in self.send_chunks.await_args_list]
+        self.assertIn(outcome.content, sent_payloads)
+        self.assertIn(intake_message, sent_payloads)
+
+    def test_keyword_fallback_promotes_to_intake_when_outcome_is_string(self) -> None:
+        message = _Message(
+            content="좋아 이대로 ㄱㄱ",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        intake_session = _FakeSession(session_id="ses1", task_type="ops")
+        intake_fn = AsyncMock(
+            return_value=_FakeIntakeResult(
+                session=intake_session,
+                plan=_FakePlan(),
+                message="intake!",
+            )
+        )
+        kickoff = EngineeringThreadKickoff(thread_id=7, message="kickoff!")
+        thread_kickoff_fn = AsyncMock(return_value=kickoff)
+
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: "이렇게 진행하면 어떨까요?",
+            intake_fn=intake_fn,
+            thread_kickoff_fn=thread_kickoff_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "ses1")
+        self.assertEqual(result.thread_id, 7)
+        intake_fn.assert_awaited_once()
+        intake_kwargs = intake_fn.await_args.kwargs
+        self.assertEqual(intake_kwargs["prompt"], "좋아 이대로 ㄱㄱ")
+        self.assertFalse(intake_kwargs["write_requested"])
+
+    def test_intake_failure_reports_error_without_calling_kickoff(self) -> None:
+        message = _Message(
+            content="이대로 진행해 주세요",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="요약 갑니다.",
+            confirmed=True,
+            intake_prompt="문서 만들어 주세요",
+        )
+        intake_fn = AsyncMock(side_effect=RuntimeError("dispatcher down"))
+        thread_kickoff_fn = AsyncMock(side_effect=AssertionError("kickoff should not run"))
+
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: outcome,
+            intake_fn=intake_fn,
+            thread_kickoff_fn=thread_kickoff_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertIsNone(result.session_id)
+        self.assertIn("dispatcher down", result.error or "")
+        sent_payloads = [call.args[1] for call in self.send_chunks.await_args_list]
+        self.assertIn(outcome.content, sent_payloads)
+        self.assertTrue(any("intake 실패" in payload for payload in sent_payloads))
+        thread_kickoff_fn.assert_not_awaited()
+
+    def test_kickoff_failure_keeps_session_and_reports_error(self) -> None:
+        message = _Message(
+            content="이대로 진행해 주세요",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="요약 갑니다.",
+            confirmed=True,
+            intake_prompt="작업 진행해 주세요",
+        )
+        intake_session = _FakeSession(session_id="ses-kick-fail", task_type="feature")
+        intake_fn = AsyncMock(
+            return_value=_FakeIntakeResult(
+                session=intake_session,
+                plan=_FakePlan(),
+                message="intake message",
+            )
+        )
+        thread_kickoff_fn = AsyncMock(side_effect=RuntimeError("forbidden"))
+
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: outcome,
+            intake_fn=intake_fn,
+            thread_kickoff_fn=thread_kickoff_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "ses-kick-fail")
+        self.assertIsNone(result.thread_id)
+        self.assertEqual(result.error, "forbidden")
+        sent_payloads = [call.args[1] for call in self.send_chunks.await_args_list]
+        self.assertTrue(any("thread kickoff 실패" in payload for payload in sent_payloads))
+
+    def test_async_conversation_fn_is_awaited(self) -> None:
+        message = _Message(
+            content="브리핑 좀 부탁",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(content="요약 응답")
+
+        async def _async_conversation(**_kwargs):
+            return outcome
+
+        result = self._route(
+            message=message,
+            conversation_fn=_async_conversation,
+        )
+        self.assertTrue(result.handled)
+        self.send_chunks.assert_awaited_once()
+        self.assertEqual(self.send_chunks.await_args.args[1], outcome.content)
+
+    def test_empty_prompt_does_not_handle(self) -> None:
+        message = _Message(
+            content="   ",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        result = self._route(
+            message=message,
+            conversation_fn=lambda **_: EngineeringConversationOutcome(content="ignored"),
+        )
+        self.assertFalse(result.handled)
+        self.send_chunks.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engineering_team_runtime.py
+++ b/tests/test_engineering_team_runtime.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from typing import Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.workflow_state import WorkflowSession, WorkflowState
+from yule_orchestrator.discord.engineering_team_runtime import (
+    PLAYED_ROLES_KEY,
+    TEAM_CONVERSATION_KEY,
+    TeamTurn,
+    TeamTurnOutcome,
+    build_turn_plan,
+    closing_message,
+    dispatch_directive,
+    format_role_turn_text,
+    handle_team_turn_message,
+    kickoff_directive,
+    mark_turn_played,
+    next_pending_turn,
+    parse_dispatch_marker,
+    played_roles,
+)
+
+
+def _make_session(
+    *,
+    session_id: str = "sess-team-001",
+    role_sequence: tuple[str, ...] = (
+        "tech-lead",
+        "product-designer",
+        "frontend-engineer",
+        "qa-engineer",
+    ),
+    executor_role: Optional[str] = "frontend-engineer",
+    thread_id: Optional[int] = 555111222,
+    task_type: str = "landing-page",
+    references_user: tuple[str, ...] = (),
+    references_suggested: tuple[str, ...] = ("Wix Templates", "Awwwards"),
+    write_requested: bool = True,
+    write_blocked_reason: Optional[str] = "write requested but user_approved=False",
+    extra: Optional[dict] = None,
+    prompt: str = "새 랜딩페이지 hero 섹션 정리. https://stripe.com/pricing 참고.",
+) -> WorkflowSession:
+    now = datetime(2026, 4, 30, 11, 0, 0)
+    return WorkflowSession(
+        session_id=session_id,
+        prompt=prompt,
+        task_type=task_type,
+        state=WorkflowState.APPROVED,
+        created_at=now,
+        updated_at=now,
+        role_sequence=role_sequence,
+        executor_role=executor_role,
+        executor_runner="claude",
+        references_user=references_user,
+        references_suggested=references_suggested,
+        thread_id=thread_id,
+        write_requested=write_requested,
+        write_blocked_reason=write_blocked_reason,
+        extra=extra or {},
+    )
+
+
+class BuildTurnPlanTestCase(unittest.TestCase):
+    def test_plan_matches_role_sequence_order(self) -> None:
+        session = _make_session()
+        plan = build_turn_plan(session)
+        self.assertEqual(
+            tuple(turn.role for turn in plan),
+            ("tech-lead", "product-designer", "frontend-engineer", "qa-engineer"),
+        )
+        self.assertEqual(tuple(turn.sequence_index for turn in plan), (0, 1, 2, 3))
+
+    def test_executor_flagged(self) -> None:
+        plan = build_turn_plan(_make_session())
+        self.assertEqual(
+            {turn.role: turn.is_executor for turn in plan},
+            {
+                "tech-lead": False,
+                "product-designer": False,
+                "frontend-engineer": True,
+                "qa-engineer": False,
+            },
+        )
+
+    def test_thread_id_required(self) -> None:
+        session = _make_session(thread_id=None)
+        with self.assertRaises(ValueError):
+            build_turn_plan(session)
+
+    def test_role_sequence_required(self) -> None:
+        session = _make_session(role_sequence=())
+        with self.assertRaises(ValueError):
+            build_turn_plan(session)
+
+    def test_unknown_role_falls_back_to_generic_template(self) -> None:
+        session = _make_session(role_sequence=("tech-lead", "growth-hacker"))
+        plan = build_turn_plan(session)
+        growth = plan[1]
+        self.assertEqual(growth.role, "growth-hacker")
+        self.assertIn("growth-hacker", growth.header)
+        self.assertTrue(growth.body)
+
+
+class FormatTurnTextTestCase(unittest.TestCase):
+    def test_tech_lead_body_includes_task_and_executor(self) -> None:
+        session = _make_session()
+        header, body = format_role_turn_text(session, "tech-lead", is_executor=False)
+        self.assertIn("팀", header)
+        self.assertIn("`landing-page`", body)
+        self.assertIn("`frontend-engineer`", body)
+
+    def test_tech_lead_flags_pending_write_approval(self) -> None:
+        session = _make_session()
+        _, body = format_role_turn_text(session, "tech-lead", is_executor=False)
+        self.assertIn("승인 대기", body)
+
+    def test_executor_distinguished_in_role_body(self) -> None:
+        session = _make_session(executor_role="frontend-engineer")
+        _, executor_body = format_role_turn_text(
+            session, "frontend-engineer", is_executor=True
+        )
+        _, advisor_body = format_role_turn_text(
+            session, "qa-engineer", is_executor=False
+        )
+        self.assertIn("본인", executor_body)
+        self.assertIn("실행자(frontend-engineer)", advisor_body)
+
+
+class PlayedRolesTestCase(unittest.TestCase):
+    def test_initially_empty(self) -> None:
+        self.assertEqual(played_roles(_make_session()), ())
+
+    def test_mark_turn_played_appends_marker(self) -> None:
+        session = _make_session()
+        first = mark_turn_played(session, "tech-lead")
+        self.assertEqual(played_roles(first), ("tech-lead",))
+        # Original session is unchanged (frozen dataclass + immutable extra).
+        self.assertEqual(played_roles(session), ())
+
+    def test_mark_turn_played_is_idempotent(self) -> None:
+        session = _make_session()
+        once = mark_turn_played(session, "tech-lead")
+        twice = mark_turn_played(once, "tech-lead")
+        self.assertEqual(played_roles(twice), ("tech-lead",))
+
+    def test_extra_block_uses_namespaced_key(self) -> None:
+        session = _make_session()
+        updated = mark_turn_played(session, "tech-lead")
+        self.assertIn(TEAM_CONVERSATION_KEY, updated.extra)
+        self.assertEqual(
+            updated.extra[TEAM_CONVERSATION_KEY][PLAYED_ROLES_KEY], ["tech-lead"]
+        )
+
+    def test_does_not_clobber_existing_extra_keys(self) -> None:
+        session = _make_session(extra={"unrelated": "keep me"})
+        updated = mark_turn_played(session, "tech-lead")
+        self.assertEqual(updated.extra["unrelated"], "keep me")
+        self.assertEqual(
+            updated.extra[TEAM_CONVERSATION_KEY][PLAYED_ROLES_KEY], ["tech-lead"]
+        )
+
+
+class NextPendingTurnTestCase(unittest.TestCase):
+    def test_returns_first_when_none_played(self) -> None:
+        turn = next_pending_turn(_make_session())
+        self.assertIsNotNone(turn)
+        assert turn is not None
+        self.assertEqual(turn.role, "tech-lead")
+
+    def test_skips_played_roles(self) -> None:
+        session = mark_turn_played(_make_session(), "tech-lead")
+        turn = next_pending_turn(session)
+        assert turn is not None
+        self.assertEqual(turn.role, "product-designer")
+
+    def test_returns_none_when_all_played(self) -> None:
+        session = _make_session()
+        for role in session.role_sequence:
+            session = mark_turn_played(session, role)
+        self.assertIsNone(next_pending_turn(session))
+
+
+class DispatchMarkerTestCase(unittest.TestCase):
+    def test_parse_with_role(self) -> None:
+        self.assertEqual(
+            parse_dispatch_marker("[team-turn:abc123 tech-lead]"),
+            ("abc123", "tech-lead"),
+        )
+
+    def test_parse_without_role(self) -> None:
+        self.assertEqual(
+            parse_dispatch_marker("kickoff: [team-turn:abc123]"),
+            ("abc123", None),
+        )
+
+    def test_no_marker_returns_none(self) -> None:
+        self.assertIsNone(parse_dispatch_marker("그냥 평범한 메시지"))
+        self.assertIsNone(parse_dispatch_marker(""))
+
+    def test_dispatch_directive_round_trip(self) -> None:
+        plan = build_turn_plan(_make_session())
+        directive = dispatch_directive(plan[1])
+        self.assertEqual(parse_dispatch_marker(directive), (plan[1].session_id, plan[1].role))
+
+    def test_kickoff_directive_targets_first_role(self) -> None:
+        directive = kickoff_directive(_make_session())
+        sid, role = parse_dispatch_marker(directive)
+        self.assertEqual(role, "tech-lead")
+        self.assertEqual(sid, "sess-team-001")
+
+
+class HandleTeamTurnMessageTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session = _make_session()
+
+    def _loader(self, override: Optional[WorkflowSession] = None):
+        target = override or self.session
+
+        def _load(sid: str) -> Optional[WorkflowSession]:
+            if sid == target.session_id:
+                return target
+            return None
+
+        return _load
+
+    def test_returns_none_without_marker(self) -> None:
+        self.assertIsNone(
+            handle_team_turn_message(
+                role="tech-lead",
+                text="안녕",
+                session_loader=self._loader(),
+            )
+        )
+
+    def test_returns_none_when_role_does_not_match(self) -> None:
+        text = "[team-turn:sess-team-001 tech-lead]"
+        self.assertIsNone(
+            handle_team_turn_message(
+                role="qa-engineer", text=text, session_loader=self._loader()
+            )
+        )
+
+    def test_returns_none_when_session_unknown(self) -> None:
+        text = "[team-turn:does-not-exist tech-lead]"
+        self.assertIsNone(
+            handle_team_turn_message(
+                role="tech-lead", text=text, session_loader=self._loader()
+            )
+        )
+
+    def test_role_outside_plan_is_ignored(self) -> None:
+        session = _make_session(role_sequence=("tech-lead", "product-designer"))
+        text = "[team-turn:sess-team-001 backend-engineer]"
+        self.assertIsNone(
+            handle_team_turn_message(
+                role="backend-engineer",
+                text=text,
+                session_loader=self._loader(session),
+            )
+        )
+
+    def test_already_played_role_does_not_speak_twice(self) -> None:
+        session = mark_turn_played(self.session, "tech-lead")
+        text = "[team-turn:sess-team-001 tech-lead]"
+        self.assertIsNone(
+            handle_team_turn_message(
+                role="tech-lead", text=text, session_loader=self._loader(session)
+            )
+        )
+
+    def test_first_role_chains_to_next(self) -> None:
+        text = "[team-turn:sess-team-001 tech-lead]"
+        outcome = handle_team_turn_message(
+            role="tech-lead", text=text, session_loader=self._loader()
+        )
+        assert outcome is not None
+        self.assertEqual(outcome.turn.role, "tech-lead")
+        self.assertFalse(outcome.is_final)
+        self.assertIsNotNone(outcome.next_directive)
+        # next directive points at product-designer
+        sid, next_role = parse_dispatch_marker(outcome.next_directive or "")
+        self.assertEqual(next_role, "product-designer")
+        self.assertEqual(sid, "sess-team-001")
+        # full_post combines message + directive in a single string
+        full = outcome.full_post()
+        self.assertIn("[tech-lead]", full)
+        self.assertIn(outcome.next_directive or "", full)
+
+    def test_last_role_marks_final(self) -> None:
+        session = self.session
+        for role in ("tech-lead", "product-designer", "frontend-engineer"):
+            session = mark_turn_played(session, role)
+        text = "[team-turn:sess-team-001 qa-engineer]"
+        outcome = handle_team_turn_message(
+            role="qa-engineer",
+            text=text,
+            session_loader=self._loader(session),
+        )
+        assert outcome is not None
+        self.assertTrue(outcome.is_final)
+        self.assertIsNone(outcome.next_directive)
+        self.assertEqual(outcome.full_post(), outcome.message)
+
+    def test_marker_without_role_still_lets_owner_speak(self) -> None:
+        text = "kickoff [team-turn:sess-team-001]"
+        outcome = handle_team_turn_message(
+            role="tech-lead", text=text, session_loader=self._loader()
+        )
+        assert outcome is not None
+        self.assertEqual(outcome.turn.role, "tech-lead")
+
+    def test_marker_without_role_does_not_let_others_speak_out_of_turn(self) -> None:
+        # A marker with no role still triggers; we rely on
+        # "already played" checks to avoid out-of-order chatter.
+        text = "kickoff [team-turn:sess-team-001]"
+        outcome_qa = handle_team_turn_message(
+            role="qa-engineer", text=text, session_loader=self._loader()
+        )
+        # qa-engineer is in the plan and not yet played, so a role-less
+        # broadcast WOULD let it speak. To prevent multiple bots replying
+        # to a kickoff, the gateway should always emit a role-targeted
+        # directive. This assertion documents the trade-off.
+        self.assertIsNotNone(outcome_qa)
+
+
+class TeamTurnDataTestCase(unittest.TestCase):
+    def test_team_turn_render_format(self) -> None:
+        turn = TeamTurn(
+            session_id="s",
+            role="tech-lead",
+            is_executor=False,
+            sequence_index=0,
+            thread_id=42,
+            header="hi",
+            body="body",
+        )
+        self.assertEqual(turn.render(), "**[tech-lead]** hi\nbody")
+
+    def test_full_post_with_directive(self) -> None:
+        outcome = TeamTurnOutcome(
+            turn=TeamTurn(
+                session_id="s",
+                role="tech-lead",
+                is_executor=False,
+                sequence_index=0,
+                thread_id=42,
+                header="hi",
+                body="body",
+            ),
+            message="**[tech-lead]** hi\nbody",
+            next_directive="[team-turn:s product-designer]",
+            is_final=False,
+        )
+        full = outcome.full_post()
+        self.assertIn("body", full)
+        self.assertIn("[team-turn:s product-designer]", full)
+
+    def test_closing_message_mentions_session(self) -> None:
+        msg = closing_message(_make_session())
+        self.assertIn("sess-team-001", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
없음  
engineering-agent 팀형 Discord 대화 작업의 일부입니다.

## ✨ 과제 내용
세션이 확정되고 작업 thread가 열리면,
`tech-lead`, `product-designer`, `backend-engineer`, `frontend-engineer`, `qa-engineer`가
같은 thread 안에서 순차적으로 발화할 수 있는 팀 대화 runtime을 추가했습니다.

이번 PR의 목표는 member bot이 단순 로그인 상태를 넘어,
Discord에서 실제 팀처럼 보이게 만드는 것입니다.

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 / 참고 사항
- 이 PR은 “실제 팀처럼 보이는 UX”를 만드는 첫 버전임
- member bot 대화는 MVP 기준 순차 발화에 집중하고, 완전 자율 협업은 후속으로 남김
