### PR TITLE
[Feature] Obsidian 리서치 노트 로컬 동기화 작업

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,3 +110,9 @@ DISCORD_GUILD_ID=
 #                    각 멤버 봇이 자기 역할 차례에 자기 계정으로 의견을 남긴다 (실제 팀 회의 느낌).
 # gateway: 게이트웨이가 모든 역할 코멘트를 대신 게시 (멤버 봇 토큰이 없을 때 폴백).
 # ENGINEERING_RESEARCH_FORUM_COMMENT_MODE=member-bots
+
+# Obsidian local sync (`yule obsidian sync`)
+# Obsidian vault의 절대경로. 이 값이 있어야 ResearchPack을 실제 Markdown 파일로 저장한다.
+# 실제 사용자 절대경로는 .env.local에 둬라 — .env.example은 git에 커밋되므로 placeholder만 둔다.
+# 예: OBSIDIAN_VAULT_PATH=/Users/<MY_USER>/local-dev/yule-agent-vault/obsidian-vault
+# OBSIDIAN_VAULT_PATH=

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ yule obsidian sync --session <session_id> --overwrite
 yule obsidian sync --session <session_id> --kind reference
 ```
 
-vault 안에는 exporter가 정한 `Agents/Engineering/<kind>/YYYY-MM-DD_<slug>.md` 경로로 떨어집니다. 예: `$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md`. 자세한 contract와 안전 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md`를 참고하세요. `yule doctor`는 `obsidian vault` 체크를 자동 수행합니다.
+vault 안에는 exporter가 정한 `Agents/Engineering/<kind>/YYYY-MM-DD_<slug>.md` 경로로 떨어집니다. 예: `$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md`. 같은 날짜·같은 slug로 sync가 반복되면 같은 폴더 안에서 `..._2.md`, `..._3.md` 식으로 자동 suffix가 붙어 기존 노트는 silently 덮이지 않고, `--overwrite`를 명시하면 suffix 없이 원래 파일을 그대로 교체합니다. 자세한 contract와 안전 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md`를 참고하세요. `yule doctor`는 `obsidian vault` 체크를 자동 수행합니다.
 
 게이트웨이가 deliberation을 끝내면 `TechLeadSynthesis`(합의안/해야 할 일/더 조사할 것/사용자 결정 필요/승인 여부)도 session에 함께 저장되어, sync는 이 값을 복원해 `Agents/Engineering/Decisions/...` 아래에 5개 섹션을 갖춘 결정 노트로 떨어뜨립니다. synthesis 키가 없는 오래된 session은 안전하게 fallback해 `Research` 폴더의 자료 노트로만 떨어집니다.
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,14 @@ yule obsidian sync --session <session_id> --kind reference
 
 vault 안에는 exporter가 정한 `Agents/Engineering/<kind>/YYYY-MM-DD_<slug>.md` 경로로 떨어집니다. 예: `$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md`. 같은 날짜·같은 slug로 sync가 반복되면 같은 폴더 안에서 `..._2.md`, `..._3.md` 식으로 자동 suffix가 붙어 기존 노트는 silently 덮이지 않고, `--overwrite`를 명시하면 suffix 없이 원래 파일을 그대로 교체합니다. 자세한 contract와 안전 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md`를 참고하세요. `yule doctor`는 `obsidian vault` 체크를 자동 수행합니다.
 
+vault를 git으로 관리한다면 `--git-commit` 옵션으로 sync 직후 자동 commit까지 남길 수 있습니다. 대상은 코드 저장소가 아니라 **Obsidian vault repo**이고, 기본 동작은 **opt-in**, **이번 sync가 만든 그 note 파일 하나만 stage/commit**, **push는 절대 하지 않음**입니다. vault repo에 이미 staged 변경이 있거나 vault가 git repo가 아니면 fail-loud로 종료합니다. `--dry-run --git-commit`은 파일/commit 모두 시뮬레이션만 합니다.
+
+```bash
+yule obsidian sync --session <session_id> --git-commit
+yule obsidian sync --session <session_id> --git-commit --git-message "obsidian sync: hero 회의"
+yule obsidian sync --session <session_id> --git-commit --dry-run
+```
+
 게이트웨이가 deliberation을 끝내면 `TechLeadSynthesis`(합의안/해야 할 일/더 조사할 것/사용자 결정 필요/승인 여부)도 session에 함께 저장되어, sync는 이 값을 복원해 `Agents/Engineering/Decisions/...` 아래에 5개 섹션을 갖춘 결정 노트로 떨어뜨립니다. synthesis 키가 없는 오래된 session은 안전하게 fallback해 `Research` 폴더의 자료 노트로만 떨어집니다.
 
 ## Discord Bot

--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ yule obsidian sync --session <session_id> --kind reference
 
 vault 안에는 exporter가 정한 `Agents/Engineering/<kind>/YYYY-MM-DD_<slug>.md` 경로로 떨어집니다. 예: `$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md`. 자세한 contract와 안전 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md`를 참고하세요. `yule doctor`는 `obsidian vault` 체크를 자동 수행합니다.
 
+게이트웨이가 deliberation을 끝내면 `TechLeadSynthesis`(합의안/해야 할 일/더 조사할 것/사용자 결정 필요/승인 여부)도 session에 함께 저장되어, sync는 이 값을 복원해 `Agents/Engineering/Decisions/...` 아래에 5개 섹션을 갖춘 결정 노트로 떨어뜨립니다. synthesis 키가 없는 오래된 session은 안전하게 fallback해 `Research` 폴더의 자료 노트로만 떨어집니다.
+
 ## Discord Bot
 
 - 단일 Discord Bot은 `yule discord bot`으로 실행합니다.

--- a/README.md
+++ b/README.md
@@ -423,6 +423,23 @@ Discord slash command는 `yule discord bot` 또는 `yule discord up` 실행 시 
 - `/engineer_review_reply`는 적용/제안/남은 이슈를 같은 review cycle에 회신합니다.
 - Discord slash command의 `complete`는 inline `references_used`를 받지 않으므로, reference 인용까지 닫으려면 CLI `yule engineer complete --references-used <json>`을 사용합니다.
 
+### Obsidian 로컬 동기화
+
+ResearchPack을 개인 Obsidian vault에 Markdown 파일로 저장하려면 `OBSIDIAN_VAULT_PATH`에 vault 절대경로를 설정합니다. **실제 절대경로는 git에 커밋되는 `.env.example`이 아니라 로컬 전용 `.env.local`에 둡니다** — `.gitignore`가 `.env*`는 제외하고 `.env.example`만 화이트리스트로 추적하기 때문입니다.
+
+```bash
+# .env.local 예시
+OBSIDIAN_VAULT_PATH=/Users/<MY_USER>/local-dev/yule-agent-vault/obsidian-vault
+
+# 사용
+yule obsidian sync --session <session_id>            # 실제 쓰기 (overwrite 금지가 기본)
+yule obsidian sync --session <session_id> --dry-run  # 경로/내용만 검증
+yule obsidian sync --session <session_id> --overwrite
+yule obsidian sync --session <session_id> --kind reference
+```
+
+vault 안에는 exporter가 정한 `Agents/Engineering/<kind>/YYYY-MM-DD_<slug>.md` 경로로 떨어집니다. 예: `$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md`. 자세한 contract와 안전 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md`를 참고하세요. `yule doctor`는 `obsidian vault` 체크를 자동 수행합니다.
+
 ## Discord Bot
 
 - 단일 Discord Bot은 `yule discord bot`으로 실행합니다.

--- a/policies/runtime/agents/engineering-agent/obsidian-memory.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-memory.md
@@ -231,8 +231,29 @@ Agents/Engineering/Research/2026-04-30_stripe-pricing_3.md    # 3회차
 - `ObsidianWriteResult.original_target_path`/`suffix_applied`로 호출자가 원래 추천 path와 실제 선택된 path를 구분할 수 있다 — CLI는 suffix가 적용되면 `note: applied auto-suffix to avoid clobbering ...` 한 줄을 추가 출력한다.
 - 같은 폴더에 1000개의 후보가 모두 차 있으면 (운영상 도달 불가 수준) `ObsidianWriteError`로 실패해 호출자가 정리 또는 `--overwrite` 결정을 내릴 수 있게 한다.
 
-### 8.8 남은 후속 작업
+### 8.8 vault git auto-commit
 
-1. vault git 통합 — vault를 git으로 관리하고 sync 직후 자동 commit.
-2. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
-3. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.
+`yule obsidian sync`는 옵션으로 vault repo에 자동 commit을 남길 수 있다. 대상 git repo는 **이 코드 저장소가 아니라** `OBSIDIAN_VAULT_PATH`가 가리키는 Obsidian vault repo다. 코드 진실 소스: `src/yule_orchestrator/agents/obsidian_git.py`.
+
+```bash
+yule obsidian sync --session abc12345 --git-commit
+yule obsidian sync --session abc12345 --git-commit --git-message "obsidian sync: hero 회의"
+yule obsidian sync --session abc12345 --git-commit --dry-run     # commit도 시뮬레이션만
+```
+
+규칙
+- **opt-in**: `--git-commit` 없으면 git 호출이 단 한 번도 일어나지 않는다 (기존 sync 그대로).
+- **단일 파일 commit**: 이번 sync가 만든/덮어쓴 그 note 파일 하나만 `git add -- <abs path>`로 stage하고 `git commit -m <msg> -- <abs path>`로 commit한다. `git add .` / `-A`는 절대 사용하지 않는다.
+- **unrelated 보호**: vault repo에 이미 staged 변경이 있으면 auto-commit은 fail-loud로 중단한다 (`error: vault repo has pre-existing staged changes ...`). 운영자가 그 상태를 인지하지 못한 채 sync commit에 다른 작업이 묶이는 사고를 막는다. unstaged 변경은 그대로 둔다.
+- **vault non-git**: vault root 또는 그 조상에서 `.git`을 못 찾으면 `--git-commit`은 fail-loud (`error: --git-commit requested but vault root ... is not a git repository`). silently skip 하지 않는다 — 사용자가 commit을 의도했는데 안 된 사실을 모르면 더 위험하다. note 파일 자체는 git 단계 직전에 이미 쓰였다.
+- **idempotent sync**: vault HEAD에 같은 내용이 이미 있으면 `git: no changes to commit (file already at vault HEAD)` 한 줄 출력 후 종료 코드 0. 재실행 안전.
+- **dry-run**: `--dry-run --git-commit`은 파일 write도, git add/commit도 실제로 하지 않고 `git: would commit ...` 메시지만 출력한다.
+- **push 금지**: 어떤 코드 경로에서도 `git push`를 호출하지 않는다.
+- **commit message**: 기본값은 `obsidian sync: <session_id> [(<kind>)] <relative_path>`. `--git-message`로 임의 문자열 override 가능. 빈 문자열은 거부.
+- **target outside repo**: writer의 path traversal 가드와 별개로, git 레이어도 commit 대상이 repo root 안인지 `relative_to`로 재검증한다.
+
+### 8.9 남은 후속 작업
+
+1. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
+2. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.
+3. auto-commit 후 선택적 push hook — 현재 정책은 push 금지. 운영자 수동 push 또는 Obsidian 동기화 플러그인 영역.

--- a/policies/runtime/agents/engineering-agent/obsidian-memory.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-memory.md
@@ -194,9 +194,28 @@ $OBSIDIAN_VAULT_PATH/Agents/Engineering/References/2026-04-30_landing-references
 - 절대경로 아님 / 디렉터리 없음: `FAIL` + hint.
 - 정상: `OK` + 해석된 절대경로.
 
-### 8.6 남은 후속 작업
+### 8.6 synthesis 복원
+
+게이트웨이가 deliberation을 마치면 `TechLeadSynthesis`(합의안/해야 할 일/더 조사할 것/사용자 결정 필요/승인 여부)는 같은 시점에 ResearchPack과 함께 `session.extra`로 영속화된다. sync는 이 값을 읽어 decision note로 그대로 흘린다.
+
+저장 키
+- `session.extra["research_synthesis"]` — `synthesis_to_dict`가 만든 dict (`v: 1` + 6필드).
+- `session.extra["research_synthesis_text"]` — 사람이 읽기 쉬운 렌더 텍스트(현재 sync는 사용 안 하지만 외부 디버그용으로 함께 보존).
+
+복원 순서 (`yule obsidian sync`):
+1. session.extra에 `research_synthesis`가 있으면 `synthesis_from_dict`로 `TechLeadSynthesis` 복원.
+2. 복원된 synthesis를 `render_research_note(pack, session=session, synthesis=synthesis, kind=...)`로 전달.
+3. exporter contract에 따라 kind 미지정 시 자동 `decision`으로 분류되어 `Agents/Engineering/Decisions/...`에 떨어진다.
+4. 본문에 `## 합의안 / ## 해야 할 일 / ## 더 조사할 것 / ## 사용자 결정 필요 / ## 승인 필요 여부` 5개 섹션이 모두 들어간다.
+
+backward compatibility
+- 저장 키가 없는 옛 session은 sync가 정상 동작하되 `research` 노트로만 떨어진다(synthesis 섹션 없음). crash하지 않는다.
+- 저장 payload가 손상되어 `synthesis_from_dict`가 실패하면 `warning: ...`을 stderr에 한 줄 남기고 synthesis 없이 진행한다.
+- `consensus`가 누락되거나 타입이 어긋나면 best-effort로 빈 본문이 들어간 합의안 섹션을 만든다 — sync 자체는 성공.
+
+### 8.7 남은 후속 작업
 
 1. vault git 통합 — vault를 git으로 관리하고 sync 직후 자동 commit.
 2. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
 3. 파일명 충돌 정책 확장 — 같은 날짜·같은 slug일 때 `_2.md` 같은 suffix 자동 부여 (현재는 `--overwrite` 명시 또는 skip).
-4. synthesis 영속화 — 현재 `WorkflowSession`에는 `TechLeadSynthesis`가 저장되지 않으므로 sync도 synthesis 본문 없이 진행된다. 필요해지면 session.extra에 함께 round-trip.
+4. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.

--- a/policies/runtime/agents/engineering-agent/obsidian-memory.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-memory.md
@@ -1,8 +1,11 @@
-# Obsidian Memory Export — v0 contract (string-only)
+# Obsidian Memory Export — v0 contract (string + local file writer)
 
-이 문서는 engineering-agent의 ResearchPack/deliberation 결과를 **개인 Obsidian vault**로 내보낼 때 사용할 Markdown 구조와 path 규칙을 정의한다. 본 단계는 **문자열 생성**까지만 다루며 실제 파일 쓰기는 호출자(또는 후속 `yule obsidian sync`)가 결정한다.
+이 문서는 engineering-agent의 ResearchPack/deliberation 결과를 **개인 Obsidian vault**로 내보낼 때 사용할 Markdown 구조와 path 규칙을 정의한다. 문자열 생성은 `obsidian_export`가, 실제 파일 쓰기는 `obsidian_writer` + `yule obsidian sync` CLI가 담당한다.
 
-코드 진실 소스: `src/yule_orchestrator/agents/obsidian_export.py`. contract 식별자: `research-forum-export/v0`.
+코드 진실 소스:
+- 문자열 생성: `src/yule_orchestrator/agents/obsidian_export.py` (contract 식별자: `research-forum-export/v0`).
+- 파일 쓰기: `src/yule_orchestrator/agents/obsidian_writer.py` (얇은 IO 레이어 — exporter contract는 그대로 유지).
+- CLI: `src/yule_orchestrator/cli/obsidian.py` (`yule obsidian sync`).
 
 ## 1. 진입점
 
@@ -128,9 +131,72 @@ yes | no   (yes일 때 — 사유)
 - vault path 변경(`Agents/Engineering/...` 트리)은 호환성 영향이 크므로 별도 PR로 처리하고 마이그레이션 스크립트를 함께 제시한다.
 - `_yaml_scalar` quoting 규칙을 바꾸면 frontmatter 파싱이 영향받으므로 본 문서 §3 마지막 항목과 함께 갱신한다.
 
-## 8. 후속 작업
+## 8. 로컬 파일 동기화 (`yule obsidian sync`)
 
-1. 실제 파일 writer (`yule obsidian sync`) — 본 contract의 `note.path.full`에 `note.content`를 쓰는 얇은 CLI.
-2. vault git 통합 — 변경 분 자동 commit.
-3. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
-4. 파일명 충돌 정책 — 같은 날짜·같은 slug일 때 suffix 처리 (`_2.md`).
+`obsidian_export`가 만든 `note.content`를 vault 안 `note.path.full` 위치에 실제 Markdown 파일로 쓰는 얇은 IO 레이어다. exporter contract는 건드리지 않는다.
+
+### 8.1 환경변수
+
+- `OBSIDIAN_VAULT_PATH`: Obsidian vault의 **절대경로**. 이 값이 없으면 sync는 즉시 실패한다.
+- 실제 사용자 절대경로는 반드시 `.env.local`에 둔다. `.env.example`은 git에 커밋되는 파일이므로 placeholder만 두고, 실제 경로는 git 추적에서 빠진 `.env.local`(또는 `.env`)에서만 읽도록 강제한다 — `.gitignore`가 `.env`/`.env.*`는 제외하고 `.env.example`만 화이트리스트로 남기는 구조와 일관된다.
+
+### 8.2 사용
+
+```bash
+# 1) session_id로 저장된 ResearchPack을 vault에 쓴다 (가장 흔한 경우)
+yule obsidian sync --session abc12345
+
+# 2) 미리 결과만 보고 싶을 때
+yule obsidian sync --session abc12345 --dry-run
+
+# 3) 같은 path가 이미 있을 때 명시적으로 덮어쓰기
+yule obsidian sync --session abc12345 --overwrite
+
+# 4) reference 노트로 분류해 저장 (kind 강제)
+yule obsidian sync --session abc12345 --kind reference
+
+# 5) env가 아닌 임시 vault로 보내기
+yule obsidian sync --session abc12345 --vault-path /tmp/sandbox-vault
+```
+
+CLI는 다음 순서로 동작한다.
+
+1. `load_session(session_id)` — workflow cache에서 세션을 읽는다. 없으면 사람 가독 에러.
+2. `session.extra["research_pack"]`를 `pack_from_dict`로 복원. 없으면 "research_pack이 없다" 안내 후 종료.
+3. `OBSIDIAN_VAULT_PATH`(또는 `--vault-path`) 검증 — 절대경로/존재/디렉터리 여부.
+4. `render_research_note(pack, session=session, kind=...)`로 `ObsidianNote` 생성 (exporter contract 그대로).
+5. `write_note(note, vault_root, overwrite=..., dry_run=...)` 호출.
+
+### 8.3 안전 정책
+
+- vault root는 절대경로여야 하고 디렉터리로 존재해야 한다.
+- 최종 target path는 `vault_root.resolve() / note.path.full`을 다시 resolve한 뒤 `relative_to(vault_root)`로 검증 — 즉 symlink 등으로 vault 밖으로 나가는 path traversal은 거부된다.
+- parent 디렉터리는 `mkdir(parents=True, exist_ok=True)`로 자동 생성한다.
+- 기본은 **overwrite 금지**: 같은 path가 이미 있으면 `skipped` 결과를 반환하고 사유를 출력한다. 덮어쓰려면 `--overwrite`를 명시해야 한다.
+- `--dry-run`은 모든 검증을 수행하지만 파일은 만들지 않는다.
+- 실패 시 `error: ...` 형식으로 stderr에 사람이 이해 가능한 메시지를 남긴다.
+
+### 8.4 출력 경로 예시
+
+`render_research_note`가 만든 vault-relative path가 그대로 vault 안에 떨어진다.
+
+```text
+$OBSIDIAN_VAULT_PATH/Agents/Engineering/Research/2026-04-30_stripe-pricing.md
+$OBSIDIAN_VAULT_PATH/Agents/Engineering/Decisions/2026-04-30_hero-합의.md
+$OBSIDIAN_VAULT_PATH/Agents/Engineering/References/2026-04-30_landing-references.md
+```
+
+### 8.5 doctor 연동
+
+`yule doctor`는 `obsidian vault` 체크를 포함한다.
+
+- 미설정: `SKIP` (sync 사용 안 하면 정상).
+- 절대경로 아님 / 디렉터리 없음: `FAIL` + hint.
+- 정상: `OK` + 해석된 절대경로.
+
+### 8.6 남은 후속 작업
+
+1. vault git 통합 — vault를 git으로 관리하고 sync 직후 자동 commit.
+2. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
+3. 파일명 충돌 정책 확장 — 같은 날짜·같은 slug일 때 `_2.md` 같은 suffix 자동 부여 (현재는 `--overwrite` 명시 또는 skip).
+4. synthesis 영속화 — 현재 `WorkflowSession`에는 `TechLeadSynthesis`가 저장되지 않으므로 sync도 synthesis 본문 없이 진행된다. 필요해지면 session.extra에 함께 round-trip.

--- a/policies/runtime/agents/engineering-agent/obsidian-memory.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-memory.md
@@ -170,10 +170,10 @@ CLI는 다음 순서로 동작한다.
 ### 8.3 안전 정책
 
 - vault root는 절대경로여야 하고 디렉터리로 존재해야 한다.
-- 최종 target path는 `vault_root.resolve() / note.path.full`을 다시 resolve한 뒤 `relative_to(vault_root)`로 검증 — 즉 symlink 등으로 vault 밖으로 나가는 path traversal은 거부된다.
+- 최종 target path는 `vault_root.resolve() / note.path.full`을 다시 resolve한 뒤 `relative_to(vault_root)`로 검증 — 즉 symlink 등으로 vault 밖으로 나가는 path traversal은 거부된다. auto-suffix가 만든 후보 경로도 같은 검증을 다시 통과해야 한다.
 - parent 디렉터리는 `mkdir(parents=True, exist_ok=True)`로 자동 생성한다.
-- 기본은 **overwrite 금지**: 같은 path가 이미 있으면 `skipped` 결과를 반환하고 사유를 출력한다. 덮어쓰려면 `--overwrite`를 명시해야 한다.
-- `--dry-run`은 모든 검증을 수행하지만 파일은 만들지 않는다.
+- 같은 path가 이미 있으면 기본 동작은 **자동 suffix**다 — 같은 폴더 안에서 `<name>_2.md`, `<name>_3.md` … 순으로 비어 있는 첫 후보를 골라 새 파일로 저장한다. 기존 노트는 절대 silently 덮이지 않고, 새 sync는 silently skip되지 않는다. `--overwrite`를 명시하면 suffix 없이 원래 파일명을 그대로 덮어쓴다.
+- `--dry-run`은 auto-suffix 선택까지 포함한 모든 검증을 수행하지만 파일은 만들지 않는다 — 출력되는 target path가 실제 sync 결과와 동일하다.
 - 실패 시 `error: ...` 형식으로 stderr에 사람이 이해 가능한 메시지를 남긴다.
 
 ### 8.4 출력 경로 예시
@@ -213,9 +213,26 @@ backward compatibility
 - 저장 payload가 손상되어 `synthesis_from_dict`가 실패하면 `warning: ...`을 stderr에 한 줄 남기고 synthesis 없이 진행한다.
 - `consensus`가 누락되거나 타입이 어긋나면 best-effort로 빈 본문이 들어간 합의안 섹션을 만든다 — sync 자체는 성공.
 
-### 8.7 남은 후속 작업
+### 8.7 파일명 충돌 정책
+
+같은 날짜·같은 slug로 export가 반복되면 writer가 같은 폴더 안에서 첫 비어 있는 이름을 자동으로 고른다.
+
+```
+Agents/Engineering/Research/2026-04-30_stripe-pricing.md      # 1회차
+Agents/Engineering/Research/2026-04-30_stripe-pricing_2.md    # 2회차
+Agents/Engineering/Research/2026-04-30_stripe-pricing_3.md    # 3회차
+```
+
+규칙
+- suffix는 `.md` 앞에 붙는다 (`<stem>_<n>.<suffix>`).
+- 같은 폴더 안에서만 검색한다.
+- `--overwrite`가 있으면 suffix를 적용하지 않고 원래 파일을 그대로 덮어쓴다.
+- `--dry-run`은 auto-suffix 후보 선택까지 미리 수행해 실제 sync와 같은 target path를 출력한다.
+- `ObsidianWriteResult.original_target_path`/`suffix_applied`로 호출자가 원래 추천 path와 실제 선택된 path를 구분할 수 있다 — CLI는 suffix가 적용되면 `note: applied auto-suffix to avoid clobbering ...` 한 줄을 추가 출력한다.
+- 같은 폴더에 1000개의 후보가 모두 차 있으면 (운영상 도달 불가 수준) `ObsidianWriteError`로 실패해 호출자가 정리 또는 `--overwrite` 결정을 내릴 수 있게 한다.
+
+### 8.8 남은 후속 작업
 
 1. vault git 통합 — vault를 git으로 관리하고 sync 직후 자동 commit.
 2. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
-3. 파일명 충돌 정책 확장 — 같은 날짜·같은 slug일 때 `_2.md` 같은 suffix 자동 부여 (현재는 `--overwrite` 명시 또는 skip).
-4. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.
+3. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.

--- a/policies/runtime/agents/engineering-agent/obsidian-memory.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-memory.md
@@ -194,7 +194,21 @@ $OBSIDIAN_VAULT_PATH/Agents/Engineering/References/2026-04-30_landing-references
 - 절대경로 아님 / 디렉터리 없음: `FAIL` + hint.
 - 정상: `OK` + 해석된 절대경로.
 
-### 8.6 synthesis 복원
+### 8.6 research_pack 영속화 (intake 직후)
+
+`yule obsidian sync`는 `session.extra["research_pack"]`를 입력으로 받는다. 이 키가 누락되면 sync 자체가 종료되므로, intake 시점에 안전하게 채워두는 일이 핵심이다.
+
+- 진실 소스: `src/yule_orchestrator/agents/research_persistence.py` (`persist_research_artifacts`).
+- 호출 시점:
+  1. **engineering channel router**가 `intake_fn`(또는 thread continuation)이 세션을 만든 직후, `outcome.research_pack`/`outcome.collection_outcome`이 있으면 즉시 호출.
+  2. **forum research-loop hook**이 deliberation을 마치고 추가로 호출 — synthesis/collection 메타데이터를 함께 저장.
+- 호출 1이 핵심 보장이다: research_loop_fn이 미배선이거나 (`--git-commit` 미사용 같은 경우), `forum_ctx`가 unconfigured거나, 짧은 confirm 메시지(`이대로 진행`)만으로 `run_research_loop`가 `insufficient`로 short-circuit해도 pack은 이미 session.extra에 들어간다.
+- 호출은 **idempotent**: 같은 pack을 두 번 써도 같은 결과. 이를 통해 1과 2의 double-write가 안전.
+- 영속화 실패는 stderr에 `warning:` 한 줄을 남기고 swallow한다 — engineering 흐름은 절대 막지 않는다.
+
+이전 버그: 첫 메시지에서 collector가 만든 pack은 process-local `_ENGINEERING_LAST_RESEARCH_CONTEXT`에만 있었고, persist는 forum hook이 `_run_pack_deliberation_loop`를 통과해야만 일어났다. recall이 실패하거나 (봇 재시작/채널 변경) confirm 텍스트만으로 hook이 insufficient short-circuit하면 session.extra에 pack이 안 들어가서 sync가 영구 실패.
+
+### 8.7 synthesis 복원
 
 게이트웨이가 deliberation을 마치면 `TechLeadSynthesis`(합의안/해야 할 일/더 조사할 것/사용자 결정 필요/승인 여부)는 같은 시점에 ResearchPack과 함께 `session.extra`로 영속화된다. sync는 이 값을 읽어 decision note로 그대로 흘린다.
 
@@ -213,7 +227,7 @@ backward compatibility
 - 저장 payload가 손상되어 `synthesis_from_dict`가 실패하면 `warning: ...`을 stderr에 한 줄 남기고 synthesis 없이 진행한다.
 - `consensus`가 누락되거나 타입이 어긋나면 best-effort로 빈 본문이 들어간 합의안 섹션을 만든다 — sync 자체는 성공.
 
-### 8.7 파일명 충돌 정책
+### 8.8 파일명 충돌 정책
 
 같은 날짜·같은 slug로 export가 반복되면 writer가 같은 폴더 안에서 첫 비어 있는 이름을 자동으로 고른다.
 
@@ -231,7 +245,7 @@ Agents/Engineering/Research/2026-04-30_stripe-pricing_3.md    # 3회차
 - `ObsidianWriteResult.original_target_path`/`suffix_applied`로 호출자가 원래 추천 path와 실제 선택된 path를 구분할 수 있다 — CLI는 suffix가 적용되면 `note: applied auto-suffix to avoid clobbering ...` 한 줄을 추가 출력한다.
 - 같은 폴더에 1000개의 후보가 모두 차 있으면 (운영상 도달 불가 수준) `ObsidianWriteError`로 실패해 호출자가 정리 또는 `--overwrite` 결정을 내릴 수 있게 한다.
 
-### 8.8 vault git auto-commit
+### 8.9 vault git auto-commit
 
 `yule obsidian sync`는 옵션으로 vault repo에 자동 commit을 남길 수 있다. 대상 git repo는 **이 코드 저장소가 아니라** `OBSIDIAN_VAULT_PATH`가 가리키는 Obsidian vault repo다. 코드 진실 소스: `src/yule_orchestrator/agents/obsidian_git.py`.
 
@@ -252,7 +266,7 @@ yule obsidian sync --session abc12345 --git-commit --dry-run     # commit도 시
 - **commit message**: 기본값은 `obsidian sync: <session_id> [(<kind>)] <relative_path>`. `--git-message`로 임의 문자열 override 가능. 빈 문자열은 거부.
 - **target outside repo**: writer의 path traversal 가드와 별개로, git 레이어도 commit 대상이 repo root 안인지 `relative_to`로 재검증한다.
 
-### 8.9 남은 후속 작업
+### 8.10 남은 후속 작업
 
 1. `[Obsidian]` 댓글이 달린 forum thread 자동 export pipeline (research-forum.md §4.3와 결합).
 2. RoleTake 영속화 — 현재 sync는 synthesis까지만 복원한다. 역할별 의견 본문(role takes)을 Obsidian에 남기려면 별도 round-trip이 필요하다.

--- a/src/yule_orchestrator/agents/deliberation.py
+++ b/src/yule_orchestrator/agents/deliberation.py
@@ -251,6 +251,67 @@ class TechLeadSynthesis:
     approval_reason: Optional[str] = None
 
 
+SYNTHESIS_PERSIST_VERSION = 1
+
+
+def synthesis_to_dict(synthesis: TechLeadSynthesis) -> dict:
+    """Serialize a :class:`TechLeadSynthesis` for ``session.extra``.
+
+    The ``v`` key lets future readers branch on schema changes; current
+    consumers read ``v=1``.
+    """
+
+    return {
+        "v": SYNTHESIS_PERSIST_VERSION,
+        "consensus": synthesis.consensus,
+        "todos": list(synthesis.todos),
+        "open_research": list(synthesis.open_research),
+        "user_decisions_needed": list(synthesis.user_decisions_needed),
+        "approval_required": bool(synthesis.approval_required),
+        "approval_reason": synthesis.approval_reason,
+    }
+
+
+def synthesis_from_dict(data: Mapping[str, Any]) -> TechLeadSynthesis:
+    """Reverse :func:`synthesis_to_dict` — best-effort reconstruction.
+
+    Missing/malformed lists fall back to empty tuples. ``consensus`` is
+    coerced to ``str`` so a malformed payload still produces a usable
+    synthesis (the export will simply have an empty consensus block).
+    """
+
+    consensus = data.get("consensus")
+    consensus_text = str(consensus) if consensus is not None else ""
+    return TechLeadSynthesis(
+        consensus=consensus_text,
+        todos=tuple(_synthesis_str_list(data.get("todos"))),
+        open_research=tuple(_synthesis_str_list(data.get("open_research"))),
+        user_decisions_needed=tuple(
+            _synthesis_str_list(data.get("user_decisions_needed"))
+        ),
+        approval_required=bool(data.get("approval_required")),
+        approval_reason=_synthesis_optional_str(data.get("approval_reason")),
+    )
+
+
+def _synthesis_str_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [value]
+    try:
+        return [str(item) for item in value if item is not None]
+    except TypeError:
+        return []
+
+
+def _synthesis_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 @dataclass(frozen=True)
 class DeliberationContext:
     """Bundled inputs for one role's deliberation turn."""

--- a/src/yule_orchestrator/agents/obsidian_git.py
+++ b/src/yule_orchestrator/agents/obsidian_git.py
@@ -1,0 +1,185 @@
+"""Optional vault git auto-commit layer for Obsidian sync.
+
+Sits next to :mod:`yule_orchestrator.agents.obsidian_writer`. The writer
+puts a Markdown file into the vault; this module — only when the caller
+opts in via ``--git-commit`` — stages that one file and commits it to
+the vault's git repository.
+
+Design constraints (encoded as code, not just docs):
+
+- Never runs ``git push``.
+- Stages exactly one file (the synced note); never ``git add .`` /
+  ``git add -A``. Other changes in the working tree stay untouched.
+- Refuses to run when the vault repo already has staged changes —
+  committing on top of a half-staged state would mix unrelated work into
+  one commit.
+- All git invocations target the resolved ``git_repo_root`` via
+  ``git -C <root> ...`` so the working directory of the caller is
+  irrelevant.
+- Failures surface as :class:`ObsidianGitError` with stderr captured.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+class ObsidianGitError(RuntimeError):
+    """Raised when a vault auto-commit cannot be honored safely."""
+
+
+@dataclass(frozen=True)
+class CommitResult:
+    """Outcome of one auto-commit attempt.
+
+    ``committed`` is False when there was nothing to commit (idempotent
+    sync) or when ``dry_run`` short-circuited the actual git calls.
+    ``commit_sha`` is None for both no-op and dry-run cases.
+    """
+
+    committed: bool
+    commit_sha: Optional[str]
+    repo_root: Path
+    target_path: Path
+    message: str
+    dry_run: bool
+    no_changes: bool = False
+
+
+def find_git_repo_root(start: Path) -> Optional[Path]:
+    """Return the nearest ancestor (inclusive) that contains ``.git``.
+
+    Returns ``None`` if no git repository is found above ``start``.
+    Uses a file/directory check rather than running ``git`` so callers
+    can ask the question without spawning a subprocess.
+    """
+
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        marker = candidate / ".git"
+        if marker.exists():
+            return candidate
+    return None
+
+
+def is_git_repo(path: Path) -> bool:
+    """True when ``path`` is inside (or equal to) a git working tree."""
+
+    return find_git_repo_root(path) is not None
+
+
+def commit_single_file(
+    repo_root: Path,
+    target_path: Path,
+    *,
+    message: str,
+    dry_run: bool = False,
+) -> CommitResult:
+    """Stage and commit exactly ``target_path`` into ``repo_root``.
+
+    The repo must have no pre-existing staged changes; this guard makes
+    sure the auto-commit never bundles unrelated work into the sync
+    commit. Other unstaged changes in the working tree are left alone.
+
+    Raises :class:`ObsidianGitError` for any policy or git failure.
+    """
+
+    if not message.strip():
+        raise ObsidianGitError("git commit message must not be empty.")
+
+    repo_root_resolved = repo_root.resolve()
+    target_resolved = target_path.resolve()
+
+    try:
+        target_resolved.relative_to(repo_root_resolved)
+    except ValueError as exc:
+        raise ObsidianGitError(
+            f"Refusing to commit a file outside the vault repo. "
+            f"repo={repo_root_resolved} target={target_resolved}"
+        ) from exc
+
+    staged = _staged_paths(repo_root_resolved)
+    if staged:
+        joined = ", ".join(staged[:5])
+        more = f" (+{len(staged) - 5} more)" if len(staged) > 5 else ""
+        raise ObsidianGitError(
+            "vault repo has pre-existing staged changes — auto-commit "
+            f"would mix them into the sync commit: {joined}{more}. "
+            "Commit or unstage them first, or rerun without --git-commit."
+        )
+
+    if dry_run:
+        return CommitResult(
+            committed=False,
+            commit_sha=None,
+            repo_root=repo_root_resolved,
+            target_path=target_resolved,
+            message=message,
+            dry_run=True,
+        )
+
+    add_proc = _run_git(repo_root_resolved, ["add", "--", str(target_resolved)])
+    if add_proc.returncode != 0:
+        raise ObsidianGitError(
+            f"git add failed: {add_proc.stderr.strip() or add_proc.stdout.strip() or 'unknown error'}"
+        )
+
+    if not _staged_paths(repo_root_resolved):
+        return CommitResult(
+            committed=False,
+            commit_sha=None,
+            repo_root=repo_root_resolved,
+            target_path=target_resolved,
+            message=message,
+            dry_run=False,
+            no_changes=True,
+        )
+
+    commit_proc = _run_git(
+        repo_root_resolved,
+        ["commit", "-m", message, "--", str(target_resolved)],
+    )
+    if commit_proc.returncode != 0:
+        raise ObsidianGitError(
+            f"git commit failed: {commit_proc.stderr.strip() or commit_proc.stdout.strip() or 'unknown error'}"
+        )
+
+    sha_proc = _run_git(repo_root_resolved, ["rev-parse", "HEAD"])
+    sha = sha_proc.stdout.strip() if sha_proc.returncode == 0 else None
+
+    return CommitResult(
+        committed=True,
+        commit_sha=sha,
+        repo_root=repo_root_resolved,
+        target_path=target_resolved,
+        message=message,
+        dry_run=False,
+    )
+
+
+def _run_git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess:
+    cmd = ["git", "-C", str(repo_root), *args]
+    env = dict(os.environ)
+    # Block any interactive prompts (auth, GPG passphrase, etc.) so the
+    # auto-commit fails fast with a readable error instead of hanging.
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    return subprocess.run(
+        cmd,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _staged_paths(repo_root: Path) -> list[str]:
+    proc = _run_git(repo_root, ["diff", "--cached", "--name-only"])
+    if proc.returncode != 0:
+        raise ObsidianGitError(
+            f"git diff --cached failed: {proc.stderr.strip() or 'unknown error'}"
+        )
+    return [line for line in proc.stdout.splitlines() if line.strip()]

--- a/src/yule_orchestrator/agents/obsidian_writer.py
+++ b/src/yule_orchestrator/agents/obsidian_writer.py
@@ -11,8 +11,13 @@ Safety guarantees:
 - The resolved file path must remain inside the vault root (no traversal
   via ``..`` or symlinks resolving outside).
 - Parent directories are created automatically.
-- Overwrite of an existing file is refused unless ``overwrite=True``.
-- ``dry_run=True`` performs all checks but never writes.
+- When the recommended path already exists and ``overwrite`` is False,
+  the writer auto-appends ``_2``, ``_3``, ... before the ``.md`` suffix
+  inside the same folder so existing notes are never silently clobbered
+  and the new write is never silently skipped.
+- ``overwrite=True`` keeps the recommended filename and replaces it.
+- ``dry_run=True`` performs all checks (including suffix selection) but
+  never writes.
 """
 
 from __future__ import annotations
@@ -32,18 +37,26 @@ class ObsidianWriteError(RuntimeError):
     """Raised when an Obsidian write request cannot be honored safely."""
 
 
+MAX_SUFFIX_ATTEMPTS = 1000
+
+
 @dataclass(frozen=True)
 class ObsidianWriteResult:
     """Outcome of one write attempt.
 
-    ``written`` is False for dry-runs and for skipped overwrites; the
-    caller can still report ``target_path`` to the user.
+    ``target_path`` is always the real path that was (or would be) written
+    — including any auto-suffix applied. ``original_target_path`` is the
+    untouched recommendation from the exporter; ``suffix_applied`` is True
+    iff the writer had to pick a different filename to avoid a collision.
+    ``written`` is False only for dry-runs.
     """
 
     target_path: Path
     written: bool
     dry_run: bool
     overwrite: bool
+    original_target_path: Optional[Path] = None
+    suffix_applied: bool = False
     skipped_reason: Optional[str] = None
 
 
@@ -93,9 +106,11 @@ def write_note(
 ) -> ObsidianWriteResult:
     """Write *note.content* to ``<vault_root>/<note.path.full>``.
 
-    Returns an :class:`ObsidianWriteResult` describing what happened.
-    Caller is expected to surface ``target_path`` and ``skipped_reason``
-    to the user.
+    When the recommended path already exists and *overwrite* is False,
+    the writer auto-appends ``_2``, ``_3``, ... before the file suffix
+    until it finds a free name in the same folder. The returned
+    :class:`ObsidianWriteResult` always reports the real path that was
+    selected, so the caller can echo it back to the user.
     """
 
     vault_root_resolved = vault_root.resolve()
@@ -110,14 +125,11 @@ def write_note(
             f"vault={vault_root_resolved} target={target}"
         ) from exc
 
+    original_target = target
+    suffix_applied = False
     if target.exists() and not overwrite:
-        return ObsidianWriteResult(
-            target_path=target,
-            written=False,
-            dry_run=dry_run,
-            overwrite=overwrite,
-            skipped_reason="file already exists; pass --overwrite to replace it",
-        )
+        target = _resolve_collision_free_target(target, vault_root_resolved)
+        suffix_applied = True
 
     if dry_run:
         return ObsidianWriteResult(
@@ -125,6 +137,8 @@ def write_note(
             written=False,
             dry_run=True,
             overwrite=overwrite,
+            original_target_path=original_target,
+            suffix_applied=suffix_applied,
         )
 
     try:
@@ -146,4 +160,36 @@ def write_note(
         written=True,
         dry_run=False,
         overwrite=overwrite,
+        original_target_path=original_target,
+        suffix_applied=suffix_applied,
+    )
+
+
+def _resolve_collision_free_target(target: Path, vault_root: Path) -> Path:
+    """Return ``target`` with ``_<n>`` appended before the suffix until free.
+
+    Searches the same folder for ``stem_2.<suffix>``, ``stem_3.<suffix>``,
+    ... (capped at :data:`MAX_SUFFIX_ATTEMPTS`). Each candidate is
+    re-validated against the vault root so symlinks or odd filesystem
+    states cannot drag the write outside the vault.
+    """
+
+    parent = target.parent
+    stem = target.stem
+    suffix = target.suffix
+    for index in range(2, MAX_SUFFIX_ATTEMPTS + 2):
+        candidate = (parent / f"{stem}_{index}{suffix}").resolve()
+        try:
+            candidate.relative_to(vault_root)
+        except ValueError as exc:
+            raise ObsidianWriteError(
+                f"Refusing to write outside the vault root. "
+                f"vault={vault_root} target={candidate}"
+            ) from exc
+        if not candidate.exists():
+            return candidate
+    raise ObsidianWriteError(
+        f"Could not find a free filename near {target} after "
+        f"{MAX_SUFFIX_ATTEMPTS} attempts. Run with --overwrite or "
+        "clean up old notes."
     )

--- a/src/yule_orchestrator/agents/obsidian_writer.py
+++ b/src/yule_orchestrator/agents/obsidian_writer.py
@@ -127,8 +127,20 @@ def write_note(
             overwrite=overwrite,
         )
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(note.content, encoding="utf-8")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ObsidianWriteError(
+            f"Could not prepare parent directories for {target}: {exc}"
+        ) from exc
+
+    try:
+        target.write_text(note.content, encoding="utf-8")
+    except OSError as exc:
+        raise ObsidianWriteError(
+            f"Could not write Obsidian note to {target}: {exc}"
+        ) from exc
+
     return ObsidianWriteResult(
         target_path=target,
         written=True,

--- a/src/yule_orchestrator/agents/obsidian_writer.py
+++ b/src/yule_orchestrator/agents/obsidian_writer.py
@@ -1,0 +1,137 @@
+"""Thin file-writer layer for Obsidian notes.
+
+Sits on top of :mod:`yule_orchestrator.agents.obsidian_export` and writes
+the rendered :class:`ObsidianNote` content to a real Obsidian vault on
+disk. The exporter still owns the contract (frontmatter, body, vault path
+shape); this module only handles IO.
+
+Safety guarantees:
+
+- Vault root must be an absolute path that already exists as a directory.
+- The resolved file path must remain inside the vault root (no traversal
+  via ``..`` or symlinks resolving outside).
+- Parent directories are created automatically.
+- Overwrite of an existing file is refused unless ``overwrite=True``.
+- ``dry_run=True`` performs all checks but never writes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .obsidian_export import ObsidianNote
+
+
+ENV_VAULT_PATH = "OBSIDIAN_VAULT_PATH"
+
+
+class ObsidianWriteError(RuntimeError):
+    """Raised when an Obsidian write request cannot be honored safely."""
+
+
+@dataclass(frozen=True)
+class ObsidianWriteResult:
+    """Outcome of one write attempt.
+
+    ``written`` is False for dry-runs and for skipped overwrites; the
+    caller can still report ``target_path`` to the user.
+    """
+
+    target_path: Path
+    written: bool
+    dry_run: bool
+    overwrite: bool
+    skipped_reason: Optional[str] = None
+
+
+def resolve_vault_root(env: Optional[dict] = None, *, override: Optional[str] = None) -> Path:
+    """Return the absolute vault root from ``override`` or ``OBSIDIAN_VAULT_PATH``.
+
+    Raises :class:`ObsidianWriteError` with a human-readable message when
+    the value is missing, not absolute, missing on disk, or not a
+    directory. Validation lives here so the CLI gets one consistent
+    failure mode regardless of how the path was supplied.
+    """
+
+    raw = (override or "").strip() if override is not None else ""
+    if not raw:
+        source = env if env is not None else os.environ
+        raw = (source.get(ENV_VAULT_PATH) or "").strip()
+    if not raw:
+        raise ObsidianWriteError(
+            f"{ENV_VAULT_PATH} is not set. "
+            "Add it to .env.local with the absolute path to your Obsidian vault."
+        )
+
+    expanded = os.path.expanduser(raw)
+    path = Path(expanded)
+    if not path.is_absolute():
+        raise ObsidianWriteError(
+            f"{ENV_VAULT_PATH} must be an absolute path; got {raw!r}."
+        )
+    if not path.exists():
+        raise ObsidianWriteError(
+            f"Obsidian vault root does not exist: {path}. "
+            "Open the vault in Obsidian once or fix the path in .env.local."
+        )
+    if not path.is_dir():
+        raise ObsidianWriteError(
+            f"Obsidian vault root is not a directory: {path}."
+        )
+    return path.resolve()
+
+
+def write_note(
+    note: ObsidianNote,
+    vault_root: Path,
+    *,
+    overwrite: bool = False,
+    dry_run: bool = False,
+) -> ObsidianWriteResult:
+    """Write *note.content* to ``<vault_root>/<note.path.full>``.
+
+    Returns an :class:`ObsidianWriteResult` describing what happened.
+    Caller is expected to surface ``target_path`` and ``skipped_reason``
+    to the user.
+    """
+
+    vault_root_resolved = vault_root.resolve()
+    relative = note.path.full
+    target = (vault_root_resolved / relative).resolve()
+
+    try:
+        target.relative_to(vault_root_resolved)
+    except ValueError as exc:
+        raise ObsidianWriteError(
+            f"Refusing to write outside the vault root. "
+            f"vault={vault_root_resolved} target={target}"
+        ) from exc
+
+    if target.exists() and not overwrite:
+        return ObsidianWriteResult(
+            target_path=target,
+            written=False,
+            dry_run=dry_run,
+            overwrite=overwrite,
+            skipped_reason="file already exists; pass --overwrite to replace it",
+        )
+
+    if dry_run:
+        return ObsidianWriteResult(
+            target_path=target,
+            written=False,
+            dry_run=True,
+            overwrite=overwrite,
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(note.content, encoding="utf-8")
+    return ObsidianWriteResult(
+        target_path=target,
+        written=True,
+        dry_run=False,
+        overwrite=overwrite,
+    )

--- a/src/yule_orchestrator/agents/research_persistence.py
+++ b/src/yule_orchestrator/agents/research_persistence.py
@@ -1,0 +1,76 @@
+"""Persist ResearchPack/synthesis artifacts onto a workflow session.
+
+Used by:
+
+- The Discord engineering channel router, immediately after ``intake_fn``
+  creates a session, so the collected ``ResearchPack`` lands in
+  ``session.extra["research_pack"]`` even if the downstream research loop
+  short-circuits as ``insufficient`` or fails entirely.
+- The forum research-loop hook, after the deliberation runs, to
+  additionally persist ``TechLeadSynthesis`` and the ``CollectionOutcome``
+  metadata.
+
+The function is idempotent — repeated calls with the same payload write
+the same ``session.extra`` keys, so persisting eagerly at intake time and
+again later from the forum hook is safe.
+
+Failures are caught and logged so this helper never breaks the caller's
+control flow; the worst case is that ``session.extra`` does not get the
+new keys, which the Obsidian sync CLI surfaces explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from typing import Any, Optional
+
+from .deliberation import synthesis_to_dict
+from .research_pack import pack_to_dict
+from .workflow_state import WorkflowSession, update_session
+
+
+def persist_research_artifacts(
+    session: Optional[WorkflowSession],
+    pack: Any = None,
+    *,
+    collection_outcome: Any = None,
+    synthesis: Any = None,
+    synthesis_text: Optional[str] = None,
+) -> Optional[WorkflowSession]:
+    """Write research artifacts onto ``session.extra`` and return the new session.
+
+    Returns the original session unchanged when there is nothing to
+    persist (all inputs None) or when the caller passed ``session=None``.
+    Errors are swallowed with a stderr-style warning so a single failure
+    cannot wedge the engineering flow.
+    """
+
+    if session is None:
+        return session
+    if pack is None and synthesis is None and collection_outcome is None:
+        return session
+    try:
+        extra = dict(getattr(session, "extra", None) or {})
+        if pack is not None:
+            extra["research_pack"] = pack_to_dict(pack)
+        if collection_outcome is not None:
+            mode = getattr(collection_outcome, "mode", None)
+            mode_value = getattr(mode, "value", mode)
+            extra["research_collection"] = {
+                "mode": str(mode_value) if mode_value is not None else None,
+                "collector_name": getattr(collection_outcome, "collector_name", None),
+                "query": getattr(collection_outcome, "query", None),
+                "auto_collected_count": getattr(
+                    collection_outcome, "auto_collected_count", None
+                ),
+            }
+        if synthesis is not None:
+            extra["research_synthesis"] = synthesis_to_dict(synthesis)
+        if synthesis_text:
+            extra["research_synthesis_text"] = str(synthesis_text)
+        updated = replace(session, extra=extra)
+        return update_session(updated, now=datetime.now().astimezone())
+    except Exception as exc:  # noqa: BLE001 - forum loop can continue without persisted context
+        print(f"warning: research pack persistence failed: {exc}")
+        return session

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -575,6 +575,19 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Render and validate the path without writing anything.",
     )
+    obsidian_sync_parser.add_argument(
+        "--git-commit",
+        action="store_true",
+        help=(
+            "After writing, stage and commit the synced note in the Obsidian "
+            "vault's git repository. Off by default. Never pushes. Refuses to "
+            "run when the vault repo has pre-existing staged changes."
+        ),
+    )
+    obsidian_sync_parser.add_argument(
+        "--git-message",
+        help="Custom commit message. Defaults to 'obsidian sync: <session_id> ...'.",
+    )
 
     return parser
 
@@ -738,6 +751,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 vault_path=args.vault_path,
                 overwrite=args.overwrite,
                 dry_run=args.dry_run,
+                git_commit=args.git_commit,
+                git_message=args.git_message,
             )
     except ContextError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -34,6 +34,7 @@ from .engineer import (
 from ..agents.workflow import WorkflowError
 from .doctor import run_doctor_command
 from .github import run_github_issues_command
+from .obsidian import run_obsidian_sync_command
 from .planning import (
     run_planning_checkpoints_command,
     run_planning_daily_command,
@@ -540,6 +541,41 @@ def build_parser() -> argparse.ArgumentParser:
     )
     engineer_show_parser.add_argument("--session", required=True, help="Session id.")
 
+    obsidian_parser = subparsers.add_parser(
+        "obsidian",
+        help="Write engineering-agent research notes into a local Obsidian vault.",
+    )
+    obsidian_subparsers = obsidian_parser.add_subparsers(dest="obsidian_command", required=True)
+
+    obsidian_sync_parser = obsidian_subparsers.add_parser(
+        "sync",
+        help="Render a session's research pack and write it under OBSIDIAN_VAULT_PATH.",
+    )
+    obsidian_sync_parser.add_argument(
+        "--session",
+        required=True,
+        help="Workflow session id whose research_pack should be exported.",
+    )
+    obsidian_sync_parser.add_argument(
+        "--kind",
+        choices=("research", "decision", "reference"),
+        help="Override export kind. Defaults to research (or decision when synthesis is present).",
+    )
+    obsidian_sync_parser.add_argument(
+        "--vault-path",
+        help="Override OBSIDIAN_VAULT_PATH for this run only.",
+    )
+    obsidian_sync_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace the target file if it already exists. Default refuses to clobber.",
+    )
+    obsidian_sync_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render and validate the path without writing anything.",
+    )
+
     return parser
 
 
@@ -695,6 +731,14 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             )
         if args.command == "engineer":
             return _dispatch_engineer_command(repo_root, args)
+        if args.command == "obsidian" and args.obsidian_command == "sync":
+            return run_obsidian_sync_command(
+                args.session,
+                kind=args.kind,
+                vault_path=args.vault_path,
+                overwrite=args.overwrite,
+                dry_run=args.dry_run,
+            )
     except ContextError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/src/yule_orchestrator/cli/obsidian.py
+++ b/src/yule_orchestrator/cli/obsidian.py
@@ -86,10 +86,19 @@ def run_obsidian_sync_command(
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    relative = note.path.full
+    try:
+        relative = result.target_path.relative_to(vault_root)
+    except ValueError:
+        relative = result.target_path
+
     if result.dry_run:
         print(f"dry-run: would write {result.target_path}")
         print(f"vault={vault_root} relative={relative}")
+        if result.suffix_applied and result.original_target_path is not None:
+            print(
+                f"note: applied auto-suffix to avoid clobbering "
+                f"{result.original_target_path}"
+            )
         return 0
     if not result.written:
         print(f"skipped: {result.target_path}")
@@ -98,4 +107,9 @@ def run_obsidian_sync_command(
         return 0
     print(f"wrote: {result.target_path}")
     print(f"vault={vault_root} relative={relative}")
+    if result.suffix_applied and result.original_target_path is not None:
+        print(
+            f"note: applied auto-suffix to avoid clobbering "
+            f"{result.original_target_path}"
+        )
     return 0

--- a/src/yule_orchestrator/cli/obsidian.py
+++ b/src/yule_orchestrator/cli/obsidian.py
@@ -5,6 +5,11 @@ from typing import Optional
 
 from ..agents.deliberation import synthesis_from_dict
 from ..agents.obsidian_export import render_research_note
+from ..agents.obsidian_git import (
+    ObsidianGitError,
+    commit_single_file,
+    find_git_repo_root,
+)
 from ..agents.obsidian_writer import (
     ObsidianWriteError,
     resolve_vault_root,
@@ -24,6 +29,8 @@ def run_obsidian_sync_command(
     vault_path: Optional[str],
     overwrite: bool,
     dry_run: bool,
+    git_commit: bool = False,
+    git_message: Optional[str] = None,
 ) -> int:
     if kind is not None and kind not in VALID_KINDS:
         print(
@@ -99,6 +106,18 @@ def run_obsidian_sync_command(
                 f"note: applied auto-suffix to avoid clobbering "
                 f"{result.original_target_path}"
             )
+        if git_commit:
+            git_rc = _run_git_commit(
+                vault_root=vault_root,
+                target_path=result.target_path,
+                relative=relative,
+                session_id=session_id,
+                kind=kind,
+                git_message=git_message,
+                dry_run=True,
+            )
+            if git_rc != 0:
+                return git_rc
         return 0
     if not result.written:
         print(f"skipped: {result.target_path}")
@@ -112,4 +131,74 @@ def run_obsidian_sync_command(
             f"note: applied auto-suffix to avoid clobbering "
             f"{result.original_target_path}"
         )
+    if git_commit:
+        git_rc = _run_git_commit(
+            vault_root=vault_root,
+            target_path=result.target_path,
+            relative=relative,
+            session_id=session_id,
+            kind=kind,
+            git_message=git_message,
+            dry_run=False,
+        )
+        if git_rc != 0:
+            return git_rc
     return 0
+
+
+def _run_git_commit(
+    *,
+    vault_root,
+    target_path,
+    relative,
+    session_id: str,
+    kind: Optional[str],
+    git_message: Optional[str],
+    dry_run: bool,
+) -> int:
+    repo_root = find_git_repo_root(vault_root)
+    if repo_root is None:
+        print(
+            f"error: --git-commit requested but vault root {vault_root} is not a "
+            "git repository. Initialize it with `git init` or rerun without --git-commit.",
+            file=sys.stderr,
+        )
+        return 1
+
+    message = (git_message or "").strip() or _default_commit_message(
+        session_id=session_id, kind=kind, relative=str(relative)
+    )
+
+    try:
+        commit = commit_single_file(
+            repo_root,
+            target_path,
+            message=message,
+            dry_run=dry_run,
+        )
+    except ObsidianGitError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if commit.dry_run:
+        print(
+            f"git: would commit {commit.target_path} to {commit.repo_root} "
+            f'with message "{commit.message}"'
+        )
+        return 0
+    if commit.no_changes:
+        print(
+            f"git: no changes to commit (file already at vault HEAD): "
+            f"{commit.target_path}"
+        )
+        return 0
+    sha_short = commit.commit_sha[:12] if commit.commit_sha else "(unknown sha)"
+    print(f"git: committed {sha_short} {relative}")
+    return 0
+
+
+def _default_commit_message(
+    *, session_id: str, kind: Optional[str], relative: str
+) -> str:
+    kind_part = f" ({kind})" if kind else ""
+    return f"obsidian sync: {session_id}{kind_part} {relative}"

--- a/src/yule_orchestrator/cli/obsidian.py
+++ b/src/yule_orchestrator/cli/obsidian.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from ..agents.obsidian_export import render_research_note
+from ..agents.obsidian_writer import (
+    ObsidianWriteError,
+    resolve_vault_root,
+    write_note,
+)
+from ..agents.research_pack import pack_from_dict
+from ..agents.workflow_state import load_session
+
+
+VALID_KINDS = ("research", "decision", "reference")
+
+
+def run_obsidian_sync_command(
+    session_id: str,
+    *,
+    kind: Optional[str],
+    vault_path: Optional[str],
+    overwrite: bool,
+    dry_run: bool,
+) -> int:
+    if kind is not None and kind not in VALID_KINDS:
+        print(
+            f"error: --kind must be one of {list(VALID_KINDS)}, got {kind!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    session = load_session(session_id)
+    if session is None:
+        print(
+            f"error: workflow session {session_id!r} not found in local cache.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pack_payload = (session.extra or {}).get("research_pack")
+    if not pack_payload:
+        print(
+            f"error: session {session_id!r} has no research_pack in session.extra. "
+            "Run the engineering-agent research flow first so a pack is collected.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        pack = pack_from_dict(pack_payload)
+    except Exception as exc:  # noqa: BLE001 - surface parse failures plainly
+        print(f"error: could not parse stored research_pack: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        vault_root = resolve_vault_root(override=vault_path)
+    except ObsidianWriteError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    note = render_research_note(pack, session=session, kind=kind)
+
+    try:
+        result = write_note(
+            note,
+            vault_root,
+            overwrite=overwrite,
+            dry_run=dry_run,
+        )
+    except ObsidianWriteError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    relative = note.path.full
+    if result.dry_run:
+        print(f"dry-run: would write {result.target_path}")
+        print(f"vault={vault_root} relative={relative}")
+        return 0
+    if not result.written:
+        print(f"skipped: {result.target_path}")
+        if result.skipped_reason:
+            print(f"reason: {result.skipped_reason}")
+        return 0
+    print(f"wrote: {result.target_path}")
+    print(f"vault={vault_root} relative={relative}")
+    return 0

--- a/src/yule_orchestrator/cli/obsidian.py
+++ b/src/yule_orchestrator/cli/obsidian.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
+from ..agents.deliberation import synthesis_from_dict
 from ..agents.obsidian_export import render_research_note
 from ..agents.obsidian_writer import (
     ObsidianWriteError,
@@ -54,13 +55,25 @@ def run_obsidian_sync_command(
         print(f"error: could not parse stored research_pack: {exc}", file=sys.stderr)
         return 1
 
+    synthesis = None
+    synthesis_payload = (session.extra or {}).get("research_synthesis")
+    if synthesis_payload:
+        try:
+            synthesis = synthesis_from_dict(synthesis_payload)
+        except Exception as exc:  # noqa: BLE001 - degrade gracefully for older payloads
+            print(
+                f"warning: could not parse stored research_synthesis ({exc}); "
+                "exporting research note without synthesis sections.",
+                file=sys.stderr,
+            )
+
     try:
         vault_root = resolve_vault_root(override=vault_path)
     except ObsidianWriteError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    note = render_research_note(pack, session=session, kind=kind)
+    note = render_research_note(pack, session=session, synthesis=synthesis, kind=kind)
 
     try:
         result = write_note(

--- a/src/yule_orchestrator/diagnostics/doctor.py
+++ b/src/yule_orchestrator/diagnostics/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import urllib.error
@@ -9,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
+from ..agents.obsidian_writer import ENV_VAULT_PATH
 from ..core.context_loader import ContextError, load_agent_context
 from ..core.tls import apply_ca_bundle_fallback, resolve_ca_bundle
 
@@ -26,6 +28,7 @@ def run_doctor(repo_root: Path, agent_id: str = "engineering-agent") -> Sequence
     checks.extend(_check_commands(["claude", "codex", "gemini", "ollama", "gh", "copilot"]))
     checks.append(_check_github_auth())
     checks.append(_check_discord_tls())
+    checks.append(_check_obsidian_vault())
 
     manifest = _load_manifest_for_agent(repo_root, agent_id, checks)
     ollama_config = _find_ollama_config(manifest)
@@ -128,6 +131,42 @@ def _check_discord_tls() -> DoctorCheck:
     if active_bundle.cafile:
         detail += f" ({active_bundle.cafile})"
     return DoctorCheck(name="discord tls", status="OK", detail=detail)
+
+
+def _check_obsidian_vault() -> DoctorCheck:
+    raw = (os.environ.get(ENV_VAULT_PATH) or "").strip()
+    if not raw:
+        return DoctorCheck(
+            name="obsidian vault",
+            status="SKIP",
+            detail=f"{ENV_VAULT_PATH} not set",
+            hint="Set OBSIDIAN_VAULT_PATH in .env.local to enable `yule obsidian sync`.",
+        )
+
+    expanded = os.path.expanduser(raw)
+    path = Path(expanded)
+    if not path.is_absolute():
+        return DoctorCheck(
+            name="obsidian vault",
+            status="FAIL",
+            detail=f"{ENV_VAULT_PATH} must be absolute (got {raw!r})",
+            hint="Use the full /Users/<you>/... path in .env.local.",
+        )
+    if not path.exists():
+        return DoctorCheck(
+            name="obsidian vault",
+            status="FAIL",
+            detail=f"vault path does not exist: {path}",
+            hint="Open the vault in Obsidian once or fix OBSIDIAN_VAULT_PATH.",
+        )
+    if not path.is_dir():
+        return DoctorCheck(
+            name="obsidian vault",
+            status="FAIL",
+            detail=f"vault path is not a directory: {path}",
+            hint="OBSIDIAN_VAULT_PATH must point to the vault root folder.",
+        )
+    return DoctorCheck(name="obsidian vault", status="OK", detail=str(path))
 
 
 def _load_manifest_for_agent(repo_root: Path, agent_id: str, checks: List[DoctorCheck]) -> Dict[str, Any]:

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -50,6 +50,7 @@ from ..agents.research_loop import (
 from ..agents.research_collector import resolve_forum_comment_mode
 from ..agents.deliberation import synthesis_to_dict
 from ..agents.research_pack import pack_to_dict
+from ..agents.research_persistence import persist_research_artifacts
 from ..agents.research_profiles import format_research_hints_block
 from .engineering_team_runtime import kickoff_directive
 from .formatter import (
@@ -1940,42 +1941,22 @@ def _persist_research_pack_for_member_bots(
     synthesis=None,
     synthesis_text=None,
 ):
-    """Persist the collected pack (and optional synthesis) for downstream readers.
+    """Thin wrapper around :func:`persist_research_artifacts`.
 
-    Member bots replay deliberation against the stored ``research_pack``;
-    the Obsidian sync CLI additionally restores ``research_synthesis`` so
-    decision notes ship with 합의안/해야 할 일/승인 여부 sections instead of
-    rendering bare research notes.
+    Kept as a stable name for the forum research-loop hook + tests that
+    already mock this symbol. The router persists the same pack earlier
+    (right after intake) — this call additionally lands synthesis and
+    collection metadata once deliberation finishes. ``persist_research_artifacts``
+    is idempotent so the double-write is safe.
     """
 
-    if session is None:
-        return session
-    if pack is None and synthesis is None:
-        return session
-    try:
-        extra = dict(getattr(session, "extra", None) or {})
-        if pack is not None:
-            extra["research_pack"] = pack_to_dict(pack)
-        if collection_outcome is not None:
-            mode = getattr(collection_outcome, "mode", None)
-            mode_value = getattr(mode, "value", mode)
-            extra["research_collection"] = {
-                "mode": str(mode_value) if mode_value is not None else None,
-                "collector_name": getattr(collection_outcome, "collector_name", None),
-                "query": getattr(collection_outcome, "query", None),
-                "auto_collected_count": getattr(
-                    collection_outcome, "auto_collected_count", None
-                ),
-            }
-        if synthesis is not None:
-            extra["research_synthesis"] = synthesis_to_dict(synthesis)
-        if synthesis_text:
-            extra["research_synthesis_text"] = str(synthesis_text)
-        updated = replace(session, extra=extra)
-        return update_session(updated, now=datetime.now().astimezone())
-    except Exception as exc:  # noqa: BLE001 - forum loop can continue without persisted context
-        print(f"warning: research pack persistence failed: {exc}")
-        return session
+    return persist_research_artifacts(
+        session,
+        pack,
+        collection_outcome=collection_outcome,
+        synthesis=synthesis,
+        synthesis_text=synthesis_text,
+    )
 
 
 def _format_research_forum_disabled_status(outcome) -> str:

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -48,6 +48,7 @@ from ..agents.research_loop import (
     run_research_loop,
 )
 from ..agents.research_collector import resolve_forum_comment_mode
+from ..agents.deliberation import synthesis_to_dict
 from ..agents.research_pack import pack_to_dict
 from ..agents.research_profiles import format_research_hints_block
 from .engineering_team_runtime import kickoff_directive
@@ -1892,6 +1893,8 @@ def _make_default_engineering_research_loop_fn(discord_module: "discord"):
             outcome.session,
             outcome.research_pack,
             collection_outcome=collection_outcome,
+            synthesis=getattr(outcome, "synthesis", None),
+            synthesis_text=getattr(outcome, "synthesis_text", None),
         )
         if persisted_session is not outcome.session:
             outcome = replace(outcome, session=persisted_session)
@@ -1934,14 +1937,25 @@ def _persist_research_pack_for_member_bots(
     pack,
     *,
     collection_outcome=None,
+    synthesis=None,
+    synthesis_text=None,
 ):
-    """Persist the collected pack so member bots can restore shared evidence."""
+    """Persist the collected pack (and optional synthesis) for downstream readers.
 
-    if session is None or pack is None:
+    Member bots replay deliberation against the stored ``research_pack``;
+    the Obsidian sync CLI additionally restores ``research_synthesis`` so
+    decision notes ship with 합의안/해야 할 일/승인 여부 sections instead of
+    rendering bare research notes.
+    """
+
+    if session is None:
+        return session
+    if pack is None and synthesis is None:
         return session
     try:
         extra = dict(getattr(session, "extra", None) or {})
-        extra["research_pack"] = pack_to_dict(pack)
+        if pack is not None:
+            extra["research_pack"] = pack_to_dict(pack)
         if collection_outcome is not None:
             mode = getattr(collection_outcome, "mode", None)
             mode_value = getattr(mode, "value", mode)
@@ -1953,6 +1967,10 @@ def _persist_research_pack_for_member_bots(
                     collection_outcome, "auto_collected_count", None
                 ),
             }
+        if synthesis is not None:
+            extra["research_synthesis"] = synthesis_to_dict(synthesis)
+        if synthesis_text:
+            extra["research_synthesis_text"] = str(synthesis_text)
         updated = replace(session, extra=extra)
         return update_session(updated, now=datetime.now().astimezone())
     except Exception as exc:  # noqa: BLE001 - forum loop can continue without persisted context

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -17,6 +17,8 @@ import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence, Union
 
+from ..agents.research_persistence import persist_research_artifacts
+
 
 # Single-source confirmation lexicon; the engineering conversation layer
 # may also detect intent and pre-set ``confirmed=True`` itself, in which
@@ -356,6 +358,11 @@ async def route_engineering_message(
             )
         if continuation is not None:
             continued_session = continuation.session
+            continued_session = _maybe_persist_research_pack(
+                continued_session,
+                research_pack=outcome.research_pack,
+                collection_outcome=outcome.collection_outcome,
+            )
             session_id = getattr(continued_session, "session_id", None)
             thread_id = continuation.thread_id
             if continuation.message:
@@ -413,6 +420,12 @@ async def route_engineering_message(
     intake_message = getattr(intake, "message", None)
     session = getattr(intake, "session", None)
     plan = getattr(intake, "plan", None)
+
+    session = _maybe_persist_research_pack(
+        session,
+        research_pack=outcome.research_pack,
+        collection_outcome=outcome.collection_outcome,
+    )
     session_id = getattr(session, "session_id", None)
 
     if intake_message:
@@ -462,6 +475,36 @@ async def route_engineering_message(
         thread_id=thread_id,
         research_loop_report=research_loop_report,
         error=kickoff_error,
+    )
+
+
+def _maybe_persist_research_pack(
+    session: Any,
+    *,
+    research_pack: Any,
+    collection_outcome: Any,
+) -> Any:
+    """Persist the conversation-layer research pack onto a fresh session.
+
+    Called immediately after intake (or thread continuation) creates the
+    session, so the pack lands in ``session.extra["research_pack"]``
+    independently of whether the downstream research loop runs, succeeds,
+    or short-circuits as ``insufficient``. The forum research-loop hook
+    persists again later for synthesis/collection metadata; the helper is
+    idempotent so the double-write is safe.
+
+    Returns the (possibly updated) session. No-op when ``session`` is None
+    or there is nothing to persist.
+    """
+
+    if session is None:
+        return session
+    if research_pack is None and collection_outcome is None:
+        return session
+    return persist_research_artifacts(
+        session,
+        research_pack,
+        collection_outcome=collection_outcome,
     )
 
 

--- a/tests/test_cli_obsidian_sync.py
+++ b/tests/test_cli_obsidian_sync.py
@@ -200,6 +200,47 @@ class ObsidianSyncCommandTestCase(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertEqual(list(Path(tmp).rglob("*.md")), [])
 
+    def test_collision_output_reflects_auto_suffix_path(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                first_buf = io.StringIO()
+                with redirect_stdout(first_buf):
+                    rc1 = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=tmp,
+                        overwrite=False,
+                        dry_run=False,
+                    )
+                self.assertEqual(rc1, 0)
+                self.assertNotIn("auto-suffix", first_buf.getvalue())
+
+                second_buf = io.StringIO()
+                with redirect_stdout(second_buf):
+                    rc2 = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=tmp,
+                        overwrite=False,
+                        dry_run=False,
+                    )
+                self.assertEqual(rc2, 0)
+                stdout = second_buf.getvalue()
+                self.assertIn("_2.md", stdout)
+                self.assertIn("auto-suffix", stdout)
+
+            written = sorted(p.name for p in Path(tmp).rglob("*.md"))
+            self.assertEqual(
+                written,
+                [
+                    "2026-04-30_stripe-pricing-패턴.md",
+                    "2026-04-30_stripe-pricing-패턴_2.md",
+                ],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_obsidian_sync.py
+++ b/tests/test_cli_obsidian_sync.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.deliberation import (
+    TechLeadSynthesis,
+    synthesis_to_dict,
+)
+from yule_orchestrator.agents.research_pack import (
+    ResearchPack,
+    ResearchSource,
+    pack_to_dict,
+)
+from yule_orchestrator.agents.workflow_state import WorkflowSession, WorkflowState
+from yule_orchestrator.cli.obsidian import run_obsidian_sync_command
+
+
+def _session(extra) -> WorkflowSession:
+    return WorkflowSession(
+        session_id="abc12345",
+        prompt="hero 정리",
+        task_type="landing-page",
+        state=WorkflowState.APPROVED,
+        created_at=datetime(2026, 4, 30, 9, 0),
+        updated_at=datetime(2026, 4, 30, 9, 5),
+        executor_role="frontend-engineer",
+        extra=extra,
+    )
+
+
+def _pack() -> ResearchPack:
+    return ResearchPack(
+        title="Stripe Pricing 패턴",
+        summary="hero step copy 강조",
+        primary_url="https://stripe.com/pricing",
+        sources=(
+            ResearchSource(
+                source_url="https://stripe.com/pricing",
+                title="Stripe Pricing",
+                author_role="engineering-agent/product-designer",
+            ),
+        ),
+        tags=("reference",),
+        created_at=datetime(2026, 4, 30, 9, 0),
+    )
+
+
+class ObsidianSyncCommandTestCase(unittest.TestCase):
+    def test_missing_session_returns_error(self) -> None:
+        with patch(
+            "yule_orchestrator.cli.obsidian.load_session", return_value=None
+        ):
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                rc = run_obsidian_sync_command(
+                    "ghost",
+                    kind=None,
+                    vault_path=None,
+                    overwrite=False,
+                    dry_run=False,
+                )
+        self.assertEqual(rc, 1)
+        self.assertIn("not found", buf_err.getvalue())
+
+    def test_session_without_pack_returns_error(self) -> None:
+        session = _session(extra={})
+        with patch(
+            "yule_orchestrator.cli.obsidian.load_session", return_value=session
+        ):
+            buf_err = io.StringIO()
+            with redirect_stderr(buf_err):
+                rc = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=None,
+                    overwrite=False,
+                    dry_run=False,
+                )
+        self.assertEqual(rc, 1)
+        self.assertIn("research_pack", buf_err.getvalue())
+
+    def test_legacy_session_without_synthesis_writes_research_note(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_out = io.StringIO()
+                with redirect_stdout(buf_out):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=tmp,
+                        overwrite=False,
+                        dry_run=False,
+                    )
+            self.assertEqual(rc, 0)
+            written = list(Path(tmp).rglob("*.md"))
+            self.assertEqual(len(written), 1)
+            content = written[0].read_text(encoding="utf-8")
+            # research kind, not decision
+            self.assertIn("Agents/Engineering/Research", str(written[0]))
+            # synthesis-only sections must NOT appear
+            self.assertNotIn("## 합의안", content)
+            self.assertNotIn("## 승인 필요 여부", content)
+
+    def test_session_with_synthesis_renders_decision_sections(self) -> None:
+        synthesis = TechLeadSynthesis(
+            consensus="hero copy를 step별로 분할 — frontend가 즉시 반영",
+            todos=("hero 카피 분할", "QA 회귀 추가"),
+            open_research=("3건 이상 reference 보강",),
+            user_decisions_needed=("배포 일정 확정",),
+            approval_required=True,
+            approval_reason="쓰기 작업 확인 필요",
+        )
+        session = _session(
+            extra={
+                "research_pack": pack_to_dict(_pack()),
+                "research_synthesis": synthesis_to_dict(synthesis),
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                rc = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=tmp,
+                    overwrite=False,
+                    dry_run=False,
+                )
+            self.assertEqual(rc, 0)
+            written = list(Path(tmp).rglob("*.md"))
+            self.assertEqual(len(written), 1)
+            self.assertIn("Agents/Engineering/Decisions", str(written[0]))
+            content = written[0].read_text(encoding="utf-8")
+            for header in (
+                "## 합의안",
+                "## 해야 할 일",
+                "## 더 조사할 것",
+                "## 사용자 결정 필요",
+                "## 승인 필요 여부",
+            ):
+                self.assertIn(header, content)
+            self.assertIn("hero 카피 분할", content)
+            self.assertIn("쓰기 작업 확인 필요", content)
+
+    def test_corrupt_synthesis_payload_warns_but_still_writes(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": pack_to_dict(_pack()),
+                "research_synthesis": "not a dict",
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_err = io.StringIO()
+                with redirect_stderr(buf_err):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=tmp,
+                        overwrite=False,
+                        dry_run=False,
+                    )
+            self.assertEqual(rc, 0)
+            self.assertIn("warning", buf_err.getvalue().lower())
+            written = list(Path(tmp).rglob("*.md"))
+            self.assertEqual(len(written), 1)
+            # Falls back to research note since synthesis was unreadable
+            self.assertIn("Agents/Engineering/Research", str(written[0]))
+
+    def test_dry_run_does_not_write(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                rc = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=tmp,
+                    overwrite=False,
+                    dry_run=True,
+                )
+            self.assertEqual(rc, 0)
+            self.assertEqual(list(Path(tmp).rglob("*.md")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_obsidian_sync.py
+++ b/tests/test_cli_obsidian_sync.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+import shutil
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -200,6 +202,27 @@ class ObsidianSyncCommandTestCase(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertEqual(list(Path(tmp).rglob("*.md")), [])
 
+    def test_default_run_does_not_invoke_git(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ), patch(
+                "yule_orchestrator.cli.obsidian.commit_single_file"
+            ) as commit_spy, patch(
+                "yule_orchestrator.cli.obsidian.find_git_repo_root"
+            ) as find_spy:
+                rc = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=tmp,
+                    overwrite=False,
+                    dry_run=False,
+                )
+            self.assertEqual(rc, 0)
+            commit_spy.assert_not_called()
+            find_spy.assert_not_called()
+
     def test_collision_output_reflects_auto_suffix_path(self) -> None:
         session = _session(extra={"research_pack": pack_to_dict(_pack())})
         with tempfile.TemporaryDirectory() as tmp:
@@ -240,6 +263,237 @@ class ObsidianSyncCommandTestCase(unittest.TestCase):
                     "2026-04-30_stripe-pricing-패턴_2.md",
                 ],
             )
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _init_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], check=True, cwd=repo_root)
+    subprocess.run(
+        ["git", "config", "user.email", "obsidian-sync@example.com"],
+        check=True,
+        cwd=repo_root,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "obsidian-sync test"],
+        check=True,
+        cwd=repo_root,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"], check=True, cwd=repo_root
+    )
+
+
+@unittest.skipUnless(_git_available(), "git executable not on PATH")
+class ObsidianSyncGitCommitTestCase(unittest.TestCase):
+    def test_git_commit_in_real_repo_commits_only_target_file(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            _init_repo(vault)
+            unrelated = vault / "untracked.md"
+            unrelated.write_text("noise\n", encoding="utf-8")
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_out = io.StringIO()
+                with redirect_stdout(buf_out):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=str(vault),
+                        overwrite=False,
+                        dry_run=False,
+                        git_commit=True,
+                    )
+            self.assertEqual(rc, 0)
+            stdout = buf_out.getvalue()
+            self.assertIn("git: committed", stdout)
+
+            tree = subprocess.run(
+                ["git", "-C", str(vault), "show", "--name-only", "--pretty=", "HEAD"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+            self.assertIn("Agents/Engineering/Research/", tree)
+            self.assertNotIn("untracked.md", tree)
+
+            status = subprocess.run(
+                ["git", "-C", str(vault), "status", "--porcelain"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+            self.assertIn("?? untracked.md", status)
+
+    def test_git_commit_dry_run_does_not_write_or_commit(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            _init_repo(vault)
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_out = io.StringIO()
+                with redirect_stdout(buf_out):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=str(vault),
+                        overwrite=False,
+                        dry_run=True,
+                        git_commit=True,
+                    )
+            self.assertEqual(rc, 0)
+            stdout = buf_out.getvalue()
+            self.assertIn("dry-run: would write", stdout)
+            self.assertIn("git: would commit", stdout)
+
+            self.assertEqual(list(vault.rglob("*.md")), [])
+            log = subprocess.run(
+                ["git", "-C", str(vault), "log", "--oneline"],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(log.stdout.strip(), "")
+
+    def test_git_commit_fails_when_vault_is_not_a_repo(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_err = io.StringIO()
+                with redirect_stderr(buf_err):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=str(vault),
+                        overwrite=False,
+                        dry_run=False,
+                        git_commit=True,
+                    )
+            self.assertEqual(rc, 1)
+            self.assertIn("not a git repository", buf_err.getvalue())
+            # Note file was still written (write happens before git step)
+            self.assertEqual(len(list(vault.rglob("*.md"))), 1)
+
+    def test_git_commit_fails_when_repo_has_staged_changes(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            _init_repo(vault)
+            other = vault / "other.md"
+            other.write_text("# other\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(vault), "add", "--", "other.md"], check=True
+            )
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                buf_err = io.StringIO()
+                with redirect_stderr(buf_err):
+                    rc = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=str(vault),
+                        overwrite=False,
+                        dry_run=False,
+                        git_commit=True,
+                    )
+            self.assertEqual(rc, 1)
+            self.assertIn("staged changes", buf_err.getvalue())
+
+    def test_custom_git_message_is_used(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            _init_repo(vault)
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                rc = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=str(vault),
+                    overwrite=False,
+                    dry_run=False,
+                    git_commit=True,
+                    git_message="custom obsidian sync message",
+                )
+            self.assertEqual(rc, 0)
+            log = subprocess.run(
+                ["git", "-C", str(vault), "log", "-1", "--pretty=%s"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+            self.assertEqual(log, "custom obsidian sync message")
+
+    def test_git_commit_with_overwrite_replaces_and_commits(self) -> None:
+        session = _session(extra={"research_pack": pack_to_dict(_pack())})
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            _init_repo(vault)
+
+            with patch(
+                "yule_orchestrator.cli.obsidian.load_session", return_value=session
+            ):
+                rc1 = run_obsidian_sync_command(
+                    session.session_id,
+                    kind=None,
+                    vault_path=str(vault),
+                    overwrite=False,
+                    dry_run=False,
+                    git_commit=True,
+                )
+                self.assertEqual(rc1, 0)
+
+                # Force the rendered file to differ so commit isn't a no-op
+                target = next(vault.rglob("*.md"))
+                target.write_text("# stale\n", encoding="utf-8")
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(vault),
+                        "commit",
+                        "-am",
+                        "stale edit",
+                    ],
+                    check=True,
+                )
+
+                buf_out = io.StringIO()
+                with redirect_stdout(buf_out):
+                    rc2 = run_obsidian_sync_command(
+                        session.session_id,
+                        kind=None,
+                        vault_path=str(vault),
+                        overwrite=True,
+                        dry_run=False,
+                        git_commit=True,
+                    )
+            self.assertEqual(rc2, 0)
+            self.assertIn("git: committed", buf_out.getvalue())
+            # Three commits total: initial sync, stale edit, overwrite sync
+            log = subprocess.run(
+                ["git", "-C", str(vault), "log", "--oneline"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+            self.assertEqual(len(log.strip().splitlines()), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_engineering_channel_router.py
+++ b/tests/test_engineering_channel_router.py
@@ -6,7 +6,7 @@ import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 try:
     import _bootstrap  # noqa: F401
@@ -664,6 +664,118 @@ class RouteEngineeringMessageWithResearchLoopTests(unittest.TestCase):
                 research_loop_fn=research_loop_fn,
             )
         )
+
+    def test_research_pack_is_persisted_after_intake_even_when_loop_insufficient(
+        self,
+    ) -> None:
+        """Regression: session.extra must contain the research_pack even if
+        the research_loop_fn short-circuits as ``insufficient`` (e.g. when
+        the confirm message text alone is too short to re-collect from).
+        """
+
+        message = _Message(
+            content="이대로 진행",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        pack = object()
+        collection_outcome = object()
+        outcome = EngineeringConversationOutcome(
+            content="좋습니다.",
+            confirmed=True,
+            intake_prompt="Obsidian 지식 저장 구조 리서치",
+            research_pack=pack,
+            collection_outcome=collection_outcome,
+        )
+
+        async def insufficient_loop_fn(**_kwargs):
+            return EngineeringResearchLoopReport(
+                follow_up_message="자료가 부족합니다.",
+                insufficient=True,
+            )
+
+        with patch(
+            "yule_orchestrator.discord.engineering_channel_router."
+            "persist_research_artifacts"
+        ) as persist_spy:
+            persist_spy.side_effect = lambda session, *_a, **_kw: session
+            result = self._route(
+                message=message,
+                research_loop_fn=insufficient_loop_fn,
+                conversation_outcome=outcome,
+            )
+
+        self.assertTrue(result.handled)
+        persist_spy.assert_called_once()
+        call_args = persist_spy.call_args
+        self.assertEqual(call_args.args[0].session_id, "abc")
+        self.assertIs(call_args.args[1], pack)
+        self.assertIs(
+            call_args.kwargs.get("collection_outcome"), collection_outcome
+        )
+
+    def test_research_pack_persisted_when_research_loop_fn_is_none(self) -> None:
+        """Even when no research_loop_fn is wired (forum unconfigured / dev
+        env), pack must still land in session.extra so Obsidian sync works.
+        """
+
+        message = _Message(
+            content="이대로 진행",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        pack = object()
+        outcome = EngineeringConversationOutcome(
+            content="좋습니다.",
+            confirmed=True,
+            intake_prompt="Obsidian 지식 저장 구조 리서치",
+            research_pack=pack,
+        )
+
+        with patch(
+            "yule_orchestrator.discord.engineering_channel_router."
+            "persist_research_artifacts"
+        ) as persist_spy:
+            persist_spy.side_effect = lambda session, *_a, **_kw: session
+            result = self._route(
+                message=message,
+                research_loop_fn=None,
+                conversation_outcome=outcome,
+            )
+
+        self.assertTrue(result.handled)
+        persist_spy.assert_called_once()
+        self.assertIs(persist_spy.call_args.args[1], pack)
+
+    def test_no_persist_call_when_outcome_has_no_research_pack(self) -> None:
+        """A bare confirm without recall context must not invoke the persist
+        helper (nothing to save) — keeps existing intakes side-effect free.
+        """
+
+        message = _Message(
+            content="이대로 진행",
+            channel=_Channel(channel_id=111, name="업무-접수"),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="좋습니다.",
+            confirmed=True,
+            intake_prompt="generic task",
+            research_pack=None,
+            collection_outcome=None,
+        )
+
+        async def loop_fn(**_kwargs):
+            return EngineeringResearchLoopReport()
+
+        with patch(
+            "yule_orchestrator.discord.engineering_channel_router."
+            "persist_research_artifacts"
+        ) as persist_spy:
+            self._route(
+                message=message,
+                research_loop_fn=loop_fn,
+                conversation_outcome=outcome,
+            )
+
+        persist_spy.assert_not_called()
 
     def test_research_loop_status_message_is_sent(self) -> None:
         message = _MessageWithAttachments(

--- a/tests/test_engineering_deliberation.py
+++ b/tests/test_engineering_deliberation.py
@@ -35,6 +35,8 @@ from yule_orchestrator.agents.deliberation import (
     run_role_deliberation,
     source_meta,
     source_type,
+    synthesis_from_dict,
+    synthesis_to_dict,
     synthesize,
 )
 from yule_orchestrator.agents.research_pack import (
@@ -294,6 +296,51 @@ class RenderTestCase(unittest.TestCase):
         self.assertIn("더 조사할 것", text)
         self.assertIn("사용자 결정 필요", text)
         self.assertIn("승인 필요: yes", text)
+
+
+class SynthesisRoundTripTestCase(unittest.TestCase):
+    def test_to_dict_then_from_dict_preserves_fields(self) -> None:
+        original = TechLeadSynthesis(
+            consensus="합의안 본문",
+            todos=("todo a", "todo b"),
+            open_research=("자료 보강",),
+            user_decisions_needed=("결정 1",),
+            approval_required=True,
+            approval_reason="쓰기 작업 확인 필요",
+        )
+        restored = synthesis_from_dict(synthesis_to_dict(original))
+        self.assertEqual(restored.consensus, original.consensus)
+        self.assertEqual(tuple(restored.todos), original.todos)
+        self.assertEqual(tuple(restored.open_research), original.open_research)
+        self.assertEqual(
+            tuple(restored.user_decisions_needed), original.user_decisions_needed
+        )
+        self.assertTrue(restored.approval_required)
+        self.assertEqual(restored.approval_reason, original.approval_reason)
+
+    def test_payload_carries_version_marker(self) -> None:
+        payload = synthesis_to_dict(TechLeadSynthesis(consensus="x"))
+        self.assertEqual(payload["v"], 1)
+
+    def test_from_dict_handles_missing_lists(self) -> None:
+        restored = synthesis_from_dict({"consensus": "only"})
+        self.assertEqual(restored.consensus, "only")
+        self.assertEqual(tuple(restored.todos), ())
+        self.assertEqual(tuple(restored.open_research), ())
+        self.assertEqual(tuple(restored.user_decisions_needed), ())
+        self.assertFalse(restored.approval_required)
+        self.assertIsNone(restored.approval_reason)
+
+    def test_from_dict_coerces_non_string_consensus(self) -> None:
+        restored = synthesis_from_dict({"consensus": 123})
+        self.assertEqual(restored.consensus, "123")
+
+    def test_from_dict_blank_approval_reason_becomes_none(self) -> None:
+        restored = synthesis_from_dict(
+            {"consensus": "x", "approval_required": True, "approval_reason": "   "}
+        )
+        self.assertTrue(restored.approval_required)
+        self.assertIsNone(restored.approval_reason)
 
 
 class RuntimeIntegrationTestCase(unittest.TestCase):

--- a/tests/test_obsidian_git.py
+++ b/tests/test_obsidian_git.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.obsidian_git import (
+    ObsidianGitError,
+    commit_single_file,
+    find_git_repo_root,
+    is_git_repo,
+)
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _init_repo(repo_root: Path) -> None:
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"],
+        check=True,
+        cwd=repo_root,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "obsidian-sync@example.com"],
+        check=True,
+        cwd=repo_root,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "obsidian-sync test"],
+        check=True,
+        cwd=repo_root,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        check=True,
+        cwd=repo_root,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+@unittest.skipUnless(_git_available(), "git executable not on PATH")
+class FindRepoRootTestCase(unittest.TestCase):
+    def test_returns_none_outside_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(find_git_repo_root(Path(tmp)))
+            self.assertFalse(is_git_repo(Path(tmp)))
+
+    def test_finds_repo_root_from_subdir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            sub = root / "Agents" / "Engineering" / "Research"
+            sub.mkdir(parents=True)
+            self.assertEqual(find_git_repo_root(sub), root.resolve())
+            self.assertTrue(is_git_repo(sub))
+
+
+@unittest.skipUnless(_git_available(), "git executable not on PATH")
+class CommitSingleFileTestCase(unittest.TestCase):
+    def test_commits_only_target_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            target = root / "Agents/Engineering/Research/note.md"
+            _write(target, "# note\n")
+            unrelated = root / "untracked.md"
+            _write(unrelated, "noise\n")
+
+            result = commit_single_file(
+                root, target, message="obsidian sync: abc note.md"
+            )
+            self.assertTrue(result.committed)
+            self.assertIsNotNone(result.commit_sha)
+            self.assertFalse(result.dry_run)
+
+            # Only target.md is in the commit
+            tree = _git(root, "show", "--name-only", "--pretty=", "HEAD").stdout
+            self.assertIn("Agents/Engineering/Research/note.md", tree)
+            self.assertNotIn("untracked.md", tree)
+
+            # Unrelated file is still untracked, not staged
+            status = _git(root, "status", "--porcelain").stdout
+            self.assertIn("?? untracked.md", status)
+
+    def test_dry_run_does_not_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            target = root / "note.md"
+            _write(target, "# note\n")
+
+            result = commit_single_file(
+                root, target, message="x", dry_run=True
+            )
+            self.assertFalse(result.committed)
+            self.assertTrue(result.dry_run)
+            self.assertIsNone(result.commit_sha)
+
+            # No commits exist yet
+            log = subprocess.run(
+                ["git", "-C", str(root), "log", "--oneline"],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(log.stdout.strip(), "")
+
+    def test_no_changes_when_file_already_at_head(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            target = root / "note.md"
+            _write(target, "# note\n")
+
+            first = commit_single_file(root, target, message="first commit")
+            self.assertTrue(first.committed)
+
+            # Same content, second commit attempt
+            second = commit_single_file(
+                root, target, message="second commit"
+            )
+            self.assertFalse(second.committed)
+            self.assertTrue(second.no_changes)
+            self.assertIsNone(second.commit_sha)
+
+    def test_refuses_when_staged_changes_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            target = root / "note.md"
+            _write(target, "# note\n")
+            other = root / "other.md"
+            _write(other, "# other\n")
+            _git(root, "add", "--", str(other))
+
+            with self.assertRaises(ObsidianGitError) as ctx:
+                commit_single_file(
+                    root, target, message="x"
+                )
+            self.assertIn("staged changes", str(ctx.exception))
+
+            # other.md remains staged, target.md remains untracked
+            status = _git(root, "status", "--porcelain").stdout
+            self.assertIn("A  other.md", status)
+
+    def test_refuses_target_outside_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "vault"
+            outside = Path(tmp) / "outside"
+            root.mkdir()
+            outside.mkdir()
+            _init_repo(root)
+
+            external = outside / "leak.md"
+            _write(external, "# leak\n")
+
+            with self.assertRaises(ObsidianGitError) as ctx:
+                commit_single_file(root, external, message="x")
+            self.assertIn("outside the vault repo", str(ctx.exception))
+
+    def test_empty_message_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _init_repo(root)
+            target = root / "note.md"
+            _write(target, "# note\n")
+
+            with self.assertRaises(ObsidianGitError):
+                commit_single_file(root, target, message="   ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_obsidian_writer.py
+++ b/tests/test_obsidian_writer.py
@@ -90,15 +90,69 @@ class WriteNoteTestCase(unittest.TestCase):
             write_note(_note(), vault)
             self.assertTrue((vault / "Agents/Engineering/Research").is_dir())
 
-    def test_refuses_overwrite_by_default(self) -> None:
+    def test_first_collision_auto_suffixes_to_2(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             vault = Path(tmp)
             first = write_note(_note(), vault)
             self.assertTrue(first.written)
+            self.assertFalse(first.suffix_applied)
+
             second = write_note(_note(), vault)
-            self.assertFalse(second.written)
-            self.assertIsNotNone(second.skipped_reason)
-            self.assertIn("already exists", second.skipped_reason or "")
+            self.assertTrue(second.written)
+            self.assertTrue(second.suffix_applied)
+            self.assertEqual(second.target_path.name, "2026-04-30_stripe_2.md")
+            self.assertEqual(
+                second.original_target_path,
+                (vault / "Agents/Engineering/Research/2026-04-30_stripe.md").resolve(),
+            )
+            # Original file is untouched
+            self.assertEqual(
+                first.target_path.read_text(encoding="utf-8"),
+                "---\ntitle: Stripe\n---\n\n# Stripe\n",
+            )
+
+    def test_second_collision_auto_suffixes_to_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            write_note(_note(), vault)
+            write_note(_note(), vault)  # creates _2.md
+
+            third = write_note(_note(), vault)
+            self.assertTrue(third.written)
+            self.assertTrue(third.suffix_applied)
+            self.assertEqual(third.target_path.name, "2026-04-30_stripe_3.md")
+
+    def test_overwrite_keeps_original_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            first = write_note(_note(), vault)
+            replacement = ObsidianNote(
+                path=ExportPath(folder="Agents/Engineering/Research", filename="2026-04-30_stripe.md"),
+                content="---\ntitle: Stripe v2\n---\n\n# Stripe v2\n",
+                frontmatter={"title": "Stripe v2"},
+            )
+            result = write_note(replacement, vault, overwrite=True)
+            self.assertTrue(result.written)
+            self.assertFalse(result.suffix_applied)
+            self.assertEqual(result.target_path, first.target_path)
+            self.assertIn("Stripe v2", result.target_path.read_text(encoding="utf-8"))
+            # No _2.md was created
+            self.assertFalse(
+                (vault / "Agents/Engineering/Research/2026-04-30_stripe_2.md").exists()
+            )
+
+    def test_dry_run_with_collision_reports_final_suffixed_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            write_note(_note(), vault)  # occupy original name
+
+            result = write_note(_note(), vault, dry_run=True)
+            self.assertFalse(result.written)
+            self.assertTrue(result.dry_run)
+            self.assertTrue(result.suffix_applied)
+            self.assertEqual(result.target_path.name, "2026-04-30_stripe_2.md")
+            # Dry-run must not create the suffixed file
+            self.assertFalse(result.target_path.exists())
 
     def test_overwrite_replaces_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_obsidian_writer.py
+++ b/tests/test_obsidian_writer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.obsidian_export import ExportPath, ObsidianNote
+from yule_orchestrator.agents.obsidian_writer import (
+    ENV_VAULT_PATH,
+    ObsidianWriteError,
+    resolve_vault_root,
+    write_note,
+)
+
+
+def _note(folder: str = "Agents/Engineering/Research", filename: str = "2026-04-30_stripe.md") -> ObsidianNote:
+    return ObsidianNote(
+        path=ExportPath(folder=folder, filename=filename),
+        content="---\ntitle: Stripe\n---\n\n# Stripe\n",
+        frontmatter={"title": "Stripe"},
+    )
+
+
+class ResolveVaultRootTestCase(unittest.TestCase):
+    def test_returns_resolved_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = resolve_vault_root(env={ENV_VAULT_PATH: tmp})
+            self.assertEqual(root, Path(tmp).resolve())
+
+    def test_override_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = resolve_vault_root(env={ENV_VAULT_PATH: "/nonexistent"}, override=tmp)
+            self.assertEqual(root, Path(tmp).resolve())
+
+    def test_missing_env_raises(self) -> None:
+        with self.assertRaises(ObsidianWriteError) as ctx:
+            resolve_vault_root(env={})
+        self.assertIn(ENV_VAULT_PATH, str(ctx.exception))
+
+    def test_blank_env_raises(self) -> None:
+        with self.assertRaises(ObsidianWriteError):
+            resolve_vault_root(env={ENV_VAULT_PATH: "   "})
+
+    def test_relative_path_raises(self) -> None:
+        with self.assertRaises(ObsidianWriteError) as ctx:
+            resolve_vault_root(env={ENV_VAULT_PATH: "relative/vault"})
+        self.assertIn("absolute", str(ctx.exception))
+
+    def test_missing_directory_raises(self) -> None:
+        with self.assertRaises(ObsidianWriteError) as ctx:
+            resolve_vault_root(env={ENV_VAULT_PATH: "/definitely/does/not/exist/yule-vault"})
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_file_path_raises(self) -> None:
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with self.assertRaises(ObsidianWriteError) as ctx:
+                resolve_vault_root(env={ENV_VAULT_PATH: tmpfile.name})
+            self.assertIn("not a directory", str(ctx.exception))
+
+    def test_expanduser_works(self) -> None:
+        home = Path(os.path.expanduser("~")).resolve()
+        root = resolve_vault_root(env={ENV_VAULT_PATH: "~"})
+        self.assertEqual(root, home)
+
+
+class WriteNoteTestCase(unittest.TestCase):
+    def test_writes_file_under_vault_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            result = write_note(_note(), vault)
+            self.assertTrue(result.written)
+            self.assertFalse(result.dry_run)
+            self.assertTrue(result.target_path.exists())
+            self.assertEqual(
+                result.target_path,
+                (vault / "Agents/Engineering/Research/2026-04-30_stripe.md").resolve(),
+            )
+            self.assertIn("# Stripe", result.target_path.read_text(encoding="utf-8"))
+
+    def test_creates_parent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            self.assertFalse((vault / "Agents/Engineering/Research").exists())
+            write_note(_note(), vault)
+            self.assertTrue((vault / "Agents/Engineering/Research").is_dir())
+
+    def test_refuses_overwrite_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            first = write_note(_note(), vault)
+            self.assertTrue(first.written)
+            second = write_note(_note(), vault)
+            self.assertFalse(second.written)
+            self.assertIsNotNone(second.skipped_reason)
+            self.assertIn("already exists", second.skipped_reason or "")
+
+    def test_overwrite_replaces_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            write_note(_note(), vault)
+            replacement = ObsidianNote(
+                path=ExportPath(folder="Agents/Engineering/Research", filename="2026-04-30_stripe.md"),
+                content="---\ntitle: Stripe v2\n---\n\n# Stripe v2\n",
+                frontmatter={"title": "Stripe v2"},
+            )
+            result = write_note(replacement, vault, overwrite=True)
+            self.assertTrue(result.written)
+            self.assertIn("Stripe v2", result.target_path.read_text(encoding="utf-8"))
+
+    def test_dry_run_does_not_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            result = write_note(_note(), vault, dry_run=True)
+            self.assertFalse(result.written)
+            self.assertTrue(result.dry_run)
+            self.assertFalse(result.target_path.exists())
+
+    def test_path_traversal_via_parent_segments_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp) / "vault"
+            vault.mkdir()
+            evil = ObsidianNote(
+                path=ExportPath(folder="../escape", filename="leak.md"),
+                content="x",
+                frontmatter={},
+            )
+            with self.assertRaises(ObsidianWriteError) as ctx:
+                write_note(evil, vault)
+            self.assertIn("outside the vault root", str(ctx.exception))
+
+    def test_path_traversal_via_symlink_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outside = Path(tmp) / "outside"
+            outside.mkdir()
+            vault = Path(tmp) / "vault"
+            vault.mkdir()
+            (vault / "Agents").symlink_to(outside, target_is_directory=True)
+
+            note = ObsidianNote(
+                path=ExportPath(folder="Agents/Engineering/Research", filename="leak.md"),
+                content="x",
+                frontmatter={},
+            )
+            with self.assertRaises(ObsidianWriteError):
+                write_note(note, vault)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_obsidian_writer.py
+++ b/tests/test_obsidian_writer.py
@@ -150,6 +150,27 @@ class WriteNoteTestCase(unittest.TestCase):
             with self.assertRaises(ObsidianWriteError):
                 write_note(note, vault)
 
+    def test_parent_directory_creation_failure_is_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            (vault / "Agents").write_text("not a directory", encoding="utf-8")
+
+            with self.assertRaises(ObsidianWriteError) as ctx:
+                write_note(_note(), vault)
+
+            self.assertIn("Could not prepare parent directories", str(ctx.exception))
+
+    def test_write_failure_is_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            target = vault / "Agents/Engineering/Research/2026-04-30_stripe.md"
+            target.mkdir(parents=True)
+
+            with self.assertRaises(ObsidianWriteError) as ctx:
+                write_note(_note(), vault, overwrite=True)
+
+            self.assertIn("Could not write Obsidian note", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #20 
- #43 

## ✨ 과제 내용
`yule-studio-agent`에서 생성되는 리서치 결과를 Obsidian Vault로 안전하게 export할 수 있도록 로컬 파일 시스템 기반 sync 경로를 추가했습니다.

이번 PR 범위
- `ResearchPack`을 Obsidian용 Markdown으로 export하는 로컬 sync CLI 추가
- persisted `TechLeadSynthesis`가 있으면 `Decision` 노트까지 함께 복원/export
- Vault 경로 검증, path traversal 방지, dry-run, overwrite, collision suffix, 선택적 vault git commit까지 포함한 안전한 writer 레이어 추가
- 환경변수/문서/doctor 점검 경로 정리

구현 상세
- `yule obsidian sync` CLI 추가
- `OBSIDIAN_VAULT_PATH` 기반 vault root 로딩
- writer 레이어에서 다음 안전 정책 적용
  - vault 절대경로 검증
  - vault root 밖으로 나가는 경로 차단
  - parent directory 자동 생성
  - `--dry-run` 지원
  - overwrite 기본 거부, `--overwrite` 명시 시만 교체
  - 동일 파일명 충돌 시 `_2.md`, `_3.md` 자동 suffix
- persisted synthesis가 있으면 `Agents/Engineering/Decisions/...` 아래에 합의안/해야 할 일/승인 필요 여부가 포함된 decision note 생성
- vault가 git repo일 때만 opt-in으로 `--git-commit` 지원
  - 기본값 off
  - 이번 sync note 파일 하나만 stage/commit
  - push는 하지 않음
- `yule doctor`에 `obsidian vault` 체크 추가
- `.env.example`, `README.md`, `obsidian-memory.md` 문서 업데이트

현재 범위에서 실제로 다루는 문서 유형
- ResearchPack
- 작업 결정 기록
- Tech Lead 최종 합의안

이번 PR 범위 밖
- PR/Issue 작업 로그 export 정교화
- Discord research flow의 실사용 안정화/추가 persistence 검증
- 자동 push 또는 사용자 승인 후 push 정책 확정

## :camera_with_flash: 스크린샷(선택)
수동 smoke test로 Obsidian sync dry-run 경로를 확인했습니다.

```bash
yule obsidian sync --session 7e84b9dba5ac \
  --vault-path /private/tmp/obsidian-vault-smoke \
  --dry-run

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
