### PR TITLE
[Feature] Role agent conversational runtime loop

### DIFF
--- a/src/yule_orchestrator/agents/knowledge_writer.py
+++ b/src/yule_orchestrator/agents/knowledge_writer.py
@@ -1,0 +1,893 @@
+"""KnowledgeNote — semantic Obsidian-bound document for human re-reading.
+
+Where :func:`obsidian_export.render_research_note` serialises a raw
+:class:`ResearchPack` (sources, attachments, links) for archival, the
+knowledge writer composes a *story* of one work session: original ask,
+collected evidence, role-by-role critique, tech-lead synthesis, decisions
+made, and the next actions. The output is a Markdown document a person
+opening the vault months later can use to reconstruct what happened.
+
+Key contracts:
+
+- ``build_knowledge_note(...)`` returns a :class:`KnowledgeNote` with a
+  stable section list — render order matches the contract spec
+  (목적 / 원문 요청 / 결론 / 자료 / 역할별 검토 / Tech Lead 종합 /
+  결정 / 다음 액션 / 관련 세션). Empty sections still render with
+  ``- (없음)`` so a reader can tell missing-by-design from absent.
+- Title resolution is **deterministic and LLM-free**: explicit
+  session/thread topic → original-prompt noun phrase → synthesis
+  consensus → pack title → ``<task_type> 작업 정리``. URL fragments and
+  filler phrases (``자료 링크``, ``오늘은``, …) are stripped before any
+  truncation so a short, semantic title survives.
+- Vault path follows the same layout policy as ``render_research_note``
+  (``10-projects/<project>/<kind>/`` under yule-agent-vault) — the
+  knowledge note registers as ``kind="knowledge"`` so
+  ``recommend_path`` routes it under a project-specific
+  ``knowledge/`` subfolder.
+
+This module never writes files. The downstream ``obsidian_writer``
+takes the rendered :class:`ObsidianNote` and persists it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+from .deliberation import (
+    RoleTake,
+    TechLeadOpening,
+    TechLeadSynthesis,
+    render_role_take,
+)
+from .research_pack import ResearchAttachment, ResearchPack, ResearchSource
+from .workflow_state import WorkflowSession
+
+
+KNOWLEDGE_KIND = "knowledge"
+KNOWLEDGE_CONTRACT_VERSION = "knowledge-note/v0"
+
+# Soft cap for the H1/title — long enough to keep semantic verbs but
+# short enough that filename slugs stay under the 100-char Obsidian/git
+# basename limit.
+KNOWLEDGE_TITLE_LIMIT = 60
+
+KNOWLEDGE_SUBDIR = "knowledge"
+
+# Section ordering is part of the contract — reorder here, not in the
+# caller, so frontmatter consumers always see the same key order in the
+# rendered document.
+SECTION_PURPOSE = "작업 목적"
+SECTION_ORIGINAL_PROMPT = "원문 요청"
+SECTION_CONCLUSION = "현재 결론"
+SECTION_SOURCES = "수집 자료"
+SECTION_ROLE_REVIEW = "역할별 검토"
+SECTION_TECH_LEAD = "Tech Lead 종합"
+SECTION_DECISIONS = "결정 / 제안"
+SECTION_NEXT_ACTIONS = "다음 액션"
+SECTION_RELATED_SESSION = "관련 세션"
+
+
+# ---------------------------------------------------------------------------
+# Title scrubbing helpers
+# ---------------------------------------------------------------------------
+
+
+# Filler phrases the prompt parser must drop *before* truncation — they
+# shorten the available budget without adding signal. Keep ordered: the
+# longest patterns first so a substring strip doesn't half-match a longer
+# phrase.
+_FILLER_PHRASES: tuple[str, ...] = (
+    "자료 링크 모음",
+    "자료 링크",
+    "오늘은",
+    "오늘",
+    "내일은",
+    "내일",
+    "지금은",
+    "지금",
+    "이번에는",
+    "이번엔",
+    "다음 주제로",
+    "다음으로",
+    "이를 위해",
+    "그래서",
+    "그러니까",
+    "이대로",
+    "먼저",
+    "한번",
+    "잠깐",
+)
+
+_SUFFIX_FILLER: tuple[str, ...] = (
+    " 고민해보려 합니다.",
+    " 고민해보려 합니다",
+    " 고민해보고자 합니다.",
+    " 고민해보고자 합니다",
+    " 정리해보려 합니다.",
+    " 정리해보려 합니다",
+    " 검토해보려 합니다.",
+    " 검토해보려 합니다",
+    " 해보려 합니다.",
+    " 해보려 합니다",
+)
+
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_LABEL_PREFIX_RE = re.compile(
+    r"^\s*\[(?:Research|Decision|Reference|Knowledge)\]\s*",
+    re.IGNORECASE,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def scrub_title_text(text: str) -> str:
+    """Strip URLs, ``[Research]``-style prefixes, bold markers, and filler.
+
+    Returns a single-line, whitespace-collapsed string. Empty input or a
+    string that becomes empty after scrubbing returns ``""`` so callers
+    can fall back to the next candidate in the resolution chain.
+    """
+
+    if not text:
+        return ""
+    cleaned = _LABEL_PREFIX_RE.sub("", text)
+    cleaned = _BOLD_RE.sub(r"\1", cleaned)
+    cleaned = _URL_RE.sub(" ", cleaned)
+    cleaned = cleaned.replace("\r", " ").replace("\n", " ")
+    for suffix in _SUFFIX_FILLER:
+        if cleaned.endswith(suffix):
+            cleaned = cleaned[: -len(suffix)]
+            break
+    for phrase in _FILLER_PHRASES:
+        cleaned = cleaned.replace(phrase, " ")
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned)
+    return cleaned.strip(" -·…,.;:")
+
+
+def _truncate_to_phrase(text: str, *, max_chars: int) -> str:
+    """Cut *text* on the earliest sentence boundary that fits *max_chars*."""
+
+    cleaned = scrub_title_text(text)
+    if not cleaned:
+        return ""
+    for sep in (". ", "! ", "? ", "。", "·", " — ", " - ", "다. ", "다 "):
+        idx = cleaned.find(sep)
+        if 0 < idx < max_chars * 4:
+            cleaned = cleaned[:idx]
+            break
+    cleaned = scrub_title_text(cleaned)
+    if not cleaned:
+        return ""
+    if len(cleaned) <= max_chars:
+        return cleaned
+    head = cleaned[:max_chars]
+    pivot = head.rfind(" ")
+    if pivot >= max_chars // 2:
+        head = head[:pivot]
+    return head.rstrip(" ,.;:") + "…"
+
+
+def _looks_like_full_prompt(text: str) -> bool:
+    """Heuristic: a sentence-shaped paragraph is probably the raw prompt."""
+
+    if any(marker in text for marker in (". ", "다. ", "다 ", "려 합니다", "고 싶")):
+        return True
+    if text.count(" ") > 8:
+        return True
+    return False
+
+
+def _session_topic(session: Optional[WorkflowSession]) -> Optional[str]:
+    """Operator-curated topic stashed on the session (if any).
+
+    The router pre-stashes one of these keys at intake time when a
+    request is clearly tied to a known thread/topic — preferring them
+    over heuristic derivation keeps the title stable across re-renders.
+    """
+
+    if session is None:
+        return None
+    extra = dict(getattr(session, "extra", None) or {})
+    for key in (
+        "topic",
+        "thread_topic",
+        "short_title",
+        "research_title",
+        "knowledge_title",
+        "routing_decision_title",
+    ):
+        candidate = extra.get(key)
+        if isinstance(candidate, str):
+            cleaned = scrub_title_text(candidate)
+            if cleaned:
+                return cleaned[:KNOWLEDGE_TITLE_LIMIT]
+    return None
+
+
+def _synthesis_title(synthesis: Optional[TechLeadSynthesis]) -> Optional[str]:
+    """Pull a title-shaped phrase out of the tech-lead synthesis."""
+
+    if synthesis is None:
+        return None
+    consensus = (synthesis.consensus or "").strip()
+    if not consensus:
+        return None
+    candidate = _truncate_to_phrase(consensus, max_chars=KNOWLEDGE_TITLE_LIMIT)
+    return candidate or None
+
+
+def _pack_title_or_summary(pack: Optional[ResearchPack]) -> Optional[str]:
+    """Best title-shaped phrase out of a research pack.
+
+    Prefers a clean, intentionally-short ``pack.title``; falls back to a
+    truncated ``pack.summary`` (often the first sentence of a Discord
+    message) so a knowledge note built directly from a forum starter
+    still gets a readable header.
+    """
+
+    if pack is None:
+        return None
+    raw_title = (getattr(pack, "title", "") or "").strip()
+    cleaned_title = scrub_title_text(raw_title)
+    if cleaned_title and len(cleaned_title) <= KNOWLEDGE_TITLE_LIMIT and not _looks_like_full_prompt(cleaned_title):
+        return cleaned_title
+    for candidate in (raw_title, getattr(pack, "summary", "") or ""):
+        derived = _truncate_to_phrase(candidate, max_chars=KNOWLEDGE_TITLE_LIMIT)
+        if derived:
+            return derived
+    return None
+
+
+def _task_type_fallback(session: Optional[WorkflowSession]) -> str:
+    """Final fallback — never lets the title collapse to ``""``."""
+
+    task_type = (
+        getattr(session, "task_type", None) if session is not None else None
+    )
+    label = (task_type or "").strip() or "engineering"
+    return f"{label} 작업 정리"
+
+
+def derive_knowledge_title(
+    *,
+    pack: Optional[ResearchPack] = None,
+    session: Optional[WorkflowSession] = None,
+    synthesis: Optional[TechLeadSynthesis] = None,
+    original_prompt: Optional[str] = None,
+    max_chars: int = KNOWLEDGE_TITLE_LIMIT,
+) -> str:
+    """Pick a short, semantic title for the knowledge note.
+
+    Resolution order (the first non-empty candidate wins):
+
+    1. ``session.extra["topic" | "thread_topic" | "short_title" | …]`` —
+       operator-curated.
+    2. Noun-phrase from *original_prompt* (or ``session.prompt``) after
+       URL/filler scrubbing.
+    3. First sentence of ``synthesis.consensus``.
+    4. ``pack.title`` (cleaned) when intentionally short, else first
+       sentence of ``pack.summary``.
+    5. ``<task_type> 작업 정리`` so the H1 is never empty.
+    """
+
+    explicit = _session_topic(session)
+    if explicit:
+        return explicit[:max_chars]
+
+    prompt = (original_prompt or "").strip() or (
+        (getattr(session, "prompt", None) or "").strip() if session else ""
+    )
+    if prompt:
+        derived = _truncate_to_phrase(prompt, max_chars=max_chars)
+        if derived:
+            return derived
+
+    synthesis_title = _synthesis_title(synthesis)
+    if synthesis_title:
+        return synthesis_title[:max_chars]
+
+    pack_title = _pack_title_or_summary(pack)
+    if pack_title:
+        return pack_title[:max_chars]
+
+    return _task_type_fallback(session)[:max_chars]
+
+
+# ---------------------------------------------------------------------------
+# Body / frontmatter assembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KnowledgeNote:
+    """The structured knowledge document, pre-render.
+
+    ``body_sections`` is an ordered ``(heading, body_markdown)`` list so
+    callers that want to splice a section (e.g. an LLM-generated summary)
+    can do so without re-parsing the rendered markdown. ``frontmatter``
+    is a plain dict for the YAML head; ``content`` lazily formats the
+    full document.
+    """
+
+    title: str
+    topic: str
+    summary: str
+    body_sections: Sequence[Tuple[str, str]]
+    frontmatter: Mapping[str, Any]
+    vault_folder: str
+    vault_filename: str
+
+    @property
+    def vault_path(self) -> str:
+        return f"{self.vault_folder}/{self.vault_filename}"
+
+
+def _bullets(items: Iterable[str]) -> str:
+    cleaned = [str(item).strip() for item in items if str(item).strip()]
+    if not cleaned:
+        return "- (없음)"
+    return "\n".join(f"- {item}" for item in cleaned)
+
+
+def _purpose_section(
+    *,
+    session: Optional[WorkflowSession],
+    synthesis: Optional[TechLeadSynthesis],
+    title: str,
+) -> str:
+    """Best-effort statement of *why* this work was undertaken.
+
+    Pulls from the operator-supplied purpose key first, falls through to
+    a synthesis-derived sentence, then a generic task_type-based line so
+    the section is never empty.
+    """
+
+    extra = dict(getattr(session, "extra", None) or {}) if session else {}
+    candidate = extra.get("work_purpose") or extra.get("purpose")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    if synthesis is not None and (synthesis.consensus or "").strip():
+        first = scrub_title_text(synthesis.consensus.split(".")[0])
+        if first:
+            return f"{first}을 정리하기 위한 작업"
+    task_type = (getattr(session, "task_type", None) or "").strip() if session else ""
+    if task_type:
+        return f"{task_type} 흐름에서 {title}을(를) 정리"
+    return f"{title}에 대한 정리"
+
+
+def _conclusion_section(
+    *,
+    synthesis: Optional[TechLeadSynthesis],
+    role_turns: Sequence[RoleTake],
+) -> str:
+    """The current conclusion line — synthesis takes priority."""
+
+    if synthesis is not None and (synthesis.consensus or "").strip():
+        return synthesis.consensus.strip()
+    # Role-take perspectives can act as a stand-in conclusion when there
+    # is no synthesis yet (mid-thread snapshot).
+    perspectives = [
+        scrub_title_text(getattr(t, "perspective", "") or "")
+        for t in role_turns
+        if getattr(t, "perspective", None)
+    ]
+    perspectives = [p for p in perspectives if p]
+    if perspectives:
+        return "현재까지 정리된 관점:\n" + _bullets(perspectives)
+    return "(아직 결론이 수렴되지 않았습니다.)"
+
+
+def _sources_section(pack: Optional[ResearchPack]) -> str:
+    """Render collected sources in a reader-oriented form.
+
+    Discord/web URLs land first as bullet links so a reader can click
+    through; attachments and code-context follow with one bullet each so
+    provenance survives review.
+    """
+
+    if pack is None:
+        return "- (없음)"
+    lines: list[str] = []
+    seen_urls: dict[str, None] = {}
+    for source in pack.sources:
+        url = (source.source_url or "").strip()
+        if url and url not in seen_urls:
+            seen_urls[url] = None
+            label = (source.title or url).strip() or url
+            label = scrub_title_text(label) or url
+            role = (source.role or "").strip()
+            role_part = f" — _{role}_" if role else ""
+            lines.append(f"- [{label}]({url}){role_part}")
+    for att in pack.attachments:
+        kind = (att.kind or "file").strip() or "file"
+        name = (att.filename or "").strip()
+        url = (att.url or "").strip()
+        descriptor = f"`{kind}`"
+        if name:
+            descriptor = f"{descriptor} {name}"
+        if url:
+            descriptor = f"{descriptor} <{url}>"
+        if att.description:
+            descriptor = f"{descriptor} — {att.description.strip()}"
+        lines.append(f"- {descriptor}")
+    if not lines:
+        return "- (없음)"
+    return "\n".join(lines)
+
+
+def _role_review_section(role_turns: Sequence[RoleTake]) -> str:
+    """Render every role take so the per-role critique is preserved.
+
+    Uses :func:`render_role_take` so the per-role 4-section contract
+    (관점/근거/리스크/다음 행동) survives into the Obsidian doc — the
+    same shape the Discord forum already shows. Each take is wrapped in
+    a ``###`` subhead so the document outline groups by role.
+    """
+
+    if not role_turns:
+        return "- (역할별 검토가 아직 기록되지 않았습니다.)"
+    blocks: list[str] = []
+    for take in role_turns:
+        role_label = getattr(take, "role", "") or "(unknown)"
+        rendered = render_role_take(take).strip()
+        blocks.append(f"### {role_label}\n{rendered}")
+    return "\n\n".join(blocks)
+
+
+def _tech_lead_section(synthesis: Optional[TechLeadSynthesis]) -> str:
+    """Render the tech-lead synthesis as a multi-paragraph block."""
+
+    if synthesis is None:
+        return "- (아직 종합 의견이 기록되지 않았습니다.)"
+    parts: list[str] = []
+    if (synthesis.consensus or "").strip():
+        parts.append(f"**합의안:** {synthesis.consensus.strip()}")
+    parts.append("**해야 할 일**\n" + _bullets(synthesis.todos))
+    parts.append("**더 조사할 것**\n" + _bullets(synthesis.open_research))
+    if synthesis.approval_required:
+        reason = (synthesis.approval_reason or "쓰기 승인 필요").strip()
+        parts.append(f"**승인 필요:** yes — {reason}")
+    else:
+        parts.append("**승인 필요:** no")
+    return "\n\n".join(parts)
+
+
+def _decisions_section(
+    *,
+    synthesis: Optional[TechLeadSynthesis],
+    role_turns: Sequence[RoleTake],
+    explicit: Sequence[str],
+) -> str:
+    """Decisions / proposals section — merges synthesis + role + explicit."""
+
+    items: list[str] = list(explicit)
+    if synthesis is not None:
+        items.extend(synthesis.user_decisions_needed)
+    for take in role_turns:
+        if isinstance(take, TechLeadOpening):
+            items.extend(take.decisions_needed)
+    return _bullets(_dedup(items))
+
+
+def _next_actions_section(
+    *,
+    synthesis: Optional[TechLeadSynthesis],
+    role_turns: Sequence[RoleTake],
+    explicit: Sequence[str],
+) -> str:
+    """Next actions section — merges synthesis todos + role next_actions."""
+
+    items: list[str] = list(explicit)
+    if synthesis is not None:
+        items.extend(synthesis.todos)
+    for take in role_turns:
+        next_actions = getattr(take, "next_actions", ()) or ()
+        items.extend(next_actions)
+    return _bullets(_dedup(items))
+
+
+def _related_session_section(session: Optional[WorkflowSession]) -> str:
+    if session is None:
+        return "- (세션 정보 없음)"
+    bits = [f"- session_id: `{session.session_id}`"]
+    task_type = (getattr(session, "task_type", None) or "").strip()
+    if task_type:
+        bits.append(f"- task_type: `{task_type}`")
+    state = getattr(getattr(session, "state", None), "value", None)
+    if state:
+        bits.append(f"- state: `{state}`")
+    if session.thread_id is not None:
+        bits.append(f"- thread_id: `{session.thread_id}`")
+    if session.executor_role:
+        bits.append(f"- executor_role: `{session.executor_role}`")
+    return "\n".join(bits)
+
+
+def _dedup(items: Iterable[str]) -> Tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for item in items:
+        if not item:
+            continue
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen[text] = None
+    return tuple(seen.keys())
+
+
+def _resolve_original_prompt(
+    *,
+    session: Optional[WorkflowSession],
+    pack: Optional[ResearchPack],
+    explicit: Optional[str] = None,
+) -> str:
+    """Pick the most authoritative original prompt to preserve.
+
+    Order: explicit kwarg → ``session.prompt`` → request topic on the
+    pack → pack.summary when it differs meaningfully from the title →
+    pack.title when it looks sentence-shaped.
+    """
+
+    if explicit and explicit.strip():
+        return explicit.strip()
+    if session is not None:
+        prompt = (getattr(session, "prompt", None) or "").strip()
+        if prompt:
+            return prompt
+    if pack is not None:
+        request = getattr(pack, "request", None)
+        if request is not None:
+            for attr in ("question", "topic"):
+                value = (getattr(request, attr, "") or "").strip()
+                if value:
+                    return value
+        summary = (getattr(pack, "summary", "") or "").strip()
+        title = (getattr(pack, "title", "") or "").strip()
+        if summary and summary != title and len(summary) > len(title):
+            return summary
+        if title and _looks_like_full_prompt(title):
+            return title
+    return ""
+
+
+def _resolve_status(
+    synthesis: Optional[TechLeadSynthesis],
+    session: Optional[WorkflowSession],
+) -> str:
+    if synthesis is not None and synthesis.approval_required:
+        return "approval-pending"
+    if synthesis is not None:
+        return "decided"
+    if session is None:
+        return "captured"
+    state = getattr(getattr(session, "state", None), "value", None)
+    if state in (None, "intake"):
+        return "captured"
+    return state
+
+
+def _resolve_roles(
+    pack: Optional[ResearchPack],
+    role_turns: Sequence[RoleTake],
+) -> list[str]:
+    seen: dict[str, None] = {}
+    for take in role_turns:
+        role = (getattr(take, "role", "") or "").strip()
+        if role and role not in seen:
+            seen[role] = None
+    if pack is not None:
+        for role in pack.author_roles:
+            cleaned = (role or "").strip()
+            if cleaned and cleaned not in seen:
+                seen[cleaned] = None
+    return list(seen.keys())
+
+
+def _resolve_sources(pack: Optional[ResearchPack]) -> list[str]:
+    if pack is None:
+        return []
+    seen: dict[str, None] = {}
+    for url in pack.urls:
+        if url and url not in seen:
+            seen[url] = None
+    for att in pack.attachments:
+        ident = att.url or att.filename
+        if ident and ident not in seen:
+            seen[ident] = None
+    return list(seen.keys())
+
+
+def _iso_or_none(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.replace(microsecond=0).isoformat()
+    return str(value)
+
+
+def _format_section_block(heading: str, body: str) -> str:
+    body_clean = body.strip() or "- (없음)"
+    return f"## {heading}\n{body_clean}"
+
+
+# ---------------------------------------------------------------------------
+# Path / project helpers
+# ---------------------------------------------------------------------------
+
+
+def recommend_knowledge_path(
+    *,
+    title: str,
+    project: Optional[str],
+    created_at: Optional[datetime],
+    layout: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+):
+    """Return the knowledge-note vault path.
+
+    Routes through :func:`obsidian_export.recommend_path` with
+    ``kind="knowledge"`` so every note lands under the project's
+    ``knowledge/`` subfolder by default. Legacy-agent layout falls back
+    to the inbox bucket because there is no historical
+    ``Agents/Engineering/Knowledge`` tree.
+    """
+
+    from .obsidian_export import (
+        FILENAME_BASENAME_LIMIT,
+        FILENAME_SLUG_LIMIT,
+        INBOX_UNSORTED,
+        LAYOUT_LEGACY_AGENT,
+        PROJECTS_BASE,
+        ExportPath,
+        _slugify,
+        resolve_default_project,
+        resolve_layout,
+    )
+
+    layout_resolved = resolve_layout(layout, env=env)
+    when = created_at or datetime.utcnow()
+    date_part = when.date().isoformat()
+    slug = _slugify(title, max_chars=FILENAME_SLUG_LIMIT) or "untitled"
+    basename = f"{date_part}_knowledge-{slug}.md"
+    if len(basename) > FILENAME_BASENAME_LIMIT:
+        keep = FILENAME_BASENAME_LIMIT - (len(date_part) + 1 + len("knowledge") + 1 + 3)
+        basename = f"{date_part}_knowledge-{slug[:max(1, keep)]}.md"
+
+    if layout_resolved == LAYOUT_LEGACY_AGENT:
+        # No legacy parent for ``knowledge/`` exists — route to the inbox
+        # bucket so notes still land somewhere predictable when a vault
+        # has not migrated to the yule-agent-vault tree.
+        return ExportPath(folder=INBOX_UNSORTED, filename=basename)
+
+    project_resolved = (project or "").strip() or resolve_default_project(env=env)
+    project_slug = _slugify(project_resolved) or "uncategorized"
+    folder = f"{PROJECTS_BASE}/{project_slug}/{KNOWLEDGE_SUBDIR}"
+    return ExportPath(folder=folder, filename=basename)
+
+
+# ---------------------------------------------------------------------------
+# Public builders
+# ---------------------------------------------------------------------------
+
+
+def build_knowledge_note(
+    *,
+    pack: Optional[ResearchPack] = None,
+    session: Optional[WorkflowSession] = None,
+    synthesis: Optional[TechLeadSynthesis] = None,
+    role_turns: Sequence[RoleTake] = (),
+    decisions: Sequence[str] = (),
+    next_actions: Sequence[str] = (),
+    original_prompt: Optional[str] = None,
+    title: Optional[str] = None,
+    project: Optional[str] = None,
+    layout: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    exported_at: Optional[datetime] = None,
+) -> KnowledgeNote:
+    """Compose a :class:`KnowledgeNote` from the available work artifacts.
+
+    Designed to be **fully tolerant of missing inputs** — a research-only
+    snapshot (``pack`` alone) still produces a well-formed knowledge
+    note; richer inputs (``synthesis`` + ``role_turns``) light up the
+    review/decision/next-action sections. Callers who curate a title or
+    purpose pre-stash them in ``session.extra``; the deterministic
+    fallback chain takes over otherwise.
+    """
+
+    resolved_title = (title or "").strip() or derive_knowledge_title(
+        pack=pack,
+        session=session,
+        synthesis=synthesis,
+        original_prompt=original_prompt,
+    )
+    prompt = _resolve_original_prompt(
+        session=session, pack=pack, explicit=original_prompt
+    )
+
+    purpose_body = _purpose_section(
+        session=session, synthesis=synthesis, title=resolved_title
+    )
+    sections: list[Tuple[str, str]] = [
+        (SECTION_PURPOSE, purpose_body),
+        (
+            SECTION_ORIGINAL_PROMPT,
+            prompt or "(원문 요청이 기록되지 않았습니다.)",
+        ),
+        (
+            SECTION_CONCLUSION,
+            _conclusion_section(synthesis=synthesis, role_turns=role_turns),
+        ),
+        (SECTION_SOURCES, _sources_section(pack)),
+        (SECTION_ROLE_REVIEW, _role_review_section(role_turns)),
+        (SECTION_TECH_LEAD, _tech_lead_section(synthesis)),
+        (
+            SECTION_DECISIONS,
+            _decisions_section(
+                synthesis=synthesis,
+                role_turns=role_turns,
+                explicit=decisions,
+            ),
+        ),
+        (
+            SECTION_NEXT_ACTIONS,
+            _next_actions_section(
+                synthesis=synthesis,
+                role_turns=role_turns,
+                explicit=next_actions,
+            ),
+        ),
+        (SECTION_RELATED_SESSION, _related_session_section(session)),
+    ]
+
+    summary = (synthesis.consensus.strip() if synthesis is not None and synthesis.consensus else "")
+    if not summary:
+        summary = (getattr(pack, "summary", "") or "").strip()
+
+    created_at = (
+        getattr(pack, "created_at", None)
+        if pack is not None
+        else None
+    )
+    if created_at is None and session is not None:
+        created_at = getattr(session, "created_at", None)
+
+    # Resolve project the same way render_research_note does so a
+    # session-stamped project survives. Caller's explicit kwarg wins.
+    project_resolved = _resolve_project(
+        project=project, session=session, layout=layout, env=env
+    )
+    vault = recommend_knowledge_path(
+        title=resolved_title,
+        project=project_resolved,
+        created_at=created_at,
+        layout=layout,
+        env=env,
+    )
+
+    frontmatter: dict[str, Any] = {
+        "title": resolved_title,
+        "topic": resolved_title,
+        "original_prompt": prompt or None,
+        "session_id": getattr(session, "session_id", None) if session else None,
+        "kind": KNOWLEDGE_KIND,
+        "status": _resolve_status(synthesis, session),
+        "roles": _resolve_roles(pack, role_turns),
+        "sources": _resolve_sources(pack),
+        "created_at": _iso_or_none(created_at),
+        "task_type": getattr(session, "task_type", None) if session else None,
+        "project": project_resolved,
+        "contract": KNOWLEDGE_CONTRACT_VERSION,
+    }
+    if synthesis is not None:
+        frontmatter["approval_required"] = bool(synthesis.approval_required)
+    if exported_at is not None:
+        frontmatter["exported_at"] = exported_at.replace(microsecond=0).isoformat()
+
+    return KnowledgeNote(
+        title=resolved_title,
+        topic=resolved_title,
+        summary=summary,
+        body_sections=tuple(sections),
+        frontmatter=frontmatter,
+        vault_folder=vault.folder,
+        vault_filename=vault.filename,
+    )
+
+
+def _resolve_project(
+    *,
+    project: Optional[str],
+    session: Optional[WorkflowSession],
+    layout: Optional[str],
+    env: Optional[Mapping[str, str]],
+) -> Optional[str]:
+    """Walk the project resolution chain, mirroring render_research_note."""
+
+    from .obsidian_export import (
+        LAYOUT_LEGACY_AGENT,
+        resolve_default_project,
+        resolve_layout,
+    )
+
+    layout_resolved = resolve_layout(layout, env=env)
+    explicit = (project or "").strip()
+    if explicit:
+        return explicit
+    if layout_resolved == LAYOUT_LEGACY_AGENT:
+        return None
+    if session is not None:
+        extra = dict(getattr(session, "extra", None) or {})
+        candidate = extra.get("project") or extra.get("project_name")
+        if candidate:
+            return str(candidate).strip() or None
+    return resolve_default_project(env=env)
+
+
+def render_knowledge_markdown(note: KnowledgeNote) -> str:
+    """Render a :class:`KnowledgeNote` to a single Markdown blob.
+
+    Frontmatter ordering follows the dict's insertion order from
+    :func:`build_knowledge_note`. Body sections render in the contract
+    order set by :func:`build_knowledge_note` — callers should reorder
+    by mutating the input dataclass before calling, not here.
+    """
+
+    from .obsidian_export import _format_frontmatter
+
+    head = _format_frontmatter(dict(note.frontmatter))
+    body = [f"# {note.title}"]
+    for heading, content in note.body_sections:
+        body.append(_format_section_block(heading, content))
+    return head + "\n\n" + "\n\n".join(body).strip() + "\n"
+
+
+def render_knowledge_note(
+    *,
+    pack: Optional[ResearchPack] = None,
+    session: Optional[WorkflowSession] = None,
+    synthesis: Optional[TechLeadSynthesis] = None,
+    role_turns: Sequence[RoleTake] = (),
+    decisions: Sequence[str] = (),
+    next_actions: Sequence[str] = (),
+    original_prompt: Optional[str] = None,
+    title: Optional[str] = None,
+    project: Optional[str] = None,
+    layout: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    exported_at: Optional[datetime] = None,
+):
+    """Build + render a knowledge note as an :class:`ObsidianNote`.
+
+    This is the public entry point used by ``obsidian_export.render_research_note``
+    when ``kind="knowledge"`` is requested, so the existing CLI/sync
+    pipeline can opt into the richer template without changing call
+    sites.
+    """
+
+    from .obsidian_export import ExportPath, ObsidianNote
+
+    note = build_knowledge_note(
+        pack=pack,
+        session=session,
+        synthesis=synthesis,
+        role_turns=role_turns,
+        decisions=decisions,
+        next_actions=next_actions,
+        original_prompt=original_prompt,
+        title=title,
+        project=project,
+        layout=layout,
+        env=env,
+        exported_at=exported_at,
+    )
+    content = render_knowledge_markdown(note)
+    return ObsidianNote(
+        path=ExportPath(folder=note.vault_folder, filename=note.vault_filename),
+        content=content,
+        frontmatter=dict(note.frontmatter),
+    )

--- a/src/yule_orchestrator/agents/obsidian_approval.py
+++ b/src/yule_orchestrator/agents/obsidian_approval.py
@@ -1,0 +1,675 @@
+"""Discord-driven Obsidian save flow: preview → approval → write.
+
+Phase D plumbing for the engineering gateway. The CLI (``yule obsidian sync``)
+still owns the headless path; this module adds an in-channel flow so the
+operator can ask "Obsidian에 정리해줘" and approve a preview without leaving
+Discord.
+
+Responsibilities:
+
+- :func:`is_obsidian_save_request` — detect the user's save intent (the
+  runtime classifier already promotes these to ``execute_existing_step``;
+  we keep the lexicon here so the router can branch independently).
+- :func:`is_obsidian_approval` — detect ``저장 승인`` / ``이대로 저장`` /
+  ``승인``. Approval phrases must NOT be promoted to a brand-new task.
+- :func:`build_save_proposal` — load the session's persisted research_pack
+  (and optional synthesis), render the :class:`ObsidianNote`, and return a
+  :class:`ObsidianSaveProposal` envelope with the human-readable preview
+  message, vault-relative target path, and serialised payload to stash on
+  ``session.extra``.
+- :func:`store_pending_proposal` / :func:`get_pending_proposal` /
+  :func:`clear_pending_proposal` — proposal memory at session scope. The
+  router writes the channel/thread/user identifiers into the payload so a
+  subsequent approval message can be matched without reading the full
+  recall pipeline.
+- :func:`execute_pending_proposal` — re-render the note and call the
+  injected writer (default: :func:`obsidian_writer.write_note`) to land
+  the file in the vault. Updates ``session.extra["obsidian"]`` with the
+  ``last_write_path`` / ``last_write_status`` event.
+
+The module is intentionally pure-Python with all IO seams injected so the
+flow can be exercised in unit tests without a real vault, real Discord, or
+real cache.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from .deliberation import TechLeadSynthesis, synthesis_from_dict
+from .knowledge_writer import render_knowledge_note
+from .obsidian_export import ObsidianNote, render_research_note
+from .obsidian_writer import (
+    ENV_VAULT_PATH,
+    ObsidianWriteError,
+    ObsidianWriteResult,
+    resolve_vault_root,
+    write_note,
+)
+from .research_pack import ResearchPack, pack_from_dict
+from .workflow_state import WorkflowSession, update_session
+
+
+# ---------------------------------------------------------------------------
+# Phrase banks
+# ---------------------------------------------------------------------------
+
+
+# Save-intent phrases. ``classify_intent_deterministic`` already promotes
+# these to ``execute_existing_step``; we keep the lexicon here so the
+# router preflight can decide *which* execute-step branch to take.
+_OBSIDIAN_SAVE_PHRASES: tuple[str, ...] = (
+    "obsidian에 정리",
+    "obsidian 에 정리",
+    "obsidian에 저장",
+    "obsidian 에 저장",
+    "obsidian 노트 정리",
+    "obsidian 동기화",
+    "옵시디언에 정리",
+    "옵시디언에 저장",
+    "옵시디언 정리",
+    "옵시디언 동기화",
+    "이 세션 기준으로 저장",
+    "토의 기록 obsidian에 남",
+    "토의 기록 옵시디언에 남",
+    "vault에 저장",
+    "vault 에 저장",
+    "save to obsidian",
+    "save to vault",
+)
+
+
+# Approval phrases. The router must check the *trimmed* text only — they
+# are short and distinct so a substring match would over-fire on long
+# free-form prompts (e.g. "이 작업도 같이 승인해줘" is not approving the
+# Obsidian write). We accept them as either the entire normalized text or
+# as a whitespace-bounded standalone phrase.
+_APPROVAL_STANDALONE: frozenset[str] = frozenset(
+    {
+        "저장 승인",
+        "저장승인",
+        "저장 해줘",
+        "저장해줘",
+        "이대로 저장",
+        "이대로 저장해",
+        "이대로 저장해줘",
+        "이대로저장",
+        "이대로 보내줘",
+        "vault 저장 승인",
+        "obsidian 저장 승인",
+        "옵시디언 저장 승인",
+        "save approved",
+        "approve save",
+        "approve and save",
+        "go ahead and save",
+    }
+)
+
+
+# Bare "승인" / "approve" tokens — accepted only when the message is exactly
+# that single word (so "이거 승인 부탁해요" does NOT fire). The router
+# additionally requires a pending proposal before acting on a bare token,
+# preventing context-free approvals from being interpreted as Obsidian
+# writes.
+_BARE_APPROVAL_TOKENS: frozenset[str] = frozenset(
+    {"승인", "확인", "approve", "approved", "go", "ok"}
+)
+
+
+_NORMALIZE_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    return _NORMALIZE_RE.sub(" ", (text or "").lower()).strip()
+
+
+def is_obsidian_save_request(text: str) -> bool:
+    """Heuristic save-intent detector.
+
+    Returns True when *text* mentions Obsidian (or 옵시디언 / vault) plus a
+    "정리/저장/남겨" verb. Used by the router to disambiguate the two
+    branches of ``INTENT_EXECUTE_EXISTING_STEP`` (save vs other future
+    execute steps).
+    """
+
+    normalized = _normalize(text)
+    if not normalized:
+        return False
+    return any(phrase in normalized for phrase in _OBSIDIAN_SAVE_PHRASES)
+
+
+def is_obsidian_approval(text: str, *, has_pending_proposal: bool = False) -> bool:
+    """Heuristic approval detector.
+
+    Phrases like ``저장 승인`` / ``이대로 저장`` are accepted as exact-trim
+    matches. Bare ``승인`` / ``approve`` is only accepted when
+    *has_pending_proposal* is True — otherwise the router would happily
+    treat a generic "approved" reply as an Obsidian write.
+    """
+
+    normalized = _normalize(text)
+    if not normalized:
+        return False
+    if normalized in _APPROVAL_STANDALONE:
+        return True
+    for phrase in _APPROVAL_STANDALONE:
+        # Allow phrases embedded inside a slightly larger sentence — e.g.
+        # "네, 저장 승인합니다" — but only when the standalone phrase is at
+        # least 4 chars so we don't trigger on "ok"/"go" tokens here.
+        if len(phrase) >= 4 and phrase in normalized and len(normalized) <= len(phrase) + 12:
+            return True
+    if has_pending_proposal and normalized in _BARE_APPROVAL_TOKENS:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Proposal data
+# ---------------------------------------------------------------------------
+
+
+PROPOSAL_KEY = "obsidian"
+PROPOSAL_PENDING_KEY = "pending_proposal"
+PROPOSAL_HISTORY_KEY = "events"
+
+
+@dataclass(frozen=True)
+class ObsidianSaveProposal:
+    """The preview the gateway proposes to the user.
+
+    ``preview_message`` is the Discord-facing text — title, vault-relative
+    path, summary, included sections, and the explicit "answer 저장 승인"
+    instruction. ``payload`` is the JSON-friendly dict the router stores on
+    ``session.extra`` so a later approval can re-render the same note
+    without going back through the conversation layer.
+    """
+
+    session_id: str
+    title: str
+    vault_relative_path: str
+    summary: str
+    sections: tuple[str, ...]
+    preview_message: str
+    payload: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ObsidianApprovalOutcome:
+    """Result of executing a pending proposal.
+
+    ``success=True`` means the writer landed the file. ``vault_relative_path``
+    is the post-collision path — possibly with ``_2`` / ``_3`` appended.
+    ``message`` is the Discord-facing line.
+    """
+
+    success: bool
+    message: str
+    vault_relative_path: Optional[str] = None
+    target_path: Optional[Path] = None
+    suffix_applied: bool = False
+    original_target_path: Optional[Path] = None
+
+
+# ---------------------------------------------------------------------------
+# Preview builder
+# ---------------------------------------------------------------------------
+
+
+def build_save_proposal(
+    session: WorkflowSession,
+    *,
+    actor_user_id: Optional[int] = None,
+    project: Optional[str] = None,
+    layout: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    now: Optional[datetime] = None,
+) -> ObsidianSaveProposal:
+    """Render an :class:`ObsidianNote` from *session* and wrap it as a proposal.
+
+    Raises :class:`ObsidianApprovalError` when the session has no persisted
+    research pack (``session.extra["research_pack"]``) — without one we
+    have no body to render. The router catches this and replies with a
+    plain-language explanation.
+
+    Channel/thread/user identifiers are stashed in the proposal payload so
+    a follow-up approval message can match the proposal even when the
+    runtime preflight cannot anchor it via thread alone (e.g. when the
+    user replied in the parent channel).
+    """
+
+    pack_payload = (session.extra or {}).get("research_pack")
+    if not pack_payload:
+        raise ObsidianApprovalError(
+            f"세션 `{session.session_id}` 에 저장할 research_pack 이 없어요. "
+            "토의/자료 정리가 끝난 뒤 다시 요청해 주세요."
+        )
+
+    try:
+        pack = pack_from_dict(pack_payload)
+    except Exception as exc:  # noqa: BLE001 — surface as friendly error
+        raise ObsidianApprovalError(
+            f"세션 `{session.session_id}` 의 research_pack 을 읽지 못했어요: {exc}"
+        ) from exc
+
+    synthesis: Optional[TechLeadSynthesis] = None
+    synthesis_payload = (session.extra or {}).get("research_synthesis")
+    if synthesis_payload:
+        try:
+            synthesis = synthesis_from_dict(synthesis_payload)
+        except Exception:  # noqa: BLE001 — degrade gracefully
+            synthesis = None
+
+    note = _render_note_for_session(
+        pack=pack,
+        session=session,
+        synthesis=synthesis,
+        project=project,
+        layout=layout,
+        env=env,
+    )
+
+    sections = _section_titles(note)
+    title = str(note.frontmatter.get("title") or note.path.filename)
+    summary = (pack.summary or "").strip() or "(요약 미포함)"
+    preview_message = _format_preview_message(
+        title=title,
+        vault_relative_path=note.path.full,
+        summary=summary,
+        sections=sections,
+        session_id=session.session_id,
+    )
+
+    payload = {
+        "session_id": session.session_id,
+        "title": title,
+        "vault_relative_path": note.path.full,
+        "summary": summary,
+        "sections": list(sections),
+        "channel_id": session.channel_id,
+        "thread_id": session.thread_id,
+        "user_id": session.user_id,
+        "actor_user_id": actor_user_id,
+        "project": project,
+        "layout": layout,
+        "created_at": (now or datetime.utcnow()).isoformat(),
+    }
+
+    return ObsidianSaveProposal(
+        session_id=session.session_id,
+        title=title,
+        vault_relative_path=note.path.full,
+        summary=summary,
+        sections=tuple(sections),
+        preview_message=preview_message,
+        payload=payload,
+    )
+
+
+def _render_note_for_session(
+    *,
+    pack: ResearchPack,
+    session: WorkflowSession,
+    synthesis: Optional[TechLeadSynthesis],
+    project: Optional[str],
+    layout: Optional[str],
+    env: Optional[Mapping[str, str]],
+) -> ObsidianNote:
+    """Render the saved note via the KnowledgeNote layer.
+
+    The KnowledgeNote template is the human-readable Phase C document
+    (목적 / 원문 / 결론 / 자료 / 역할별 검토 / Tech Lead 종합 / 결정 /
+    다음 액션 / 관련 세션). When it can't be rendered (older sessions,
+    missing imports), we fall back to the legacy ``render_research_note``
+    so the operator still gets a valid note rather than a hard failure.
+    """
+
+    try:
+        return render_knowledge_note(
+            pack=pack,
+            session=session,
+            synthesis=synthesis,
+            project=project,
+            layout=layout,
+            env=env,
+        )
+    except Exception:  # noqa: BLE001 — fall back to research-only rendering
+        return render_research_note(
+            pack,
+            session=session,
+            synthesis=synthesis,
+            project=project,
+            layout=layout,
+            env=env,
+        )
+
+
+def _section_titles(note: ObsidianNote) -> tuple[str, ...]:
+    """Pull `## ...` headings out of *note.content* in document order."""
+
+    titles: list[str] = []
+    for line in note.content.splitlines():
+        if line.startswith("## "):
+            titles.append(line[3:].strip())
+    return tuple(titles)
+
+
+def _format_preview_message(
+    *,
+    title: str,
+    vault_relative_path: str,
+    summary: str,
+    sections: Sequence[str],
+    session_id: str,
+) -> str:
+    """Render the Discord-facing preview block."""
+
+    section_lines = "\n".join(f"- {title}" for title in sections) if sections else "- (없음)"
+    summary_block = summary
+    if len(summary_block) > 600:
+        summary_block = summary_block[:600].rstrip() + "…"
+    return (
+        "**[engineering-agent] Obsidian 저장 미리보기**\n"
+        f"세션: `{session_id}`\n"
+        f"제목: {title}\n"
+        f"저장 경로: `{vault_relative_path}`\n\n"
+        "요약:\n"
+        f"{summary_block}\n\n"
+        "포함 섹션:\n"
+        f"{section_lines}\n\n"
+        "저장하려면 `저장 승인` 이라고 답해 주세요. "
+        "수정이 필요하면 변경 요청만 답해 주시면 다시 미리보기를 만들어 드릴게요."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pending proposal storage on session.extra
+# ---------------------------------------------------------------------------
+
+
+def store_pending_proposal(
+    session: WorkflowSession,
+    proposal: ObsidianSaveProposal,
+    *,
+    now: Optional[datetime] = None,
+) -> WorkflowSession:
+    """Persist *proposal* into ``session.extra["obsidian"]["pending_proposal"]``.
+
+    Returns the updated session. Idempotent: storing twice replaces the
+    pending proposal with the latest preview.
+    """
+
+    extra = dict(session.extra or {})
+    obs = dict(extra.get(PROPOSAL_KEY) or {})
+    obs[PROPOSAL_PENDING_KEY] = dict(proposal.payload)
+    obs["pending_note_title"] = proposal.title
+    obs["pending_path"] = proposal.vault_relative_path
+    extra[PROPOSAL_KEY] = obs
+    updated = replace(session, extra=extra)
+    return update_session(updated, now=now or datetime.now().astimezone())
+
+
+def get_pending_proposal(session: WorkflowSession) -> Optional[Mapping[str, Any]]:
+    """Return the pending proposal payload, or ``None`` when there isn't one."""
+
+    obs = (session.extra or {}).get(PROPOSAL_KEY) or {}
+    pending = obs.get(PROPOSAL_PENDING_KEY)
+    if isinstance(pending, Mapping):
+        return pending
+    return None
+
+
+def clear_pending_proposal(
+    session: WorkflowSession, *, now: Optional[datetime] = None
+) -> WorkflowSession:
+    """Drop the pending proposal from ``session.extra``.
+
+    Called immediately after a successful write (or when the operator
+    explicitly cancels). Failing writes keep the proposal so the operator
+    can retry without re-rendering.
+    """
+
+    extra = dict(session.extra or {})
+    obs = dict(extra.get(PROPOSAL_KEY) or {})
+    obs.pop(PROPOSAL_PENDING_KEY, None)
+    obs.pop("pending_note_title", None)
+    obs.pop("pending_path", None)
+    extra[PROPOSAL_KEY] = obs
+    updated = replace(session, extra=extra)
+    return update_session(updated, now=now or datetime.now().astimezone())
+
+
+def record_write_event(
+    session: WorkflowSession,
+    *,
+    status: str,
+    vault_relative_path: Optional[str] = None,
+    error: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> WorkflowSession:
+    """Append a status event to ``session.extra["obsidian"]["events"]``.
+
+    Also pins the most recent ``last_write_path`` / ``last_write_status``
+    keys so status diagnostic questions can answer "Obsidian 저장 어떻게
+    됐어?" without scanning the events list.
+    """
+
+    extra = dict(session.extra or {})
+    obs = dict(extra.get(PROPOSAL_KEY) or {})
+    events = list(obs.get(PROPOSAL_HISTORY_KEY) or [])
+    occurred = (now or datetime.now().astimezone()).isoformat()
+    events.append(
+        {
+            "status": status,
+            "vault_relative_path": vault_relative_path,
+            "error": error,
+            "occurred_at": occurred,
+        }
+    )
+    obs[PROPOSAL_HISTORY_KEY] = events
+    obs["last_write_status"] = status
+    obs["last_write_at"] = occurred
+    if vault_relative_path:
+        obs["last_write_path"] = vault_relative_path
+    if error:
+        obs["last_write_error"] = error
+    extra[PROPOSAL_KEY] = obs
+    updated = replace(session, extra=extra)
+    return update_session(updated, now=now or datetime.now().astimezone())
+
+
+# ---------------------------------------------------------------------------
+# Approval execution
+# ---------------------------------------------------------------------------
+
+
+WriterFn = Callable[..., ObsidianWriteResult]
+
+
+class ObsidianApprovalError(RuntimeError):
+    """Raised when a preview can't be rendered or executed safely.
+
+    The router wraps these into a friendly chat message so a missing
+    research pack / missing vault path / writer failure never produces a
+    bare traceback in Discord.
+    """
+
+
+def execute_pending_proposal(
+    session: WorkflowSession,
+    *,
+    vault_path_override: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    writer_fn: Optional[WriterFn] = None,
+    project: Optional[str] = None,
+    layout: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> tuple[WorkflowSession, ObsidianApprovalOutcome]:
+    """Execute the pending proposal stored on *session*.
+
+    Re-renders the note from the persisted research_pack/synthesis (the
+    preview payload is for human review only — we never trust it as the
+    source of truth for body content). Calls *writer_fn* (defaults to
+    :func:`obsidian_writer.write_note`) with the resolved vault root.
+
+    Returns ``(updated_session, outcome)``. The session reflects the
+    cleared pending proposal and an appended ``events`` row. On vault /
+    writer failure the proposal is preserved so the operator can retry
+    after fixing the issue.
+    """
+
+    pending = get_pending_proposal(session)
+    if not pending:
+        raise ObsidianApprovalError(
+            "지금은 대기 중인 Obsidian 저장 제안이 없어요. "
+            "먼저 `Obsidian에 정리해줘` 처럼 저장 미리보기를 요청해 주세요."
+        )
+
+    try:
+        vault_root = resolve_vault_root(env=env, override=vault_path_override)
+    except ObsidianWriteError as exc:
+        message = (
+            f"⚠️ Obsidian vault 경로를 사용할 수 없어요: {exc}\n"
+            f"`{ENV_VAULT_PATH}` 환경 변수를 확인하고 다시 `저장 승인` 해 주세요."
+        )
+        updated = record_write_event(
+            session,
+            status="vault_unavailable",
+            error=str(exc),
+            now=now,
+        )
+        return updated, ObsidianApprovalOutcome(success=False, message=message)
+
+    pack_payload = (session.extra or {}).get("research_pack")
+    if not pack_payload:
+        message = (
+            "⚠️ 세션에 research_pack 이 더 이상 보이지 않아 저장을 진행할 수 없어요. "
+            "다시 `Obsidian에 정리해줘` 로 미리보기부터 만들어 주세요."
+        )
+        updated = record_write_event(
+            session,
+            status="missing_pack",
+            error="research_pack disappeared from session.extra",
+            now=now,
+        )
+        return updated, ObsidianApprovalOutcome(success=False, message=message)
+
+    try:
+        pack = pack_from_dict(pack_payload)
+    except Exception as exc:  # noqa: BLE001
+        message = (
+            f"⚠️ 저장 직전 research_pack 파싱이 실패했어요: {exc}. "
+            "vault 경로 / 세션 상태를 확인하고 다시 시도해 주세요."
+        )
+        updated = record_write_event(
+            session,
+            status="pack_parse_error",
+            error=str(exc),
+            now=now,
+        )
+        return updated, ObsidianApprovalOutcome(success=False, message=message)
+
+    synthesis: Optional[TechLeadSynthesis] = None
+    synthesis_payload = (session.extra or {}).get("research_synthesis")
+    if synthesis_payload:
+        try:
+            synthesis = synthesis_from_dict(synthesis_payload)
+        except Exception:  # noqa: BLE001
+            synthesis = None
+
+    project_resolved = project or pending.get("project") or None
+    layout_resolved = layout or pending.get("layout") or None
+
+    note = _render_note_for_session(
+        pack=pack,
+        session=session,
+        synthesis=synthesis,
+        project=project_resolved,
+        layout=layout_resolved,
+        env=env,
+    )
+
+    write_callable: WriterFn = writer_fn or write_note
+    try:
+        # Default writer signature: write_note(note, vault_root, *, overwrite, dry_run).
+        result = write_callable(note, vault_root, overwrite=False, dry_run=False)
+    except ObsidianWriteError as exc:
+        message = (
+            f"⚠️ Obsidian 쓰기 실패: {exc}. "
+            "vault 권한이나 경로를 확인하고 다시 `저장 승인` 해 주세요."
+        )
+        updated = record_write_event(
+            session,
+            status="write_failed",
+            error=str(exc),
+            now=now,
+        )
+        return updated, ObsidianApprovalOutcome(success=False, message=message)
+    except Exception as exc:  # noqa: BLE001 — wrap arbitrary writer exceptions
+        message = (
+            f"⚠️ Obsidian 쓰기 중 예상치 못한 오류: {exc}. 잠시 뒤 다시 시도해 주세요."
+        )
+        updated = record_write_event(
+            session,
+            status="write_failed",
+            error=str(exc),
+            now=now,
+        )
+        return updated, ObsidianApprovalOutcome(success=False, message=message)
+
+    target_path = result.target_path
+    try:
+        relative = target_path.relative_to(vault_root)
+        relative_str = str(relative)
+    except (ValueError, AttributeError):
+        relative_str = str(target_path)
+
+    cleared = clear_pending_proposal(session, now=now)
+    updated = record_write_event(
+        cleared,
+        status="written",
+        vault_relative_path=relative_str,
+        now=now,
+    )
+
+    suffix_note = ""
+    if result.suffix_applied and result.original_target_path is not None:
+        suffix_note = (
+            f"\n기존 파일과 충돌해 자동으로 `{Path(relative_str).name}` 로 저장했어요 "
+            f"(원래 경로: `{result.original_target_path.name}`)."
+        )
+
+    message = (
+        f"Obsidian 저장 완료 ✅\n"
+        f"vault relative path: `{relative_str}`"
+        f"{suffix_note}"
+    )
+
+    return updated, ObsidianApprovalOutcome(
+        success=True,
+        message=message,
+        vault_relative_path=relative_str,
+        target_path=target_path,
+        suffix_applied=result.suffix_applied,
+        original_target_path=result.original_target_path,
+    )
+
+
+__all__ = (
+    "ObsidianApprovalError",
+    "ObsidianApprovalOutcome",
+    "ObsidianSaveProposal",
+    "PROPOSAL_KEY",
+    "PROPOSAL_PENDING_KEY",
+    "build_save_proposal",
+    "clear_pending_proposal",
+    "execute_pending_proposal",
+    "get_pending_proposal",
+    "is_obsidian_approval",
+    "is_obsidian_save_request",
+    "record_write_event",
+    "store_pending_proposal",
+)

--- a/src/yule_orchestrator/agents/obsidian_export.py
+++ b/src/yule_orchestrator/agents/obsidian_export.py
@@ -82,6 +82,7 @@ PROJECT_DECISIONS_SUBDIR = "decisions"
 PROJECT_REFERENCES_SUBDIR = "references"
 PROJECT_TASK_LOGS_SUBDIR = "task-logs"
 PROJECT_MEETING_NOTES_SUBDIR = "meeting-notes"
+PROJECT_KNOWLEDGE_SUBDIR = "knowledge"
 
 # Legacy-agent layout (kept for opt-in legacy mode + back-compat imports).
 VAULT_BASE = "Agents/Engineering"
@@ -104,6 +105,7 @@ _KIND_TO_PROJECT_SUBDIR: Mapping[str, str] = {
     "meeting": PROJECT_MEETING_NOTES_SUBDIR,
     "meeting-note": PROJECT_MEETING_NOTES_SUBDIR,
     "meeting-notes": PROJECT_MEETING_NOTES_SUBDIR,
+    "knowledge": PROJECT_KNOWLEDGE_SUBDIR,
 }
 
 # Filename label per kind (used by ``recommend_path`` to build basenames
@@ -121,6 +123,7 @@ _KIND_TO_LABEL: Mapping[str, str] = {
     "meeting": "meeting",
     "meeting-note": "meeting",
     "meeting-notes": "meeting",
+    "knowledge": "knowledge",
 }
 
 
@@ -340,6 +343,22 @@ def render_research_note(
     """
 
     chosen_kind = (kind or _infer_kind(synthesis)).lower()
+    if chosen_kind == "knowledge":
+        # Knowledge mode delegates to the richer template — semantic
+        # title, role-by-role review, decisions/next-actions split — so
+        # the existing research/decision/reference branches stay
+        # byte-stable for vaults that haven't migrated.
+        from .knowledge_writer import render_knowledge_note
+
+        return render_knowledge_note(
+            pack=pack,
+            session=session,
+            synthesis=synthesis,
+            project=project,
+            layout=layout,
+            env=env,
+            exported_at=exported_at,
+        )
     layout_resolved = resolve_layout(layout, env=env)
     chosen_project = _resolve_project(
         project=project,
@@ -668,23 +687,40 @@ _FILLER_SUFFIXES = (
 )
 
 
-_RESEARCH_PREFIX_RE = re.compile(r"^\s*\[(?:Research|Decision|Reference)\]\s*", re.IGNORECASE)
+_RESEARCH_PREFIX_RE = re.compile(
+    r"^\s*\[(?:Research|Decision|Reference|Knowledge)\]\s*",
+    re.IGNORECASE,
+)
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_URL_IN_TEXT_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+# Filler phrases the title generator must drop *before* truncation —
+# they shorten the available budget without adding signal.
+_TITLE_FILLER_PHRASES: tuple[str, ...] = (
+    "자료 링크 모음",
+    "자료 링크",
+    "이대로",
+)
 
 
 def _clean_title(text: str) -> str:
     """Strip Discord/Obsidian markup that doesn't belong in a title.
 
-    Removes ``[Research]`` / ``[Decision]`` style prefixes, markdown
-    ``**bold**`` markers, line breaks, and runs of whitespace. The output
-    is a single-line plain string that downstream summarisation /
-    truncation can work on without escape-sequence surprises.
+    Removes ``[Research]`` / ``[Decision]`` / ``[Knowledge]`` style
+    prefixes, markdown ``**bold**`` markers, raw URLs (which sometimes
+    end up in auto-generated titles like ``자료 링크 https://...``),
+    body filler phrases (``자료 링크``, ``이대로``), line breaks, and
+    runs of whitespace. The output is a single-line plain string that
+    downstream summarisation / truncation can work on without escape-
+    sequence surprises.
     """
 
     if not text:
         return ""
     cleaned = _RESEARCH_PREFIX_RE.sub("", text)
     cleaned = _BOLD_RE.sub(r"\1", cleaned)
+    cleaned = _URL_IN_TEXT_RE.sub(" ", cleaned)
+    for phrase in _TITLE_FILLER_PHRASES:
+        cleaned = cleaned.replace(phrase, " ")
     cleaned = cleaned.replace("\r", " ").replace("\n", " ")
     cleaned = re.sub(r"\s+", " ", cleaned)
     return cleaned.strip(" -·…")

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -49,6 +49,13 @@ from .models import (
     SessionCandidate,
 )
 from .loop import run_runtime_loop
+from .recall import (
+    AMBIGUITY_MARGIN,
+    RECALL_SEEKING_INTENTS,
+    SCORE_HIGH,
+    SCORE_MEDIUM,
+    make_recall_fn,
+)
 from .understand import (
     IntentClassifier,
     classify_intent_deterministic,
@@ -88,8 +95,13 @@ __all__ = (
     "RuntimeResearchPlan",
     "RuntimeResult",
     "SessionCandidate",
+    "AMBIGUITY_MARGIN",
     "IntentClassifier",
+    "RECALL_SEEKING_INTENTS",
+    "SCORE_HIGH",
+    "SCORE_MEDIUM",
     "classify_intent_deterministic",
+    "make_recall_fn",
     "make_understand_fn",
     "run_runtime_loop",
 )

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -49,6 +49,7 @@ from .models import (
     SessionCandidate,
 )
 from .loop import run_runtime_loop
+from .policies import RolePolicy, all_role_policies, role_policy_for
 from .recall import (
     AMBIGUITY_MARGIN,
     RECALL_SEEKING_INTENTS,
@@ -98,10 +99,13 @@ __all__ = (
     "AMBIGUITY_MARGIN",
     "IntentClassifier",
     "RECALL_SEEKING_INTENTS",
+    "RolePolicy",
     "SCORE_HIGH",
     "SCORE_MEDIUM",
+    "all_role_policies",
     "classify_intent_deterministic",
     "make_recall_fn",
     "make_understand_fn",
+    "role_policy_for",
     "run_runtime_loop",
 )

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -49,6 +49,11 @@ from .models import (
     SessionCandidate,
 )
 from .loop import run_runtime_loop
+from .understand import (
+    IntentClassifier,
+    classify_intent_deterministic,
+    make_understand_fn,
+)
 
 __all__ = (
     "ACTION_APPEND_CONTEXT",
@@ -83,5 +88,8 @@ __all__ = (
     "RuntimeResearchPlan",
     "RuntimeResult",
     "SessionCandidate",
+    "IntentClassifier",
+    "classify_intent_deterministic",
+    "make_understand_fn",
     "run_runtime_loop",
 )

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -1,0 +1,88 @@
+"""Engineering Agent Runtime — shared conversational loop.
+
+Every engineering role bot (gateway, tech-lead, ai/backend/frontend/
+product/qa/devops) flows through the same seven-stage loop:
+
+    Observe → Understand → Recall → Research → Decide → Act → Record
+
+Each stage is a pluggable function so the same skeleton can host both
+the deterministic fallback runtime (used by tests and offline
+operation) and an LLM-backed runtime (added in later phases).
+
+Phase 1 lands the dataclasses + skeleton loop only. The Discord
+gateway and member bots keep using their existing routing modules; the
+runtime is wired in incrementally in later phases.
+
+This commit lands the model layer; the loop driver lands in the next
+commit.
+"""
+
+from .models import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    KNOWN_INTENTS,
+    ACTION_APPEND_CONTEXT,
+    ACTION_ASK_CLARIFICATION,
+    ACTION_CREATE_SESSION,
+    ACTION_JOIN_SESSION,
+    ACTION_NOOP,
+    ACTION_PROPOSE_APPROVAL,
+    ACTION_PUBLISH_FORUM,
+    ACTION_RECORD_MEMORY,
+    ACTION_REPLY,
+    ACTION_REQUEST_ROLE_TURN,
+    ACTION_RUN_RESEARCH,
+    KNOWN_ACTIONS,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeRecord,
+    RuntimeResearchPlan,
+    RuntimeResult,
+    SessionCandidate,
+)
+
+__all__ = (
+    "ACTION_APPEND_CONTEXT",
+    "ACTION_ASK_CLARIFICATION",
+    "ACTION_CREATE_SESSION",
+    "ACTION_JOIN_SESSION",
+    "ACTION_NOOP",
+    "ACTION_PROPOSE_APPROVAL",
+    "ACTION_PUBLISH_FORUM",
+    "ACTION_RECORD_MEMORY",
+    "ACTION_REPLY",
+    "ACTION_REQUEST_ROLE_TURN",
+    "ACTION_RUN_RESEARCH",
+    "INTENT_APPEND_CONTEXT",
+    "INTENT_CLARIFICATION_NEEDED",
+    "INTENT_CONTINUE_EXISTING_WORK",
+    "INTENT_DIAGNOSTIC_QUESTION",
+    "INTENT_EXECUTE_EXISTING_STEP",
+    "INTENT_GENERAL_CHAT",
+    "INTENT_NEW_WORK_REQUEST",
+    "INTENT_STATUS_QUESTION",
+    "INTENT_SUMMARIZE_PREVIOUS_WORK",
+    "KNOWN_ACTIONS",
+    "KNOWN_INTENTS",
+    "RuntimeAction",
+    "RuntimeDecision",
+    "RuntimeInput",
+    "RuntimeIntent",
+    "RuntimeObservation",
+    "RuntimeRecallResult",
+    "RuntimeRecord",
+    "RuntimeResearchPlan",
+    "RuntimeResult",
+    "SessionCandidate",
+)

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -48,6 +48,7 @@ from .models import (
     RuntimeResult,
     SessionCandidate,
 )
+from .decide import decide_default
 from .loop import run_runtime_loop
 from .policies import RolePolicy, all_role_policies, role_policy_for
 from .recall import (
@@ -104,6 +105,7 @@ __all__ = (
     "SCORE_MEDIUM",
     "all_role_policies",
     "classify_intent_deterministic",
+    "decide_default",
     "make_recall_fn",
     "make_understand_fn",
     "role_policy_for",

--- a/src/yule_orchestrator/agents/runtime/__init__.py
+++ b/src/yule_orchestrator/agents/runtime/__init__.py
@@ -12,9 +12,6 @@ operation) and an LLM-backed runtime (added in later phases).
 Phase 1 lands the dataclasses + skeleton loop only. The Discord
 gateway and member bots keep using their existing routing modules; the
 runtime is wired in incrementally in later phases.
-
-This commit lands the model layer; the loop driver lands in the next
-commit.
 """
 
 from .models import (
@@ -51,6 +48,7 @@ from .models import (
     RuntimeResult,
     SessionCandidate,
 )
+from .loop import run_runtime_loop
 
 __all__ = (
     "ACTION_APPEND_CONTEXT",
@@ -85,4 +83,5 @@ __all__ = (
     "RuntimeResearchPlan",
     "RuntimeResult",
     "SessionCandidate",
+    "run_runtime_loop",
 )

--- a/src/yule_orchestrator/agents/runtime/decide.py
+++ b/src/yule_orchestrator/agents/runtime/decide.py
@@ -1,0 +1,274 @@
+"""Decide stage — turn (intent, recall) into ordered runtime actions.
+
+Phase 4 keeps Decide deterministic: given an intent and a recall
+result, pick the smallest set of actions a role bot should take. The
+actions themselves are still abstract (``ACTION_JOIN_SESSION``,
+``ACTION_ASK_CLARIFICATION``, ...); the router preflight that wires
+this into Discord then turns each action into a concrete IO call.
+
+Mapping (gateway role):
+
+- ``status_question`` → reply (variant=status)
+- ``diagnostic_question`` → reply (variant=diagnostic)
+- ``continue_existing_work`` / ``summarize_previous_work`` /
+  ``execute_existing_step`` →
+    - matched session → join_session
+    - no matched session → ask_clarification
+- ``append_context`` →
+    - matched session → append_context
+    - no matched session → ask_clarification
+- ``new_work_request`` → create_session
+- ``clarification_needed`` → ask_clarification
+- ``general_chat`` → reply (variant=chat)
+
+The decision keeps the original ``RuntimeIntent`` + research plan so
+downstream consumers (router preflight, future record stage) get the
+full context without having to reach back into the recall result.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+from .models import (
+    ACTION_APPEND_CONTEXT,
+    ACTION_ASK_CLARIFICATION,
+    ACTION_CREATE_SESSION,
+    ACTION_JOIN_SESSION,
+    ACTION_REPLY,
+    INTENT_APPEND_CONTEXT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeResearchPlan,
+    SessionCandidate,
+)
+
+
+_SESSION_SEEKING_INTENTS = frozenset(
+    {
+        INTENT_CONTINUE_EXISTING_WORK,
+        INTENT_SUMMARIZE_PREVIOUS_WORK,
+        INTENT_EXECUTE_EXISTING_STEP,
+    }
+)
+
+
+def decide_default(
+    observation: RuntimeObservation,
+    intent: RuntimeIntent,
+    recall: RuntimeRecallResult,
+    plan: RuntimeResearchPlan,
+    input_: RuntimeInput,
+) -> RuntimeDecision:
+    """Build the deterministic action sequence for *intent*.
+
+    The router preflight (Phase 4B) only branches on the first action's
+    ``action_id``; the rest of the action list is preserved for future
+    stages (e.g. Phase 5 record_memory) so the decision object remains
+    rich without forcing every consumer to look at it.
+    """
+
+    intent_id = intent.intent_id
+
+    if intent_id == INTENT_STATUS_QUESTION:
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_REPLY,
+                    payload={
+                        "variant": "status",
+                        "matched_session_id": recall.matched_session_id,
+                    },
+                    reason="status question",
+                ),
+            ),
+            notes="status",
+        )
+
+    if intent_id == INTENT_DIAGNOSTIC_QUESTION:
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_REPLY,
+                    payload={
+                        "variant": "diagnostic",
+                        "matched_session_id": recall.matched_session_id,
+                    },
+                    reason="diagnostic question",
+                ),
+            ),
+            notes="diagnostic",
+        )
+
+    if intent_id in _SESSION_SEEKING_INTENTS:
+        if recall.matched_session_id is not None:
+            return _decision(
+                intent,
+                plan,
+                (
+                    RuntimeAction(
+                        action_id=ACTION_JOIN_SESSION,
+                        payload={
+                            "session_id": recall.matched_session_id,
+                            "thread_id": recall.matched_thread_id,
+                            "forum_thread_id": recall.matched_forum_thread_id,
+                            "intent": intent_id,
+                        },
+                        reason=f"matched existing work · {recall.reason}",
+                    ),
+                ),
+                notes="join existing work",
+            )
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_ASK_CLARIFICATION,
+                    payload={
+                        "intent": intent_id,
+                        "reason": "no_matched_session",
+                        "candidates": _pack_candidates(recall.candidates),
+                    },
+                    reason="no matched session for back-reference",
+                ),
+            ),
+            notes="ask clarification — no session match",
+        )
+
+    if intent_id == INTENT_APPEND_CONTEXT:
+        if recall.matched_session_id is not None:
+            return _decision(
+                intent,
+                plan,
+                (
+                    RuntimeAction(
+                        action_id=ACTION_APPEND_CONTEXT,
+                        payload={
+                            "session_id": recall.matched_session_id,
+                            "thread_id": recall.matched_thread_id,
+                            "forum_thread_id": recall.matched_forum_thread_id,
+                        },
+                        reason=f"append to {recall.matched_session_id}",
+                    ),
+                ),
+                notes="append context",
+            )
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_ASK_CLARIFICATION,
+                    payload={
+                        "intent": intent_id,
+                        "reason": "no_matched_session",
+                        "candidates": _pack_candidates(recall.candidates),
+                    },
+                    reason="append-context but no matched session",
+                ),
+            ),
+            notes="ask clarification — append context",
+        )
+
+    if intent_id == INTENT_NEW_WORK_REQUEST:
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_CREATE_SESSION,
+                    payload={"prompt": observation.message_text},
+                    reason="new work request",
+                ),
+            ),
+            notes="create new session",
+        )
+
+    if intent_id == INTENT_CLARIFICATION_NEEDED:
+        return _decision(
+            intent,
+            plan,
+            (
+                RuntimeAction(
+                    action_id=ACTION_ASK_CLARIFICATION,
+                    payload={"reason": "vague"},
+                    reason="clarification needed",
+                ),
+            ),
+            notes="ask clarification — vague",
+        )
+
+    # general_chat (or any unknown intent) → reply.
+    return _decision(
+        intent,
+        plan,
+        (
+            RuntimeAction(
+                action_id=ACTION_REPLY,
+                payload={"variant": "chat"},
+                reason="general chat / fallback",
+            ),
+        ),
+        notes="general chat",
+    )
+
+
+def _decision(
+    intent: RuntimeIntent,
+    plan: RuntimeResearchPlan,
+    actions: Tuple[RuntimeAction, ...],
+    *,
+    notes: str = "",
+) -> RuntimeDecision:
+    return RuntimeDecision(
+        intent=intent,
+        research_plan=plan,
+        actions=actions,
+        notes=notes,
+    )
+
+
+def _pack_candidates(candidates: Sequence[SessionCandidate]):
+    """Render candidates as JSON-friendly dicts for the action payload.
+
+    Action payloads round-trip through Discord/CLI so we keep them as
+    plain dicts; the candidate dataclass itself isn't pickled.
+    """
+
+    out = []
+    for cand in candidates[:5]:
+        out.append(
+            {
+                "session_id": cand.session_id,
+                "title": cand.title,
+                "score": cand.score,
+                "why": cand.why,
+                "state": cand.state,
+                "task_type": cand.task_type,
+                "thread_id": cand.thread_id,
+                "forum_thread_id": cand.forum_thread_id,
+                "has_research_pack": cand.has_research_pack,
+                "has_synthesis": cand.has_synthesis,
+            }
+        )
+    return out
+
+
+__all__ = ("decide_default",)

--- a/src/yule_orchestrator/agents/runtime/loop.py
+++ b/src/yule_orchestrator/agents/runtime/loop.py
@@ -1,0 +1,292 @@
+"""Skeleton runtime loop.
+
+``run_runtime_loop`` walks a :class:`RuntimeInput` through seven
+stages — Observe → Understand → Recall → Research → Decide → Act →
+Record — and returns a :class:`RuntimeResult`. Every stage is a
+pluggable callable so:
+
+- production wiring (Phase 4+) can pass real classifiers / lookups /
+  IO actors,
+- tests can pass mocks that record call ordering or short-circuit a
+  stage,
+- callers that don't care about a stage can pass ``None`` and the
+  loop will use a safe deterministic default.
+
+The default observers/decoders here are intentionally minimal — Phase
+2 / 3 / 4 land the real logic. The loop must already accept enough
+inputs for those phases without breaking the contract.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from datetime import datetime
+from typing import Any, Callable, Optional
+
+from .models import (
+    ACTION_NOOP,
+    ACTION_REPLY,
+    INTENT_GENERAL_CHAT,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeRecord,
+    RuntimeResearchPlan,
+    RuntimeResult,
+)
+
+
+ObserveFn = Callable[[RuntimeInput], RuntimeObservation]
+UnderstandFn = Callable[[RuntimeObservation, RuntimeInput], RuntimeIntent]
+RecallFn = Callable[[RuntimeObservation, RuntimeIntent, RuntimeInput], RuntimeRecallResult]
+ResearchFn = Callable[
+    [RuntimeObservation, RuntimeIntent, RuntimeRecallResult, RuntimeInput],
+    RuntimeResearchPlan,
+]
+DecideFn = Callable[
+    [
+        RuntimeObservation,
+        RuntimeIntent,
+        RuntimeRecallResult,
+        RuntimeResearchPlan,
+        RuntimeInput,
+    ],
+    RuntimeDecision,
+]
+ActFn = Callable[[RuntimeDecision, RuntimeInput], "tuple[RuntimeAction, ...]"]
+RecordFn = Callable[[RuntimeResult, RuntimeInput], "tuple[RuntimeRecord, ...]"]
+
+
+_URL_RE = re.compile(r"https?://[^\s<>\"]+")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _default_observe(input_: RuntimeInput) -> RuntimeObservation:
+    """Pure normalisation: collapse whitespace, extract URLs.
+
+    Stays free of IO so tests can inject a custom observe_fn that
+    e.g. attaches Discord channel name; the default one is enough for
+    Phase 1's contract tests.
+    """
+
+    raw = input_.message_text or ""
+    normalized = _WHITESPACE_RE.sub(" ", raw).strip().lower()
+    extracted = tuple(_URL_RE.findall(raw))
+    return RuntimeObservation(
+        role_id=input_.role_id,
+        message_text=raw,
+        normalized_text=normalized,
+        channel_id=input_.channel_id,
+        thread_id=input_.thread_id,
+        author_id=input_.author_id,
+        message_id=input_.message_id,
+        extracted_urls=extracted,
+        has_attachments=bool(input_.attachments),
+        received_at=input_.received_at,
+        last_proposed_prompt=input_.last_proposed_prompt,
+    )
+
+
+def _default_understand(_obs: RuntimeObservation, _input: RuntimeInput) -> RuntimeIntent:
+    """Phase 1 default: everything is general chat.
+
+    Phase 2 replaces this with a real deterministic classifier. The
+    skeleton's contract is just "always produce a valid intent" so
+    Decide / Act always have something to act on.
+    """
+
+    return RuntimeIntent(intent_id=INTENT_GENERAL_CHAT, confidence="low", reason="default")
+
+
+def _default_recall(
+    _obs: RuntimeObservation,
+    _intent: RuntimeIntent,
+    _input: RuntimeInput,
+) -> RuntimeRecallResult:
+    return RuntimeRecallResult(confidence="low", reason="default")
+
+
+def _default_research(
+    _obs: RuntimeObservation,
+    _intent: RuntimeIntent,
+    _recall: RuntimeRecallResult,
+    _input: RuntimeInput,
+) -> RuntimeResearchPlan:
+    return RuntimeResearchPlan(run=False, reason="default")
+
+
+def _default_decide(
+    _obs: RuntimeObservation,
+    intent: RuntimeIntent,
+    _recall: RuntimeRecallResult,
+    plan: RuntimeResearchPlan,
+    _input: RuntimeInput,
+) -> RuntimeDecision:
+    return RuntimeDecision(
+        intent=intent,
+        research_plan=plan,
+        actions=(RuntimeAction(action_id=ACTION_NOOP, reason="default"),),
+        notes="default-decision",
+    )
+
+
+def _default_act(
+    decision: RuntimeDecision,
+    _input: RuntimeInput,
+) -> "tuple[RuntimeAction, ...]":
+    """Default Act echoes the decision's actions verbatim.
+
+    Real wiring will translate the action_id into an actual Discord
+    send / forum publish / state update; the default is a pure
+    pass-through so contract tests can assert ordering without IO.
+    """
+
+    return tuple(decision.actions)
+
+
+def _default_record(
+    _result: RuntimeResult,
+    _input: RuntimeInput,
+) -> "tuple[RuntimeRecord, ...]":
+    return ()
+
+
+def run_runtime_loop(
+    input_: RuntimeInput,
+    *,
+    observe_fn: Optional[ObserveFn] = None,
+    understand_fn: Optional[UnderstandFn] = None,
+    recall_fn: Optional[RecallFn] = None,
+    research_fn: Optional[ResearchFn] = None,
+    decide_fn: Optional[DecideFn] = None,
+    act_fn: Optional[ActFn] = None,
+    record_fn: Optional[RecordFn] = None,
+) -> RuntimeResult:
+    """Drive *input_* through the seven-stage loop and return a result.
+
+    Stage ordering is fixed: Observe → Understand → Recall → Research
+    → Decide → Act → Record. Each stage receives the prior stages'
+    outputs so callers can build context cheaply. A stage callable
+    that raises is caught and surfaced via :attr:`RuntimeResult.error`
+    so a single misbehaving stage does not crash the whole bot.
+
+    The result is always returned with the most-recent-known fields
+    filled — even after an error — so the caller can show whichever
+    stages already completed (e.g. intent succeeded but recall raised).
+    """
+
+    obs_fn = observe_fn or _default_observe
+    und_fn = understand_fn or _default_understand
+    rec_fn = recall_fn or _default_recall
+    res_fn = research_fn or _default_research
+    dec_fn = decide_fn or _default_decide
+    act_fn_ = act_fn or _default_act
+    rec_record_fn = record_fn or _default_record
+
+    error: Optional[str] = None
+
+    try:
+        observation = obs_fn(input_)
+    except Exception as exc:  # noqa: BLE001 - never crash the bot from a stage
+        return RuntimeResult(
+            role_id=input_.role_id,
+            observation=RuntimeObservation(
+                role_id=input_.role_id,
+                message_text=input_.message_text,
+            ),
+            intent=RuntimeIntent(intent_id=INTENT_GENERAL_CHAT, reason="observe-failed"),
+            recall=RuntimeRecallResult(),
+            research_plan=RuntimeResearchPlan(),
+            decision=RuntimeDecision(
+                intent=RuntimeIntent(
+                    intent_id=INTENT_GENERAL_CHAT, reason="observe-failed"
+                ),
+            ),
+            error=f"observe: {exc}",
+        )
+
+    intent: RuntimeIntent
+    try:
+        intent = und_fn(observation, input_)
+    except Exception as exc:  # noqa: BLE001
+        intent = RuntimeIntent(
+            intent_id=INTENT_GENERAL_CHAT,
+            confidence="low",
+            reason=f"understand-failed: {exc}",
+        )
+        error = _join_error(error, f"understand: {exc}")
+
+    try:
+        recall = rec_fn(observation, intent, input_)
+    except Exception as exc:  # noqa: BLE001
+        recall = RuntimeRecallResult(reason=f"recall-failed: {exc}")
+        error = _join_error(error, f"recall: {exc}")
+
+    try:
+        plan = res_fn(observation, intent, recall, input_)
+    except Exception as exc:  # noqa: BLE001
+        plan = RuntimeResearchPlan(reason=f"research-failed: {exc}")
+        error = _join_error(error, f"research: {exc}")
+
+    try:
+        decision = dec_fn(observation, intent, recall, plan, input_)
+    except Exception as exc:  # noqa: BLE001
+        decision = RuntimeDecision(
+            intent=intent,
+            research_plan=plan,
+            actions=(
+                RuntimeAction(
+                    action_id=ACTION_REPLY,
+                    payload={"text": "내부 처리 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요."},
+                    reason="decide-failed",
+                ),
+            ),
+            notes=f"decide-failed: {exc}",
+        )
+        error = _join_error(error, f"decide: {exc}")
+
+    try:
+        actions_taken = act_fn_(decision, input_)
+    except Exception as exc:  # noqa: BLE001
+        actions_taken = ()
+        error = _join_error(error, f"act: {exc}")
+
+    pre_record = RuntimeResult(
+        role_id=input_.role_id,
+        observation=observation,
+        intent=intent,
+        recall=recall,
+        research_plan=plan,
+        decision=decision,
+        actions_taken=tuple(actions_taken),
+        records=(),
+        error=error,
+    )
+
+    try:
+        records = rec_record_fn(pre_record, input_)
+    except Exception as exc:  # noqa: BLE001
+        records = ()
+        error = _join_error(error, f"record: {exc}")
+
+    return replace(pre_record, records=tuple(records), error=error)
+
+
+def _join_error(prev: Optional[str], new: str) -> str:
+    return f"{prev} · {new}" if prev else new
+
+
+__all__ = (
+    "run_runtime_loop",
+    "ObserveFn",
+    "UnderstandFn",
+    "RecallFn",
+    "ResearchFn",
+    "DecideFn",
+    "ActFn",
+    "RecordFn",
+)

--- a/src/yule_orchestrator/agents/runtime/models.py
+++ b/src/yule_orchestrator/agents/runtime/models.py
@@ -1,0 +1,264 @@
+"""Dataclasses + intent/action vocabularies for the runtime loop.
+
+Phase 1 keeps everything frozen, immutable, and free of Discord/IO
+imports so unit tests can build inputs without touching the
+orchestrator's heavier modules. ``role_id`` is a free-form string
+(e.g. ``"engineering-agent/tech-lead"`` or just ``"gateway"``); the
+loop does not validate it so policy modules added later can map it to
+a richer policy object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Intent + action vocabularies
+# ---------------------------------------------------------------------------
+
+
+INTENT_NEW_WORK_REQUEST = "new_work_request"
+INTENT_CONTINUE_EXISTING_WORK = "continue_existing_work"
+INTENT_SUMMARIZE_PREVIOUS_WORK = "summarize_previous_work"
+INTENT_STATUS_QUESTION = "status_question"
+INTENT_DIAGNOSTIC_QUESTION = "diagnostic_question"
+INTENT_EXECUTE_EXISTING_STEP = "execute_existing_step"
+INTENT_GENERAL_CHAT = "general_chat"
+INTENT_CLARIFICATION_NEEDED = "clarification_needed"
+INTENT_APPEND_CONTEXT = "append_context"
+
+KNOWN_INTENTS = (
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    INTENT_STATUS_QUESTION,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_APPEND_CONTEXT,
+)
+
+
+ACTION_REPLY = "reply"
+ACTION_ASK_CLARIFICATION = "ask_clarification"
+ACTION_CREATE_SESSION = "create_session"
+ACTION_JOIN_SESSION = "join_session"
+ACTION_APPEND_CONTEXT = "append_context"
+ACTION_RUN_RESEARCH = "run_research"
+ACTION_PUBLISH_FORUM = "publish_forum"
+ACTION_REQUEST_ROLE_TURN = "request_role_turn"
+ACTION_RECORD_MEMORY = "record_memory"
+ACTION_PROPOSE_APPROVAL = "propose_approval"
+ACTION_NOOP = "noop"
+
+KNOWN_ACTIONS = (
+    ACTION_REPLY,
+    ACTION_ASK_CLARIFICATION,
+    ACTION_CREATE_SESSION,
+    ACTION_JOIN_SESSION,
+    ACTION_APPEND_CONTEXT,
+    ACTION_RUN_RESEARCH,
+    ACTION_PUBLISH_FORUM,
+    ACTION_REQUEST_ROLE_TURN,
+    ACTION_RECORD_MEMORY,
+    ACTION_PROPOSE_APPROVAL,
+    ACTION_NOOP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Runtime stage I/O
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RuntimeInput:
+    """The raw envelope a role bot sees when a Discord message arrives.
+
+    ``role_id`` identifies which role's policy the loop should apply
+    (``gateway``, ``engineering-agent/tech-lead``, ...). ``message_text``
+    is the user-facing prompt; ``attachments``, ``user_links``, and
+    ``mentions`` carry side-channel context. ``channel_id`` /
+    ``thread_id`` / ``author_id`` / ``message_id`` are the Discord
+    identifiers used by Recall to scope session lookups.
+
+    ``policy`` is a free-form mapping the runtime caller can use to
+    feed role-specific knobs (memory namespace, intent overrides, ...)
+    into Understand / Recall / Decide.
+    """
+
+    role_id: str
+    message_text: str
+    channel_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    author_id: Optional[int] = None
+    message_id: Optional[int] = None
+    attachments: Sequence[Any] = field(default_factory=tuple)
+    user_links: Sequence[str] = field(default_factory=tuple)
+    mentions: Sequence[int] = field(default_factory=tuple)
+    received_at: Optional[datetime] = None
+    last_proposed_prompt: Optional[str] = None
+    policy: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeObservation:
+    """Normalised view of the input — what the loop saw and prepared.
+
+    Observe is allowed to enrich (e.g. extract URLs from message text,
+    normalise role_id, compute message digest for dedupe) but must not
+    perform IO. Tests can inject a custom observe_fn that returns a
+    pre-built RuntimeObservation.
+    """
+
+    role_id: str
+    message_text: str
+    normalized_text: str = ""
+    channel_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    author_id: Optional[int] = None
+    message_id: Optional[int] = None
+    extracted_urls: Sequence[str] = field(default_factory=tuple)
+    has_attachments: bool = False
+    received_at: Optional[datetime] = None
+    last_proposed_prompt: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeIntent:
+    """What the user seems to want.
+
+    ``intent_id`` must be one of :data:`KNOWN_INTENTS`. ``confidence``
+    is "low" / "medium" / "high" (free-form string for now to match the
+    existing engineering_conversation API). ``alt_intents`` carries the
+    runner-up intents so Decide can fall back to clarification when the
+    margin is thin.
+    """
+
+    intent_id: str
+    confidence: str = "medium"
+    reason: str = ""
+    alt_intents: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SessionCandidate:
+    """One candidate from session/memory recall, with a score."""
+
+    session_id: str
+    title: str = ""
+    score: float = 0.0
+    why: str = ""
+    state: Optional[str] = None
+    task_type: Optional[str] = None
+    thread_id: Optional[int] = None
+    forum_thread_id: Optional[int] = None
+    has_research_pack: bool = False
+    has_synthesis: bool = False
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeRecallResult:
+    """Output of Recall: which sessions / memories matched.
+
+    ``matched_session_id`` is set only when the loop is confident
+    enough to attach. When several candidates score similarly the loop
+    leaves it None and the Decide stage emits ``ask_clarification``.
+    ``memory_hits`` mirrors the memory adapter's free-form mapping per
+    hit so role bots can show citations.
+    """
+
+    matched_session_id: Optional[str] = None
+    matched_thread_id: Optional[int] = None
+    matched_forum_thread_id: Optional[int] = None
+    candidates: Tuple[SessionCandidate, ...] = field(default_factory=tuple)
+    memory_hits: Tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
+    confidence: str = "low"
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class RuntimeResearchPlan:
+    """Runtime decides whether to spend a research budget right now.
+
+    ``run`` is True only after intent is ``new_work_request`` and Recall
+    did not surface a usable existing pack. ``providers`` /
+    ``max_provider_calls`` mirror the research_collector knobs but
+    stay optional so the deterministic skeleton can leave them empty.
+    """
+
+    run: bool = False
+    reason: str = ""
+    providers: Sequence[str] = field(default_factory=tuple)
+    max_provider_calls: int = 0
+    role_targets: Sequence[Tuple[str, int]] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RuntimeAction:
+    """One concrete action the loop wants to take.
+
+    ``action_id`` must be one of :data:`KNOWN_ACTIONS`. ``payload`` is
+    the action-specific blob (reply text, session id to join, role for
+    the role-turn request, ...). The loop may emit several actions per
+    decision; Act will dispatch them in order.
+    """
+
+    action_id: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class RuntimeDecision:
+    """Bundle of intent + research plan + ordered actions."""
+
+    intent: RuntimeIntent
+    research_plan: RuntimeResearchPlan = field(default_factory=lambda: RuntimeResearchPlan())
+    actions: Tuple[RuntimeAction, ...] = field(default_factory=tuple)
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class RuntimeRecord:
+    """Append-only event the runtime emits for session.extra / memory.
+
+    ``kind`` is a short identifier (``intent_detected``,
+    ``recall_completed``, ``decision_made``, ``action_taken``,
+    ``role_turn_recorded``). ``data`` is JSON-friendly so it round-
+    trips through ``save_json_cache`` without surprises.
+    """
+
+    kind: str
+    data: Mapping[str, Any] = field(default_factory=dict)
+    occurred_at: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class RuntimeResult:
+    """Composite outcome of one ``run_runtime_loop`` call."""
+
+    role_id: str
+    observation: RuntimeObservation
+    intent: RuntimeIntent
+    recall: RuntimeRecallResult
+    research_plan: RuntimeResearchPlan
+    decision: RuntimeDecision
+    actions_taken: Tuple[RuntimeAction, ...] = field(default_factory=tuple)
+    records: Tuple[RuntimeRecord, ...] = field(default_factory=tuple)
+    error: Optional[str] = None
+
+    @property
+    def primary_action_id(self) -> Optional[str]:
+        if self.actions_taken:
+            return self.actions_taken[0].action_id
+        if self.decision.actions:
+            return self.decision.actions[0].action_id
+        return None

--- a/src/yule_orchestrator/agents/runtime/policies.py
+++ b/src/yule_orchestrator/agents/runtime/policies.py
@@ -1,0 +1,167 @@
+"""Per-role policy used by the runtime Recall and Decide stages.
+
+Phase 3B introduces a tiny RolePolicy registry so Recall can pick a
+role-shaped memory filter and Decide can later use the policy notes
+to pick role-specific actions. Kept deliberately small — the goal is
+just enough structure to feed Recall's role-aware lookup without a
+full DI framework.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class RolePolicy:
+    """How one role wants to look at memory / source candidates.
+
+    ``role_id`` is the canonical id (e.g. ``"engineering-agent/tech-lead"``
+    or just ``"gateway"``).
+    ``memory_role_filter`` is the value to pass to
+    :func:`memory.search.search`'s ``role`` kwarg — a string the indexer
+    used at write-time. ``None`` means "no role filter".
+    ``preferred_source_kinds`` is an ordered list (most-preferred first)
+    of memory ``source_kind`` values; the runtime issues a search per
+    kind and merges results in order so the primary signal wins ties.
+    ``description`` is a short human-readable summary for the gateway
+    to surface in clarification messages.
+    """
+
+    role_id: str
+    short_name: str
+    memory_role_filter: Optional[str] = None
+    preferred_source_kinds: Tuple[str, ...] = field(default_factory=tuple)
+    preferred_note_kinds: Tuple[str, ...] = field(default_factory=tuple)
+    description: str = ""
+
+
+_GATEWAY = RolePolicy(
+    role_id="gateway",
+    short_name="gateway",
+    memory_role_filter=None,
+    preferred_source_kinds=("session", "discord"),
+    preferred_note_kinds=("decision", "summary"),
+    description="운영 매니저 — 새 작업/기존 작업/상태/승인을 분류하고 흐름을 조율한다.",
+)
+
+_TECH_LEAD = RolePolicy(
+    role_id="engineering-agent/tech-lead",
+    short_name="tech-lead",
+    memory_role_filter="tech-lead",
+    preferred_source_kinds=("session", "obsidian", "discord"),
+    preferred_note_kinds=("decision", "synthesis", "plan"),
+    description="팀장 — 작업 분해, 역할별 의견 종합, 충돌 조정, 합의안과 승인 문서 초안.",
+)
+
+_AI_ENGINEER = RolePolicy(
+    role_id="engineering-agent/ai-engineer",
+    short_name="ai-engineer",
+    memory_role_filter="ai-engineer",
+    preferred_source_kinds=("obsidian", "session", "research_pack"),
+    preferred_note_kinds=("research", "evaluation", "decision"),
+    description="LLM/RAG/memory/prompt/model/evaluation 관점 판단.",
+)
+
+_BACKEND_ENGINEER = RolePolicy(
+    role_id="engineering-agent/backend-engineer",
+    short_name="backend-engineer",
+    memory_role_filter="backend-engineer",
+    preferred_source_kinds=("session", "code", "obsidian"),
+    preferred_note_kinds=("decision", "design", "incident"),
+    description="persistence/API/queue/state/reliability 관점 판단.",
+)
+
+_FRONTEND_ENGINEER = RolePolicy(
+    role_id="engineering-agent/frontend-engineer",
+    short_name="frontend-engineer",
+    memory_role_filter="frontend-engineer",
+    preferred_source_kinds=("discord", "obsidian", "session"),
+    preferred_note_kinds=("ux", "design", "decision"),
+    description="Discord/Obsidian 표시 UX, 사용자 피드백 루프, UI 구조 관점 판단.",
+)
+
+_PRODUCT_DESIGNER = RolePolicy(
+    role_id="engineering-agent/product-designer",
+    short_name="product-designer",
+    memory_role_filter="product-designer",
+    preferred_source_kinds=("obsidian", "discord", "session"),
+    preferred_note_kinds=("ux", "research", "decision"),
+    description="사용자 의도, 운영 플로우, 정보 구조, 승인 UX 관점 판단.",
+)
+
+_QA_ENGINEER = RolePolicy(
+    role_id="engineering-agent/qa-engineer",
+    short_name="qa-engineer",
+    memory_role_filter="qa-engineer",
+    preferred_source_kinds=("session", "code", "discord"),
+    preferred_note_kinds=("test", "incident", "decision"),
+    description="실패 케이스, 회귀 테스트, smoke test, acceptance criteria 관점 판단.",
+)
+
+_DEVOPS_ENGINEER = RolePolicy(
+    role_id="engineering-agent/devops-engineer",
+    short_name="devops-engineer",
+    memory_role_filter="devops-engineer",
+    preferred_source_kinds=("session", "code", "obsidian"),
+    preferred_note_kinds=("incident", "deploy", "decision"),
+    description="env/실행 프로세스/supervisor/배포/모니터링/장애 복구 관점 판단.",
+)
+
+
+_DEFAULT_POLICY = RolePolicy(
+    role_id="*",
+    short_name="default",
+    memory_role_filter=None,
+    description="알 수 없는 role — gateway-equivalent 기본 정책.",
+)
+
+
+_ROLE_POLICIES: Dict[str, RolePolicy] = {
+    policy.role_id: policy
+    for policy in (
+        _GATEWAY,
+        _TECH_LEAD,
+        _AI_ENGINEER,
+        _BACKEND_ENGINEER,
+        _FRONTEND_ENGINEER,
+        _PRODUCT_DESIGNER,
+        _QA_ENGINEER,
+        _DEVOPS_ENGINEER,
+    )
+}
+
+
+def role_policy_for(role_id: str) -> RolePolicy:
+    """Return the canonical RolePolicy for *role_id*.
+
+    Accepts either fully-qualified ``engineering-agent/<short>`` or the
+    short form. Unknown roles fall back to the safe gateway-equivalent
+    default so the runtime never crashes for a typo.
+    """
+
+    if not role_id:
+        return _DEFAULT_POLICY
+    if role_id in _ROLE_POLICIES:
+        return _ROLE_POLICIES[role_id]
+    short_lookup = f"engineering-agent/{role_id}"
+    if short_lookup in _ROLE_POLICIES:
+        return _ROLE_POLICIES[short_lookup]
+    if role_id == _GATEWAY.role_id:
+        return _GATEWAY
+    return _DEFAULT_POLICY
+
+
+def all_role_policies() -> Sequence[RolePolicy]:
+    """Stable ordered list — handy for tests and for the gateway when
+    it wants to enumerate role descriptions."""
+
+    return tuple(_ROLE_POLICIES.values())
+
+
+__all__ = (
+    "RolePolicy",
+    "role_policy_for",
+    "all_role_policies",
+)

--- a/src/yule_orchestrator/agents/runtime/recall.py
+++ b/src/yule_orchestrator/agents/runtime/recall.py
@@ -45,6 +45,7 @@ from .models import (
     RuntimeRecallResult,
     SessionCandidate,
 )
+from .policies import RolePolicy, role_policy_for
 
 
 SCORE_HIGH = 0.45
@@ -124,6 +125,7 @@ _STOPWORDS = frozenset(
 
 
 ListSessionsFn = Callable[..., Sequence[Any]]
+MemorySearchFn = Callable[..., Sequence[Any]]
 
 
 def make_recall_fn(
@@ -131,6 +133,8 @@ def make_recall_fn(
     *,
     limit: int = 50,
     open_state_filter: Optional[Callable[[Any], bool]] = None,
+    memory_search_fn: Optional[MemorySearchFn] = None,
+    memory_search_limit: int = 5,
 ):
     """Build a ``recall_fn`` for ``run_runtime_loop``.
 
@@ -143,6 +147,12 @@ def make_recall_fn(
     *open_state_filter* identifies which sessions are still "open"
     (i.e. eligible for recall). The default skips terminal states
     (``COMPLETED`` / ``REJECTED``).
+
+    *memory_search_fn* is the callable that wraps
+    :func:`memory.search.search` (or any compatible fake). When
+    provided we run the role-shaped query and attach hits to
+    ``RuntimeRecallResult.memory_hits``. Errors there are non-fatal —
+    the session lookup result still flows through.
     """
 
     state_filter = open_state_filter or _default_open_filter
@@ -152,139 +162,215 @@ def make_recall_fn(
         intent: RuntimeIntent,
         input_: RuntimeInput,
     ) -> RuntimeRecallResult:
-        if list_sessions_fn is None:
-            return RuntimeRecallResult(reason="no list_sessions_fn provided")
-
-        if intent.intent_id == INTENT_NEW_WORK_REQUEST:
-            # Even for explicit new work we still surface the channel/
-            # thread-bound session if any — the Decide stage may want
-            # to warn the operator that another session is open in the
-            # same thread. But we skip token scoring entirely.
-            anchor = _find_anchor_session(
-                list_sessions_fn=list_sessions_fn,
-                limit=limit,
-                state_filter=state_filter,
-                input_=input_,
-            )
-            if anchor is None:
-                return RuntimeRecallResult(reason="new work — no anchor session")
-            return RuntimeRecallResult(
-                matched_session_id=None,  # do NOT auto-attach for new work
-                candidates=(_session_to_candidate(anchor, score=0.0, why="anchor (channel/thread)"),),
-                confidence="low",
-                reason="new work — anchor session in same channel/thread",
-            )
-
-        try:
-            raw_sessions = list_sessions_fn(limit=limit)
-        except TypeError:
-            # Older list_sessions_fn signatures don't accept kwargs.
-            raw_sessions = list_sessions_fn()
-
-        sessions = [s for s in raw_sessions if state_filter(s)]
-        if not sessions:
-            return RuntimeRecallResult(reason="no open sessions")
-
-        # 1. Channel/thread anchoring — wins outright when present.
-        anchor_id = _resolve_thread_anchor(sessions, input_)
-        if anchor_id is not None:
-            anchored = next(s for s in sessions if s.session_id == anchor_id)
-            return RuntimeRecallResult(
-                matched_session_id=anchored.session_id,
-                matched_thread_id=getattr(anchored, "thread_id", None),
-                matched_forum_thread_id=_extract_forum_thread_id(anchored),
-                candidates=tuple(
-                    _session_to_candidate(
-                        s,
-                        score=1.0 if s.session_id == anchor_id else 0.0,
-                        why="thread anchor" if s.session_id == anchor_id else "in scope",
-                    )
-                    for s in sessions[:MAX_CANDIDATES_RETURNED]
-                ),
-                confidence="high",
-                reason="thread/channel anchor",
-            )
-
-        # 2. Token scoring against prompt / pack / synthesis.
-        prompt_tokens = _tokenize(observation.message_text)
-        scored: list[tuple[float, Any, str]] = []
-        for session in sessions:
-            score, why = _score_session(prompt_tokens, session)
-            if score > 0:
-                scored.append((score, session, why))
-        scored.sort(key=lambda t: t[0], reverse=True)
-
-        # 3. Recency fallback — when the user said "어제/방금/지난번"
-        # without a distinct token match, pick the most-recently-updated
-        # open session.
-        if not scored and _has_recency_cue(observation):
-            recent = _most_recent(sessions)
-            if recent is not None:
-                return RuntimeRecallResult(
-                    matched_session_id=recent.session_id,
-                    matched_thread_id=getattr(recent, "thread_id", None),
-                    matched_forum_thread_id=_extract_forum_thread_id(recent),
-                    candidates=(
-                        _session_to_candidate(
-                            recent,
-                            score=0.5,
-                            why="recency fallback",
-                        ),
-                    ),
-                    confidence="medium",
-                    reason="recency cue + latest open session",
-                )
-
-        if not scored:
-            return RuntimeRecallResult(
-                candidates=(),
-                confidence="low",
-                reason="no token match",
-            )
-
-        top_score, top_session, top_why = scored[0]
-        runner_up_score = scored[1][0] if len(scored) > 1 else 0.0
-        margin = top_score - runner_up_score
-
-        candidates = tuple(
-            _session_to_candidate(s, score=score, why=why)
-            for score, s, why in scored[:MAX_CANDIDATES_RETURNED]
+        base = _compute_session_recall(
+            observation=observation,
+            intent=intent,
+            input_=input_,
+            list_sessions_fn=list_sessions_fn,
+            state_filter=state_filter,
+            limit=limit,
         )
-
-        if top_score >= SCORE_HIGH and margin >= AMBIGUITY_MARGIN:
-            return RuntimeRecallResult(
-                matched_session_id=top_session.session_id,
-                matched_thread_id=getattr(top_session, "thread_id", None),
-                matched_forum_thread_id=_extract_forum_thread_id(top_session),
-                candidates=candidates,
-                confidence="high",
-                reason=f"top score {top_score:.2f} · {top_why}",
-            )
-        if top_score >= SCORE_MEDIUM and margin >= AMBIGUITY_MARGIN:
-            return RuntimeRecallResult(
-                matched_session_id=top_session.session_id,
-                matched_thread_id=getattr(top_session, "thread_id", None),
-                matched_forum_thread_id=_extract_forum_thread_id(top_session),
-                candidates=candidates,
-                confidence="medium",
-                reason=f"top score {top_score:.2f} · {top_why}",
-            )
-        # Ambiguous — surface candidates but do NOT match.
-        return RuntimeRecallResult(
-            candidates=candidates,
-            confidence="low",
-            reason=(
-                f"ambiguous · top {top_score:.2f} vs runner-up {runner_up_score:.2f} "
-                f"(margin {margin:.2f})"
-            ),
+        # Memory hits flow on top of whatever the session lookup decided
+        # so callers always get role-aware citations even on a no-match.
+        memory_hits = _run_memory_search(
+            memory_search_fn=memory_search_fn,
+            observation=observation,
+            input_=input_,
+            limit=memory_search_limit,
         )
+        if memory_hits:
+            return replace(base, memory_hits=tuple(memory_hits))
+        return base
 
     return recall
+
+
+def _compute_session_recall(
+    *,
+    observation: RuntimeObservation,
+    intent: RuntimeIntent,
+    input_: RuntimeInput,
+    list_sessions_fn: Optional[ListSessionsFn],
+    state_filter: Callable[[Any], bool],
+    limit: int,
+) -> RuntimeRecallResult:
+    if list_sessions_fn is None:
+        return RuntimeRecallResult(reason="no list_sessions_fn provided")
+
+    if intent.intent_id == INTENT_NEW_WORK_REQUEST:
+        # Even for explicit new work we still surface the channel/
+        # thread-bound session if any — the Decide stage may want
+        # to warn the operator that another session is open in the
+        # same thread. But we skip token scoring entirely.
+        anchor = _find_anchor_session(
+            list_sessions_fn=list_sessions_fn,
+            limit=limit,
+            state_filter=state_filter,
+            input_=input_,
+        )
+        if anchor is None:
+            return RuntimeRecallResult(reason="new work — no anchor session")
+        return RuntimeRecallResult(
+            matched_session_id=None,  # do NOT auto-attach for new work
+            candidates=(_session_to_candidate(anchor, score=0.0, why="anchor (channel/thread)"),),
+            confidence="low",
+            reason="new work — anchor session in same channel/thread",
+        )
+
+    try:
+        raw_sessions = list_sessions_fn(limit=limit)
+    except TypeError:
+        # Older list_sessions_fn signatures don't accept kwargs.
+        raw_sessions = list_sessions_fn()
+
+    sessions = [s for s in raw_sessions if state_filter(s)]
+    if not sessions:
+        return RuntimeRecallResult(reason="no open sessions")
+
+    # 1. Channel/thread anchoring — wins outright when present.
+    anchor_id = _resolve_thread_anchor(sessions, input_)
+    if anchor_id is not None:
+        anchored = next(s for s in sessions if s.session_id == anchor_id)
+        return RuntimeRecallResult(
+            matched_session_id=anchored.session_id,
+            matched_thread_id=getattr(anchored, "thread_id", None),
+            matched_forum_thread_id=_extract_forum_thread_id(anchored),
+            candidates=tuple(
+                _session_to_candidate(
+                    s,
+                    score=1.0 if s.session_id == anchor_id else 0.0,
+                    why="thread anchor" if s.session_id == anchor_id else "in scope",
+                )
+                for s in sessions[:MAX_CANDIDATES_RETURNED]
+            ),
+            confidence="high",
+            reason="thread/channel anchor",
+        )
+
+    # 2. Token scoring against prompt / pack / synthesis.
+    prompt_tokens = _tokenize(observation.message_text)
+    scored: list[tuple[float, Any, str]] = []
+    for session in sessions:
+        score, why = _score_session(prompt_tokens, session)
+        if score > 0:
+            scored.append((score, session, why))
+    scored.sort(key=lambda t: t[0], reverse=True)
+
+    # 3. Recency fallback — when the user said "어제/방금/지난번"
+    # without a distinct token match, pick the most-recently-updated
+    # open session.
+    if not scored and _has_recency_cue(observation):
+        recent = _most_recent(sessions)
+        if recent is not None:
+            return RuntimeRecallResult(
+                matched_session_id=recent.session_id,
+                matched_thread_id=getattr(recent, "thread_id", None),
+                matched_forum_thread_id=_extract_forum_thread_id(recent),
+                candidates=(
+                    _session_to_candidate(
+                        recent,
+                        score=0.5,
+                        why="recency fallback",
+                    ),
+                ),
+                confidence="medium",
+                reason="recency cue + latest open session",
+            )
+
+    if not scored:
+        return RuntimeRecallResult(
+            candidates=(),
+            confidence="low",
+            reason="no token match",
+        )
+
+    top_score, top_session, top_why = scored[0]
+    runner_up_score = scored[1][0] if len(scored) > 1 else 0.0
+    margin = top_score - runner_up_score
+
+    candidates = tuple(
+        _session_to_candidate(s, score=score, why=why)
+        for score, s, why in scored[:MAX_CANDIDATES_RETURNED]
+    )
+
+    if top_score >= SCORE_HIGH and margin >= AMBIGUITY_MARGIN:
+        return RuntimeRecallResult(
+            matched_session_id=top_session.session_id,
+            matched_thread_id=getattr(top_session, "thread_id", None),
+            matched_forum_thread_id=_extract_forum_thread_id(top_session),
+            candidates=candidates,
+            confidence="high",
+            reason=f"top score {top_score:.2f} · {top_why}",
+        )
+    if top_score >= SCORE_MEDIUM and margin >= AMBIGUITY_MARGIN:
+        return RuntimeRecallResult(
+            matched_session_id=top_session.session_id,
+            matched_thread_id=getattr(top_session, "thread_id", None),
+            matched_forum_thread_id=_extract_forum_thread_id(top_session),
+            candidates=candidates,
+            confidence="medium",
+            reason=f"top score {top_score:.2f} · {top_why}",
+        )
+    # Ambiguous — surface candidates but do NOT match.
+    return RuntimeRecallResult(
+        candidates=candidates,
+        confidence="low",
+        reason=(
+            f"ambiguous · top {top_score:.2f} vs runner-up {runner_up_score:.2f} "
+            f"(margin {margin:.2f})"
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _run_memory_search(
+    *,
+    memory_search_fn: Optional[MemorySearchFn],
+    observation: RuntimeObservation,
+    input_: RuntimeInput,
+    limit: int,
+) -> Sequence[Any]:
+    """Run the role-shaped memory search if one is wired in.
+
+    The runtime gives the search function the role policy's filter +
+    the canonical search query (the message text). Errors are swallowed
+    here so a memory outage never derails the session-recall result —
+    operators see ``memory_hits=()`` and can investigate separately.
+    """
+
+    if memory_search_fn is None:
+        return ()
+    text = (observation.message_text or "").strip()
+    if not text:
+        return ()
+    policy = role_policy_for(input_.role_id)
+    try:
+        kwargs: dict[str, Any] = {
+            "limit": limit,
+            "role": policy.memory_role_filter,
+        }
+        # Only pass note_kind when the policy expressed a preference,
+        # so the underlying search adapter doesn't filter the result
+        # set down to nothing for roles without a strong preference.
+        if policy.preferred_note_kinds:
+            kwargs["note_kind"] = policy.preferred_note_kinds[0]
+        if policy.preferred_source_kinds:
+            kwargs["source_kind"] = policy.preferred_source_kinds[0]
+        try:
+            hits = memory_search_fn(text, **kwargs)
+        except TypeError:
+            # Adapter doesn't take all kwargs — degrade gracefully to
+            # a positional-only call so tests with simple fakes work.
+            hits = memory_search_fn(text)
+    except Exception:  # noqa: BLE001 - never propagate
+        return ()
+    if not hits:
+        return ()
+    return tuple(hits)
 
 
 def _default_open_filter(session: Any) -> bool:

--- a/src/yule_orchestrator/agents/runtime/recall.py
+++ b/src/yule_orchestrator/agents/runtime/recall.py
@@ -1,0 +1,455 @@
+"""Session candidate recall — match Discord messages to existing work.
+
+Phase 3A wires the runtime Recall stage onto the workflow session
+store. The classifier in Phase 2 produced an intent like
+``continue_existing_work`` / ``summarize_previous_work``; Recall's job
+is to translate "어제 작업", "헤르메스 작업", "그 작업" etc. into a
+concrete session id (or a small candidate list for clarification).
+
+Design choices:
+
+- ``list_sessions_fn`` is injected so tests can supply a synthetic
+  list and the production wiring can hand in
+  :func:`workflow_state.list_sessions`.
+- Channel / thread match is the strongest signal: a thread already
+  scoped to a session id wins over any token overlap.
+- Token scoring borrows the rules used by ``agents.routing._score_one``
+  but we keep a separate copy here so the runtime layer doesn't depend
+  on the engineering router.
+- When the top two candidates are within ``AMBIGUITY_MARGIN`` of each
+  other we deliberately leave ``matched_session_id`` empty so the
+  Decide stage can ask for clarification.
+
+Phase 3B will plug in memory hits and role-aware filtering on top of
+this base.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Optional, Sequence, Tuple
+
+from .models import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    SessionCandidate,
+)
+
+
+SCORE_HIGH = 0.45
+SCORE_MEDIUM = 0.20
+AMBIGUITY_MARGIN = 0.10
+MAX_CANDIDATES_RETURNED = 5
+
+
+# Intents where Recall must search for an existing session before the
+# loop is allowed to proceed. Used by ``make_recall_fn`` to short-
+# circuit lookups for clearly-new requests.
+RECALL_SEEKING_INTENTS = frozenset(
+    {
+        INTENT_CONTINUE_EXISTING_WORK,
+        INTENT_SUMMARIZE_PREVIOUS_WORK,
+        INTENT_STATUS_QUESTION,
+        INTENT_DIAGNOSTIC_QUESTION,
+        INTENT_EXECUTE_EXISTING_STEP,
+        INTENT_APPEND_CONTEXT,
+    }
+)
+
+
+_RECENCY_CUES: Tuple[str, ...] = (
+    "어제",
+    "그제",
+    "지난번",
+    "지난 번",
+    "방금",
+    "아까",
+    "조금 전",
+    "조금전",
+    "최근",
+    "yesterday",
+    "earlier",
+    "just now",
+)
+
+
+_TOKEN_RE = re.compile(r"[0-9A-Za-z가-힣]+")
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "with",
+        "into",
+        "from",
+        "that",
+        "this",
+        "have",
+        "그리고",
+        "그래서",
+        "근데",
+        "그냥",
+        "다시",
+        "일단",
+        "하면",
+        "하자",
+        "처럼",
+        "관련",
+        "내용",
+        "부분",
+        "작업",
+        "이어서",
+        "정리",
+        "정리해줘",
+        "요약",
+        "요약해줘",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+ListSessionsFn = Callable[..., Sequence[Any]]
+
+
+def make_recall_fn(
+    list_sessions_fn: Optional[ListSessionsFn] = None,
+    *,
+    limit: int = 50,
+    open_state_filter: Optional[Callable[[Any], bool]] = None,
+):
+    """Build a ``recall_fn`` for ``run_runtime_loop``.
+
+    *list_sessions_fn* must return a sequence of objects with at least
+    ``session_id``, ``prompt``, ``task_type``, ``state``, ``updated_at``,
+    ``channel_id``, ``thread_id``, ``extra``, ``summary``. The production
+    wiring will pass :func:`workflow_state.list_sessions`. Tests can
+    pass a list literal.
+
+    *open_state_filter* identifies which sessions are still "open"
+    (i.e. eligible for recall). The default skips terminal states
+    (``COMPLETED`` / ``REJECTED``).
+    """
+
+    state_filter = open_state_filter or _default_open_filter
+
+    def recall(
+        observation: RuntimeObservation,
+        intent: RuntimeIntent,
+        input_: RuntimeInput,
+    ) -> RuntimeRecallResult:
+        if list_sessions_fn is None:
+            return RuntimeRecallResult(reason="no list_sessions_fn provided")
+
+        if intent.intent_id == INTENT_NEW_WORK_REQUEST:
+            # Even for explicit new work we still surface the channel/
+            # thread-bound session if any — the Decide stage may want
+            # to warn the operator that another session is open in the
+            # same thread. But we skip token scoring entirely.
+            anchor = _find_anchor_session(
+                list_sessions_fn=list_sessions_fn,
+                limit=limit,
+                state_filter=state_filter,
+                input_=input_,
+            )
+            if anchor is None:
+                return RuntimeRecallResult(reason="new work — no anchor session")
+            return RuntimeRecallResult(
+                matched_session_id=None,  # do NOT auto-attach for new work
+                candidates=(_session_to_candidate(anchor, score=0.0, why="anchor (channel/thread)"),),
+                confidence="low",
+                reason="new work — anchor session in same channel/thread",
+            )
+
+        try:
+            raw_sessions = list_sessions_fn(limit=limit)
+        except TypeError:
+            # Older list_sessions_fn signatures don't accept kwargs.
+            raw_sessions = list_sessions_fn()
+
+        sessions = [s for s in raw_sessions if state_filter(s)]
+        if not sessions:
+            return RuntimeRecallResult(reason="no open sessions")
+
+        # 1. Channel/thread anchoring — wins outright when present.
+        anchor_id = _resolve_thread_anchor(sessions, input_)
+        if anchor_id is not None:
+            anchored = next(s for s in sessions if s.session_id == anchor_id)
+            return RuntimeRecallResult(
+                matched_session_id=anchored.session_id,
+                matched_thread_id=getattr(anchored, "thread_id", None),
+                matched_forum_thread_id=_extract_forum_thread_id(anchored),
+                candidates=tuple(
+                    _session_to_candidate(
+                        s,
+                        score=1.0 if s.session_id == anchor_id else 0.0,
+                        why="thread anchor" if s.session_id == anchor_id else "in scope",
+                    )
+                    for s in sessions[:MAX_CANDIDATES_RETURNED]
+                ),
+                confidence="high",
+                reason="thread/channel anchor",
+            )
+
+        # 2. Token scoring against prompt / pack / synthesis.
+        prompt_tokens = _tokenize(observation.message_text)
+        scored: list[tuple[float, Any, str]] = []
+        for session in sessions:
+            score, why = _score_session(prompt_tokens, session)
+            if score > 0:
+                scored.append((score, session, why))
+        scored.sort(key=lambda t: t[0], reverse=True)
+
+        # 3. Recency fallback — when the user said "어제/방금/지난번"
+        # without a distinct token match, pick the most-recently-updated
+        # open session.
+        if not scored and _has_recency_cue(observation):
+            recent = _most_recent(sessions)
+            if recent is not None:
+                return RuntimeRecallResult(
+                    matched_session_id=recent.session_id,
+                    matched_thread_id=getattr(recent, "thread_id", None),
+                    matched_forum_thread_id=_extract_forum_thread_id(recent),
+                    candidates=(
+                        _session_to_candidate(
+                            recent,
+                            score=0.5,
+                            why="recency fallback",
+                        ),
+                    ),
+                    confidence="medium",
+                    reason="recency cue + latest open session",
+                )
+
+        if not scored:
+            return RuntimeRecallResult(
+                candidates=(),
+                confidence="low",
+                reason="no token match",
+            )
+
+        top_score, top_session, top_why = scored[0]
+        runner_up_score = scored[1][0] if len(scored) > 1 else 0.0
+        margin = top_score - runner_up_score
+
+        candidates = tuple(
+            _session_to_candidate(s, score=score, why=why)
+            for score, s, why in scored[:MAX_CANDIDATES_RETURNED]
+        )
+
+        if top_score >= SCORE_HIGH and margin >= AMBIGUITY_MARGIN:
+            return RuntimeRecallResult(
+                matched_session_id=top_session.session_id,
+                matched_thread_id=getattr(top_session, "thread_id", None),
+                matched_forum_thread_id=_extract_forum_thread_id(top_session),
+                candidates=candidates,
+                confidence="high",
+                reason=f"top score {top_score:.2f} · {top_why}",
+            )
+        if top_score >= SCORE_MEDIUM and margin >= AMBIGUITY_MARGIN:
+            return RuntimeRecallResult(
+                matched_session_id=top_session.session_id,
+                matched_thread_id=getattr(top_session, "thread_id", None),
+                matched_forum_thread_id=_extract_forum_thread_id(top_session),
+                candidates=candidates,
+                confidence="medium",
+                reason=f"top score {top_score:.2f} · {top_why}",
+            )
+        # Ambiguous — surface candidates but do NOT match.
+        return RuntimeRecallResult(
+            candidates=candidates,
+            confidence="low",
+            reason=(
+                f"ambiguous · top {top_score:.2f} vs runner-up {runner_up_score:.2f} "
+                f"(margin {margin:.2f})"
+            ),
+        )
+
+    return recall
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_open_filter(session: Any) -> bool:
+    state = getattr(session, "state", None)
+    state_value = getattr(state, "value", state)
+    return str(state_value).lower() not in {"completed", "rejected"}
+
+
+def _resolve_thread_anchor(
+    sessions: Sequence[Any],
+    input_: RuntimeInput,
+) -> Optional[str]:
+    if input_.thread_id is not None:
+        for session in sessions:
+            if getattr(session, "thread_id", None) == input_.thread_id:
+                return session.session_id
+    return None
+
+
+def _find_anchor_session(
+    *,
+    list_sessions_fn: ListSessionsFn,
+    limit: int,
+    state_filter: Callable[[Any], bool],
+    input_: RuntimeInput,
+) -> Optional[Any]:
+    if input_.thread_id is None and input_.channel_id is None:
+        return None
+    try:
+        raw_sessions = list_sessions_fn(limit=limit)
+    except TypeError:
+        raw_sessions = list_sessions_fn()
+    sessions = [s for s in raw_sessions if state_filter(s)]
+    for session in sessions:
+        if input_.thread_id is not None and getattr(session, "thread_id", None) == input_.thread_id:
+            return session
+    if input_.channel_id is not None:
+        for session in sessions:
+            if getattr(session, "channel_id", None) == input_.channel_id:
+                return session
+    return None
+
+
+def _tokenize(text: str) -> set:
+    if not text:
+        return set()
+    raw = _TOKEN_RE.findall(text.lower())
+    return {tok for tok in raw if len(tok) >= 2 and tok not in _STOPWORDS}
+
+
+def _score_session(prompt_tokens: set, session: Any) -> Tuple[float, str]:
+    if not prompt_tokens:
+        return 0.0, ""
+    fields: list[Tuple[str, str]] = []
+    fields.append(("prompt", getattr(session, "prompt", "") or ""))
+    fields.append(("task_type", getattr(session, "task_type", "") or ""))
+    summary = getattr(session, "summary", None)
+    if summary:
+        fields.append(("summary", summary))
+    extra = dict(getattr(session, "extra", None) or {})
+    pack = extra.get("research_pack")
+    if isinstance(pack, dict):
+        if pack.get("title"):
+            fields.append(("pack.title", str(pack.get("title"))))
+        if pack.get("summary"):
+            fields.append(("pack.summary", str(pack.get("summary"))))
+    synthesis = extra.get("research_synthesis")
+    if isinstance(synthesis, dict):
+        consensus = synthesis.get("consensus")
+        if consensus:
+            fields.append(("synthesis.consensus", str(consensus)))
+
+    best_overlap = 0
+    best_field: Optional[str] = None
+    union_tokens: set = set()
+    for label, text in fields:
+        toks = _tokenize(text)
+        if not toks:
+            continue
+        union_tokens.update(toks)
+        overlap = len(prompt_tokens & toks)
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_field = label
+
+    if best_overlap == 0:
+        return 0.0, ""
+
+    score = best_overlap / max(1, len(prompt_tokens))
+    if best_field == "prompt" and best_overlap >= 2:
+        score = min(1.0, score + 0.1)
+    why = (
+        f"매칭 {best_overlap}/{len(prompt_tokens)} 토큰 (영역: {best_field or 'union'})"
+    )
+    return score, why
+
+
+def _has_recency_cue(observation: RuntimeObservation) -> bool:
+    haystack = observation.normalized_text or (observation.message_text or "").lower()
+    return any(cue in haystack for cue in _RECENCY_CUES)
+
+
+def _most_recent(sessions: Sequence[Any]) -> Optional[Any]:
+    if not sessions:
+        return None
+    def _key(s: Any) -> datetime:
+        value = getattr(s, "updated_at", None)
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+    return max(sessions, key=_key)
+
+
+def _session_to_candidate(session: Any, *, score: float, why: str) -> SessionCandidate:
+    extra = dict(getattr(session, "extra", None) or {})
+    pack = extra.get("research_pack")
+    title = ""
+    if isinstance(pack, dict) and pack.get("title"):
+        title = str(pack.get("title"))
+    elif getattr(session, "summary", None):
+        title = str(session.summary)
+    elif getattr(session, "prompt", None):
+        prompt = str(session.prompt)
+        title = prompt[:80] + ("..." if len(prompt) > 80 else "")
+
+    state = getattr(session, "state", None)
+    state_value = getattr(state, "value", state)
+    return SessionCandidate(
+        session_id=session.session_id,
+        title=title,
+        score=score,
+        why=why,
+        state=str(state_value) if state_value is not None else None,
+        task_type=getattr(session, "task_type", None),
+        thread_id=getattr(session, "thread_id", None),
+        forum_thread_id=_extract_forum_thread_id(session),
+        has_research_pack=isinstance(pack, dict) and bool(pack),
+        has_synthesis=isinstance(extra.get("research_synthesis"), dict)
+        and bool(extra.get("research_synthesis")),
+        extra={"updated_at": _isoformat_or_none(getattr(session, "updated_at", None))},
+    )
+
+
+def _extract_forum_thread_id(session: Any) -> Optional[int]:
+    extra = dict(getattr(session, "extra", None) or {})
+    raw = extra.get("research_forum_thread_id") or extra.get("forum_thread_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _isoformat_or_none(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return None
+
+
+__all__ = (
+    "RECALL_SEEKING_INTENTS",
+    "SCORE_HIGH",
+    "SCORE_MEDIUM",
+    "AMBIGUITY_MARGIN",
+    "make_recall_fn",
+)

--- a/src/yule_orchestrator/agents/runtime/understand.py
+++ b/src/yule_orchestrator/agents/runtime/understand.py
@@ -166,6 +166,12 @@ _EXECUTE_STEP_PHRASES: tuple[str, ...] = (
     "obsidian export",
     "obsidian 동기화",
     "옵시디언 동기화",
+    "운영-리서치에 정리",
+    "운영 리서치에 정리",
+    "운영-리서치 정리",
+    "운영 리서치 정리",
+    "운영-리서치에 저장",
+    "운영 리서치에 저장",
     "토의 기록 정리",
     "토의기록 정리",
     "토의 결과 정리",
@@ -175,11 +181,60 @@ _EXECUTE_STEP_PHRASES: tuple[str, ...] = (
     "회고 정리",
     "노트 정리",
     "결과 정리",
+    "이 세션 기준",
+    "이 세션 기준으로",
+    "이 세션 정리",
+    "이 세션 기록",
+    "이 thread 기준",
+    "이 스레드 기준",
     "approval 만들",
     "승인 문서 만들",
     "approval 문서",
     "vault 에 저장",
     "vault에 저장",
+)
+
+
+# Phrases that explicitly mean "stay on the existing work" — they
+# come up after the gateway has already shown a clarification (or the
+# user is sitting inside a work thread) and replies with a plain
+# "기존 세션으로 진행" / "여기서 이어가자" rather than naming the
+# session. These must NOT collide with ``_FORCE_NEW_WORK_PHRASES``
+# (which contains "새 작업으로 진행"); detection order in
+# :func:`classify_intent_deterministic` checks force-new first so
+# "새 작업으로 진행" still wins.
+_FORCE_CONTINUE_WORK_PHRASES: tuple[str, ...] = (
+    "기존 세션으로 진행",
+    "기존 세션으로 시작",
+    "기존 세션 진행",
+    "기존 세션으로 이어",
+    "기존 작업으로 진행",
+    "기존 작업으로 시작",
+    "기존 작업 진행",
+    "기존 작업으로 이어",
+    "기존 작업으로 등록",
+    "기존 thread로 진행",
+    "기존 thread에서 진행",
+    "기존 thread에서 이어",
+    "기존 스레드로 진행",
+    "기존 스레드에서 진행",
+    "기존 스레드에서 이어",
+    "이 thread로 진행",
+    "이 thread에서 진행",
+    "이 thread에서 이어",
+    "이 thread에서 가",
+    "이 스레드로 진행",
+    "이 스레드에서 진행",
+    "이 스레드에서 이어",
+    "여기서 진행",
+    "여기서 이어",
+    "여기 thread에서",
+    "여기 스레드에서",
+    "이 세션으로 진행",
+    "이 세션으로 이어",
+    "continue this thread",
+    "continue this session",
+    "stay on this thread",
 )
 
 
@@ -395,6 +450,18 @@ def classify_intent_deterministic(
             intent_id=INTENT_NEW_WORK_REQUEST,
             confidence="high",
             reason="explicit new-work phrase",
+        )
+
+    # 2b. Explicit "stay on existing work" override. Detected before
+    # status/diagnostic so a phrase like "기존 세션으로 진행" doesn't
+    # accidentally match a status pattern (e.g. "진행 상황" inside the
+    # diagnostic bank). Order matters: force-new wins above so
+    # "새 작업으로 진행" still creates a fresh session.
+    if _matches_any(text, _FORCE_CONTINUE_WORK_PHRASES):
+        return RuntimeIntent(
+            intent_id=INTENT_CONTINUE_EXISTING_WORK,
+            confidence="high",
+            reason="explicit continuation phrase",
         )
 
     # 3. Status / diagnostic.

--- a/src/yule_orchestrator/agents/runtime/understand.py
+++ b/src/yule_orchestrator/agents/runtime/understand.py
@@ -1,0 +1,619 @@
+"""Deterministic conversational intent classifier for the runtime loop.
+
+Phase 2 lands a keyword/phrase-based classifier that maps every Discord
+message to one of the nine runtime intents defined in
+``runtime.models.KNOWN_INTENTS``. The classifier is intentionally
+deterministic so:
+
+- the Discord gateway never silently ships a new intake when the user
+  is actually asking a status / continuation question,
+- tests can cover real Korean phrasings without an LLM in the loop,
+- the LLM-backed classifier added later can plug in via the
+  :class:`IntentClassifier` protocol while keeping this module as the
+  fallback.
+
+Detection order matters — the most-specific intents are checked first
+so a phrase like ``어제 작업 이어서 요약해줘`` resolves to
+``summarize_previous_work`` (back-reference + summarize verb) instead
+of being captured by the broader ``continue_existing_work`` rule.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Protocol, Sequence
+
+from .models import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+)
+
+
+class IntentClassifier(Protocol):
+    """LLM-backed classifier seam.
+
+    Returns a :class:`RuntimeIntent` to override the deterministic
+    fallback, or ``None`` to defer. The runtime loop always falls
+    back to :func:`classify_intent_deterministic` when the protocol
+    returns ``None`` — that way an LLM outage or low-confidence
+    response never silently downgrades a clear deterministic match.
+    """
+
+    def __call__(
+        self,
+        observation: RuntimeObservation,
+        input_: RuntimeInput,
+    ) -> Optional[RuntimeIntent]:  # pragma: no cover - structural typing
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Phrase banks — Korean & English
+# ---------------------------------------------------------------------------
+
+
+_BACKREFERENCE_PHRASES: tuple[str, ...] = (
+    "어제",
+    "그제",
+    "이틀 전",
+    "지난번",
+    "지난 번",
+    "지난주",
+    "지난 주",
+    "지난달",
+    "지난 달",
+    "방금",
+    "아까",
+    "조금 전",
+    "조금전",
+    "전에",
+    "그 작업",
+    "그작업",
+    "그 세션",
+    "그세션",
+    "그 thread",
+    "그 토의",
+    "그 흐름",
+    "이전 작업",
+    "이전작업",
+    "기존 작업",
+    "기존작업",
+    "기존 세션",
+    "기존 토의",
+    "기존 토론",
+    "기존 thread",
+    "yesterday",
+    "earlier",
+    "previous task",
+    "the previous",
+    "the prior",
+    "last session",
+)
+
+
+# Distinct project / topic name references — exact tokens that, when
+# combined with any verb, almost certainly point to an existing piece
+# of work (e.g. "헤르메스 작업 이어서 가자"). These are kept short and
+# case-insensitive; phrase tests append " 작업" / " 검토" combinations
+# to detect the wrap-around forms.
+_NAMED_PROJECT_CUES: tuple[str, ...] = (
+    "헤르메스",
+    "hermes",
+    "프로젝트 a",
+    "프로젝트a",
+    "project a",
+)
+
+
+_CONTINUE_VERBS: tuple[str, ...] = (
+    "이어가",
+    "이어 가",
+    "이어서 가",
+    "이어서가",
+    "이어서 진행",
+    "이어 진행",
+    "계속 가자",
+    "계속 진행",
+    "계속해",
+    "이어서",
+    "이어서 해",
+    "이어서해",
+    "그대로 진행",
+    "continue from",
+    "pick up where",
+    "keep going",
+    "resume",
+)
+
+
+_SUMMARY_VERBS: tuple[str, ...] = (
+    "요약",
+    "요약해",
+    "요약 해줘",
+    "요약해줘",
+    "정리해줘",
+    "정리 해줘",
+    "정리 해 줘",
+    "정리 해주",
+    "정리해 주",
+    "정리해 줘",
+    "summarize",
+    "summary",
+    "recap",
+    "tldr",
+    "tl;dr",
+)
+
+
+_EXECUTE_STEP_PHRASES: tuple[str, ...] = (
+    "obsidian에 정리",
+    "obsidian 에 정리",
+    "obsidian 에 저장",
+    "obsidian에 저장",
+    "옵시디언에 정리",
+    "옵시디언에 저장",
+    "옵시디언에 export",
+    "obsidian export",
+    "obsidian 동기화",
+    "옵시디언 동기화",
+    "토의 기록 정리",
+    "토의기록 정리",
+    "토의 결과 정리",
+    "토의 정리",
+    "회의록 정리",
+    "회의 정리",
+    "회고 정리",
+    "노트 정리",
+    "결과 정리",
+    "approval 만들",
+    "승인 문서 만들",
+    "approval 문서",
+    "vault 에 저장",
+    "vault에 저장",
+)
+
+
+_APPEND_CONTEXT_PHRASES: tuple[str, ...] = (
+    "기존 작업에 참고",
+    "기존 작업에 자료",
+    "기존 작업에 붙",
+    "기존 세션에 참고",
+    "기존 세션에 붙",
+    "이 자료만 기존",
+    "이 자료만 참고",
+    "이 자료를 참고로",
+    "이 자료 참고로",
+    "이 링크만 참고",
+    "참고로 붙여",
+    "참고만 붙여",
+    "맥락만 추가",
+    "context만 추가",
+    "append context",
+    "as context only",
+    "as a reference only",
+)
+
+
+_STATUS_DIAGNOSTIC_PHRASES: tuple[str, ...] = (
+    "운영 리서치는 안 열",
+    "운영-리서치는 안 열",
+    "운영 리서치 안 열",
+    "운영-리서치 안 열",
+    "운영 리서치 왜 안 열",
+    "운영-리서치 왜 안 열",
+    "운영 리서치 왜",
+    "운영-리서치 왜",
+    "리서치 왜 실패",
+    "리서치 왜 안",
+    "리서치는 왜 안",
+    "리서치 어떻게 됐",
+    "왜 안 됐",
+    "왜 안됐",
+    "왜 멈췄",
+    "왜 멈춰",
+    "왜 막혔",
+    "왜 막혀",
+    "왜 안 열",
+    "왜 안열",
+    "왜 안 열렸",
+    "왜 안열렸",
+    "왜 못",
+    "왜 실패",
+    "지금 뭐 하",
+    "지금 뭐하",
+    "지금 무엇",
+    "지금 어떤 상태",
+    "지금 어디까지",
+    "현재 상태",
+    "현재 진행",
+    "상태 알려",
+    "상태 좀 알려",
+    "상태 확인",
+    "상태 체크",
+    "다시 확인해",
+    "다시 한번 확인",
+    "다시 한 번 확인",
+    "진행 상황",
+    "진행상황",
+    "진행 어디",
+    "진행 어떻게",
+    "어디까지 됐",
+    "어디까지 갔",
+    "어디까지 진행",
+    "어떻게 됐",
+    "어떻게 되어",
+    "어떻게 되고",
+    "어떻게 진행",
+    "obsidian 왜 안",
+    "obsidian 왜 못",
+    "obsidian 안 들어갔",
+    "obsidian 안들어갔",
+    "옵시디언 왜 안",
+    "옵시디언 안 들어갔",
+    "forum 왜 안",
+    "forum 안 열",
+    "포럼 왜 안",
+    "포럼 안 열",
+    "what's the status",
+    "what is the status",
+    "what happened",
+    "where are we",
+    "why did it fail",
+    "why didn't it",
+    "status check",
+    "status update",
+    "progress check",
+)
+
+
+# Phrases that explicitly mean "this should be a brand-new session" —
+# they override every back-reference rule above.
+_FORCE_NEW_WORK_PHRASES: tuple[str, ...] = (
+    "새 작업으로 진행",
+    "새 작업으로 시작",
+    "새로 등록",
+    "새 스레드로",
+    "새 thread로",
+    "새 세션으로",
+    "new thread",
+    "new session",
+    "start a new task",
+)
+
+
+# Single-line confirmation tokens — when the message is *only* one of
+# these, classification depends on whether the gateway has a pending
+# proposal (``last_proposed_prompt``).
+_CONFIRMATION_STANDALONE: frozenset[str] = frozenset(
+    {
+        "ok",
+        "okay",
+        "오케이",
+        "오케",
+        "오키",
+        "yes",
+        "yep",
+        "go",
+        "고",
+        "ㄱㄱ",
+        "확정",
+        "진행",
+        "등록",
+    }
+)
+
+
+_CONFIRMATION_PHRASES: tuple[str, ...] = (
+    "이대로 진행",
+    "이대로 등록",
+    "이걸로 등록",
+    "이걸로 진행",
+    "그럼 이걸로",
+    "그럼 등록",
+    "그럼 진행",
+    "그렇게 진행",
+    "그렇게 등록",
+    "진행해줘",
+    "진행해 주세요",
+    "등록해줘",
+    "등록해 주세요",
+    "yes 진행",
+    "yes 등록",
+)
+
+
+_VAGUE_TOKENS: tuple[str, ...] = (
+    "도와줘",
+    "도와 줘",
+    "할 일 있어",
+    "할일 있어",
+    "작업 있어",
+    "뭐 해야",
+    "뭐해야",
+    "할 거",
+    "할거",
+)
+
+
+_QUESTION_TAILS: tuple[str, ...] = ("?", "?", "까", "어", "야")
+
+
+_NORMALIZE_RE = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_intent_deterministic(
+    observation: RuntimeObservation,
+    input_: RuntimeInput,
+) -> RuntimeIntent:
+    """Return the deterministic intent for *observation*.
+
+    Detection ordering (top wins):
+
+    1. Empty / very short → ``clarification_needed``.
+    2. Explicit "force new work" override → ``new_work_request``.
+    3. Status / diagnostic phrases → ``status_question`` /
+       ``diagnostic_question`` (diagnostic when the message names a
+       failure verb like 실패/안 열렸/막혔).
+    4. Append-context phrases → ``append_context``.
+    5. Back-reference + summary verb → ``summarize_previous_work``.
+    6. Back-reference / named project + continue verb →
+       ``continue_existing_work``.
+    7. Execute-existing-step phrases → ``execute_existing_step``.
+    8. Standalone confirmation token → ``new_work_request`` if a
+       pending proposal exists, else ``clarification_needed``.
+    9. Confirmation phrase → ``new_work_request``.
+    10. Otherwise → ``new_work_request`` for substantive content,
+        ``general_chat`` for very short pleasantries.
+    """
+
+    text = observation.normalized_text or _normalize(observation.message_text)
+    if not text:
+        return RuntimeIntent(
+            intent_id=INTENT_CLARIFICATION_NEEDED,
+            confidence="high",
+            reason="empty message",
+        )
+
+    # 2. Explicit override — always wins.
+    if _matches_any(text, _FORCE_NEW_WORK_PHRASES):
+        return RuntimeIntent(
+            intent_id=INTENT_NEW_WORK_REQUEST,
+            confidence="high",
+            reason="explicit new-work phrase",
+        )
+
+    # 3. Status / diagnostic.
+    if _matches_any(text, _STATUS_DIAGNOSTIC_PHRASES):
+        if any(token in text for token in ("실패", "안 열", "안열", "막혔", "막혀", "왜")):
+            return RuntimeIntent(
+                intent_id=INTENT_DIAGNOSTIC_QUESTION,
+                confidence="high",
+                reason="diagnostic phrase",
+            )
+        return RuntimeIntent(
+            intent_id=INTENT_STATUS_QUESTION,
+            confidence="high",
+            reason="status phrase",
+        )
+
+    # 4. Append context.
+    if _matches_any(text, _APPEND_CONTEXT_PHRASES):
+        return RuntimeIntent(
+            intent_id=INTENT_APPEND_CONTEXT,
+            confidence="high",
+            reason="append-context phrase",
+        )
+
+    has_backref = _matches_any(text, _BACKREFERENCE_PHRASES) or _matches_any(
+        text, _NAMED_PROJECT_CUES
+    )
+
+    # 5. Summarize previous work.
+    if has_backref and _matches_any(text, _SUMMARY_VERBS):
+        return RuntimeIntent(
+            intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK,
+            confidence="high",
+            reason="back-reference + summarize verb",
+        )
+
+    # 6. Continue existing work.
+    if has_backref and _matches_any(text, _CONTINUE_VERBS):
+        return RuntimeIntent(
+            intent_id=INTENT_CONTINUE_EXISTING_WORK,
+            confidence="high",
+            reason="back-reference + continue verb",
+        )
+
+    # 6b. Even without a continue verb, a clear back-reference + work
+    # noun ("헤르메스 작업 정리") that isn't a summary/status falls
+    # through to continue_existing_work since recall must look it up.
+    if _matches_any(text, _NAMED_PROJECT_CUES) and _has_work_noun(text):
+        return RuntimeIntent(
+            intent_id=INTENT_CONTINUE_EXISTING_WORK,
+            confidence="medium",
+            reason="named project + work noun",
+        )
+
+    # 7. Execute existing step.
+    if _matches_any(text, _EXECUTE_STEP_PHRASES):
+        return RuntimeIntent(
+            intent_id=INTENT_EXECUTE_EXISTING_STEP,
+            confidence="high",
+            reason="execute-step phrase",
+        )
+
+    # 8. Standalone confirmation token.
+    if text in _CONFIRMATION_STANDALONE:
+        if input_.last_proposed_prompt and input_.last_proposed_prompt.strip():
+            return RuntimeIntent(
+                intent_id=INTENT_NEW_WORK_REQUEST,
+                confidence="high",
+                reason="confirm pending proposal",
+            )
+        return RuntimeIntent(
+            intent_id=INTENT_CLARIFICATION_NEEDED,
+            confidence="medium",
+            reason="bare confirmation without pending proposal",
+        )
+
+    # 9. Multi-token confirmation phrase.
+    if _matches_any(text, _CONFIRMATION_PHRASES):
+        if input_.last_proposed_prompt and input_.last_proposed_prompt.strip():
+            return RuntimeIntent(
+                intent_id=INTENT_NEW_WORK_REQUEST,
+                confidence="high",
+                reason="confirmation phrase + pending proposal",
+            )
+        # Without a prior proposal we still treat ``이대로 진행`` as a
+        # commit-to-this gesture but mark medium confidence so Decide
+        # can ask for clarification if Recall finds nothing.
+        return RuntimeIntent(
+            intent_id=INTENT_NEW_WORK_REQUEST,
+            confidence="medium",
+            reason="confirmation phrase without pending proposal",
+        )
+
+    # 10. Default.
+    # Pleasantry runs before the vague-short check because "안녕하세요"
+    # is a single word but it's clearly social, not "give me work".
+    if _looks_like_pleasantry(text):
+        return RuntimeIntent(
+            intent_id=INTENT_GENERAL_CHAT,
+            confidence="medium",
+            reason="short pleasantry",
+        )
+
+    if _looks_too_vague(text):
+        return RuntimeIntent(
+            intent_id=INTENT_CLARIFICATION_NEEDED,
+            confidence="medium",
+            reason="vague short message",
+        )
+
+    return RuntimeIntent(
+        intent_id=INTENT_NEW_WORK_REQUEST,
+        confidence="medium",
+        reason="default — substantive new task content",
+    )
+
+
+def make_understand_fn(classifier: Optional[IntentClassifier] = None):
+    """Build an ``understand_fn`` for ``run_runtime_loop``.
+
+    When *classifier* is provided, its result wins as long as it
+    returns a non-None :class:`RuntimeIntent`; otherwise (or on
+    classifier exception) we fall back to the deterministic rule set.
+    The deterministic path always works without network / LLM, so the
+    runtime stays usable in every environment.
+    """
+
+    def understand(observation: RuntimeObservation, input_: RuntimeInput) -> RuntimeIntent:
+        if classifier is not None:
+            try:
+                override = classifier(observation, input_)
+            except Exception as exc:  # noqa: BLE001 - never crash the bot
+                deterministic = classify_intent_deterministic(observation, input_)
+                return _annotate(
+                    deterministic,
+                    f"classifier exception → deterministic fallback: {exc}",
+                )
+            if override is not None:
+                return override
+        return classify_intent_deterministic(observation, input_)
+
+    return understand
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(text: str) -> str:
+    return _NORMALIZE_RE.sub(" ", (text or "").lower()).strip()
+
+
+def _matches_any(haystack: str, needles: Sequence[str]) -> bool:
+    return any(needle in haystack for needle in needles)
+
+
+_WORK_NOUN_TOKENS: tuple[str, ...] = (
+    "작업",
+    "task",
+    "프로젝트",
+    "project",
+    "세션",
+    "토의",
+    "thread",
+    "검토",
+    "이슈",
+)
+
+
+def _has_work_noun(text: str) -> bool:
+    return _matches_any(text, _WORK_NOUN_TOKENS)
+
+
+def _looks_too_vague(text: str) -> bool:
+    if len(text) <= 3:
+        return True
+    word_count = len(text.split())
+    if word_count == 1:
+        return True
+    if word_count <= 3 and _matches_any(text, _VAGUE_TOKENS):
+        return True
+    return False
+
+
+_PLEASANTRY_TOKENS: tuple[str, ...] = (
+    "안녕",
+    "ㅎㅇ",
+    "hi",
+    "hello",
+    "hey",
+    "thanks",
+    "thank you",
+    "고마",
+    "감사",
+    "수고",
+    "잘 자",
+    "good night",
+    "good morning",
+)
+
+
+def _looks_like_pleasantry(text: str) -> bool:
+    return len(text.split()) <= 4 and _matches_any(text, _PLEASANTRY_TOKENS)
+
+
+def _annotate(intent: RuntimeIntent, suffix: str) -> RuntimeIntent:
+    new_reason = (intent.reason + " · " + suffix).strip(" ·") if intent.reason else suffix
+    return RuntimeIntent(
+        intent_id=intent.intent_id,
+        confidence=intent.confidence,
+        reason=new_reason,
+        alt_intents=intent.alt_intents,
+        metadata=intent.metadata,
+    )
+
+
+__all__ = (
+    "IntentClassifier",
+    "classify_intent_deterministic",
+    "make_understand_fn",
+)

--- a/src/yule_orchestrator/agents/session_status.py
+++ b/src/yule_orchestrator/agents/session_status.py
@@ -1,0 +1,637 @@
+"""Read-only diagnostic over a :class:`WorkflowSession`.
+
+The Discord operator runs ``yule discord up`` and then has no obvious way
+to ask "where is each session stuck?" without re-running CLI commands.
+Phase E adds a single pure-Python place where we *detect / report /
+propose* — never auto-write, never auto-commit.
+
+This module deliberately:
+
+- Imports nothing from the Discord runtime so it can be unit-tested
+  without Discord/network present.
+- Reads only the persisted ``WorkflowSession`` shape (state +
+  ``extra``). It never touches the cache directly.
+- Produces a structured :class:`SessionStatusReport` plus a short
+  Korean-language summary the gateway / supervisor CLI can print.
+
+Detected states map 1:1 to the operator-facing complaints in Phase E:
+
+- ``research_pack`` 있음 but open-call 없음
+- open-call 있음 but role_turn 없음
+- role_turn 있음 but synthesis 없음
+- synthesis 있음 but Obsidian proposal 없음
+- pending Obsidian approval
+- Obsidian write failed
+
+The :class:`SessionStatusSignal` carries severity (``info`` / ``stale``
+/ ``blocked`` / ``failed``) plus a short proposal so callers can render
+"감지된 다음 단계" without re-deriving the rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Signal codes — stable identifiers for the detected session states.
+# ---------------------------------------------------------------------------
+
+RESEARCH_PACK_MISSING = "research_pack_missing"
+OPEN_CALL_MISSING = "open_call_missing"
+OPEN_CALL_FAILED = "open_call_failed"
+FORUM_PUBLISH_FAILED = "forum_publish_failed"
+ROLE_TURN_MISSING = "role_turn_missing"
+SYNTHESIS_MISSING = "synthesis_missing"
+OBSIDIAN_PROPOSAL_MISSING = "obsidian_proposal_missing"
+OBSIDIAN_PENDING_APPROVAL = "obsidian_pending_approval"
+OBSIDIAN_WRITE_FAILED = "obsidian_write_failed"
+RESEARCH_LOOP_ERROR = "research_loop_error"
+SESSION_CLOSED = "session_closed"
+
+
+# Severity ordering — used by callers that want to surface the "worst"
+# signal first. ``failed`` outranks ``blocked`` outranks ``stale``
+# outranks ``info``. The renderer below is severity-stable.
+_SEVERITY_ORDER = {"failed": 0, "blocked": 1, "stale": 2, "info": 3}
+
+
+@dataclass(frozen=True)
+class SessionStatusSignal:
+    """One detected state for a workflow session.
+
+    ``code`` is a stable id (the constants above) so tests / supervisor
+    CLI can match without depending on the Korean label phrasing.
+
+    ``propose`` is intentionally a *suggestion*, not an action. Phase E
+    is detect/report/propose only — auto-execute is a future phase.
+    """
+
+    code: str
+    severity: str
+    title: str
+    detail: Optional[str] = None
+    propose: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SessionStatusReport:
+    """Structured snapshot of a workflow session for the diagnostic layer."""
+
+    session_id: Optional[str]
+    state: Optional[str]
+    task_type: Optional[str]
+    prompt: Optional[str]
+    has_research_pack: bool
+    forum_thread_id: Optional[int]
+    forum_thread_url: Optional[str]
+    forum_publish_error: Optional[str]
+    forum_comment_mode: Optional[str]
+    forum_kickoff_posted: Optional[bool]
+    forum_kickoff_error: Optional[str]
+    role_sequence: Tuple[str, ...]
+    played_roles: Tuple[str, ...]
+    has_synthesis: bool
+    write_requested: bool
+    write_blocked_reason: Optional[str]
+    obsidian_proposal_present: bool
+    obsidian_write_error: Optional[str]
+    research_loop_error: Optional[str]
+    last_progress_note: Optional[str]
+    signals: Tuple[SessionStatusSignal, ...] = field(default_factory=tuple)
+
+    def has_signal(self, code: str) -> bool:
+        return any(signal.code == code for signal in self.signals)
+
+    def signal(self, code: str) -> Optional[SessionStatusSignal]:
+        for signal in self.signals:
+            if signal.code == code:
+                return signal
+        return None
+
+    def primary_signal(self) -> Optional[SessionStatusSignal]:
+        """Return the highest-severity actionable signal.
+
+        ``info`` signals are skipped — they are "everything fine, just
+        nothing to do yet" markers the renderer still surfaces but a
+        diagnostic primary should not lead with them.
+        """
+
+        candidates = tuple(s for s in self.signals if s.severity != "info")
+        if not candidates:
+            return None
+        return min(candidates, key=lambda s: _SEVERITY_ORDER.get(s.severity, 99))
+
+
+# ---------------------------------------------------------------------------
+# Diagnose
+# ---------------------------------------------------------------------------
+
+
+def diagnose_session(session: Optional[Any]) -> SessionStatusReport:
+    """Build a :class:`SessionStatusReport` for *session*.
+
+    A ``None`` session is allowed so callers can pass the result of
+    :func:`find_latest_open_session` straight in. The returned report
+    has no signals — the renderer treats it as "no session matched".
+    """
+
+    if session is None:
+        return SessionStatusReport(
+            session_id=None,
+            state=None,
+            task_type=None,
+            prompt=None,
+            has_research_pack=False,
+            forum_thread_id=None,
+            forum_thread_url=None,
+            forum_publish_error=None,
+            forum_comment_mode=None,
+            forum_kickoff_posted=None,
+            forum_kickoff_error=None,
+            role_sequence=(),
+            played_roles=(),
+            has_synthesis=False,
+            write_requested=False,
+            write_blocked_reason=None,
+            obsidian_proposal_present=False,
+            obsidian_write_error=None,
+            research_loop_error=None,
+            last_progress_note=None,
+            signals=(),
+        )
+
+    extra = dict(getattr(session, "extra", {}) or {})
+
+    research_pack = extra.get("research_pack")
+    has_research_pack = bool(research_pack)
+
+    forum_thread_id = _coerce_int(
+        extra.get("research_forum_thread_id") or extra.get("forum_thread_id")
+    )
+    forum_thread_url = _coerce_str(
+        extra.get("forum_thread_url") or extra.get("research_forum_thread_url")
+    )
+    forum_publish_error = _coerce_str(
+        extra.get("forum_publish_error") or extra.get("research_forum_error")
+    )
+    forum_comment_mode = _coerce_str(extra.get("forum_comment_mode"))
+    forum_kickoff_posted = extra.get("forum_kickoff_posted")
+    if forum_kickoff_posted is not None:
+        forum_kickoff_posted = bool(forum_kickoff_posted)
+    forum_kickoff_error = _coerce_str(extra.get("forum_kickoff_error"))
+
+    role_sequence = tuple(
+        str(role) for role in (getattr(session, "role_sequence", ()) or ())
+    )
+    played_roles = _extract_played_roles(extra)
+    has_synthesis = bool(extra.get("research_synthesis")) or bool(
+        extra.get("research_synthesis_text")
+    )
+
+    write_requested = bool(getattr(session, "write_requested", False))
+    write_blocked_reason = _coerce_str(getattr(session, "write_blocked_reason", None))
+
+    obsidian_proposal_present = _detect_obsidian_proposal(extra)
+    obsidian_write_error = _coerce_str(
+        extra.get("obsidian_write_error") or extra.get("obsidian_export_error")
+    )
+
+    research_loop_error = _extract_research_loop_error(extra)
+
+    progress_notes = tuple(getattr(session, "progress_notes", ()) or ())
+    last_progress_note = str(progress_notes[-1]) if progress_notes else None
+
+    state_value = getattr(session, "state", None)
+    state_label = getattr(state_value, "value", state_value)
+
+    signals = _detect_signals(
+        state=state_label,
+        has_research_pack=has_research_pack,
+        forum_thread_id=forum_thread_id,
+        forum_publish_error=forum_publish_error,
+        forum_comment_mode=forum_comment_mode,
+        forum_kickoff_posted=forum_kickoff_posted,
+        forum_kickoff_error=forum_kickoff_error,
+        played_roles=played_roles,
+        role_sequence=role_sequence,
+        has_synthesis=has_synthesis,
+        write_requested=write_requested,
+        write_blocked_reason=write_blocked_reason,
+        obsidian_proposal_present=obsidian_proposal_present,
+        obsidian_write_error=obsidian_write_error,
+        research_loop_error=research_loop_error,
+    )
+
+    return SessionStatusReport(
+        session_id=_coerce_str(getattr(session, "session_id", None)),
+        state=_coerce_str(state_label),
+        task_type=_coerce_str(getattr(session, "task_type", None)),
+        prompt=_coerce_str(getattr(session, "prompt", None)),
+        has_research_pack=has_research_pack,
+        forum_thread_id=forum_thread_id,
+        forum_thread_url=forum_thread_url,
+        forum_publish_error=forum_publish_error,
+        forum_comment_mode=forum_comment_mode,
+        forum_kickoff_posted=forum_kickoff_posted,
+        forum_kickoff_error=forum_kickoff_error,
+        role_sequence=role_sequence,
+        played_roles=played_roles,
+        has_synthesis=has_synthesis,
+        write_requested=write_requested,
+        write_blocked_reason=write_blocked_reason,
+        obsidian_proposal_present=obsidian_proposal_present,
+        obsidian_write_error=obsidian_write_error,
+        research_loop_error=research_loop_error,
+        last_progress_note=last_progress_note,
+        signals=signals,
+    )
+
+
+def _detect_signals(
+    *,
+    state: Optional[str],
+    has_research_pack: bool,
+    forum_thread_id: Optional[int],
+    forum_publish_error: Optional[str],
+    forum_comment_mode: Optional[str],
+    forum_kickoff_posted: Optional[bool],
+    forum_kickoff_error: Optional[str],
+    played_roles: Sequence[str],
+    role_sequence: Sequence[str],
+    has_synthesis: bool,
+    write_requested: bool,
+    write_blocked_reason: Optional[str],
+    obsidian_proposal_present: bool,
+    obsidian_write_error: Optional[str],
+    research_loop_error: Optional[str],
+) -> Tuple[SessionStatusSignal, ...]:
+    """Walk the session shape and emit signals in pipeline order."""
+
+    signals: list[SessionStatusSignal] = []
+
+    if state in {"completed", "rejected"}:
+        signals.append(
+            SessionStatusSignal(
+                code=SESSION_CLOSED,
+                severity="info",
+                title=f"세션 종료 상태({state})",
+                propose="추가 작업이 필요하면 새 세션을 시작하세요.",
+            )
+        )
+        return tuple(signals)
+
+    # 1) research_pack 단계 진단
+    if not has_research_pack:
+        signals.append(
+            SessionStatusSignal(
+                code=RESEARCH_PACK_MISSING,
+                severity="info",
+                title="research_pack 미수집",
+                detail="아직 1차 자료가 모이지 않은 단계입니다.",
+                propose=(
+                    "intake 메시지에 자료/링크를 보강하거나 collector 실행 결과를 확인하세요."
+                ),
+            )
+        )
+
+    # 2) forum publish / open-call 단계
+    if has_research_pack and forum_thread_id is None and forum_publish_error:
+        signals.append(
+            SessionStatusSignal(
+                code=FORUM_PUBLISH_FAILED,
+                severity="failed",
+                title="운영-리서치 forum 게시 실패",
+                detail=forum_publish_error,
+                propose="forum publisher 로그/권한을 확인하고 다시 시도하세요.",
+            )
+        )
+    elif (
+        has_research_pack
+        and forum_thread_id is None
+        and not forum_publish_error
+    ):
+        signals.append(
+            SessionStatusSignal(
+                code=OPEN_CALL_MISSING,
+                severity="stale",
+                title="research_pack 있음 · open-call 미게시",
+                detail="자료는 모였지만 운영-리서치 thread / open-call 단계가 아직 실행되지 않았습니다.",
+                propose=(
+                    "publisher 단계가 호출됐는지 / starter 메시지가 4000자를 넘었는지 점검하세요."
+                ),
+            )
+        )
+
+    # member-bots 모드에서 open-call directive 자체가 실패한 경우
+    if forum_comment_mode == "member-bots":
+        if forum_kickoff_posted is False:
+            signals.append(
+                SessionStatusSignal(
+                    code=OPEN_CALL_FAILED,
+                    severity="failed",
+                    title="open-call directive 게시 실패",
+                    detail=forum_kickoff_error or "원인 미확인",
+                    propose=(
+                        "gateway 봇 권한과 forum_kickoff 재시도를 점검하세요. (auto-retry 없음)"
+                    ),
+                )
+            )
+
+    # 3) role_turn 단계 — open-call(또는 forum thread)은 있는데 멤버 turn이 없을 때
+    open_call_active = (
+        forum_thread_id is not None
+        and (
+            forum_comment_mode != "member-bots"
+            or forum_kickoff_posted is True
+        )
+    )
+    if open_call_active and not played_roles:
+        signals.append(
+            SessionStatusSignal(
+                code=ROLE_TURN_MISSING,
+                severity="stale",
+                title="open-call 게시됨 · 멤버 봇 turn 없음",
+                detail=(
+                    "운영-리서치 forum은 열렸지만 어떤 역할도 아직 응답하지 않았습니다."
+                ),
+                propose=(
+                    "멤버 봇들이 살아 있는지(`yule discord up` 인벤토리), "
+                    "그리고 토큰이 채워졌는지 점검하세요."
+                ),
+            )
+        )
+
+    # 4) synthesis 단계 — role_turn은 있는데 synthesis가 없을 때
+    if played_roles and not has_synthesis:
+        signals.append(
+            SessionStatusSignal(
+                code=SYNTHESIS_MISSING,
+                severity="stale",
+                title="role turn 있음 · tech-lead synthesis 없음",
+                detail=(
+                    f"{len(played_roles)}개 역할이 응답했지만 synthesis 단계가 아직 기록되지 않았습니다."
+                ),
+                propose="research_loop synthesize 단계가 호출됐는지 / 오류 로그가 있는지 확인하세요.",
+            )
+        )
+
+    # 5) Obsidian 단계 — synthesis는 있는데 proposal이 없을 때
+    if has_synthesis and not obsidian_proposal_present and not obsidian_write_error:
+        signals.append(
+            SessionStatusSignal(
+                code=OBSIDIAN_PROPOSAL_MISSING,
+                severity="stale",
+                title="synthesis 있음 · Obsidian proposal 없음",
+                detail="vault 내보내기 제안이 아직 만들어지지 않았습니다.",
+                propose=(
+                    "운영자가 `yule obsidian sync --session <id> --dry-run` 으로 미리 확인하세요."
+                ),
+            )
+        )
+
+    # 6) Pending Obsidian approval — workflow가 이미 막아둔 상태
+    if write_requested and write_blocked_reason:
+        signals.append(
+            SessionStatusSignal(
+                code=OBSIDIAN_PENDING_APPROVAL,
+                severity="blocked",
+                title="Obsidian write 승인 대기",
+                detail=write_blocked_reason,
+                propose=(
+                    "검토 후 `yule engineer approve --session <id>` 로 승인하거나 reject 하세요."
+                ),
+            )
+        )
+
+    # 7) Obsidian write failed — 가장 최근 실패가 extra에 남아 있을 때
+    if obsidian_write_error:
+        signals.append(
+            SessionStatusSignal(
+                code=OBSIDIAN_WRITE_FAILED,
+                severity="failed",
+                title="Obsidian write 실패",
+                detail=obsidian_write_error,
+                propose=(
+                    "vault 경로/권한과 git working tree 상태를 점검한 뒤 sync를 다시 시도하세요."
+                ),
+            )
+        )
+
+    # 8) research-loop hook 자체가 에러를 보고한 경우
+    if research_loop_error:
+        signals.append(
+            SessionStatusSignal(
+                code=RESEARCH_LOOP_ERROR,
+                severity="failed",
+                title="research loop 보고 오류",
+                detail=research_loop_error,
+                propose="bot 로그에서 마지막 publish/synthesize 에러를 확인하세요.",
+            )
+        )
+
+    return tuple(signals)
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def render_diagnostic_summary(report: SessionStatusReport) -> str:
+    """Multi-line Korean summary aimed at the Discord status response.
+
+    Lines mirror :func:`format_status_diagnostic_response` so both call
+    sites stay consistent without copy-pasting the rule logic. When no
+    signals fire we still print the basic state header.
+    """
+
+    if report.session_id is None:
+        return (
+            "현재 채널/스레드에 매칭되는 열린 engineering-agent 세션이 보이지 않아요.\n"
+            "확인하려는 작업의 session id를 알려 주시거나, "
+            "이어갈 thread 안에서 다시 말씀해 주세요."
+        )
+
+    lines: list[str] = ["현재 engineering-agent 세션 상태를 확인했어요.", ""]
+    lines.append(f"- 세션: `{report.session_id}`")
+    lines.append(f"- 상태: {report.state or 'unknown'}")
+    lines.append(f"- 종류: {report.task_type or 'unknown'}")
+
+    actionable = tuple(s for s in report.signals if s.severity != "info")
+    if actionable:
+        lines.append("")
+        lines.append("감지된 다음 단계:")
+        for signal in actionable:
+            tag = _severity_tag(signal.severity)
+            lines.append(f"- {tag} {signal.title}")
+            if signal.detail:
+                lines.append(f"  · 상세: {_one_line(signal.detail)}")
+            if signal.propose:
+                lines.append(f"  · 제안: {_one_line(signal.propose)}")
+
+    if report.last_progress_note:
+        short = _one_line(report.last_progress_note)
+        if len(short) > 160:
+            short = short[:157] + "..."
+        lines.append("")
+        lines.append(f"마지막 진행 노트: {short}")
+
+    return "\n".join(lines)
+
+
+def render_member_bot_summary(report: SessionStatusReport) -> str:
+    """Short summary tuned to "멤버 봇들은 뭐 하고 있어?" questions.
+
+    The forum thread is where the *actual* role comments land; this
+    summary points the operator there instead of duplicating their
+    content. It also calls out the open-call directive state explicitly
+    so a missing kickoff is surfaced even when the rest of the pipeline
+    looks healthy.
+    """
+
+    if report.session_id is None:
+        return (
+            "현재 매칭되는 세션이 없어 멤버 봇 활동을 확인할 수 없어요. "
+            "session id를 알려 주시거나 해당 thread에서 다시 호출해 주세요."
+        )
+
+    lines: list[str] = [f"멤버 봇 진행 상태 (`{report.session_id}`):"]
+
+    if report.forum_thread_id is None:
+        if report.forum_publish_error:
+            lines.append(
+                f"- 운영-리서치 forum 미게시 — 게시 실패: {_one_line(report.forum_publish_error)}"
+            )
+        else:
+            lines.append("- 운영-리서치 forum이 아직 열리지 않아 멤버 봇이 호출되지 않았어요.")
+        return "\n".join(lines)
+
+    mode = report.forum_comment_mode or "(미기록)"
+    lines.append(f"- 댓글 모드: {mode}")
+
+    if report.forum_comment_mode == "member-bots":
+        if report.forum_kickoff_posted is True:
+            lines.append("- open-call directive: 게시 완료")
+        elif report.forum_kickoff_posted is False:
+            reason = report.forum_kickoff_error or "원인 미확인"
+            lines.append(f"- open-call directive: 게시 실패 — {_one_line(reason)}")
+        else:
+            lines.append("- open-call directive: 상태 미기록")
+
+    if report.played_roles:
+        lines.append(
+            f"- 응답한 역할({len(report.played_roles)}): {', '.join(report.played_roles)}"
+        )
+    else:
+        lines.append("- 아직 응답한 멤버 봇이 없어요.")
+
+    if report.has_synthesis:
+        lines.append("- tech-lead synthesis: 기록됨")
+    else:
+        lines.append("- tech-lead synthesis: 아직 없음")
+
+    lines.append("- 후속 댓글은 운영-리서치 thread에서 직접 확인해 주세요.")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_played_roles(extra: Mapping[str, Any]) -> Tuple[str, ...]:
+    """Pull ``team_conversation.played_roles`` defensively from *extra*.
+
+    Older sessions stored the list under a flat ``played_roles`` key.
+    Both shapes are tolerated so the diagnostic stays useful across
+    cache versions.
+    """
+
+    block = extra.get("team_conversation")
+    if isinstance(block, Mapping):
+        played = block.get("played_roles")
+        if played:
+            return tuple(str(role) for role in played)
+    flat = extra.get("played_roles")
+    if flat:
+        return tuple(str(role) for role in flat)
+    return ()
+
+
+def _detect_obsidian_proposal(extra: Mapping[str, Any]) -> bool:
+    """Heuristic check for whether an Obsidian export proposal exists."""
+
+    for key in (
+        "obsidian_export",
+        "obsidian_proposal",
+        "obsidian_write_result",
+        "obsidian_path",
+    ):
+        if extra.get(key):
+            return True
+    return False
+
+
+def _extract_research_loop_error(extra: Mapping[str, Any]) -> Optional[str]:
+    report = extra.get("research_loop_report")
+    if report is None:
+        return None
+    if isinstance(report, Mapping):
+        error = report.get("error")
+    else:
+        error = getattr(report, "error", None)
+    return _coerce_str(error)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _one_line(text: str) -> str:
+    return " ".join(str(text).split())
+
+
+_SEVERITY_TAGS = {
+    "failed": "[FAILED]",
+    "blocked": "[BLOCKED]",
+    "stale": "[STALE]",
+    "info": "[INFO]",
+}
+
+
+def _severity_tag(severity: str) -> str:
+    return _SEVERITY_TAGS.get(severity, f"[{severity.upper()}]")
+
+
+__all__ = [
+    "RESEARCH_PACK_MISSING",
+    "OPEN_CALL_MISSING",
+    "OPEN_CALL_FAILED",
+    "FORUM_PUBLISH_FAILED",
+    "ROLE_TURN_MISSING",
+    "SYNTHESIS_MISSING",
+    "OBSIDIAN_PROPOSAL_MISSING",
+    "OBSIDIAN_PENDING_APPROVAL",
+    "OBSIDIAN_WRITE_FAILED",
+    "RESEARCH_LOOP_ERROR",
+    "SESSION_CLOSED",
+    "SessionStatusSignal",
+    "SessionStatusReport",
+    "diagnose_session",
+    "render_diagnostic_summary",
+    "render_member_bot_summary",
+]

--- a/src/yule_orchestrator/cli/main.py
+++ b/src/yule_orchestrator/cli/main.py
@@ -41,6 +41,7 @@ from .planning import (
     run_planning_daily_command,
     run_planning_snapshot_command,
 )
+from .supervisor import run_supervisor_run_once_command
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -559,7 +560,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     obsidian_sync_parser.add_argument(
         "--kind",
-        choices=("research", "decision", "reference"),
+        choices=("research", "decision", "reference", "knowledge"),
         help="Override export kind. Defaults to research (or decision when synthesis is present).",
     )
     obsidian_sync_parser.add_argument(
@@ -604,6 +605,42 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Override OBSIDIAN_EXPORT_LAYOUT. Defaults to yule-agent-vault. "
             "Use legacy-agent only for vaults still on Agents/Engineering/..."
+        ),
+    )
+
+    supervisor_parser = subparsers.add_parser(
+        "supervisor",
+        help="Read-only runtime status diagnostic for engineering-agent sessions.",
+    )
+    supervisor_subparsers = supervisor_parser.add_subparsers(
+        dest="supervisor_command", required=True
+    )
+    supervisor_run_parser = supervisor_subparsers.add_parser(
+        "run",
+        help=(
+            "Print a runtime status summary across recent sessions. "
+            "Detect/report/propose only — never auto-writes."
+        ),
+    )
+    supervisor_run_parser.add_argument(
+        "--once",
+        action="store_true",
+        help=(
+            "Run once and exit. Reserved for future continuous mode; "
+            "currently the supervisor always runs once."
+        ),
+    )
+    supervisor_run_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of recent sessions to inspect. Defaults to 20.",
+    )
+    supervisor_run_parser.add_argument(
+        "--only-actionable",
+        action="store_true",
+        help=(
+            "Only print sessions with at least one stale / blocked / failed signal."
         ),
     )
 
@@ -829,6 +866,11 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             )
         if args.command == "engineer":
             return _dispatch_engineer_command(repo_root, args)
+        if args.command == "supervisor" and args.supervisor_command == "run":
+            return run_supervisor_run_once_command(
+                limit=args.limit,
+                only_actionable=args.only_actionable,
+            )
         if args.command == "memory" and args.memory_command == "reindex":
             return run_memory_reindex_command(
                 repo_root,

--- a/src/yule_orchestrator/cli/obsidian.py
+++ b/src/yule_orchestrator/cli/obsidian.py
@@ -19,7 +19,7 @@ from ..agents.research_pack import pack_from_dict
 from ..agents.workflow_state import load_session
 
 
-VALID_KINDS = ("research", "decision", "reference")
+VALID_KINDS = ("research", "decision", "reference", "knowledge")
 
 
 def run_obsidian_sync_command(

--- a/src/yule_orchestrator/cli/supervisor.py
+++ b/src/yule_orchestrator/cli/supervisor.py
@@ -1,0 +1,184 @@
+"""``yule supervisor`` CLI — read-only runtime status surface.
+
+Phase E intentionally adds *no* automatic write/commit/push from the
+supervisor. ``supervisor run --once`` walks the persisted workflow
+sessions through :func:`diagnose_session` and prints a summary so the
+operator can see "왜 멈춰 있는지" without invoking individual CLIs by
+hand.
+
+The command is network-free: it reads only from the local workflow
+cache via :func:`list_sessions` and never contacts Discord, GitHub, or
+the calendar. Tests inject their own ``loader`` to exercise the
+formatting against synthetic sessions.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable, Iterable, Optional, Sequence, TextIO
+
+from ..agents.session_status import (
+    SessionStatusReport,
+    diagnose_session,
+)
+
+
+SessionLoader = Callable[..., Sequence[Any]]
+
+
+def run_supervisor_run_once_command(
+    *,
+    limit: int = 20,
+    only_actionable: bool = False,
+    loader: Optional[SessionLoader] = None,
+    out_stream: Optional[TextIO] = None,
+) -> int:
+    """Print a runtime status summary for recent workflow sessions.
+
+    Returns ``0`` whenever the read finishes (even if no sessions exist
+    or all are healthy). Returns ``2`` when *loader* raises — surfacing
+    the cache failure to the shell without crashing the supervisor.
+    Phase E never returns failure for "stuck" sessions; it only reports.
+    """
+
+    stream = out_stream if out_stream is not None else sys.stdout
+    sessions = _load_sessions(loader=loader, limit=limit, stream=stream)
+    if sessions is None:
+        return 2
+
+    if not sessions:
+        print("info: no workflow sessions found in local cache.", file=stream)
+        return 0
+
+    reports = tuple(diagnose_session(session) for session in sessions)
+    if only_actionable:
+        reports = tuple(
+            report
+            for report in reports
+            if any(signal.severity != "info" for signal in report.signals)
+        )
+
+    if not reports:
+        print(
+            "info: every recent session is at an info-only state — nothing actionable detected.",
+            file=stream,
+        )
+        return 0
+
+    print(
+        f"supervisor runtime status — {len(reports)} session(s) inspected",
+        file=stream,
+    )
+    print(
+        "(detect/report/propose only — supervisor does not auto-write/commit)",
+        file=stream,
+    )
+    print("", file=stream)
+
+    for index, report in enumerate(reports, start=1):
+        for line in render_session_block(report, index=index):
+            print(line, file=stream)
+        print("", file=stream)
+
+    actionable = sum(
+        1
+        for report in reports
+        if any(signal.severity != "info" for signal in report.signals)
+    )
+    print(
+        f"summary: {actionable} actionable / {len(reports) - actionable} info-only",
+        file=stream,
+    )
+    return 0
+
+
+def render_session_block(
+    report: SessionStatusReport,
+    *,
+    index: Optional[int] = None,
+) -> Iterable[str]:
+    """Yield the supervisor-facing lines for a single session report.
+
+    Kept as a separate function so tests assert on the structured
+    output without invoking the CLI dispatcher.
+    """
+
+    header = f"[{index}] " if index is not None else ""
+    session_label = f"`{report.session_id}`" if report.session_id else "(no session)"
+    yield f"{header}session={session_label} state={report.state or 'unknown'} type={report.task_type or 'unknown'}"
+    if report.prompt:
+        prompt_short = " ".join(report.prompt.split())
+        if len(prompt_short) > 120:
+            prompt_short = prompt_short[:117] + "..."
+        yield f"  prompt: {prompt_short}"
+
+    yield (
+        "  pipeline: "
+        f"research_pack={'있음' if report.has_research_pack else '없음'} · "
+        f"forum_thread={'O' if report.forum_thread_id else 'X'} · "
+        f"played={len(report.played_roles)}/{len(report.role_sequence)} · "
+        f"synthesis={'O' if report.has_synthesis else 'X'} · "
+        f"obsidian_proposal={'O' if report.obsidian_proposal_present else 'X'}"
+    )
+
+    if report.signals:
+        actionable = tuple(s for s in report.signals if s.severity != "info")
+        info_only = tuple(s for s in report.signals if s.severity == "info")
+        if actionable:
+            yield "  signals:"
+            for signal in actionable:
+                tag = _SEVERITY_TAGS.get(signal.severity, signal.severity)
+                yield f"    - {tag} {signal.title}"
+                if signal.detail:
+                    detail = " ".join(str(signal.detail).split())
+                    if len(detail) > 200:
+                        detail = detail[:197] + "..."
+                    yield f"        원인: {detail}"
+                if signal.propose:
+                    propose = " ".join(str(signal.propose).split())
+                    if len(propose) > 200:
+                        propose = propose[:197] + "..."
+                    yield f"        제안: {propose}"
+        elif info_only:
+            yield (
+                f"  signals: info-only ({', '.join(s.code for s in info_only)})"
+            )
+    else:
+        yield "  signals: (none)"
+
+
+def _load_sessions(
+    *,
+    loader: Optional[SessionLoader],
+    limit: int,
+    stream: TextIO,
+) -> Optional[Sequence[Any]]:
+    if loader is None:
+        from ..agents.workflow_state import list_sessions as default_loader
+
+        loader = default_loader
+    try:
+        return tuple(loader(limit=limit))
+    except TypeError:
+        try:
+            return tuple(loader())
+        except Exception as exc:  # noqa: BLE001 - surface cache failures
+            print(f"error: failed to load sessions: {exc}", file=stream)
+            return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: failed to load sessions: {exc}", file=stream)
+        return None
+
+
+_SEVERITY_TAGS = {
+    "failed": "[FAILED]",
+    "blocked": "[BLOCKED]",
+    "stale": "[STALE]",
+    "info": "[INFO]",
+}
+
+
+__all__ = [
+    "run_supervisor_run_once_command",
+    "render_session_block",
+]

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -2092,16 +2092,48 @@ def _research_loop_report_from_publish(
             error=thread.error,
         )
 
-    role_count = len(publish.role_comments)
-    decision_ok = bool(publish.decision_comment and publish.decision_comment.posted)
-    lines = ["✅ 운영-리서치 forum 게시 완료"]
+    # member-bots mode signal: the publisher only sets
+    # ``kickoff_comment`` when it tried to post the open-call directive
+    # that the per-role member bots react to. Gateway mode never sets
+    # it. Use that to switch summary wording — gateway-mode "역할별
+    # 댓글 N건" is misleading in member-bots mode where the gateway
+    # never posts those comments by design.
+    kickoff_comment = getattr(publish, "kickoff_comment", None)
+    is_member_bots_mode = kickoff_comment is not None
+    kickoff_posted_flag: Optional[bool] = (
+        bool(getattr(kickoff_comment, "posted", False))
+        if kickoff_comment is not None
+        else None
+    )
+    kickoff_error_text: Optional[str] = (
+        _optional_str_value(getattr(kickoff_comment, "error", None))
+        if kickoff_comment is not None
+        else None
+    )
+
+    lines: list[str] = ["✅ 운영-리서치 forum 게시 완료"]
     if thread.thread_url:
         lines.append(f"thread: {thread.thread_url}")
     elif thread.thread_id:
         lines.append(f"thread id: {thread.thread_id}")
-    lines.append(
-        f"역할별 댓글 {role_count}건 · tech-lead 종합 {'기록' if decision_ok else '미기록'}"
-    )
+
+    if is_member_bots_mode:
+        lines.append("모드: member-bots (각 멤버 봇이 자기 계정으로 댓글)")
+        if kickoff_posted_flag:
+            lines.append("open-call directive: 게시 완료")
+        else:
+            reason = kickoff_error_text or "원인 미확인"
+            lines.append(f"open-call directive: 게시 실패 — {reason}")
+        lines.append(
+            "각 멤버 봇의 후속 댓글은 운영-리서치 thread에서 확인하세요."
+        )
+    else:
+        role_count = len(publish.role_comments)
+        decision_ok = bool(publish.decision_comment and publish.decision_comment.posted)
+        lines.append(
+            f"역할별 댓글 {role_count}건 · tech-lead 종합 {'기록' if decision_ok else '미기록'}"
+        )
+
     if outcome.assignments:
         executor = next((a for a in outcome.assignments if a.is_executor), None)
         if executor:
@@ -2117,7 +2149,21 @@ def _research_loop_report_from_publish(
         forum_status_message="\n".join(lines),
         forum_thread_id=thread.thread_id,
         forum_thread_url=thread.thread_url,
+        forum_comment_mode="member-bots" if is_member_bots_mode else "gateway",
+        kickoff_posted=kickoff_posted_flag,
+        kickoff_error=kickoff_error_text,
     )
+
+
+def _optional_str_value(value: Any) -> Optional[str]:
+    """Tiny helper for normalising error strings — kept out of the
+    `_research_loop_report_from_publish` body so the top-level reads as
+    ``mode → wording → return``."""
+
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _make_default_research_forum_create_thread_fn(discord_module: "discord"):

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -15,7 +15,11 @@ from ..agents import (
     WorkflowOrchestrator,
     build_participants_pool,
 )
-from ..agents.workflow_state import find_latest_open_session, update_session
+from ..agents.workflow_state import (
+    find_latest_open_session,
+    list_sessions as workflow_list_sessions,
+    update_session,
+)
 from ..integrations.calendar import list_naver_calendar_items
 from ..integrations.calendar.models import build_fallback_item_uid
 from ..integrations.github.issues import list_open_issues
@@ -187,6 +191,12 @@ def run_discord_bot(repo_root: Path) -> None:
                         send_chunks=send_chunks,
                         research_loop_fn=_make_default_engineering_research_loop_fn(discord),
                         thread_continuation_fn=_make_default_thread_continuation_fn(discord),
+                        # Phase 4 — runtime preflight uses the live
+                        # workflow session store so "어제 작업 이어서
+                        # 요약해줘" et al. never reach
+                        # auto_collect=True. Disabled flag-style by
+                        # tests that inject their own routing seam.
+                        list_sessions_fn=workflow_list_sessions,
                     )
                 if engineering_result.handled:
                     return

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -1993,9 +1993,51 @@ def _make_default_engineering_research_loop_fn(discord_module: "discord"):
                 error=f"forum publish 실패: {exc}",
             )
 
+        # Persist forum publication mode + kickoff outcome onto the
+        # session so the status / diagnostic responder can describe the
+        # live setup ("member-bots 모드, open-call 게시 완료") without
+        # having to reach back into the publish object. Best-effort —
+        # the report itself is what the user sees right now, so a
+        # cache write failure must not crash the hook.
+        try:
+            _persist_forum_comment_mode_to_session(
+                session=outcome.session,
+                publish=publish,
+            )
+        except Exception:  # noqa: BLE001 - cache failure is non-fatal
+            pass
+
         return _research_loop_report_from_publish(outcome, publish)
 
     return _hook
+
+
+def _persist_forum_comment_mode_to_session(*, session, publish) -> None:
+    """Merge member-bots / gateway mode signals into ``session.extra``.
+
+    Called after every successful forum publish so subsequent status
+    diagnostic answers reflect the actual mode that ran. Idempotent —
+    if the same session is republished the keys are simply overwritten.
+    """
+
+    kickoff = getattr(publish, "kickoff_comment", None)
+    is_member_bots = kickoff is not None
+    extra_updates = {
+        "forum_comment_mode": "member-bots" if is_member_bots else "gateway",
+    }
+    if is_member_bots:
+        extra_updates["forum_kickoff_posted"] = bool(getattr(kickoff, "posted", False))
+        kickoff_error = getattr(kickoff, "error", None)
+        if kickoff_error is not None:
+            extra_updates["forum_kickoff_error"] = str(kickoff_error)
+        else:
+            # Drop a stale error from a previous failure so the next
+            # diagnostic doesn't surface it after a retry succeeded.
+            extra_updates["forum_kickoff_error"] = None
+
+    merged_extra = {**dict(getattr(session, "extra", {}) or {}), **extra_updates}
+    updated = replace(session, extra=merged_extra)
+    update_session(updated, now=datetime.now().astimezone())
 
 
 def _persist_research_pack_for_member_bots(

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -27,6 +27,20 @@ from ..agents.routing import (
     decide_routing,
     list_open_sessions,
 )
+from ..agents.runtime import (
+    ACTION_APPEND_CONTEXT as RUNTIME_ACTION_APPEND_CONTEXT,
+    ACTION_ASK_CLARIFICATION as RUNTIME_ACTION_ASK_CLARIFICATION,
+    ACTION_JOIN_SESSION as RUNTIME_ACTION_JOIN_SESSION,
+    INTENT_APPEND_CONTEXT as RUNTIME_INTENT_APPEND_CONTEXT,
+    INTENT_CONTINUE_EXISTING_WORK as RUNTIME_INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_EXECUTE_EXISTING_STEP as RUNTIME_INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_SUMMARIZE_PREVIOUS_WORK as RUNTIME_INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeResearchPlan,
+    classify_intent_deterministic,
+    decide_default,
+    make_recall_fn,
+)
 
 
 # Single-source confirmation lexicon; the engineering conversation layer
@@ -308,16 +322,25 @@ async def route_engineering_message(
     send_chunks: SendChunksFn,
     research_loop_fn: Optional[ResearchLoopFn] = None,
     thread_continuation_fn: Optional[ThreadContinuationFn] = None,
+    list_sessions_fn: Optional[Callable[..., Sequence[Any]]] = None,
 ) -> EngineeringRouteResult:
     """Drive the engineering channel response.
 
     Order:
       1. If the message is not in an engineering channel, return ``handled=False``.
-      2. Call the conversation layer; reply with whatever it produced.
-      3. If the conversation (or fallback heuristic) says the user just
+      2. Runtime preflight (only when ``list_sessions_fn`` is provided).
+         When the message intent is one of ``continue_existing_work``,
+         ``summarize_previous_work``, ``execute_existing_step`` or
+         ``append_context``, we recall the matching workflow session
+         and either join/append directly or send a clarification — both
+         paths skip ``conversation_fn`` so ``auto_collect=True`` never
+         runs for non-new-work intents.
+      3. Otherwise: call the conversation layer; reply with whatever it
+         produced.
+      4. If the conversation (or fallback heuristic) says the user just
          confirmed, call ``intake_fn`` to create a workflow session.
-      4. Post the intake summary, then kick off a thread.
-      5. If ``research_loop_fn`` is provided, run it after kickoff and
+      5. Post the intake summary, then kick off a thread.
+      6. If ``research_loop_fn`` is provided, run it after kickoff and
          surface its follow-up / forum status message back to the user.
          Failures in the research loop are *non-fatal*: intake + kickoff
          already landed, so we report a `⚠️` line and return.
@@ -330,6 +353,23 @@ async def route_engineering_message(
     prompt_text = (prompt_text or "").strip()
     if not prompt_text:
         return EngineeringRouteResult(handled=False)
+
+    # Runtime preflight — opt-in via ``list_sessions_fn``. The production
+    # gateway in bot.py wires this to ``workflow_state.list_sessions`` so
+    # auto_collect-first traffic for "어제 작업 이어서 요약해줘" and
+    # similar back-references is intercepted before conversation_fn is
+    # reached. Tests that don't inject a sessions source skip preflight,
+    # preserving the legacy keyword-driven flow.
+    if list_sessions_fn is not None:
+        preflight = await _run_runtime_preflight(
+            message=message,
+            prompt_text=prompt_text,
+            list_sessions_fn=list_sessions_fn,
+            send_chunks=send_chunks,
+            thread_continuation_fn=thread_continuation_fn,
+        )
+        if preflight is not None:
+            return preflight
 
     attachments = extract_message_attachments(message)
     user_links = extract_user_links_from_message(message, prompt_text)
@@ -543,6 +583,204 @@ async def route_engineering_message(
         error=kickoff_error,
         routing_decision=routing_decision,
     )
+
+
+_PREFLIGHT_SHORT_CIRCUIT_INTENTS = frozenset(
+    {
+        RUNTIME_INTENT_CONTINUE_EXISTING_WORK,
+        RUNTIME_INTENT_SUMMARIZE_PREVIOUS_WORK,
+        RUNTIME_INTENT_EXECUTE_EXISTING_STEP,
+        RUNTIME_INTENT_APPEND_CONTEXT,
+    }
+)
+
+
+async def _run_runtime_preflight(
+    *,
+    message: Any,
+    prompt_text: str,
+    list_sessions_fn: Callable[..., Sequence[Any]],
+    send_chunks: SendChunksFn,
+    thread_continuation_fn: Optional[ThreadContinuationFn],
+) -> Optional[EngineeringRouteResult]:
+    """Try to handle the message with the runtime loop's intent +
+    recall result. Returns a populated :class:`EngineeringRouteResult`
+    when the runtime took over (so the legacy flow must skip), or
+    ``None`` to fall through to ``conversation_fn`` + intake.
+
+    Short-circuits only the four "pointing-back-at-existing-work"
+    intents: ``continue_existing_work``, ``summarize_previous_work``,
+    ``execute_existing_step``, ``append_context``. Status / diagnostic
+    questions still flow through ``conversation_fn`` because the
+    existing layer has the actual session-state responder; new-work
+    requests, confirmations, vague text, and pleasantries also flow
+    through unchanged so all existing tests keep their contracts.
+    """
+
+    runtime_input = RuntimeInput(
+        role_id="gateway",
+        message_text=prompt_text,
+        channel_id=getattr(getattr(message, "channel", None), "id", None),
+        thread_id=_thread_id_for_runtime(message),
+        author_id=getattr(getattr(message, "author", None), "id", None),
+        message_id=getattr(message, "id", None),
+    )
+    observation = _observation_for_runtime(runtime_input)
+    intent = classify_intent_deterministic(observation, runtime_input)
+    if intent.intent_id not in _PREFLIGHT_SHORT_CIRCUIT_INTENTS:
+        return None
+
+    recall_fn = make_recall_fn(list_sessions_fn=list_sessions_fn)
+    recall = recall_fn(observation, intent, runtime_input)
+    decision = decide_default(
+        observation,
+        intent,
+        recall,
+        RuntimeResearchPlan(),
+        runtime_input,
+    )
+    if not decision.actions:
+        return None
+
+    primary = decision.actions[0]
+    if primary.action_id == RUNTIME_ACTION_JOIN_SESSION and thread_continuation_fn is not None:
+        # Re-use the legacy join/append helper so research_loop_hook
+        # still runs against the resumed session. The helper expects an
+        # EngineeringConversationOutcome shape; we synthesise a minimal
+        # one carrying the prompt text as ``intake_prompt``.
+        synthetic_outcome = EngineeringConversationOutcome(
+            content="",
+            intake_prompt=prompt_text,
+        )
+        synthetic_decision = EngineeringRoutingDecision(
+            action=ACTION_JOIN,
+            matched_session_id=primary.payload.get("session_id"),
+            matched_thread_id=primary.payload.get("thread_id"),
+            matched_forum_thread_id=primary.payload.get("forum_thread_id"),
+            confidence=intent.confidence,
+            reason=f"runtime preflight · {intent.intent_id}",
+        )
+        result = await _handle_join_or_append(
+            message=message,
+            outcome=synthetic_outcome,
+            decision=synthetic_decision,
+            intake_prompt=prompt_text,
+            send_chunks=send_chunks,
+            thread_continuation_fn=thread_continuation_fn,
+            research_loop_fn=None,  # Phase 4 MVP: no auto research loop here
+        )
+        if result is not None:
+            return result
+        # Fallthrough to clarification when continuation couldn't reach
+        # the matched thread (e.g. it's archived) — do NOT silently
+        # create a new session.
+        await send_chunks(
+            message.channel,
+            _format_runtime_preflight_clarification(intent.intent_id, recall.candidates),
+        )
+        return EngineeringRouteResult(
+            handled=True,
+            error="runtime preflight: continuation thread not reachable",
+        )
+
+    if primary.action_id in (
+        RUNTIME_ACTION_ASK_CLARIFICATION,
+        RUNTIME_ACTION_APPEND_CONTEXT,
+    ):
+        # ASK_CLARIFICATION: not enough confidence in any session match.
+        # APPEND_CONTEXT with no thread_continuation_fn fallback: degrade
+        # to clarification rather than silently dropping the user's
+        # context append. Either way the message reuses the same
+        # template so the operator sees what's missing.
+        await send_chunks(
+            message.channel,
+            _format_runtime_preflight_clarification(intent.intent_id, recall.candidates),
+        )
+        return EngineeringRouteResult(handled=True)
+
+    if primary.action_id == RUNTIME_ACTION_APPEND_CONTEXT:
+        # Future: route into a dedicated append helper. For Phase 4 MVP
+        # we treat append as a join + ack without re-running research.
+        if thread_continuation_fn is None:
+            await send_chunks(
+                message.channel,
+                _format_runtime_preflight_clarification(intent.intent_id, recall.candidates),
+            )
+            return EngineeringRouteResult(handled=True)
+
+    return None
+
+
+def _thread_id_for_runtime(message: Any) -> Optional[int]:
+    channel = getattr(message, "channel", None)
+    if channel is None:
+        return None
+    # Discord threads expose ``id`` (the thread id) and ``parent_id``
+    # (the channel they live under). For non-thread channels we leave
+    # thread_id None so recall doesn't apply a spurious anchor.
+    parent_id = getattr(channel, "parent_id", None)
+    if parent_id is None and getattr(channel, "parent", None) is None:
+        return None
+    return getattr(channel, "id", None)
+
+
+def _observation_for_runtime(input_: RuntimeInput):
+    """Build a minimal observation locally so we don't import the
+    runtime loop's default observe (keeps the router's import surface
+    small)."""
+
+    from ..agents.runtime.models import RuntimeObservation
+
+    text = input_.message_text or ""
+    return RuntimeObservation(
+        role_id=input_.role_id,
+        message_text=text,
+        normalized_text=" ".join(text.lower().split()),
+        channel_id=input_.channel_id,
+        thread_id=input_.thread_id,
+        author_id=input_.author_id,
+        message_id=input_.message_id,
+        has_attachments=bool(input_.attachments),
+        last_proposed_prompt=input_.last_proposed_prompt,
+    )
+
+
+def _format_runtime_preflight_clarification(intent_id: str, candidates) -> str:
+    """Render a clarification message for the four short-circuited
+    intents when no session matched.
+
+    Surfaces up to three candidate session ids so the operator can
+    point at the right one with ``기존 세션 <id>``.
+    """
+
+    intent_labels = {
+        RUNTIME_INTENT_CONTINUE_EXISTING_WORK: "기존 작업 이어가기",
+        RUNTIME_INTENT_SUMMARIZE_PREVIOUS_WORK: "이전 작업 요약",
+        RUNTIME_INTENT_EXECUTE_EXISTING_STEP: "기존 작업 후속 실행",
+        RUNTIME_INTENT_APPEND_CONTEXT: "기존 작업에 자료 첨부",
+    }
+    label = intent_labels.get(intent_id, "기존 작업 처리")
+    lines = [
+        f"**[engineering-agent] 어떤 작업을 가리키시는지 확인이 필요해요.**",
+        f"요청 의도: {label}",
+        "",
+    ]
+    if candidates:
+        lines.append("최근 열린 후보 세션이에요:")
+        for cand in list(candidates)[:3]:
+            tail = []
+            if cand.task_type:
+                tail.append(cand.task_type)
+            if cand.thread_id is not None:
+                tail.append(f"thread `{cand.thread_id}`")
+            tail.append(f"score {cand.score:.2f}")
+            head = cand.title or cand.session_id
+            lines.append(f"- `{cand.session_id}` — {head} ({' · '.join(tail)})")
+        lines.append("")
+    lines.append(
+        "이어갈 세션 ID를 `기존 세션 <id>` 처럼 답하시거나, 새 작업이라면 `새 작업으로 진행`이라고 답해 주세요."
+    )
+    return "\n".join(lines)
 
 
 async def _handle_join_or_append(

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -166,6 +166,17 @@ class EngineeringResearchLoopReport:
     forum_thread_url: Optional[str] = None
     insufficient: bool = False
     error: Optional[str] = None
+    # member-bots vs gateway publication mode signal — populated by the
+    # research-loop hook from the publication outcome so status /
+    # diagnostic responses can describe the live setup correctly.
+    forum_comment_mode: Optional[str] = None
+    # member-bots mode only: did the gateway successfully post the
+    # ``[research-open:<session_id>]`` open-call directive that each
+    # member bot is supposed to react to? ``None`` in gateway mode.
+    kickoff_posted: Optional[bool] = None
+    # member-bots mode only: stringified error from the open-call
+    # directive post when ``kickoff_posted`` is False; otherwise None.
+    kickoff_error: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -1159,6 +1170,7 @@ def _coerce_research_loop_report(raw: Any) -> EngineeringResearchLoopReport:
         return raw
     if raw is None:
         return EngineeringResearchLoopReport()
+    raw_kickoff_posted = getattr(raw, "kickoff_posted", None)
     return EngineeringResearchLoopReport(
         follow_up_message=_optional_str(getattr(raw, "follow_up_message", None)),
         forum_status_message=_optional_str(getattr(raw, "forum_status_message", None)),
@@ -1166,6 +1178,11 @@ def _coerce_research_loop_report(raw: Any) -> EngineeringResearchLoopReport:
         forum_thread_url=_optional_str(getattr(raw, "forum_thread_url", None)),
         insufficient=bool(getattr(raw, "insufficient", False)),
         error=_optional_str(getattr(raw, "error", None)),
+        forum_comment_mode=_optional_str(getattr(raw, "forum_comment_mode", None)),
+        kickoff_posted=(
+            bool(raw_kickoff_posted) if raw_kickoff_posted is not None else None
+        ),
+        kickoff_error=_optional_str(getattr(raw, "kickoff_error", None)),
     )
 
 

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -17,6 +17,15 @@ import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence, Union
 
+from ..agents.obsidian_approval import (
+    ObsidianApprovalError,
+    build_save_proposal,
+    execute_pending_proposal,
+    get_pending_proposal,
+    is_obsidian_approval,
+    is_obsidian_save_request,
+    store_pending_proposal,
+)
 from ..agents.research_persistence import persist_research_artifacts
 from ..agents.routing import (
     ACTION_APPEND_CONTEXT,
@@ -334,6 +343,8 @@ async def route_engineering_message(
     research_loop_fn: Optional[ResearchLoopFn] = None,
     thread_continuation_fn: Optional[ThreadContinuationFn] = None,
     list_sessions_fn: Optional[Callable[..., Sequence[Any]]] = None,
+    obsidian_writer_fn: Optional[Callable[..., Any]] = None,
+    obsidian_env: Optional[Any] = None,
 ) -> EngineeringRouteResult:
     """Drive the engineering channel response.
 
@@ -365,6 +376,21 @@ async def route_engineering_message(
     if not prompt_text:
         return EngineeringRouteResult(handled=False)
 
+    # Obsidian approval gate — runs before runtime preflight so an
+    # explicit "저장 승인" / "이대로 저장" never falls through to the
+    # default new-work classifier and intakes a brand-new session.
+    if list_sessions_fn is not None:
+        approval = await _run_obsidian_approval_gate(
+            message=message,
+            prompt_text=prompt_text,
+            list_sessions_fn=list_sessions_fn,
+            send_chunks=send_chunks,
+            writer_fn=obsidian_writer_fn,
+            env=obsidian_env,
+        )
+        if approval is not None:
+            return approval
+
     # Runtime preflight — opt-in via ``list_sessions_fn``. The production
     # gateway in bot.py wires this to ``workflow_state.list_sessions`` so
     # auto_collect-first traffic for "어제 작업 이어서 요약해줘" and
@@ -378,6 +404,8 @@ async def route_engineering_message(
             list_sessions_fn=list_sessions_fn,
             send_chunks=send_chunks,
             thread_continuation_fn=thread_continuation_fn,
+            obsidian_writer_fn=obsidian_writer_fn,
+            obsidian_env=obsidian_env,
         )
         if preflight is not None:
             return preflight
@@ -606,6 +634,430 @@ _PREFLIGHT_SHORT_CIRCUIT_INTENTS = frozenset(
 )
 
 
+# ---------------------------------------------------------------------------
+# Clarification follow-up memory
+#
+# When the gateway shows the user a clarification with multiple candidate
+# sessions, we cache the candidates per (channel_or_thread_id, user_id)
+# so the next message can be a short pick like "1번" or "이걸로". The
+# state is overwritten on each new clarification and cleared on any
+# successful selection — no TTL is enforced because a stale entry only
+# fires when the next message looks like a candidate selector, which is
+# the exact case where reusing it is correct.
+# ---------------------------------------------------------------------------
+
+
+_GATEWAY_CLARIFICATION_CONTEXT: dict[
+    tuple[Optional[int], Optional[int]], tuple[dict, ...]
+] = {}
+
+
+_NUMERIC_SELECTION_RE = __import__("re").compile(
+    r"^\s*(\d{1,2})\s*(번|번째|개|위치)?\s*\.?\s*$"
+)
+
+# Map a Korean ordinal/positional prefix to a 1-based candidate index.
+# We match by ``startswith`` after whitespace removal so phrases like
+# "첫 번째 거" / "두번째로" still resolve.
+_ORDINAL_KO_PREFIXES: tuple[tuple[str, int], ...] = (
+    ("첫번째", 1),
+    ("첫 번째", 1),
+    ("첫째", 1),
+    ("두번째", 2),
+    ("두 번째", 2),
+    ("둘째", 2),
+    ("세번째", 3),
+    ("세 번째", 3),
+    ("셋째", 3),
+    ("네번째", 4),
+    ("네 번째", 4),
+    ("넷째", 4),
+    ("다섯번째", 5),
+    ("다섯 번째", 5),
+    ("다섯째", 5),
+)
+
+
+# Phrases that mean "the one I just showed" — only meaningful with at
+# least one stored candidate. With multiple candidates these stay
+# ambiguous and we ask for a number; with a single candidate they pick
+# it. ``기존 세션으로 진행`` is included so users who saw a
+# single-candidate clarification can confirm with that exact wording.
+_DEMONSTRATIVE_SELECTION_PHRASES: tuple[str, ...] = (
+    "이걸로",
+    "이거로",
+    "이걸루",
+    "이거",
+    "저걸로",
+    "그걸로",
+    "위에 거",
+    "위에거",
+    "위 거",
+    "위 것",
+    "방금 그거",
+    "방금 그것",
+    "방금 거",
+    "기존 세션으로 진행",
+    "기존 작업으로 진행",
+)
+
+
+def _clarification_context_key(message: Any) -> tuple[Optional[int], Optional[int]]:
+    """Scope key for the clarification cache.
+
+    Uses the channel/thread id the user is currently typing in, plus
+    the author id, so a clarification shown to user A in #업무-접수
+    doesn't get hijacked by user B's "1번" reply in the same channel.
+    """
+
+    channel = getattr(message, "channel", None)
+    scope_id = getattr(channel, "id", None)
+    user_id = getattr(getattr(message, "author", None), "id", None)
+    return (scope_id, user_id)
+
+
+def _remember_clarification_candidates(
+    message: Any,
+    candidates: Sequence[Any],
+) -> None:
+    """Stash candidate session ids + thread ids from the recall result.
+
+    Stored as plain dicts so the cache value round-trips through
+    pickling-friendly types and we never hold a reference to a
+    dataclass that may grow new fields underneath us.
+    """
+
+    if not candidates:
+        return
+    serialized = tuple(
+        {
+            "session_id": getattr(cand, "session_id", None),
+            "title": getattr(cand, "title", "") or "",
+            "score": float(getattr(cand, "score", 0.0) or 0.0),
+            "thread_id": getattr(cand, "thread_id", None),
+            "forum_thread_id": getattr(cand, "forum_thread_id", None),
+            "task_type": getattr(cand, "task_type", None),
+        }
+        for cand in candidates[:5]
+        if getattr(cand, "session_id", None)
+    )
+    if serialized:
+        _GATEWAY_CLARIFICATION_CONTEXT[_clarification_context_key(message)] = serialized
+
+
+def _recall_clarification_candidates(message: Any) -> tuple[dict, ...]:
+    return _GATEWAY_CLARIFICATION_CONTEXT.get(_clarification_context_key(message), ())
+
+
+def _clear_clarification_context(message: Any) -> None:
+    _GATEWAY_CLARIFICATION_CONTEXT.pop(_clarification_context_key(message), None)
+
+
+def _try_select_candidate(
+    text: str,
+    candidates: tuple[dict, ...],
+) -> Optional[dict]:
+    """Resolve a follow-up message into a stored candidate, or None.
+
+    Recognises:
+    - bare number ``"1"`` / ordinal-shaped ``"1번"`` / ``"2번째"``
+    - Korean ordinals ``"첫 번째"`` / ``"두번째"`` / ...
+    - demonstrative phrases (``"이걸로"`` / ``"기존 세션으로 진행"``)
+      — only return a hit when there's exactly one stored candidate so
+      multi-candidate ambiguity falls through to a fresh clarification
+      instead of being silently resolved.
+
+    Out-of-range numbers (e.g. user typed "9번" but only 3 candidates)
+    return None so the router can re-ask. The cache is left in place
+    because the next reply might still be a valid pick.
+    """
+
+    if not candidates:
+        return None
+    cleaned = (text or "").strip().lower()
+    if not cleaned:
+        return None
+
+    numeric_match = _NUMERIC_SELECTION_RE.match(cleaned)
+    if numeric_match is not None:
+        index = int(numeric_match.group(1)) - 1
+        if 0 <= index < len(candidates):
+            return candidates[index]
+        return None
+
+    for prefix, idx in _ORDINAL_KO_PREFIXES:
+        if cleaned.startswith(prefix) and idx <= len(candidates):
+            return candidates[idx - 1]
+
+    if any(phrase in cleaned for phrase in _DEMONSTRATIVE_SELECTION_PHRASES):
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
+
+    return None
+
+
+async def _handle_clarification_selection(
+    *,
+    message: Any,
+    selected: dict,
+    prompt_text: str,
+    send_chunks: SendChunksFn,
+    thread_continuation_fn: Optional[ThreadContinuationFn],
+) -> Optional[EngineeringRouteResult]:
+    """Drive the legacy join helper for a clarification follow-up
+    selection. Returns a populated result on success or ``None`` to
+    leave the cache in place and fall through to the regular flow."""
+
+    if thread_continuation_fn is None:
+        return None
+    synthetic_outcome = EngineeringConversationOutcome(
+        content="",
+        intake_prompt=prompt_text,
+    )
+    synthetic_decision = EngineeringRoutingDecision(
+        action=ACTION_JOIN,
+        matched_session_id=selected.get("session_id"),
+        matched_thread_id=selected.get("thread_id"),
+        matched_forum_thread_id=selected.get("forum_thread_id"),
+        confidence="high",
+        reason="clarification follow-up selection",
+    )
+    return await _handle_join_or_append(
+        message=message,
+        outcome=synthetic_outcome,
+        decision=synthetic_decision,
+        intake_prompt=prompt_text,
+        send_chunks=send_chunks,
+        thread_continuation_fn=thread_continuation_fn,
+        research_loop_fn=None,
+    )
+
+
+async def _run_obsidian_approval_gate(
+    *,
+    message: Any,
+    prompt_text: str,
+    list_sessions_fn: Callable[..., Sequence[Any]],
+    send_chunks: SendChunksFn,
+    writer_fn: Optional[Callable[..., Any]] = None,
+    env: Optional[Any] = None,
+) -> Optional[EngineeringRouteResult]:
+    """Try to interpret *prompt_text* as an Obsidian save approval.
+
+    Returns a populated :class:`EngineeringRouteResult` when the message
+    was an approval phrase (regardless of whether the write succeeded),
+    or ``None`` to fall through to the runtime preflight + conversation
+    flow. We deliberately keep this branch above the runtime classifier
+    so a bare "저장 승인" never gets promoted to ``new_work_request``.
+    """
+
+    if not is_obsidian_approval(prompt_text):
+        return None
+
+    candidate = _find_session_with_pending_proposal(
+        message=message,
+        list_sessions_fn=list_sessions_fn,
+    )
+    if candidate is None:
+        await send_chunks(
+            message.channel,
+            (
+                "지금은 대기 중인 Obsidian 저장 제안이 없어요.\n"
+                "먼저 `Obsidian에 정리해줘` 처럼 저장 미리보기를 만들어 주세요."
+            ),
+        )
+        return EngineeringRouteResult(handled=True)
+
+    try:
+        updated, outcome = execute_pending_proposal(
+            candidate,
+            env=env,
+            writer_fn=writer_fn,
+        )
+    except ObsidianApprovalError as exc:
+        await send_chunks(message.channel, f"⚠️ Obsidian 저장 실패: {exc}")
+        return EngineeringRouteResult(handled=True, error=str(exc))
+    except Exception as exc:  # noqa: BLE001 — never let the bot crash on save
+        await send_chunks(
+            message.channel,
+            f"⚠️ Obsidian 저장 중 예상치 못한 오류: {exc}",
+        )
+        return EngineeringRouteResult(handled=True, error=str(exc))
+
+    await send_chunks(message.channel, outcome.message)
+    return EngineeringRouteResult(
+        handled=True,
+        session_id=getattr(updated, "session_id", None),
+    )
+
+
+async def _run_obsidian_preview_branch(
+    *,
+    message: Any,
+    prompt_text: str,
+    decision_payload: Any,
+    list_sessions_fn: Callable[..., Sequence[Any]],
+    send_chunks: SendChunksFn,
+) -> Optional[EngineeringRouteResult]:
+    """Render the preview for an Obsidian save request and store the proposal.
+
+    Called from :func:`_run_runtime_preflight` when the runtime intent
+    classifier identified an Obsidian save request and Recall matched a
+    session. We never call ``thread_continuation_fn`` here — joining the
+    thread isn't the user's goal; they want to see what we'd write before
+    approving it.
+    """
+
+    target_session_id: Optional[str] = None
+    if hasattr(decision_payload, "get"):
+        raw = decision_payload.get("session_id")
+        target_session_id = str(raw) if raw is not None else None
+
+    session = _load_session_by_id(list_sessions_fn, target_session_id)
+    if session is None:
+        await send_chunks(
+            message.channel,
+            (
+                "**[engineering-agent] Obsidian 저장 대상 세션을 찾지 못했어요.**\n"
+                "어떤 세션을 저장할지 `기존 세션 <id>` 처럼 답해 주세요."
+            ),
+        )
+        return EngineeringRouteResult(
+            handled=True,
+            error="obsidian preview: matched session not loadable",
+        )
+
+    try:
+        proposal = build_save_proposal(
+            session,
+            actor_user_id=getattr(getattr(message, "author", None), "id", None),
+        )
+    except ObsidianApprovalError as exc:
+        await send_chunks(message.channel, f"⚠️ {exc}")
+        return EngineeringRouteResult(handled=True, error=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        await send_chunks(
+            message.channel,
+            f"⚠️ Obsidian 미리보기 생성 실패: {exc}",
+        )
+        return EngineeringRouteResult(handled=True, error=str(exc))
+
+    try:
+        store_pending_proposal(session, proposal)
+    except Exception as exc:  # noqa: BLE001 — preview survives even if persist fails
+        await send_chunks(
+            message.channel,
+            f"⚠️ 저장 제안 기록 실패: {exc}\n미리보기는 아래에서 확인하실 수 있어요.",
+        )
+
+    await send_chunks(message.channel, proposal.preview_message)
+    return EngineeringRouteResult(
+        handled=True,
+        session_id=session.session_id,
+        thread_id=getattr(session, "thread_id", None),
+    )
+
+
+def _find_session_with_pending_proposal(
+    *,
+    message: Any,
+    list_sessions_fn: Callable[..., Sequence[Any]],
+) -> Optional[Any]:
+    """Return the session that owns the most relevant pending proposal.
+
+    Match priority:
+      1. Sessions whose ``thread_id`` equals the message's channel id
+         (for thread messages — Discord exposes the thread id as
+         ``channel.id`` and the channel id as ``channel.parent_id``).
+      2. Sessions in the same channel + same author with a proposal.
+      3. Most recently updated session with a proposal.
+
+    Returns ``None`` when no candidate has a pending proposal stashed in
+    ``session.extra``.
+    """
+
+    try:
+        try:
+            sessions = list_sessions_fn(limit=50)
+        except TypeError:
+            sessions = list_sessions_fn()
+    except Exception:  # noqa: BLE001 — recall outage must not crash bot
+        return None
+    if not sessions:
+        return None
+
+    channel = getattr(message, "channel", None)
+    channel_id = getattr(channel, "id", None)
+    parent_id = getattr(channel, "parent_id", None)
+    if parent_id is None and getattr(channel, "parent", None) is None:
+        thread_id = None
+        scoped_channel_id = channel_id
+    else:
+        thread_id = channel_id
+        scoped_channel_id = parent_id
+    user_id = getattr(getattr(message, "author", None), "id", None)
+
+    candidates_with_proposal = [
+        s for s in sessions if get_pending_proposal(s) is not None
+    ]
+    if not candidates_with_proposal:
+        return None
+
+    if thread_id is not None:
+        for session in candidates_with_proposal:
+            if getattr(session, "thread_id", None) == thread_id:
+                return session
+
+    if scoped_channel_id is not None:
+        same_scope = [
+            s
+            for s in candidates_with_proposal
+            if getattr(s, "channel_id", None) == scoped_channel_id
+            and (user_id is None or getattr(s, "user_id", None) == user_id)
+        ]
+        if same_scope:
+            return _most_recent_session(same_scope)
+
+    return _most_recent_session(candidates_with_proposal)
+
+
+def _load_session_by_id(
+    list_sessions_fn: Callable[..., Sequence[Any]],
+    session_id: Optional[str],
+) -> Optional[Any]:
+    if not session_id:
+        return None
+    try:
+        try:
+            sessions = list_sessions_fn(limit=50)
+        except TypeError:
+            sessions = list_sessions_fn()
+    except Exception:  # noqa: BLE001
+        return None
+    for session in sessions or ():
+        if getattr(session, "session_id", None) == session_id:
+            return session
+    return None
+
+
+def _most_recent_session(sessions: Sequence[Any]) -> Optional[Any]:
+    if not sessions:
+        return None
+
+    def _sort_key(s: Any):
+        ts = getattr(s, "updated_at", None)
+        if ts is None:
+            return (0, 0)
+        try:
+            epoch = ts.timestamp()
+        except Exception:  # noqa: BLE001
+            epoch = 0
+        return (1, epoch)
+
+    return max(sessions, key=_sort_key)
+
+
 async def _run_runtime_preflight(
     *,
     message: Any,
@@ -613,6 +1065,8 @@ async def _run_runtime_preflight(
     list_sessions_fn: Callable[..., Sequence[Any]],
     send_chunks: SendChunksFn,
     thread_continuation_fn: Optional[ThreadContinuationFn],
+    obsidian_writer_fn: Optional[Callable[..., Any]] = None,
+    obsidian_env: Optional[Any] = None,
 ) -> Optional[EngineeringRouteResult]:
     """Try to handle the message with the runtime loop's intent +
     recall result. Returns a populated :class:`EngineeringRouteResult`
@@ -627,6 +1081,26 @@ async def _run_runtime_preflight(
     requests, confirmations, vague text, and pleasantries also flow
     through unchanged so all existing tests keep their contracts.
     """
+
+    # 0. Clarification follow-up — fires before the classifier so a
+    # short reply like "1번" or "기존 세션으로 진행" lands on the
+    # right session even though those messages don't carry enough
+    # context to classify on their own. Only consulted when we have a
+    # cached set of candidates from a prior clarification turn.
+    stored_candidates = _recall_clarification_candidates(message)
+    if stored_candidates:
+        selected = _try_select_candidate(prompt_text, stored_candidates)
+        if selected is not None:
+            join_result = await _handle_clarification_selection(
+                message=message,
+                selected=selected,
+                prompt_text=prompt_text,
+                send_chunks=send_chunks,
+                thread_continuation_fn=thread_continuation_fn,
+            )
+            if join_result is not None:
+                _clear_clarification_context(message)
+                return join_result
 
     runtime_input = RuntimeInput(
         role_id="gateway",
@@ -654,6 +1128,24 @@ async def _run_runtime_preflight(
         return None
 
     primary = decision.actions[0]
+
+    # Obsidian save request with a matched session: build a preview and
+    # store a pending proposal instead of joining + re-running research.
+    # The user explicitly asked to save, not to resume work — we surface
+    # the note we *would* write so they can confirm with `저장 승인`.
+    if (
+        intent.intent_id == RUNTIME_INTENT_EXECUTE_EXISTING_STEP
+        and is_obsidian_save_request(prompt_text)
+        and primary.action_id == RUNTIME_ACTION_JOIN_SESSION
+    ):
+        return await _run_obsidian_preview_branch(
+            message=message,
+            prompt_text=prompt_text,
+            decision_payload=primary.payload,
+            list_sessions_fn=list_sessions_fn,
+            send_chunks=send_chunks,
+        )
+
     if primary.action_id == RUNTIME_ACTION_JOIN_SESSION and thread_continuation_fn is not None:
         # Re-use the legacy join/append helper so research_loop_hook
         # still runs against the resumed session. The helper expects an
@@ -684,7 +1176,9 @@ async def _run_runtime_preflight(
             return result
         # Fallthrough to clarification when continuation couldn't reach
         # the matched thread (e.g. it's archived) — do NOT silently
-        # create a new session.
+        # create a new session. Stash the candidates so the user can
+        # reply with "1번" / "기존 세션으로 진행" on the next turn.
+        _remember_clarification_candidates(message, recall.candidates)
         await send_chunks(
             message.channel,
             _format_runtime_preflight_clarification(intent.intent_id, recall.candidates),
@@ -702,7 +1196,9 @@ async def _run_runtime_preflight(
         # APPEND_CONTEXT with no thread_continuation_fn fallback: degrade
         # to clarification rather than silently dropping the user's
         # context append. Either way the message reuses the same
-        # template so the operator sees what's missing.
+        # template so the operator sees what's missing — and we cache
+        # the candidate list so a follow-up "1번" turn resolves cleanly.
+        _remember_clarification_candidates(message, recall.candidates)
         await send_chunks(
             message.channel,
             _format_runtime_preflight_clarification(intent.intent_id, recall.candidates),
@@ -974,6 +1470,14 @@ async def _run_research_loop_hook(
         return report
 
     report = _coerce_research_loop_report(raw)
+    # Persist forum publication / open-call signals onto session.extra
+    # so the diagnostic responder can describe the live setup later
+    # without round-tripping through the publish object. Best-effort —
+    # a cache write failure must not block the user-visible reply.
+    try:
+        persist_research_forum_status(session=session, report=report)
+    except Exception:  # noqa: BLE001 - persistence is non-fatal
+        pass
     if report.follow_up_message:
         await send_chunks(message.channel, report.follow_up_message)
     if report.forum_status_message:
@@ -981,6 +1485,90 @@ async def _run_research_loop_hook(
     if report.error and not report.follow_up_message and not report.forum_status_message:
         await send_chunks(message.channel, f"⚠️ research loop: {report.error}")
     return report
+
+
+def persist_research_forum_status(
+    *,
+    session: Any,
+    report: EngineeringResearchLoopReport,
+) -> None:
+    """Merge the research-loop report's mode/kickoff signals into session.extra.
+
+    Writes the canonical Phase B keys so the diagnostic / status
+    responder can describe the live setup later:
+
+    - ``forum_comment_mode`` — ``"member-bots"`` or ``"gateway"``.
+    - ``research_forum_thread_id`` / ``research_forum_thread_url`` — the
+      forum thread the directive went into (or would go into).
+    - ``research_open_call_posted`` — ``True`` / ``False`` / ``None``
+      depending on whether the gateway posted the
+      ``[research-open:<sid>]`` directive itself. ``None`` means the
+      path didn't reach the kickoff post.
+    - ``research_open_call_error`` — stringified failure reason when
+      ``research_open_call_posted`` is ``False``; cleared on retry
+      success.
+
+    For backward compatibility the legacy ``forum_kickoff_posted`` /
+    ``forum_kickoff_error`` keys are kept in sync — bot-side
+    ``_persist_forum_comment_mode_to_session`` and existing diagnostic
+    tests still consume those names.
+
+    No-op when ``session`` has no ``session_id`` (e.g. lightweight test
+    stubs) so callers don't need to special-case the path.
+    """
+
+    if session is None:
+        return
+    session_id = getattr(session, "session_id", None)
+    if not session_id:
+        return
+
+    extra_updates: dict[str, Any] = {}
+    if report.forum_comment_mode is not None:
+        extra_updates["forum_comment_mode"] = report.forum_comment_mode
+    if report.forum_thread_id is not None:
+        extra_updates["research_forum_thread_id"] = report.forum_thread_id
+    if report.forum_thread_url is not None:
+        extra_updates["research_forum_thread_url"] = report.forum_thread_url
+
+    if report.forum_comment_mode == "member-bots":
+        # Always stamp the open-call signal pair — including ``None`` —
+        # so a retry that succeeded clears the previous failure note.
+        extra_updates["research_open_call_posted"] = report.kickoff_posted
+        extra_updates["research_open_call_error"] = report.kickoff_error
+        extra_updates["forum_kickoff_posted"] = report.kickoff_posted
+        extra_updates["forum_kickoff_error"] = report.kickoff_error
+
+    if not extra_updates:
+        return
+
+    try:
+        from dataclasses import replace
+        from datetime import datetime
+
+        from ..agents.workflow_state import update_session
+    except Exception:  # noqa: BLE001 - degrade silently for partial installs
+        return
+
+    existing_extra = dict(getattr(session, "extra", {}) or {})
+    merged = {**existing_extra, **extra_updates}
+    try:
+        updated = replace(session, extra=merged)
+    except TypeError:
+        # ``replace`` only works on dataclasses — test stubs that use
+        # plain objects fall through to mutating the live extra dict so
+        # at least the in-memory session reflects the change.
+        try:
+            live = getattr(session, "extra", None)
+            if isinstance(live, dict):
+                live.update(extra_updates)
+        except Exception:  # noqa: BLE001
+            pass
+        return
+    try:
+        update_session(updated, now=datetime.now().astimezone())
+    except Exception:  # noqa: BLE001
+        pass
 
 
 async def make_default_research_loop(
@@ -1030,6 +1618,14 @@ async def make_default_research_loop(
     forum_thread_url: Optional[str] = None
     insufficient = False
     error: Optional[str] = None
+    # Tracked through the member-bots branch so the report can describe
+    # whether the gateway actually got the open-call directive in front of
+    # the role bots, plus the failure reason if it didn't. Stays ``None``
+    # in gateway mode and in any code path that never reaches the kickoff
+    # post (forum publish failed, post_to_forum_thread missing, ...).
+    kickoff_posted: Optional[bool] = None
+    kickoff_error: Optional[str] = None
+    posted = False
 
     has_pack = research_pack is not None
 
@@ -1101,9 +1697,41 @@ async def make_default_research_loop(
                     for piece in pieces:
                         await post_to_forum_thread(forum_thread_id, piece)
                 except Exception as exc:  # noqa: BLE001
-                    error = (error + " · " if error else "") + (
-                        f"forum kickoff 게시 실패: {exc}"
+                    kickoff_posted = False
+                    kickoff_error = f"forum kickoff 게시 실패: {exc}"
+                    error = (error + " · " if error else "") + kickoff_error
+                else:
+                    kickoff_posted = True
+                    # Replace the gateway-flavoured "자료 정리를 남겼어요."
+                    # blurb with a member-bots-aware status. Operators were
+                    # otherwise seeing "역할별 댓글 0건"-style wording even
+                    # though each member bot is responsible for the role
+                    # comment in this mode.
+                    forum_status = _format_member_bots_forum_status(
+                        thread_id=forum_thread_id,
+                        thread_url=forum_thread_url,
+                        kickoff_posted=True,
+                        kickoff_error=None,
                     )
+            else:
+                # Couldn't compute the open-call directive (import failed or
+                # research_open_call_directive raised) — record the
+                # member-bots mode signal so diagnostics know the gateway
+                # tried but the directive never made it into the thread.
+                kickoff_posted = False
+                kickoff_error = "research_open_call_directive 미생성"
+                error = (error + " · " if error else "") + kickoff_error
+        elif forum_comment_mode == "member-bots" and posted:
+            # Mode is correct but the caller didn't wire ``post_to_forum_thread``
+            # (e.g. early dev runs with a stub publisher). Surface a
+            # member-bots-aware status anyway so the gateway summary doesn't
+            # imply the gateway is going to post role comments.
+            forum_status = _format_member_bots_forum_status(
+                thread_id=forum_thread_id,
+                thread_url=forum_thread_url,
+                kickoff_posted=None,
+                kickoff_error=None,
+            )
 
     # 2. Deliberation in the working thread — gateway mode only.
     # member-bots mode hands the deliberation to each member bot via the
@@ -1162,7 +1790,51 @@ async def make_default_research_loop(
         forum_thread_url=forum_thread_url,
         insufficient=insufficient,
         error=error,
+        forum_comment_mode=forum_comment_mode,
+        kickoff_posted=kickoff_posted,
+        kickoff_error=kickoff_error,
     )
+
+
+def _format_member_bots_forum_status(
+    *,
+    thread_id: Optional[int],
+    thread_url: Optional[str],
+    kickoff_posted: Optional[bool],
+    kickoff_error: Optional[str],
+) -> str:
+    """Render the member-bots forum status surface.
+
+    Avoids the gateway-mode "역할별 댓글 N건" wording — in member-bots
+    mode the gateway never posts role comments by design, so reporting
+    "0건" looks like a failure to operators. Instead we describe the
+    mode, the open-call directive status, and where to actually find
+    the role comments (the forum thread itself).
+    """
+
+    lines: list[str] = ["✅ 운영-리서치 forum 게시 완료"]
+    if thread_url:
+        lines.append(f"thread: {thread_url}")
+    elif thread_id is not None:
+        lines.append(f"thread id: {thread_id}")
+    lines.append("모드: member-bots (각 멤버 봇이 자기 계정으로 댓글)")
+    if kickoff_posted is True:
+        lines.append("open-call directive: 게시 완료")
+    elif kickoff_posted is False:
+        reason = kickoff_error or "원인 미확인"
+        lines.append(f"open-call directive: 게시 실패 — {reason}")
+    else:
+        # ``post_to_forum_thread`` wasn't wired by the caller, so the
+        # gateway never even tried to post the directive. Operators
+        # need to know that — otherwise they'd assume the gateway is
+        # going to post role comments itself, like in legacy mode.
+        lines.append(
+            "open-call directive: 미게시 (post_to_forum_thread 미연결)"
+        )
+    lines.append(
+        "각 멤버 봇의 후속 댓글은 운영-리서치 thread에서 확인하세요."
+    )
+    return "\n".join(lines)
 
 
 def _coerce_research_loop_report(raw: Any) -> EngineeringResearchLoopReport:

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -917,6 +917,9 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
     )
     research_loop_report = extra.get("research_loop_report")
     synthesis = extra.get("research_synthesis")
+    forum_comment_mode = extra.get("forum_comment_mode")
+    forum_kickoff_posted = extra.get("forum_kickoff_posted")
+    forum_kickoff_error = extra.get("forum_kickoff_error")
 
     state_value = getattr(session, "state", None)
     state_label = getattr(state_value, "value", state_value) or "unknown"
@@ -942,6 +945,26 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
         lines.append("- 운영-리서치 forum: 아직 게시되지 않음 (자료는 수집 완료)")
     else:
         lines.append("- 운영-리서치 forum: 자료 수집 전이라 게시 단계가 아님")
+
+    # Forum comment mode signals — only meaningful once the forum
+    # publish actually ran (so we condition on having a thread or an
+    # explicit error). In member-bots mode we explain that per-role
+    # comments come from each member bot, not the gateway.
+    if forum_comment_mode == "member-bots":
+        lines.append("- 모드: member-bots (각 멤버 봇이 자기 계정으로 댓글)")
+        if forum_kickoff_posted is True:
+            lines.append("  · open-call directive: 게시 완료")
+        elif forum_kickoff_posted is False:
+            reason = forum_kickoff_error or "원인 미확인"
+            lines.append(f"  · open-call directive: 게시 실패 — {reason}")
+        # Always close with a pointer to where the actual role comments
+        # land so the operator knows the gateway summary isn't where to
+        # judge member bot work.
+        lines.append(
+            "  · 후속 댓글은 운영-리서치 thread에서 직접 확인해 주세요."
+        )
+    elif forum_comment_mode == "gateway":
+        lines.append("- 모드: gateway (역할별 댓글을 게이트웨이가 직접 게시)")
 
     if research_loop_report:
         report_error = None

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -39,6 +39,10 @@ from ..agents.research_pack import (
     ResearchSource,
     extract_urls,
 )
+from ..agents.session_status import (
+    diagnose_session,
+    render_member_bot_summary,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +159,11 @@ def build_engineering_conversation_response(
                 session = status_session_loader()
             except Exception:  # noqa: BLE001 - loader failures must not crash gateway
                 session = None
-        body = format_status_diagnostic_response(session)
+        is_member_bot_question = _asks_about_member_bots(message_text)
+        body = format_status_diagnostic_response(
+            session,
+            is_member_bot_question=is_member_bot_question,
+        )
         return EngineeringConversationResponse(
             content=_prepend_mention(body, mention_user_id),
             intent_id=STATUS_DIAGNOSTIC,
@@ -644,6 +652,12 @@ def _asks_to_start_new_thread(text: str) -> bool:
 
 
 _STATUS_DIAGNOSTIC_PHRASES = (
+    "멤버 봇",
+    "멤버봇",
+    "역할 봇",
+    "역할봇",
+    "member bot",
+    "member-bot",
     "운영 리서치는 안 열",
     "운영-리서치는 안 열",
     "운영 리서치 안 열",
@@ -884,7 +898,11 @@ def _format_general_help() -> str:
     )
 
 
-def format_status_diagnostic_response(session: Optional[Any]) -> str:
+def format_status_diagnostic_response(
+    session: Optional[Any],
+    *,
+    is_member_bot_question: bool = False,
+) -> str:
     """Render a real-state status answer for the gateway.
 
     Reads ``session.state``, ``session.extra``, and known keys
@@ -893,6 +911,11 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
     can say "research_pack: 있음 · forum: 게시 실패 · 마지막 오류: 4000자
     초과" instead of guessing. When *session* is None we explicitly tell
     the operator we couldn't find an open session.
+
+    *is_member_bot_question* tilts the answer toward "멤버 봇들은 뭐 하고
+    있어?" — we still print the full state header but append a short
+    member-bot focused section pointing at the forum thread instead of
+    duplicating role comments here.
     """
 
     if session is None:
@@ -952,10 +975,18 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
     # comments come from each member bot, not the gateway.
     if forum_comment_mode == "member-bots":
         lines.append("- 모드: member-bots (각 멤버 봇이 자기 계정으로 댓글)")
-        if forum_kickoff_posted is True:
+        # Phase B canonical names (research_open_call_*) override the
+        # legacy forum_kickoff_* keys when both are present so the
+        # diagnostic always describes the latest writer's intent.
+        kickoff_posted = extra.get("research_open_call_posted")
+        kickoff_error = extra.get("research_open_call_error")
+        if kickoff_posted is None and forum_kickoff_posted is not None:
+            kickoff_posted = forum_kickoff_posted
+            kickoff_error = forum_kickoff_error
+        if kickoff_posted is True:
             lines.append("  · open-call directive: 게시 완료")
-        elif forum_kickoff_posted is False:
-            reason = forum_kickoff_error or "원인 미확인"
+        elif kickoff_posted is False:
+            reason = kickoff_error or "원인 미확인"
             lines.append(f"  · open-call directive: 게시 실패 — {reason}")
         # Always close with a pointer to where the actual role comments
         # land so the operator knows the gateway summary isn't where to
@@ -965,6 +996,27 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
         )
     elif forum_comment_mode == "gateway":
         lines.append("- 모드: gateway (역할별 댓글을 게이트웨이가 직접 게시)")
+
+    role_turns = extra.get("role_turns")
+    if isinstance(role_turns, Mapping) and role_turns:
+        # Phase B activity log — show each role that actually spoke (or
+        # tried to). Sorted by role name for stable diagnostic output.
+        lines.append("- 역할 활동 기록:")
+        for role_name in sorted(role_turns.keys()):
+            entry = role_turns.get(role_name)
+            if not isinstance(entry, Mapping):
+                continue
+            status = entry.get("status") or "?"
+            kind = entry.get("kind") or "?"
+            posted_at = entry.get("posted_at")
+            error = entry.get("error")
+            descriptor = f"{role_name}: {status} ({kind}"
+            if posted_at:
+                descriptor += f", {posted_at}"
+            descriptor += ")"
+            if error:
+                descriptor += f" — {error}"
+            lines.append(f"  · {descriptor}")
 
     if research_loop_report:
         report_error = None
@@ -998,11 +1050,62 @@ def format_status_diagnostic_response(session: Optional[Any]) -> str:
             last_short = last_short[:157] + "..."
         lines.append(f"- 마지막 진행 노트: {last_short}")
 
+    # Phase E: surface the structured diagnostic helper signals so the
+    # operator sees "왜 멈췄는지" without re-deriving the rules.
+    # ``primary_signal`` skips info-only signals so we never crowd the
+    # response with "research_pack 미수집" noise when the session is
+    # genuinely just at the start.
+    report = diagnose_session(session)
+    actionable = tuple(s for s in report.signals if s.severity != "info")
+    if actionable:
+        lines.append("")
+        lines.append("감지된 다음 단계:")
+        for signal in actionable:
+            tag = _STATUS_SEVERITY_TAGS.get(signal.severity, signal.severity)
+            lines.append(f"- {tag} {signal.title}")
+            if signal.detail:
+                detail = " ".join(str(signal.detail).split())
+                if len(detail) > 200:
+                    detail = detail[:197] + "..."
+                lines.append(f"  · 원인: {detail}")
+            if signal.propose:
+                propose = " ".join(str(signal.propose).split())
+                if len(propose) > 200:
+                    propose = propose[:197] + "..."
+                lines.append(f"  · 제안: {propose}")
+
+    if is_member_bot_question:
+        lines.append("")
+        lines.extend(render_member_bot_summary(report).splitlines())
+
     lines.append("")
     lines.append(
         "추가로 보고 싶은 항목(예: 출처 목록, role take 진행)을 알려 주시면 그 부분만 더 자세히 정리해 드릴게요."
     )
     return "\n".join(lines)
+
+
+_STATUS_SEVERITY_TAGS = {
+    "failed": "[FAILED]",
+    "blocked": "[BLOCKED]",
+    "stale": "[STALE]",
+    "info": "[INFO]",
+}
+
+
+_MEMBER_BOT_PHRASES = (
+    "멤버 봇",
+    "멤버봇",
+    "역할 봇",
+    "역할봇",
+    "member bot",
+    "member-bot",
+)
+
+
+def _asks_about_member_bots(message_text: str) -> bool:
+    normalized = _normalize(message_text)
+    return any(phrase in normalized for phrase in _MEMBER_BOT_PHRASES)
 
 
 def _format_clarification_question(message_text: str) -> str:

--- a/src/yule_orchestrator/discord/engineering_team_runtime.py
+++ b/src/yule_orchestrator/discord/engineering_team_runtime.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field, replace
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
+from datetime import datetime
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 from ..agents.deliberation import (
     DeliberationContext,
@@ -625,11 +626,33 @@ def _handle_research_open_call(
         research_pack=research_pack,
         previous_turns=(),
     )
-    message = (
-        f"{rendered}\n\n"
-        "자율 조사 메모: 이 댓글은 gateway가 정한 순번이 아니라, "
-        "해당 역할 봇이 공개 research 요청을 보고 독립적으로 제출한 take입니다."
+
+    # Phase B role-runtime MVP: prepend a runtime-shaped preface so the
+    # output meets the 5-section contract (이해한 작업 / 역할 관점의 판단
+    # / 참고한 자료 / 리스크 / 다음 행동). The deterministic deliberation
+    # render already covers 관점 / 근거 / 리스크 / 다음 행동, so the
+    # preface only adds the missing 'understood task' line plus the role
+    # policy short_name + memory filter so an operator can see which
+    # policy drove the take. Failures fall back to the deterministic
+    # render with the legacy memo footer — deterministic templates stay
+    # the safety net.
+    preface = _render_role_runtime_preface(
+        session=session,
+        role=role,
+        research_pack=research_pack,
     )
+    if preface:
+        message = (
+            f"{preface}\n\n{rendered}\n\n"
+            "자율 조사 메모: 이 댓글은 gateway가 정한 순번이 아니라, "
+            "해당 역할 봇이 공개 research 요청을 보고 독립적으로 제출한 take입니다."
+        )
+    else:
+        message = (
+            f"{rendered}\n\n"
+            "자율 조사 메모: 이 댓글은 gateway가 정한 순번이 아니라, "
+            "해당 역할 봇이 공개 research 요청을 보고 독립적으로 제출한 take입니다."
+        )
     return ResearchTurnOutcome(
         role=role,
         session_id=session_id,
@@ -637,6 +660,114 @@ def _handle_research_open_call(
         next_directive=None,
         is_synthesis=False,
     )
+
+
+def _render_role_runtime_preface(
+    *,
+    session: WorkflowSession,
+    role: str,
+    research_pack: Any,
+) -> Optional[str]:
+    """Build the runtime-shaped preface for the open-call comment.
+
+    Drives :func:`run_runtime_loop` with a :class:`RuntimeInput` carrying
+    the role policy so the policy is *visibly* part of the runtime
+    contract (tests can assert role policy presence in the input even
+    when the deterministic fallback fires). The returned text frames the
+    "이해한 작업" line plus a short policy stamp; the deterministic role
+    take rendered by :func:`deliberation_role_turn` follows immediately
+    afterwards and contributes 관점/근거/리스크/다음 행동.
+
+    Returns ``None`` when the runtime layer can't be imported or the
+    session has no usable prompt — in that case the caller falls back to
+    the legacy memo footer alone so the post still goes through.
+    """
+
+    try:
+        from ..agents.runtime import (
+            RuntimeInput,
+            role_policy_for,
+            run_runtime_loop,
+        )
+    except Exception:  # noqa: BLE001 - partial install fallback
+        return None
+
+    prompt = (getattr(session, "prompt", "") or "").strip()
+    if not prompt:
+        return None
+
+    role_id = _role_address(role)
+    policy = role_policy_for(role_id)
+    pack_title = ""
+    pack_summary = ""
+    if research_pack is not None:
+        pack_title = (getattr(research_pack, "title", "") or "").strip()
+        pack_summary = (getattr(research_pack, "summary", "") or "").strip()
+
+    runtime_input = RuntimeInput(
+        role_id=role_id,
+        message_text=prompt,
+        last_proposed_prompt=getattr(session, "prompt", None),
+        policy={
+            "role_policy": {
+                "short_name": policy.short_name,
+                "memory_role_filter": policy.memory_role_filter,
+                "preferred_source_kinds": list(policy.preferred_source_kinds),
+                "preferred_note_kinds": list(policy.preferred_note_kinds),
+                "description": policy.description,
+            },
+            "research_pack_title": pack_title or None,
+            "task_type": getattr(session, "task_type", None),
+        },
+    )
+    # Run the loop to confirm the runtime can produce a result; we only
+    # use the input/policy in the rendered preface for now, but the call
+    # exercises the contract end-to-end so future phases can swap the
+    # deterministic decide with an LLM-backed one without changing the
+    # member bot wiring.
+    try:
+        run_runtime_loop(runtime_input)
+    except Exception:  # noqa: BLE001 - runtime failure must not block the post
+        pass
+
+    understood = _summarize_open_call_prompt(prompt)
+    role_short = policy.short_name or role
+    lines = [
+        f"**[{role_short}] 역할 runtime 결과**",
+        f"- 이해한 작업: {understood}",
+    ]
+    perspective_bits: list[str] = []
+    if policy.description:
+        perspective_bits.append(policy.description)
+    if policy.memory_role_filter and policy.memory_role_filter != role_short:
+        perspective_bits.append(f"memory filter `{policy.memory_role_filter}`")
+    if perspective_bits:
+        lines.append(
+            "- 내 역할 관점의 판단 근거: " + " · ".join(perspective_bits)
+        )
+    if pack_title:
+        lines.append(f"- 참고한 research_pack: {pack_title}")
+    elif pack_summary:
+        # Title missing but summary present — still cite it so the
+        # operator can tell the bot did read the pack.
+        lines.append(
+            "- 참고한 research_pack: " + _truncate_one_line(pack_summary, 80)
+        )
+    return "\n".join(lines)
+
+
+def _summarize_open_call_prompt(prompt: str, *, limit: int = 120) -> str:
+    """Return a one-line summary of the user prompt for the runtime preface."""
+
+    cleaned = " ".join((prompt or "").split())
+    return _truncate_one_line(cleaned, limit)
+
+
+def _truncate_one_line(text: str, limit: int) -> str:
+    cleaned = (text or "").strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: max(1, limit - 1)].rstrip() + "…"
 
 
 def _collect_role_research_pack(*, session: WorkflowSession, role: str) -> Any:
@@ -720,6 +851,102 @@ def reset_handled_turns_for_tests() -> None:
 
     _HANDLED_TURNS.clear()
     _HANDLED_TURNS_SET.clear()
+
+
+# ---------------------------------------------------------------------------
+# Role-turn activity events (Phase B observability)
+# ---------------------------------------------------------------------------
+#
+# When a member bot reacts to a research-open / research-turn marker we
+# record a lightweight event under ``session.extra["role_turns"][<role>]``
+# so the gateway's diagnostic responder can describe which roles actually
+# spoke. The event shape is intentionally JSON-friendly so it survives
+# the cache round-trip without custom encoders.
+
+ROLE_TURN_STATUS_POSTED = "posted"
+ROLE_TURN_STATUS_ERROR = "error"
+ROLE_TURN_STATUS_SKIPPED = "skipped"
+
+ROLE_TURN_KIND_OPEN = "open"
+ROLE_TURN_KIND_TURN = "turn"
+ROLE_TURN_KIND_SYNTHESIS = "synthesis"
+
+
+def record_role_turn_event(
+    *,
+    session_id: str,
+    role: str,
+    kind: str,
+    status: str,
+    error: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> None:
+    """Append a role-turn event onto ``session.extra["role_turns"][role]``.
+
+    Best-effort: any exception (cache miss, write failure, malformed
+    session) is swallowed so a logging failure never blocks the Discord
+    post. The event carries:
+
+    - ``status`` — one of :data:`ROLE_TURN_STATUS_POSTED` /
+      :data:`ROLE_TURN_STATUS_ERROR` / :data:`ROLE_TURN_STATUS_SKIPPED`.
+    - ``kind`` — :data:`ROLE_TURN_KIND_OPEN` for open-call replies,
+      :data:`ROLE_TURN_KIND_TURN` for legacy chained turns,
+      :data:`ROLE_TURN_KIND_SYNTHESIS` for the tech-lead closing comment.
+    - ``posted_at`` — ISO-8601 timestamp the event was recorded at.
+    - ``error`` — stringified failure reason when ``status="error"``.
+    """
+
+    if not session_id or not role:
+        return
+    try:
+        from dataclasses import replace as _replace
+        from datetime import datetime as _dt
+        from ..agents.workflow_state import (
+            load_session as _load,
+            update_session as _update,
+        )
+    except Exception:  # noqa: BLE001 - partial install fallback
+        return
+    try:
+        session = _load(session_id)
+    except Exception:  # noqa: BLE001
+        return
+    if session is None:
+        return
+
+    occurred = (now or _dt.now().astimezone()).replace(microsecond=0)
+    event: Dict[str, Any] = {
+        "status": status,
+        "kind": kind,
+        "posted_at": occurred.isoformat(),
+    }
+    if error:
+        event["error"] = str(error)
+
+    extra = dict(getattr(session, "extra", None) or {})
+    role_turns = dict(extra.get("role_turns") or {})
+    short = role.split("/", 1)[-1].strip() or role
+    # Keep history-light: store only the latest event per role so the
+    # diagnostic surface stays compact. If callers ever need the full
+    # history they can read it from per-event records elsewhere.
+    role_turns[short] = event
+    extra["role_turns"] = role_turns
+
+    try:
+        updated = _replace(session, extra=extra)
+    except TypeError:
+        # Plain object stub — best-effort mutation.
+        try:
+            live = getattr(session, "extra", None)
+            if isinstance(live, dict):
+                live["role_turns"] = role_turns
+        except Exception:  # noqa: BLE001
+            pass
+        return
+    try:
+        _update(updated, now=occurred)
+    except Exception:  # noqa: BLE001 - never crash the bot from a record
+        pass
 
 
 def _load_synthesis_text_from_session_extra(session: WorkflowSession) -> Optional[str]:

--- a/src/yule_orchestrator/discord/member_bot.py
+++ b/src/yule_orchestrator/discord/member_bot.py
@@ -9,11 +9,17 @@ from ..agents.workflow_state import load_session, update_session
 from .config import DiscordBotConfig
 from .engineering_channel_router import EngineeringRouteContext
 from .engineering_team_runtime import (
+    ROLE_TURN_KIND_OPEN,
+    ROLE_TURN_KIND_SYNTHESIS,
+    ROLE_TURN_KIND_TURN,
+    ROLE_TURN_STATUS_ERROR,
+    ROLE_TURN_STATUS_POSTED,
     ResearchTurnOutcome,
     TeamTurnOutcome,
     handle_research_turn_message,
     handle_team_turn_message,
     mark_turn_played,
+    record_role_turn_event,
 )
 from .member_bots import GATEWAY_ROLE_KEY, MemberBotProfile
 from .research_forum import ResearchForumContext, chunk_for_discord_message
@@ -330,11 +336,62 @@ async def _post_research_turn(channel, outcome: ResearchTurnOutcome) -> None:
     the next role bot without the gateway impersonating anyone. Long
     takes get chunked the same way as ``_post_team_turn`` so a verbose
     take never trips Discord's per-message limit.
+
+    After the post lands, the bot records a role-turn event under
+    ``session.extra["role_turns"][<role>]`` so the gateway diagnostic
+    responder can describe which roles actually spoke. Persistence
+    failure is silenced (``record_role_turn_event`` swallows internally)
+    so a logging miss never blocks the Discord post.
     """
 
     body = outcome.message
-    for piece in chunk_for_discord_message(body) or (body,):
-        await channel.send(piece)
+    # Pull recorder-relevant fields defensively so the test/dev seams that
+    # pass a partial outcome (e.g. SimpleNamespace with only ``message``)
+    # still go through the chunk path. We only record an event when both
+    # session_id and role are present — otherwise the recorder has nothing
+    # to anchor against.
+    session_id = getattr(outcome, "session_id", None) or ""
+    role = getattr(outcome, "role", None) or ""
+    kind = _research_turn_event_kind(outcome)
+    try:
+        for piece in chunk_for_discord_message(body) or (body,):
+            await channel.send(piece)
+    except Exception as exc:  # noqa: BLE001 - record failure then re-raise
+        if session_id and role:
+            record_role_turn_event(
+                session_id=session_id,
+                role=role,
+                kind=kind,
+                status=ROLE_TURN_STATUS_ERROR,
+                error=str(exc),
+            )
+        raise
+    if session_id and role:
+        record_role_turn_event(
+            session_id=session_id,
+            role=role,
+            kind=kind,
+            status=ROLE_TURN_STATUS_POSTED,
+        )
+
+
+def _research_turn_event_kind(outcome: Any) -> str:
+    """Pick the role-turn event ``kind`` based on the outcome shape.
+
+    - ``synthesis`` for the closing tech-lead comment.
+    - ``open`` for open-call replies (no chained next directive).
+    - ``turn`` for legacy chained dispatch turns.
+
+    Tolerant of partial outcomes (``SimpleNamespace`` with only
+    ``message`` set, used by chunk-cap tests) — defaults to ``open`` in
+    that case so the chunk-cap test path still hits the chunker.
+    """
+
+    if getattr(outcome, "is_synthesis", False):
+        return ROLE_TURN_KIND_SYNTHESIS
+    if getattr(outcome, "next_directive", None) is None:
+        return ROLE_TURN_KIND_OPEN
+    return ROLE_TURN_KIND_TURN
 
 
 def _mark_team_turn_persisted(outcome: TeamTurnOutcome) -> None:

--- a/tests/discord/test_member_bots.py
+++ b/tests/discord/test_member_bots.py
@@ -405,5 +405,127 @@ class ReferencesBlockTestCase(unittest.TestCase):
         self.assertEqual(block.count("item-"), 3)
 
 
+# ---------------------------------------------------------------------------
+# Phase B — _post_research_turn records role activity events on session.extra
+# ---------------------------------------------------------------------------
+
+
+class PostResearchTurnRecordsRoleEventTestCase(unittest.TestCase):
+    """When the member bot posts a research-turn outcome, the post path
+    must record a role-turn event so the gateway diagnostic responder
+    can describe which roles actually spoke."""
+
+    def setUp(self) -> None:
+        try:
+            from tests._helpers import isolate_cache_for_test
+        except ImportError:  # pragma: no cover - bootstrap path
+            from _helpers import isolate_cache_for_test  # type: ignore
+
+        isolate_cache_for_test(self)
+
+        from datetime import datetime
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            save_session,
+        )
+
+        now = datetime(2026, 4, 30)
+        self._session = WorkflowSession(
+            session_id="sess-mb-evt",
+            prompt="hero 정리",
+            task_type="landing-page",
+            state=WorkflowState.APPROVED,
+            created_at=now,
+            updated_at=now,
+        )
+        save_session(self._session)
+
+    def _reload(self):
+        from yule_orchestrator.agents.workflow_state import load_session
+
+        return load_session("sess-mb-evt")
+
+    def _make_outcome(self, *, is_synthesis: bool = False, next_directive=None):
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            ResearchTurnOutcome,
+        )
+
+        return ResearchTurnOutcome(
+            role="ai-engineer",
+            session_id="sess-mb-evt",
+            message="**[ai-engineer]** ...take...",
+            next_directive=next_directive,
+            is_synthesis=is_synthesis,
+        )
+
+    def _fake_channel(self, *, raise_on_send: bool = False):
+        sent: list[str] = []
+
+        class _Channel:
+            async def send(self_inner, content):
+                if raise_on_send:
+                    raise RuntimeError("discord 5xx")
+                sent.append(content)
+
+        return _Channel(), sent
+
+    def test_open_call_post_records_posted_event(self) -> None:
+        import asyncio
+
+        from yule_orchestrator.discord.member_bot import _post_research_turn
+
+        channel, sent = self._fake_channel()
+        outcome = self._make_outcome()  # next_directive=None → kind=open
+        asyncio.run(_post_research_turn(channel, outcome))
+        self.assertTrue(sent)
+
+        role_turns = dict((self._reload().extra or {}).get("role_turns") or {})
+        self.assertIn("ai-engineer", role_turns)
+        event = role_turns["ai-engineer"]
+        self.assertEqual(event["status"], "posted")
+        self.assertEqual(event["kind"], "open")
+        self.assertIn("posted_at", event)
+
+    def test_synthesis_post_records_synthesis_kind(self) -> None:
+        import asyncio
+
+        from yule_orchestrator.discord.member_bot import _post_research_turn
+
+        channel, sent = self._fake_channel()
+        outcome = self._make_outcome(is_synthesis=True)
+        asyncio.run(_post_research_turn(channel, outcome))
+
+        role_turns = dict((self._reload().extra or {}).get("role_turns") or {})
+        self.assertEqual(role_turns["ai-engineer"]["kind"], "synthesis")
+
+    def test_chained_turn_post_records_turn_kind(self) -> None:
+        import asyncio
+
+        from yule_orchestrator.discord.member_bot import _post_research_turn
+
+        channel, sent = self._fake_channel()
+        outcome = self._make_outcome(next_directive="[research-turn:sess-mb-evt qa-engineer]")
+        asyncio.run(_post_research_turn(channel, outcome))
+
+        role_turns = dict((self._reload().extra or {}).get("role_turns") or {})
+        self.assertEqual(role_turns["ai-engineer"]["kind"], "turn")
+
+    def test_send_failure_records_error_and_re_raises(self) -> None:
+        import asyncio
+
+        from yule_orchestrator.discord.member_bot import _post_research_turn
+
+        channel, _ = self._fake_channel(raise_on_send=True)
+        outcome = self._make_outcome()
+        with self.assertRaises(RuntimeError):
+            asyncio.run(_post_research_turn(channel, outcome))
+
+        role_turns = dict((self._reload().extra or {}).get("role_turns") or {})
+        event = role_turns.get("ai-engineer") or {}
+        self.assertEqual(event.get("status"), "error")
+        self.assertIn("discord 5xx", event.get("error") or "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/discord/test_status_diagnostic.py
+++ b/tests/discord/test_status_diagnostic.py
@@ -182,6 +182,52 @@ class StatusDiagnosticResponseFormatterTests(unittest.TestCase):
         self.assertIn("research loop 오류", body)
         self.assertIn("forum starter", body)
 
+    def test_member_bots_mode_with_kickoff_posted(self) -> None:
+        # When the publisher set member-bots mode and the open-call
+        # directive landed cleanly, the diagnostic must say so and
+        # point operators to the forum thread for actual role comments.
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("모드: member-bots", body)
+        self.assertIn("open-call directive: 게시 완료", body)
+        self.assertIn("후속 댓글은 운영-리서치 thread", body)
+
+    def test_member_bots_mode_with_kickoff_failed_surfaces_reason(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": False,
+                "forum_kickoff_error": "rate limit 503",
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("모드: member-bots", body)
+        self.assertIn("open-call directive: 게시 실패", body)
+        self.assertIn("rate limit 503", body)
+
+    def test_gateway_mode_describes_gateway_comment_path(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "gateway",
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("모드: gateway", body)
+        # member-bots-only wording must not appear in gateway mode.
+        self.assertNotIn("open-call directive", body)
+        self.assertNotIn("멤버 봇이 자기 계정으로", body)
+
 
 class BuildResponseStatusQueryTests(unittest.TestCase):
     """End-to-end: status questions never set ready_to_intake and never

--- a/tests/discord/test_status_diagnostic.py
+++ b/tests/discord/test_status_diagnostic.py
@@ -228,6 +228,59 @@ class StatusDiagnosticResponseFormatterTests(unittest.TestCase):
         self.assertNotIn("open-call directive", body)
         self.assertNotIn("멤버 봇이 자기 계정으로", body)
 
+    def test_role_turns_section_lists_recorded_role_activity(self) -> None:
+        # Phase B: when member bots record their activity onto
+        # session.extra["role_turns"], the diagnostic responder must
+        # surface each role's status / kind / posted_at and any error.
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "research_open_call_posted": True,
+                "role_turns": {
+                    "ai-engineer": {
+                        "status": "posted",
+                        "kind": "open",
+                        "posted_at": "2026-05-06T10:00:00+09:00",
+                    },
+                    "qa-engineer": {
+                        "status": "error",
+                        "kind": "turn",
+                        "posted_at": "2026-05-06T10:01:00+09:00",
+                        "error": "discord 5xx",
+                    },
+                },
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("역할 활동 기록", body)
+        self.assertIn("ai-engineer", body)
+        self.assertIn("posted (open", body)
+        self.assertIn("qa-engineer", body)
+        self.assertIn("error (turn", body)
+        self.assertIn("discord 5xx", body)
+
+    def test_research_open_call_keys_take_precedence_over_legacy(self) -> None:
+        # Phase B canonical keys (research_open_call_*) must override
+        # the legacy forum_kickoff_* keys when both are present so the
+        # diagnostic always reflects the latest writer's intent.
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "research_open_call_posted": False,
+                "research_open_call_error": "rate limit 503",
+                # Legacy keys say "ok" — must be ignored.
+                "forum_kickoff_posted": True,
+                "forum_kickoff_error": None,
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("open-call directive: 게시 실패", body)
+        self.assertIn("rate limit 503", body)
+
 
 class BuildResponseStatusQueryTests(unittest.TestCase):
     """End-to-end: status questions never set ready_to_intake and never
@@ -355,6 +408,97 @@ class RouterStatusQueryShortCircuitTests(unittest.TestCase):
         # The conversation status answer was the only message sent.
         self.assertEqual(len(sent), 1)
         self.assertIn("운영-리서치 forum 게시 실패", sent[0])
+
+
+class MemberBotPhraseDetectionTests(unittest.TestCase):
+    """Phase E expansion — explicit "멤버 봇" questions must route to
+    the status diagnostic intent so the response can include the
+    member-bot summary block instead of falling through to intake."""
+
+    def test_korean_member_bot_phrasings_detected_as_status(self) -> None:
+        cases = (
+            "멤버 봇들은 뭐 하고 있어?",
+            "멤버봇 진행 상황 알려줘",
+            "역할 봇들 어떻게 됐어?",
+            "member bot 상태 확인",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                intent = detect_engineering_intent(text)
+                self.assertEqual(intent.intent_id, STATUS_DIAGNOSTIC, text)
+
+
+class DiagnosticSignalsAppearInResponseTests(unittest.TestCase):
+    """The format function must surface the structured signals so
+    the operator sees "왜 멈췄는지" without re-deriving the rules."""
+
+    def test_research_pack_without_open_call_appends_stale_signal(self) -> None:
+        session = _session(extra={"research_pack": {"title": "x"}})
+        body = format_status_diagnostic_response(session)
+        self.assertIn("감지된 다음 단계:", body)
+        self.assertIn("[STALE]", body)
+        self.assertIn("research_pack 있음", body)
+
+    def test_obsidian_pending_approval_renders_blocked_tag(self) -> None:
+        session = _session(
+            write_requested=True,
+            write_blocked_reason="작성 승인이 필요합니다",
+            extra={
+                "research_pack": {"title": "x"},
+                "research_synthesis": {"summary": "ok"},
+            },
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("[BLOCKED]", body)
+        self.assertIn("Obsidian write 승인 대기", body)
+        self.assertIn("yule engineer approve", body)
+
+    def test_obsidian_write_failed_renders_failed_tag(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_synthesis": {"summary": "ok"},
+                "obsidian_write_error": "Permission denied at /vault",
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertIn("[FAILED]", body)
+        self.assertIn("Obsidian write 실패", body)
+        self.assertIn("Permission denied", body)
+
+    def test_member_bot_question_appends_member_bot_summary(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+                "team_conversation": {"played_roles": ["tech-lead"]},
+            }
+        )
+        # Simulate the gateway reaching format with the flag on.
+        body = format_status_diagnostic_response(
+            session, is_member_bot_question=True
+        )
+        self.assertIn("멤버 봇 진행 상태", body)
+        self.assertIn("응답한 역할(1)", body)
+
+
+class StatusQueryNoMemberBotPathDoesNotLeakBlockTests(unittest.TestCase):
+    """Calling without the flag must NOT include the member-bot block —
+    keeps the regular '지금 뭐 하는 중?' answer compact."""
+
+    def test_default_call_omits_member_bot_block(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+            }
+        )
+        body = format_status_diagnostic_response(session)
+        self.assertNotIn("멤버 봇 진행 상태", body)
 
 
 if __name__ == "__main__":

--- a/tests/discord/test_supervisor_status.py
+++ b/tests/discord/test_supervisor_status.py
@@ -1,0 +1,170 @@
+"""Phase E tests — ``yule supervisor run --once`` runtime status.
+
+The supervisor must:
+
+- inspect every recent workflow session via the injected loader,
+- print stale/pending/blocked/failed signals from
+  :func:`session_status.diagnose_session`,
+- never auto-write/commit/push (Phase E is detect/report/propose only),
+- exit zero even when sessions are stuck — operators want a status
+  report, not a non-zero shell exit on stale work.
+
+Tests inject synthetic ``WorkflowSession`` objects so the run is fully
+network-free.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from datetime import datetime
+from typing import Any
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.workflow_state import WorkflowSession, WorkflowState
+from yule_orchestrator.cli.supervisor import (
+    render_session_block,
+    run_supervisor_run_once_command,
+)
+
+
+def _session(**overrides: Any) -> WorkflowSession:
+    base = dict(
+        session_id="sess-stale-1",
+        prompt="결제 모듈 멱등성 검증",
+        task_type="research",
+        state=WorkflowState.IN_PROGRESS,
+        created_at=datetime(2026, 5, 5, 10, 0),
+        updated_at=datetime(2026, 5, 6, 9, 0),
+    )
+    base.update(overrides)
+    return WorkflowSession(**base)
+
+
+class SupervisorRunOnceTests(unittest.TestCase):
+    def test_empty_loader_returns_zero_with_info_message(self) -> None:
+        out = io.StringIO()
+        rc = run_supervisor_run_once_command(
+            loader=lambda **_kw: (),
+            out_stream=out,
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("no workflow sessions", out.getvalue())
+
+    def test_loader_failure_returns_two(self) -> None:
+        def loader(**_kw: Any) -> Any:
+            raise RuntimeError("cache offline")
+
+        out = io.StringIO()
+        rc = run_supervisor_run_once_command(loader=loader, out_stream=out)
+        self.assertEqual(rc, 2)
+        self.assertIn("cache offline", out.getvalue())
+
+    def test_renders_each_session_block_with_signals(self) -> None:
+        sessions = (
+            # 1) research_pack but no forum thread — stale
+            _session(
+                session_id="sess-stale",
+                extra={"research_pack": {"title": "Stripe"}},
+            ),
+            # 2) Obsidian write failed — failed
+            _session(
+                session_id="sess-failed",
+                extra={
+                    "research_pack": {"title": "x"},
+                    "research_synthesis": {"summary": "ok"},
+                    "obsidian_write_error": "vault offline",
+                },
+            ),
+            # 3) pending Obsidian approval — blocked
+            _session(
+                session_id="sess-blocked",
+                write_requested=True,
+                write_blocked_reason="작성 승인 필요",
+                extra={"research_pack": {"title": "x"}},
+            ),
+        )
+        out = io.StringIO()
+        rc = run_supervisor_run_once_command(
+            loader=lambda **_kw: sessions,
+            out_stream=out,
+        )
+        self.assertEqual(rc, 0)
+        body = out.getvalue()
+        for sid in ("sess-stale", "sess-failed", "sess-blocked"):
+            self.assertIn(sid, body)
+        self.assertIn("[STALE]", body)
+        self.assertIn("[FAILED]", body)
+        self.assertIn("[BLOCKED]", body)
+        # Phase E guarantee — supervisor never claims to auto-execute.
+        self.assertIn("detect/report/propose only", body)
+        self.assertNotIn("auto-committed", body.lower())
+        self.assertNotIn("auto-pushed", body.lower())
+        self.assertNotIn("auto-merged", body.lower())
+
+    def test_only_actionable_filters_out_info_only_sessions(self) -> None:
+        sessions = (
+            # info-only: pack missing
+            _session(session_id="sess-info"),
+            # actionable: write failed
+            _session(
+                session_id="sess-failed",
+                extra={"obsidian_write_error": "vault offline"},
+            ),
+        )
+        out = io.StringIO()
+        rc = run_supervisor_run_once_command(
+            loader=lambda **_kw: sessions,
+            only_actionable=True,
+            out_stream=out,
+        )
+        self.assertEqual(rc, 0)
+        body = out.getvalue()
+        self.assertIn("sess-failed", body)
+        self.assertNotIn("sess-info", body)
+
+    def test_summary_line_counts_actionable_vs_info(self) -> None:
+        sessions = (
+            _session(session_id="info1"),
+            _session(
+                session_id="failed1",
+                extra={"obsidian_write_error": "x"},
+            ),
+        )
+        out = io.StringIO()
+        run_supervisor_run_once_command(
+            loader=lambda **_kw: sessions, out_stream=out
+        )
+        body = out.getvalue()
+        self.assertIn("summary: 1 actionable / 1 info-only", body)
+
+
+class RenderSessionBlockTests(unittest.TestCase):
+    def test_block_includes_pipeline_state_marks(self) -> None:
+        from yule_orchestrator.agents.session_status import diagnose_session
+
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 99,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+                "team_conversation": {"played_roles": ["tech-lead"]},
+            },
+            role_sequence=("tech-lead", "ai-engineer", "qa-engineer"),
+        )
+        report = diagnose_session(session)
+        lines = list(render_session_block(report, index=1))
+        joined = "\n".join(lines)
+        self.assertIn("research_pack=있음", joined)
+        self.assertIn("forum_thread=O", joined)
+        self.assertIn("played=1/3", joined)
+        self.assertIn("synthesis=X", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_decide.py
+++ b/tests/engineering/runtime/test_decide.py
@@ -1,0 +1,177 @@
+"""Phase 4A — runtime Decide stage tests.
+
+The deterministic mapping must be sticky enough that the router
+preflight in Phase 4B can rely on a single ``primary_action_id`` per
+intent + recall combination.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    ACTION_APPEND_CONTEXT,
+    ACTION_ASK_CLARIFICATION,
+    ACTION_CREATE_SESSION,
+    ACTION_JOIN_SESSION,
+    ACTION_REPLY,
+    INTENT_APPEND_CONTEXT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeResearchPlan,
+    SessionCandidate,
+)
+from yule_orchestrator.agents.runtime.decide import decide_default
+
+
+def _obs(text: str = "msg") -> RuntimeObservation:
+    return RuntimeObservation(role_id="gateway", message_text=text)
+
+
+def _input(text: str = "msg") -> RuntimeInput:
+    return RuntimeInput(role_id="gateway", message_text=text)
+
+
+def _recall_match(session_id: str = "abc", *, thread_id: int | None = None) -> RuntimeRecallResult:
+    return RuntimeRecallResult(
+        matched_session_id=session_id,
+        matched_thread_id=thread_id,
+        candidates=(SessionCandidate(session_id=session_id, score=0.7),),
+        confidence="high",
+        reason="match",
+    )
+
+
+def _recall_ambiguous() -> RuntimeRecallResult:
+    return RuntimeRecallResult(
+        candidates=(
+            SessionCandidate(session_id="a", title="A", score=0.4),
+            SessionCandidate(session_id="b", title="B", score=0.35),
+        ),
+        confidence="low",
+        reason="ambiguous",
+    )
+
+
+def _decide(intent_id: str, recall: RuntimeRecallResult | None = None):
+    return decide_default(
+        _obs(),
+        RuntimeIntent(intent_id=intent_id),
+        recall or RuntimeRecallResult(),
+        RuntimeResearchPlan(),
+        _input(),
+    )
+
+
+class StatusDiagnosticDecisionTests(unittest.TestCase):
+    def test_status_question_replies(self) -> None:
+        decision = _decide(INTENT_STATUS_QUESTION)
+        self.assertEqual(decision.actions[0].action_id, ACTION_REPLY)
+        self.assertEqual(decision.actions[0].payload["variant"], "status")
+
+    def test_diagnostic_question_replies(self) -> None:
+        decision = _decide(INTENT_DIAGNOSTIC_QUESTION)
+        self.assertEqual(decision.actions[0].action_id, ACTION_REPLY)
+        self.assertEqual(decision.actions[0].payload["variant"], "diagnostic")
+
+
+class JoinSessionDecisionTests(unittest.TestCase):
+    def test_continue_with_match_yields_join(self) -> None:
+        decision = _decide(INTENT_CONTINUE_EXISTING_WORK, _recall_match("s1", thread_id=99))
+        action = decision.actions[0]
+        self.assertEqual(action.action_id, ACTION_JOIN_SESSION)
+        self.assertEqual(action.payload["session_id"], "s1")
+        self.assertEqual(action.payload["thread_id"], 99)
+        self.assertEqual(action.payload["intent"], INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_summarize_with_match_yields_join(self) -> None:
+        decision = _decide(INTENT_SUMMARIZE_PREVIOUS_WORK, _recall_match("s2"))
+        self.assertEqual(decision.actions[0].action_id, ACTION_JOIN_SESSION)
+
+    def test_execute_with_match_yields_join(self) -> None:
+        decision = _decide(INTENT_EXECUTE_EXISTING_STEP, _recall_match("s3"))
+        self.assertEqual(decision.actions[0].action_id, ACTION_JOIN_SESSION)
+
+
+class AskClarificationDecisionTests(unittest.TestCase):
+    def test_continue_without_match_asks_clarification_with_candidates(self) -> None:
+        decision = _decide(INTENT_CONTINUE_EXISTING_WORK, _recall_ambiguous())
+        action = decision.actions[0]
+        self.assertEqual(action.action_id, ACTION_ASK_CLARIFICATION)
+        self.assertEqual(action.payload["intent"], INTENT_CONTINUE_EXISTING_WORK)
+        self.assertEqual(action.payload["reason"], "no_matched_session")
+        self.assertEqual(len(action.payload["candidates"]), 2)
+        self.assertEqual(action.payload["candidates"][0]["session_id"], "a")
+
+    def test_summarize_without_match_asks_clarification(self) -> None:
+        decision = _decide(INTENT_SUMMARIZE_PREVIOUS_WORK)
+        self.assertEqual(decision.actions[0].action_id, ACTION_ASK_CLARIFICATION)
+
+    def test_execute_without_match_asks_clarification(self) -> None:
+        decision = _decide(INTENT_EXECUTE_EXISTING_STEP)
+        self.assertEqual(decision.actions[0].action_id, ACTION_ASK_CLARIFICATION)
+
+    def test_clarification_needed_intent_yields_clarification(self) -> None:
+        decision = _decide(INTENT_CLARIFICATION_NEEDED)
+        self.assertEqual(decision.actions[0].action_id, ACTION_ASK_CLARIFICATION)
+
+
+class AppendContextDecisionTests(unittest.TestCase):
+    def test_append_with_match_yields_append(self) -> None:
+        decision = _decide(INTENT_APPEND_CONTEXT, _recall_match("s4"))
+        action = decision.actions[0]
+        self.assertEqual(action.action_id, ACTION_APPEND_CONTEXT)
+        self.assertEqual(action.payload["session_id"], "s4")
+
+    def test_append_without_match_asks_clarification(self) -> None:
+        decision = _decide(INTENT_APPEND_CONTEXT)
+        self.assertEqual(decision.actions[0].action_id, ACTION_ASK_CLARIFICATION)
+
+
+class NewWorkAndChatDecisionTests(unittest.TestCase):
+    def test_new_work_yields_create_session(self) -> None:
+        decision = _decide(INTENT_NEW_WORK_REQUEST)
+        action = decision.actions[0]
+        self.assertEqual(action.action_id, ACTION_CREATE_SESSION)
+        self.assertIn("prompt", action.payload)
+
+    def test_general_chat_yields_reply_chat(self) -> None:
+        decision = _decide(INTENT_GENERAL_CHAT)
+        action = decision.actions[0]
+        self.assertEqual(action.action_id, ACTION_REPLY)
+        self.assertEqual(action.payload["variant"], "chat")
+
+
+class DecisionInvariantsTests(unittest.TestCase):
+    def test_decision_preserves_intent_and_plan(self) -> None:
+        intent = RuntimeIntent(intent_id=INTENT_NEW_WORK_REQUEST, confidence="high")
+        plan = RuntimeResearchPlan(run=False, reason="not needed")
+        decision = decide_default(
+            _obs(),
+            intent,
+            RuntimeRecallResult(),
+            plan,
+            _input(),
+        )
+        self.assertIs(decision.intent, intent)
+        self.assertIs(decision.research_plan, plan)
+        self.assertGreaterEqual(len(decision.actions), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_loop.py
+++ b/tests/engineering/runtime/test_loop.py
@@ -1,0 +1,239 @@
+"""Phase 1 — runtime loop skeleton contract tests.
+
+The skeleton loop's contract is purely about ordering and stage
+isolation: every stage must be reachable, calls must happen in the
+documented order, mocks must be injectable, and a stage exception
+must not crash the whole run. The actual classifier / recall / decide
+logic comes in Phases 2–5.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    ACTION_NOOP,
+    ACTION_REPLY,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeRecord,
+    RuntimeResearchPlan,
+    run_runtime_loop,
+)
+
+
+def _input(message: str = "안녕", role: str = "gateway") -> RuntimeInput:
+    return RuntimeInput(role_id=role, message_text=message)
+
+
+class StageOrderingTests(unittest.TestCase):
+    def test_default_loop_visits_every_stage_in_order(self) -> None:
+        order: list[str] = []
+
+        def observe(_in):
+            order.append("observe")
+            return RuntimeObservation(role_id=_in.role_id, message_text=_in.message_text)
+
+        def understand(_obs, _in):
+            order.append("understand")
+            return RuntimeIntent(intent_id=INTENT_GENERAL_CHAT)
+
+        def recall(_obs, _intent, _in):
+            order.append("recall")
+            return RuntimeRecallResult()
+
+        def research(_obs, _intent, _recall, _in):
+            order.append("research")
+            return RuntimeResearchPlan()
+
+        def decide(_obs, intent, _recall, plan, _in):
+            order.append("decide")
+            return RuntimeDecision(
+                intent=intent,
+                research_plan=plan,
+                actions=(RuntimeAction(action_id=ACTION_NOOP),),
+            )
+
+        def act(decision, _in):
+            order.append("act")
+            return tuple(decision.actions)
+
+        def record(_result, _in):
+            order.append("record")
+            return (RuntimeRecord(kind="action_taken"),)
+
+        result = run_runtime_loop(
+            _input(),
+            observe_fn=observe,
+            understand_fn=understand,
+            recall_fn=recall,
+            research_fn=research,
+            decide_fn=decide,
+            act_fn=act,
+            record_fn=record,
+        )
+        self.assertEqual(
+            order,
+            ["observe", "understand", "recall", "research", "decide", "act", "record"],
+        )
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.records[0].kind, "action_taken")
+
+
+class StagePropagationTests(unittest.TestCase):
+    def test_observation_flows_into_understand(self) -> None:
+        captured: dict = {}
+
+        def observe(_in):
+            return RuntimeObservation(
+                role_id=_in.role_id,
+                message_text=_in.message_text,
+                normalized_text="custom",
+            )
+
+        def understand(obs, _in):
+            captured["observed_text"] = obs.normalized_text
+            return RuntimeIntent(intent_id=INTENT_NEW_WORK_REQUEST, confidence="high")
+
+        result = run_runtime_loop(
+            _input("hello"),
+            observe_fn=observe,
+            understand_fn=understand,
+        )
+        self.assertEqual(captured["observed_text"], "custom")
+        self.assertEqual(result.intent.intent_id, INTENT_NEW_WORK_REQUEST)
+        self.assertEqual(result.intent.confidence, "high")
+
+    def test_recall_sees_intent(self) -> None:
+        captured: dict = {}
+
+        def understand(_obs, _in):
+            return RuntimeIntent(intent_id=INTENT_STATUS_QUESTION)
+
+        def recall(_obs, intent, _in):
+            captured["intent_id"] = intent.intent_id
+            return RuntimeRecallResult(reason="seen")
+
+        result = run_runtime_loop(
+            _input("status?"),
+            understand_fn=understand,
+            recall_fn=recall,
+        )
+        self.assertEqual(captured["intent_id"], INTENT_STATUS_QUESTION)
+        self.assertEqual(result.recall.reason, "seen")
+
+    def test_decide_sees_research_plan(self) -> None:
+        captured: dict = {}
+
+        def research(_obs, _intent, _recall, _in):
+            return RuntimeResearchPlan(run=True, reason="needs-collection", max_provider_calls=4)
+
+        def decide(_obs, intent, _recall, plan, _in):
+            captured["plan_run"] = plan.run
+            captured["plan_max_calls"] = plan.max_provider_calls
+            return RuntimeDecision(
+                intent=intent,
+                research_plan=plan,
+                actions=(RuntimeAction(action_id=ACTION_NOOP),),
+            )
+
+        run_runtime_loop(
+            _input(),
+            research_fn=research,
+            decide_fn=decide,
+        )
+        self.assertTrue(captured["plan_run"])
+        self.assertEqual(captured["plan_max_calls"], 4)
+
+
+class DefaultStagesProduceSafeOutputTests(unittest.TestCase):
+    def test_default_stages_yield_general_chat_noop(self) -> None:
+        result = run_runtime_loop(_input("hello"))
+        self.assertEqual(result.intent.intent_id, INTENT_GENERAL_CHAT)
+        self.assertEqual(result.recall.candidates, ())
+        self.assertFalse(result.research_plan.run)
+        self.assertEqual(result.primary_action_id, ACTION_NOOP)
+        # Default record returns nothing — keeps things side-effect free.
+        self.assertEqual(result.records, ())
+        self.assertIsNone(result.error)
+
+    def test_default_observation_extracts_urls_and_normalizes(self) -> None:
+        result = run_runtime_loop(_input("Hello https://example.com/a    world"))
+        self.assertIn("https://example.com/a", result.observation.extracted_urls)
+        self.assertEqual(result.observation.normalized_text, "hello https://example.com/a world")
+
+
+class StageFailureIsCapturedTests(unittest.TestCase):
+    def test_understand_failure_falls_back_and_records_error(self) -> None:
+        def understand(_obs, _in):
+            raise RuntimeError("classifier exploded")
+
+        result = run_runtime_loop(_input(), understand_fn=understand)
+        # Loop continued and produced a deterministic fallback intent
+        # so Decide / Act always have something usable.
+        self.assertEqual(result.intent.intent_id, INTENT_GENERAL_CHAT)
+        self.assertIn("understand", result.error or "")
+        self.assertIn("classifier exploded", result.error or "")
+
+    def test_decide_failure_emits_safe_reply_action(self) -> None:
+        def decide(*_a, **_kw):
+            raise RuntimeError("decide blew up")
+
+        result = run_runtime_loop(_input(), decide_fn=decide)
+        self.assertEqual(result.primary_action_id, ACTION_REPLY)
+        self.assertIn("decide", result.error or "")
+
+    def test_observe_failure_short_circuits_with_error(self) -> None:
+        def observe(_in):
+            raise RuntimeError("observe down")
+
+        result = run_runtime_loop(_input(), observe_fn=observe)
+        self.assertIn("observe", result.error or "")
+        # The result is still safe to render — every field is filled.
+        self.assertEqual(result.observation.role_id, "gateway")
+
+    def test_record_failure_does_not_clobber_actions(self) -> None:
+        def act(decision, _in):
+            return tuple(decision.actions) or (RuntimeAction(action_id=ACTION_NOOP),)
+
+        def record(_result, _in):
+            raise RuntimeError("record down")
+
+        result = run_runtime_loop(_input(), act_fn=act, record_fn=record)
+        # Action survived even though record failed.
+        self.assertEqual(result.actions_taken[0].action_id, ACTION_NOOP)
+        self.assertEqual(result.records, ())
+        self.assertIn("record", result.error or "")
+
+
+class ActionPropagationTests(unittest.TestCase):
+    def test_act_can_override_decision_actions(self) -> None:
+        def decide(_obs, intent, _recall, plan, _in):
+            return RuntimeDecision(
+                intent=intent,
+                research_plan=plan,
+                actions=(RuntimeAction(action_id=ACTION_NOOP),),
+            )
+
+        def act(_decision, _in):
+            return (RuntimeAction(action_id=ACTION_REPLY, payload={"text": "안녕"}),)
+
+        result = run_runtime_loop(_input(), decide_fn=decide, act_fn=act)
+        self.assertEqual(result.primary_action_id, ACTION_REPLY)
+        self.assertEqual(result.actions_taken[0].payload["text"], "안녕")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_models.py
+++ b/tests/engineering/runtime/test_models.py
@@ -1,0 +1,233 @@
+"""Phase 1 — runtime data model contract tests.
+
+The runtime hands these dataclasses through every stage, so the
+defaults and invariants matter: every field should default to a value
+that's safe to render (no None where a tuple is expected, intents and
+actions stay in the documented vocabulary, etc.).
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    ACTION_NOOP,
+    ACTION_REPLY,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    KNOWN_ACTIONS,
+    KNOWN_INTENTS,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+    RuntimeRecallResult,
+    RuntimeRecord,
+    RuntimeResearchPlan,
+    RuntimeResult,
+    SessionCandidate,
+)
+
+
+class IntentVocabularyTests(unittest.TestCase):
+    def test_known_intents_include_all_required_categories(self) -> None:
+        # The phase-2 classifier promises these eight categories.
+        required = {
+            "new_work_request",
+            "continue_existing_work",
+            "summarize_previous_work",
+            "status_question",
+            "diagnostic_question",
+            "execute_existing_step",
+            "general_chat",
+            "clarification_needed",
+            "append_context",
+        }
+        self.assertTrue(required.issubset(set(KNOWN_INTENTS)))
+
+    def test_known_actions_include_all_required_categories(self) -> None:
+        required = {
+            "reply",
+            "ask_clarification",
+            "create_session",
+            "join_session",
+            "append_context",
+            "run_research",
+            "publish_forum",
+            "request_role_turn",
+            "record_memory",
+            "propose_approval",
+            "noop",
+        }
+        self.assertTrue(required.issubset(set(KNOWN_ACTIONS)))
+
+
+class RuntimeInputDefaultsTests(unittest.TestCase):
+    def test_required_fields_only(self) -> None:
+        item = RuntimeInput(role_id="gateway", message_text="hi")
+        self.assertEqual(item.role_id, "gateway")
+        self.assertEqual(item.message_text, "hi")
+        # Tuples / mappings default to empty so callers can iterate
+        # without ``or ()``.
+        self.assertEqual(tuple(item.attachments), ())
+        self.assertEqual(tuple(item.user_links), ())
+        self.assertEqual(tuple(item.mentions), ())
+        self.assertEqual(dict(item.policy), {})
+        self.assertIsNone(item.received_at)
+        self.assertIsNone(item.last_proposed_prompt)
+
+    def test_full_construction_round_trip(self) -> None:
+        now = datetime.now(timezone.utc)
+        item = RuntimeInput(
+            role_id="engineering-agent/tech-lead",
+            message_text="어제 작업 이어서",
+            channel_id=10,
+            thread_id=20,
+            author_id=30,
+            message_id=40,
+            attachments=("a",),
+            user_links=("https://example.test",),
+            mentions=(99,),
+            received_at=now,
+            last_proposed_prompt="이전 제안 텍스트",
+            policy={"role_focus": "tech-lead"},
+        )
+        self.assertEqual(item.policy["role_focus"], "tech-lead")
+        self.assertEqual(tuple(item.user_links), ("https://example.test",))
+
+
+class RuntimeObservationTests(unittest.TestCase):
+    def test_defaults_are_renderable(self) -> None:
+        obs = RuntimeObservation(role_id="r", message_text="x")
+        self.assertEqual(obs.normalized_text, "")
+        self.assertFalse(obs.has_attachments)
+        self.assertEqual(tuple(obs.extracted_urls), ())
+
+
+class RuntimeIntentTests(unittest.TestCase):
+    def test_intent_id_must_use_known_vocabulary_in_practice(self) -> None:
+        # The dataclass itself doesn't enforce the vocabulary (so future
+        # phases can extend), but every runtime intent we construct in
+        # production uses a known id. Pin that contract here so an
+        # accidental typo in another module fails loudly.
+        intent = RuntimeIntent(intent_id=INTENT_NEW_WORK_REQUEST)
+        self.assertIn(intent.intent_id, KNOWN_INTENTS)
+
+    def test_alt_intents_default_empty(self) -> None:
+        intent = RuntimeIntent(intent_id=INTENT_GENERAL_CHAT)
+        self.assertEqual(tuple(intent.alt_intents), ())
+        self.assertEqual(intent.confidence, "medium")
+
+
+class SessionCandidateTests(unittest.TestCase):
+    def test_minimal_construction(self) -> None:
+        cand = SessionCandidate(session_id="abc")
+        self.assertEqual(cand.session_id, "abc")
+        self.assertEqual(cand.score, 0.0)
+        self.assertEqual(dict(cand.extra), {})
+
+    def test_rich_construction(self) -> None:
+        cand = SessionCandidate(
+            session_id="abc",
+            title="Hermes intake",
+            score=0.7,
+            why="title overlap",
+            state="in_progress",
+            task_type="research",
+            thread_id=42,
+            forum_thread_id=4242,
+            has_research_pack=True,
+            has_synthesis=False,
+            extra={"updated_at": "2026-05-06"},
+        )
+        self.assertEqual(cand.score, 0.7)
+        self.assertTrue(cand.has_research_pack)
+        self.assertFalse(cand.has_synthesis)
+
+
+class RuntimeRecallResultTests(unittest.TestCase):
+    def test_defaults_are_safe(self) -> None:
+        result = RuntimeRecallResult()
+        self.assertIsNone(result.matched_session_id)
+        self.assertEqual(result.candidates, ())
+        self.assertEqual(result.memory_hits, ())
+        self.assertEqual(result.confidence, "low")
+
+
+class RuntimeResearchPlanTests(unittest.TestCase):
+    def test_default_does_not_run(self) -> None:
+        plan = RuntimeResearchPlan()
+        self.assertFalse(plan.run)
+        self.assertEqual(tuple(plan.providers), ())
+        self.assertEqual(plan.max_provider_calls, 0)
+
+
+class RuntimeActionTests(unittest.TestCase):
+    def test_default_payload_is_mutable_friendly(self) -> None:
+        action = RuntimeAction(action_id=ACTION_REPLY)
+        self.assertEqual(dict(action.payload), {})
+
+    def test_action_id_uses_known_vocabulary_in_practice(self) -> None:
+        for action_id in (ACTION_REPLY, ACTION_NOOP):
+            self.assertIn(action_id, KNOWN_ACTIONS)
+
+
+class RuntimeDecisionTests(unittest.TestCase):
+    def test_default_research_plan_is_inert(self) -> None:
+        decision = RuntimeDecision(intent=RuntimeIntent(intent_id=INTENT_GENERAL_CHAT))
+        self.assertFalse(decision.research_plan.run)
+        self.assertEqual(decision.actions, ())
+
+
+class RuntimeRecordTests(unittest.TestCase):
+    def test_kind_required(self) -> None:
+        record = RuntimeRecord(kind="intent_detected")
+        self.assertEqual(record.kind, "intent_detected")
+        self.assertEqual(dict(record.data), {})
+
+
+class RuntimeResultPrimaryActionTests(unittest.TestCase):
+    def _bare_result(
+        self,
+        *,
+        actions_taken: tuple = (),
+        decision_actions: tuple = (),
+    ) -> RuntimeResult:
+        intent = RuntimeIntent(intent_id=INTENT_GENERAL_CHAT)
+        return RuntimeResult(
+            role_id="gateway",
+            observation=RuntimeObservation(role_id="gateway", message_text=""),
+            intent=intent,
+            recall=RuntimeRecallResult(),
+            research_plan=RuntimeResearchPlan(),
+            decision=RuntimeDecision(intent=intent, actions=decision_actions),
+            actions_taken=actions_taken,
+        )
+
+    def test_primary_action_id_prefers_actions_taken(self) -> None:
+        result = self._bare_result(
+            actions_taken=(RuntimeAction(action_id=ACTION_REPLY),),
+            decision_actions=(RuntimeAction(action_id=ACTION_NOOP),),
+        )
+        self.assertEqual(result.primary_action_id, ACTION_REPLY)
+
+    def test_primary_action_id_falls_back_to_decision(self) -> None:
+        result = self._bare_result(
+            decision_actions=(RuntimeAction(action_id=ACTION_NOOP),),
+        )
+        self.assertEqual(result.primary_action_id, ACTION_NOOP)
+
+    def test_primary_action_id_none_when_empty(self) -> None:
+        result = self._bare_result()
+        self.assertIsNone(result.primary_action_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_policies.py
+++ b/tests/engineering/runtime/test_policies.py
@@ -1,0 +1,68 @@
+"""Phase 3B — role policy registry tests."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime.policies import (
+    RolePolicy,
+    all_role_policies,
+    role_policy_for,
+)
+
+
+class RolePolicyLookupTests(unittest.TestCase):
+    def test_gateway_policy_has_no_memory_role_filter(self) -> None:
+        policy = role_policy_for("gateway")
+        self.assertEqual(policy.short_name, "gateway")
+        self.assertIsNone(policy.memory_role_filter)
+
+    def test_full_role_id_resolves(self) -> None:
+        policy = role_policy_for("engineering-agent/tech-lead")
+        self.assertEqual(policy.short_name, "tech-lead")
+        self.assertEqual(policy.memory_role_filter, "tech-lead")
+
+    def test_short_role_id_resolves_to_engineering_agent(self) -> None:
+        policy = role_policy_for("backend-engineer")
+        self.assertEqual(policy.short_name, "backend-engineer")
+        self.assertEqual(policy.memory_role_filter, "backend-engineer")
+
+    def test_unknown_role_falls_back_to_default(self) -> None:
+        policy = role_policy_for("ops-foo")
+        self.assertEqual(policy.short_name, "default")
+        self.assertIsNone(policy.memory_role_filter)
+
+    def test_blank_role_returns_default(self) -> None:
+        policy = role_policy_for("")
+        self.assertEqual(policy.short_name, "default")
+
+    def test_all_policies_lists_eight(self) -> None:
+        # gateway + 7 engineering-agent member roles.
+        self.assertEqual(len(all_role_policies()), 8)
+        names = {p.short_name for p in all_role_policies()}
+        self.assertEqual(
+            names,
+            {
+                "gateway",
+                "tech-lead",
+                "ai-engineer",
+                "backend-engineer",
+                "frontend-engineer",
+                "product-designer",
+                "qa-engineer",
+                "devops-engineer",
+            },
+        )
+
+    def test_each_policy_has_description(self) -> None:
+        for policy in all_role_policies():
+            self.assertGreater(len(policy.description), 0, policy.short_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_recall.py
+++ b/tests/engineering/runtime/test_recall.py
@@ -1,0 +1,321 @@
+"""Phase 3 — runtime Recall stage: session candidate lookup.
+
+Recall translates "어제/방금/그 작업" / "헤르메스 작업" / arbitrary
+back-references into actual workflow session candidates. The tests
+here use fake session objects (no DB / no IO) so the rules stay
+pinned exactly: thread anchor wins, named project beats vague
+recency, ambiguous candidates do NOT auto-attach, no open sessions
+yields a safe empty result.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+)
+from yule_orchestrator.agents.runtime.recall import (
+    AMBIGUITY_MARGIN,
+    SCORE_HIGH,
+    make_recall_fn,
+)
+
+
+@dataclass
+class FakeSession:
+    session_id: str
+    prompt: str = ""
+    task_type: str = "unknown"
+    state: str = "in_progress"
+    summary: Optional[str] = None
+    channel_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    updated_at: Optional[datetime] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _now(offset_minutes: int = 0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+def _obs(text: str) -> RuntimeObservation:
+    return RuntimeObservation(
+        role_id="gateway",
+        message_text=text,
+        normalized_text=" ".join(text.lower().split()),
+    )
+
+
+def _input(text: str, *, channel_id=None, thread_id=None) -> RuntimeInput:
+    return RuntimeInput(
+        role_id="gateway",
+        message_text=text,
+        channel_id=channel_id,
+        thread_id=thread_id,
+    )
+
+
+class NoOpenSessionsTests(unittest.TestCase):
+    def test_returns_safe_empty_result_when_no_sessions(self) -> None:
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: [])
+        result = recall(
+            _obs("어제 작업 이어서 요약해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("어제 작업 이어서 요약해줘"),
+        )
+        self.assertEqual(result.candidates, ())
+        self.assertEqual(result.confidence, "low")
+        self.assertIsNone(result.matched_session_id)
+
+
+class NamedProjectTokenMatchTests(unittest.TestCase):
+    def test_hermes_matches_session_with_hermes_in_pack_title(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="ab12",
+                prompt="결제 모듈 멱등성 검토",
+                updated_at=_now(-90),
+            ),
+            FakeSession(
+                session_id="cd34",
+                prompt="헤르메스 RAG 구조 설계 작업",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "헤르메스 학습 루프"}},
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("헤르메스 작업 이어서 가자"),
+            RuntimeIntent(intent_id=INTENT_CONTINUE_EXISTING_WORK),
+            _input("헤르메스 작업 이어서 가자"),
+        )
+        self.assertEqual(result.matched_session_id, "cd34")
+        self.assertEqual(result.confidence, "high")
+        self.assertEqual(result.candidates[0].session_id, "cd34")
+
+    def test_named_project_does_not_match_unrelated_sessions(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="x",
+                prompt="결제 모듈 멱등성 검토",
+                updated_at=_now(-30),
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("헤르메스 작업 이어서 가자"),
+            RuntimeIntent(intent_id=INTENT_CONTINUE_EXISTING_WORK),
+            _input("헤르메스 작업 이어서 가자"),
+        )
+        self.assertIsNone(result.matched_session_id)
+
+
+class RecencyFallbackTests(unittest.TestCase):
+    def test_yesterday_falls_back_to_latest_open_session(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="old",
+                prompt="결제 모듈 멱등성 검토",
+                updated_at=_now(-1440),
+            ),
+            FakeSession(
+                session_id="new",
+                prompt="onboarding flow 검토",
+                updated_at=_now(-30),
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("어제 작업 이어서 요약해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("어제 작업 이어서 요약해줘"),
+        )
+        self.assertEqual(result.matched_session_id, "new")
+        self.assertEqual(result.confidence, "medium")
+
+    def test_no_recency_cue_no_token_match_yields_no_attachment(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="x",
+                prompt="결제 모듈 멱등성 검토",
+                updated_at=_now(-30),
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        # No "어제/방금" cue and no token overlap with the prompt.
+        result = recall(
+            _obs("Obsidian에 정리해줘"),
+            RuntimeIntent(intent_id=INTENT_EXECUTE_EXISTING_STEP),
+            _input("Obsidian에 정리해줘"),
+        )
+        self.assertIsNone(result.matched_session_id)
+        self.assertEqual(result.confidence, "low")
+
+
+class AmbiguityTests(unittest.TestCase):
+    def test_two_similar_sessions_do_not_auto_attach(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="a",
+                prompt="hermes 학습 루프 구조 설계",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+            FakeSession(
+                session_id="b",
+                prompt="hermes 학습 루프 구조 검증",
+                updated_at=_now(-60),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("hermes 학습 루프 구조 어떻게 됐어?"),
+            RuntimeIntent(intent_id=INTENT_STATUS_QUESTION),
+            _input("hermes 학습 루프 구조 어떻게 됐어?"),
+        )
+        # Either both candidates surface and we don't pick (margin too
+        # small) or one wins clearly — but never silently auto-create.
+        if result.matched_session_id is not None:
+            top = result.candidates[0]
+            runner_up = result.candidates[1]
+            self.assertGreaterEqual(top.score - runner_up.score, AMBIGUITY_MARGIN)
+        self.assertGreaterEqual(len(result.candidates), 2)
+
+
+class ThreadAnchorTests(unittest.TestCase):
+    def test_thread_id_anchor_wins_over_token_score(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="thread-bound",
+                prompt="다른 주제 자료",
+                thread_id=4242,
+                updated_at=_now(-5),
+            ),
+            FakeSession(
+                session_id="token-match",
+                prompt="hermes 학습 루프",
+                updated_at=_now(-1),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("hermes 학습 루프 어디까지 됐어?"),
+            RuntimeIntent(intent_id=INTENT_STATUS_QUESTION),
+            _input("hermes 학습 루프 어디까지 됐어?", thread_id=4242),
+        )
+        self.assertEqual(result.matched_session_id, "thread-bound")
+        self.assertEqual(result.confidence, "high")
+
+
+class NewWorkRequestTests(unittest.TestCase):
+    def test_new_work_does_not_auto_attach_even_with_anchor(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="thread-bound",
+                prompt="다른 작업",
+                thread_id=4242,
+                updated_at=_now(-5),
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("새 작업으로 진행"),
+            RuntimeIntent(intent_id=INTENT_NEW_WORK_REQUEST),
+            _input("새 작업으로 진행", thread_id=4242),
+        )
+        self.assertIsNone(result.matched_session_id)
+        # Anchor session is still surfaced so Decide can warn.
+        self.assertEqual(result.candidates[0].session_id, "thread-bound")
+
+
+class CompletedSessionsAreSkippedTests(unittest.TestCase):
+    def test_completed_session_does_not_match(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="done",
+                prompt="hermes 학습 루프",
+                state="completed",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "hermes"}},
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("헤르메스 작업 정리해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("헤르메스 작업 정리해줘"),
+        )
+        self.assertIsNone(result.matched_session_id)
+
+
+class CandidateDataShapeTests(unittest.TestCase):
+    def test_candidate_carries_pack_and_synthesis_flags(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="abc",
+                prompt="hermes 학습 루프 구조",
+                state="in_progress",
+                thread_id=99,
+                updated_at=_now(-5),
+                extra={
+                    "research_pack": {"title": "hermes 학습 루프"},
+                    "research_synthesis": {"consensus": "안정화된 안"},
+                    "research_forum_thread_id": 555,
+                },
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("hermes 학습 루프 구조 정리해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("hermes 학습 루프 구조 정리해줘"),
+        )
+        self.assertEqual(result.matched_session_id, "abc")
+        self.assertEqual(result.matched_forum_thread_id, 555)
+        self.assertEqual(result.matched_thread_id, 99)
+        cand = result.candidates[0]
+        self.assertTrue(cand.has_research_pack)
+        self.assertTrue(cand.has_synthesis)
+        self.assertEqual(cand.title, "hermes 학습 루프")
+
+
+class AppendContextRecallTests(unittest.TestCase):
+    def test_append_context_uses_token_match_against_existing(self) -> None:
+        sessions = [
+            FakeSession(
+                session_id="abc",
+                prompt="hermes 학습 루프 구조 설계",
+                updated_at=_now(-5),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+        ]
+        recall = make_recall_fn(list_sessions_fn=lambda **_kw: sessions)
+        result = recall(
+            _obs("이 자료만 hermes 학습 루프에 참고로 붙여줘"),
+            RuntimeIntent(intent_id=INTENT_APPEND_CONTEXT),
+            _input("이 자료만 hermes 학습 루프에 참고로 붙여줘"),
+        )
+        self.assertEqual(result.matched_session_id, "abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_recall_memory.py
+++ b/tests/engineering/runtime/test_recall_memory.py
@@ -1,0 +1,179 @@
+"""Phase 3B — Recall stage with memory_search_fn wired in.
+
+The runtime treats memory hits as a parallel signal: even when there's
+no session match the role policy still runs a role-shaped search and
+attaches the hits so the gateway can surface citations. Errors in the
+memory adapter must never propagate.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+)
+from yule_orchestrator.agents.runtime.recall import make_recall_fn
+
+
+@dataclass
+class FakeSession:
+    session_id: str
+    prompt: str = ""
+    task_type: str = "unknown"
+    state: str = "in_progress"
+    summary: Optional[str] = None
+    channel_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    updated_at: Optional[datetime] = None
+    extra: Mapping[str, Any] = lambda: {}  # type: ignore[assignment]
+
+
+def _now(offset_minutes: int = 0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+def _obs(text: str) -> RuntimeObservation:
+    return RuntimeObservation(
+        role_id="engineering-agent/backend-engineer",
+        message_text=text,
+        normalized_text=" ".join(text.lower().split()),
+    )
+
+
+def _input(text: str, role: str = "engineering-agent/backend-engineer") -> RuntimeInput:
+    return RuntimeInput(role_id=role, message_text=text)
+
+
+class MemorySearchInjectionTests(unittest.TestCase):
+    def test_memory_search_fn_called_with_role_filter(self) -> None:
+        captured: dict = {}
+
+        def fake_search(query, **kwargs):
+            captured["query"] = query
+            captured["kwargs"] = kwargs
+            return [{"doc_id": "abc", "title": "queue ack design"}]
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=fake_search,
+        )
+        result = recall(
+            _obs("hermes 학습 루프 정리해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("hermes 학습 루프 정리해줘"),
+        )
+        self.assertEqual(captured["query"], "hermes 학습 루프 정리해줘")
+        # backend-engineer's memory_role_filter is "backend-engineer".
+        self.assertEqual(captured["kwargs"]["role"], "backend-engineer")
+        # And one memory hit landed on the result.
+        self.assertEqual(len(result.memory_hits), 1)
+        self.assertEqual(result.memory_hits[0]["doc_id"], "abc")
+
+    def test_memory_search_failure_is_swallowed(self) -> None:
+        def explosive(query, **_kw):
+            raise RuntimeError("index offline")
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=explosive,
+        )
+        result = recall(
+            _obs("hermes 학습 루프 정리해줘"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("hermes 학습 루프 정리해줘"),
+        )
+        # No hits, but no exception — recall returned its base result.
+        self.assertEqual(result.memory_hits, ())
+        self.assertEqual(result.confidence, "low")
+
+    def test_simple_search_fn_without_kwargs_still_works(self) -> None:
+        def simple_search(query):
+            return [{"doc_id": "x", "title": "fallback"}]
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=simple_search,
+        )
+        result = recall(
+            _obs("hermes 학습 루프"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("hermes 학습 루프"),
+        )
+        self.assertEqual(len(result.memory_hits), 1)
+        self.assertEqual(result.memory_hits[0]["doc_id"], "x")
+
+    def test_gateway_role_passes_no_role_filter(self) -> None:
+        captured: dict = {}
+
+        def fake_search(query, **kwargs):
+            captured["kwargs"] = kwargs
+            return []
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=fake_search,
+        )
+        recall(
+            _obs("hermes 학습 루프"),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input("hermes 학습 루프", role="gateway"),
+        )
+        # Gateway policy has memory_role_filter=None, which we forward
+        # so the search adapter keeps the role unfiltered.
+        self.assertIsNone(captured["kwargs"]["role"])
+
+    def test_empty_message_skips_memory_search(self) -> None:
+        called: dict[str, int] = {"n": 0}
+
+        def fake_search(query, **kwargs):
+            called["n"] += 1
+            return []
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=fake_search,
+        )
+        recall(
+            _obs(""),
+            RuntimeIntent(intent_id=INTENT_SUMMARIZE_PREVIOUS_WORK),
+            _input(""),
+        )
+        self.assertEqual(called["n"], 0)
+
+    def test_new_work_intent_still_runs_memory_search(self) -> None:
+        captured: dict = {}
+
+        def fake_search(query, **kwargs):
+            captured["query"] = query
+            return [{"doc_id": "ref", "title": "prior reference"}]
+
+        recall = make_recall_fn(
+            list_sessions_fn=lambda **_kw: [],
+            memory_search_fn=fake_search,
+        )
+        result = recall(
+            _obs("결제 모듈 멱등성 구현해줘"),
+            RuntimeIntent(intent_id=INTENT_NEW_WORK_REQUEST),
+            _input("결제 모듈 멱등성 구현해줘"),
+        )
+        # Even on new-work the memory search still gives the runtime
+        # something to cite — Decide will choose whether to use it.
+        self.assertEqual(captured["query"], "결제 모듈 멱등성 구현해줘")
+        self.assertEqual(len(result.memory_hits), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_understand.py
+++ b/tests/engineering/runtime/test_understand.py
@@ -131,6 +131,61 @@ class ContinueExistingWorkTests(unittest.TestCase):
         self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
 
 
+class ForceContinuePhraseTests(unittest.TestCase):
+    """Phase A: explicit continuation phrases that historically were
+    misclassified as new_work_request because they only contain
+    confirm-shaped text + a back-reference noun (no continue verb)."""
+
+    def test_existing_session_progress_phrase(self) -> None:
+        intent = _classify("기존 세션으로 진행")
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+        self.assertEqual(intent.confidence, "high")
+
+    def test_existing_work_progress_phrase(self) -> None:
+        intent = _classify("기존 작업으로 진행")
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_existing_session_continue_phrase(self) -> None:
+        intent = _classify("기존 세션으로 이어가자")
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_in_this_thread_phrase(self) -> None:
+        for text in (
+            "이 thread에서 이어가자",
+            "이 thread로 진행",
+            "이 스레드에서 진행",
+            "여기서 진행해줘",
+            "여기서 이어가자",
+        ):
+            with self.subTest(text=text):
+                intent = _classify(text)
+                self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_force_new_work_still_wins_over_continue(self) -> None:
+        # Even with "기존" present, an explicit "새 작업으로 진행" must
+        # remain a brand-new session — force-new is checked first.
+        intent = _classify("기존 작업이랑 비슷하지만 새 작업으로 진행")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+
+class ExpandedExecuteStepTests(unittest.TestCase):
+    def test_research_forum_directive(self) -> None:
+        intent = _classify("운영-리서치에 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+    def test_research_forum_directive_no_dash(self) -> None:
+        intent = _classify("운영 리서치에 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+    def test_session_scoped_summary(self) -> None:
+        intent = _classify("이 세션 기준으로 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+    def test_thread_scoped_summary(self) -> None:
+        intent = _classify("이 스레드 기준으로 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+
 class ExecuteExistingStepTests(unittest.TestCase):
     def test_obsidian_export_request(self) -> None:
         intent = _classify("이건 Obsidian에 정리해줘")

--- a/tests/engineering/runtime/test_understand.py
+++ b/tests/engineering/runtime/test_understand.py
@@ -1,0 +1,249 @@
+"""Phase 2 — runtime intent classifier tests.
+
+The deterministic classifier is the only thing standing between the
+gateway and ``auto_collect=True`` for every Discord message. Pin every
+required phrasing here so a regression that re-promotes "어제 작업
+이어서 요약해줘" to a brand-new task fails loudly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CLARIFICATION_NEEDED,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_GENERAL_CHAT,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    RuntimeIntent,
+    RuntimeObservation,
+)
+from yule_orchestrator.agents.runtime.understand import (
+    classify_intent_deterministic,
+    make_understand_fn,
+)
+
+
+def _classify(text: str, *, last_proposed: str | None = None, role: str = "gateway") -> RuntimeIntent:
+    obs = RuntimeObservation(
+        role_id=role,
+        message_text=text,
+        normalized_text=" ".join(text.lower().split()),
+    )
+    inp = RuntimeInput(
+        role_id=role,
+        message_text=text,
+        last_proposed_prompt=last_proposed,
+    )
+    return classify_intent_deterministic(obs, inp)
+
+
+class ExplicitNewWorkOverrideTests(unittest.TestCase):
+    def test_force_new_work_phrase_is_new_work_request(self) -> None:
+        intent = _classify("새 작업으로 진행")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+        self.assertEqual(intent.confidence, "high")
+
+    def test_force_new_work_overrides_backreference(self) -> None:
+        # Even with "어제" present, an explicit "새 작업으로 시작" must win.
+        intent = _classify("어제 작업이랑 비슷하지만 새 작업으로 시작해줘")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+
+class StatusAndDiagnosticTests(unittest.TestCase):
+    def test_status_phrases(self) -> None:
+        cases = (
+            "지금 뭐 하는 중이야?",
+            "현재 상태 알려줘",
+            "진행상황 좀",
+            "어디까지 갔어?",
+            "어떻게 됐어?",
+            "status check please",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                intent = _classify(text)
+                self.assertEqual(intent.intent_id, INTENT_STATUS_QUESTION, text)
+
+    def test_diagnostic_phrases(self) -> None:
+        cases = (
+            "운영 리서치는 안 열어?",
+            "왜 안 됐어?",
+            "리서치 왜 실패했어?",
+            "옵시디언 왜 안 들어갔어?",
+            "왜 멈췄어",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                intent = _classify(text)
+                self.assertEqual(intent.intent_id, INTENT_DIAGNOSTIC_QUESTION, text)
+
+
+class SummarizePreviousWorkTests(unittest.TestCase):
+    def test_yesterday_continue_summarize(self) -> None:
+        intent = _classify("어제 작업 이어서 요약해줘")
+        self.assertEqual(intent.intent_id, INTENT_SUMMARIZE_PREVIOUS_WORK)
+
+    def test_named_project_summary(self) -> None:
+        intent = _classify("헤르메스 작업 어디까지 했는지 정리해줘")
+        # "어디까지 했는지" hits the status pattern first which is fine —
+        # status responder will still surface the existing session. The
+        # follow-up "정리해줘" alone (no status verb) is the pure
+        # summarize variant covered below.
+        self.assertIn(
+            intent.intent_id,
+            {INTENT_SUMMARIZE_PREVIOUS_WORK, INTENT_STATUS_QUESTION},
+        )
+
+    def test_pure_summarize_named_project(self) -> None:
+        intent = _classify("헤르메스 작업 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_SUMMARIZE_PREVIOUS_WORK)
+
+    def test_recap_english(self) -> None:
+        intent = _classify("recap of yesterday's task please")
+        self.assertEqual(intent.intent_id, INTENT_SUMMARIZE_PREVIOUS_WORK)
+
+
+class ContinueExistingWorkTests(unittest.TestCase):
+    def test_named_project_continue(self) -> None:
+        intent = _classify("헤르메스 작업 이어서 가자")
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_backreference_continue(self) -> None:
+        intent = _classify("어제 작업 이어서 진행하자")
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_named_project_without_continue_verb_falls_through(self) -> None:
+        intent = _classify("헤르메스 검토 다시 보자")
+        # Named project + work noun should still route to continue, not
+        # be promoted to a fresh new_work_request.
+        self.assertEqual(intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+
+class ExecuteExistingStepTests(unittest.TestCase):
+    def test_obsidian_export_request(self) -> None:
+        intent = _classify("이건 Obsidian에 정리해줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+    def test_meeting_record_summary(self) -> None:
+        intent = _classify("토의 기록 정리해서 남겨줘")
+        self.assertEqual(intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+
+class AppendContextTests(unittest.TestCase):
+    def test_append_context_phrase(self) -> None:
+        intent = _classify(
+            "이 자료만 기존 작업에 참고로 붙여줘 https://example.test/a"
+        )
+        self.assertEqual(intent.intent_id, INTENT_APPEND_CONTEXT)
+
+
+class ConfirmationTests(unittest.TestCase):
+    def test_standalone_ok_with_pending_proposal(self) -> None:
+        intent = _classify("ok", last_proposed="결제 모듈 리팩터링 1차 안")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+    def test_standalone_ok_without_pending_proposal(self) -> None:
+        intent = _classify("ok")
+        self.assertEqual(intent.intent_id, INTENT_CLARIFICATION_NEEDED)
+
+    def test_phrase_confirm_with_pending_proposal(self) -> None:
+        intent = _classify("이대로 진행", last_proposed="제안 텍스트")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+        self.assertEqual(intent.confidence, "high")
+
+    def test_phrase_confirm_without_pending_proposal_is_medium(self) -> None:
+        intent = _classify("이대로 진행")
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+        self.assertEqual(intent.confidence, "medium")
+
+
+class NewWorkRequestDefaultTests(unittest.TestCase):
+    def test_typical_implementation_request(self) -> None:
+        intent = _classify(
+            "Stripe pricing 페이지 hero copy 정리하는 프론트엔드 작업 만들어줘"
+        )
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+    def test_followup_step_does_not_become_new_work(self) -> None:
+        # Common regression: gateway promoted "Obsidian에 저장해줘"
+        # to a new task when it should reuse the existing session.
+        intent = _classify("Obsidian에 저장해줘")
+        self.assertNotEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+
+class VagueAndPleasantryTests(unittest.TestCase):
+    def test_empty_message_is_clarification(self) -> None:
+        intent = _classify("")
+        self.assertEqual(intent.intent_id, INTENT_CLARIFICATION_NEEDED)
+
+    def test_too_short_is_clarification(self) -> None:
+        intent = _classify("뭐")
+        self.assertEqual(intent.intent_id, INTENT_CLARIFICATION_NEEDED)
+
+    def test_pleasantry_is_general_chat(self) -> None:
+        intent = _classify("안녕하세요")
+        # 4-token rule: short pleasantry should land as general_chat.
+        self.assertEqual(intent.intent_id, INTENT_GENERAL_CHAT)
+
+
+class MakeUnderstandFnTests(unittest.TestCase):
+    def test_classifier_override_wins(self) -> None:
+        def fake(_obs, _in):
+            return RuntimeIntent(
+                intent_id=INTENT_GENERAL_CHAT,
+                confidence="high",
+                reason="llm-said-so",
+            )
+
+        understand = make_understand_fn(classifier=fake)
+        obs = RuntimeObservation(role_id="gateway", message_text="새 작업으로 진행")
+        inp = RuntimeInput(role_id="gateway", message_text="새 작업으로 진행")
+        intent = understand(obs, inp)
+        self.assertEqual(intent.intent_id, INTENT_GENERAL_CHAT)
+        self.assertEqual(intent.reason, "llm-said-so")
+
+    def test_classifier_returning_none_falls_back(self) -> None:
+        def fake(_obs, _in):
+            return None
+
+        understand = make_understand_fn(classifier=fake)
+        obs = RuntimeObservation(
+            role_id="gateway",
+            message_text="새 작업으로 진행",
+            normalized_text="새 작업으로 진행",
+        )
+        inp = RuntimeInput(role_id="gateway", message_text="새 작업으로 진행")
+        intent = understand(obs, inp)
+        self.assertEqual(intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+    def test_classifier_exception_falls_back_with_annotation(self) -> None:
+        def fake(_obs, _in):
+            raise RuntimeError("llm down")
+
+        understand = make_understand_fn(classifier=fake)
+        obs = RuntimeObservation(
+            role_id="gateway",
+            message_text="어제 작업 이어서 요약해줘",
+            normalized_text="어제 작업 이어서 요약해줘",
+        )
+        inp = RuntimeInput(role_id="gateway", message_text="어제 작업 이어서 요약해줘")
+        intent = understand(obs, inp)
+        self.assertEqual(intent.intent_id, INTENT_SUMMARIZE_PREVIOUS_WORK)
+        self.assertIn("llm down", intent.reason)
+        self.assertIn("fallback", intent.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/runtime/test_understand_loop_integration.py
+++ b/tests/engineering/runtime/test_understand_loop_integration.py
@@ -1,0 +1,92 @@
+"""Phase 2 — runtime loop with the deterministic classifier wired in.
+
+The classifier is the only stage that has been replaced from default;
+recall / research / decide / act / record stay at their Phase 1
+no-op defaults. This pins the contract that gateway / member bots
+will use in Phase 4: ``run_runtime_loop(input, understand_fn=
+make_understand_fn())`` produces a usable intent without any other
+stage doing IO.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.runtime import (
+    INTENT_APPEND_CONTEXT,
+    INTENT_CONTINUE_EXISTING_WORK,
+    INTENT_DIAGNOSTIC_QUESTION,
+    INTENT_EXECUTE_EXISTING_STEP,
+    INTENT_NEW_WORK_REQUEST,
+    INTENT_STATUS_QUESTION,
+    INTENT_SUMMARIZE_PREVIOUS_WORK,
+    RuntimeInput,
+    make_understand_fn,
+    run_runtime_loop,
+)
+
+
+class LoopWithClassifierTests(unittest.TestCase):
+    def _run(self, message: str, *, last_proposed: str | None = None):
+        understand = make_understand_fn()
+        return run_runtime_loop(
+            RuntimeInput(
+                role_id="gateway",
+                message_text=message,
+                last_proposed_prompt=last_proposed,
+            ),
+            understand_fn=understand,
+        )
+
+    def test_summarize_routes_through_classifier(self) -> None:
+        result = self._run("어제 작업 이어서 요약해줘")
+        self.assertEqual(result.intent.intent_id, INTENT_SUMMARIZE_PREVIOUS_WORK)
+
+    def test_continue_routes_through_classifier(self) -> None:
+        result = self._run("헤르메스 작업 이어서 가자")
+        self.assertEqual(result.intent.intent_id, INTENT_CONTINUE_EXISTING_WORK)
+
+    def test_status_routes_through_classifier(self) -> None:
+        result = self._run("지금 뭐 하는 중이야?")
+        self.assertEqual(result.intent.intent_id, INTENT_STATUS_QUESTION)
+
+    def test_diagnostic_routes_through_classifier(self) -> None:
+        result = self._run("운영 리서치는 안 열어?")
+        self.assertEqual(result.intent.intent_id, INTENT_DIAGNOSTIC_QUESTION)
+
+    def test_execute_existing_step_routes_through_classifier(self) -> None:
+        result = self._run("Obsidian에 정리해줘")
+        self.assertEqual(result.intent.intent_id, INTENT_EXECUTE_EXISTING_STEP)
+
+    def test_append_context_routes_through_classifier(self) -> None:
+        result = self._run("이 자료만 기존 작업에 참고로 붙여줘")
+        self.assertEqual(result.intent.intent_id, INTENT_APPEND_CONTEXT)
+
+    def test_explicit_new_work_routes_through_classifier(self) -> None:
+        result = self._run("새 작업으로 진행")
+        self.assertEqual(result.intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+    def test_typical_implementation_request_is_new_work(self) -> None:
+        result = self._run(
+            "결제 모듈 멱등성 검증 흐름 백엔드에 추가하는 작업 만들어줘"
+        )
+        self.assertEqual(result.intent.intent_id, INTENT_NEW_WORK_REQUEST)
+
+    def test_loop_default_research_stage_does_not_run(self) -> None:
+        # Classifier wired in, every other stage default. The default
+        # research stage must not return run=True regardless of intent.
+        result = self._run("새 작업으로 진행")
+        self.assertFalse(result.research_plan.run)
+
+    def test_loop_records_no_error_for_classifier_path(self) -> None:
+        result = self._run("어제 작업 이어서 요약해줘")
+        self.assertIsNone(result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_channel_router_forum.py
+++ b/tests/engineering/test_channel_router_forum.py
@@ -737,5 +737,488 @@ class HandleResearchTurnMessageTests(unittest.TestCase):
         self.assertIsNone(outcome)
 
 
+# ---------------------------------------------------------------------------
+# Phase B — member-bots summary + open-call status persistence + role policy
+# ---------------------------------------------------------------------------
+
+
+class MemberBotsSummaryAndPersistenceTests(unittest.TestCase):
+    """Phase B regression: member-bots mode must (1) produce a summary
+    that does NOT mention "역할별 댓글 N건" gateway-mode wording, and
+    (2) persist the kickoff status onto session.extra so the diagnostic
+    responder can describe the live setup."""
+
+    def _session_factory(self):
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+        )
+
+        return WorkflowSession(
+            session_id="sess-mb",
+            prompt="hero 정리",
+            task_type="landing-page",
+            state=WorkflowState.APPROVED,
+            created_at=datetime(2026, 4, 30),
+            updated_at=datetime(2026, 4, 30),
+            role_sequence=("tech-lead", "ai-engineer"),
+        )
+
+    def _publisher(self, *, posted: bool, thread_id=7777, thread_url=None):
+        async def forum_publisher(**_):
+            class _Outcome:
+                pass
+
+            outcome = _Outcome()
+            outcome.posted = posted
+            outcome.thread_id = thread_id
+            outcome.thread_url = thread_url
+            outcome.error = None
+            return outcome
+
+        return forum_publisher
+
+    def test_summary_drops_role_comment_count_in_member_bots_mode(self) -> None:
+        """The default research loop's summary must not include
+        ``역할별 댓글 N건`` wording in member-bots mode — that line is
+        gateway-mode only and confuses operators when each member bot
+        is responsible for the role comment."""
+
+        from yule_orchestrator.discord.engineering_channel_router import (
+            make_default_research_loop,
+        )
+
+        forum_posts: list[tuple[int, str]] = []
+
+        async def post_to_forum_thread(thread_id, content):
+            forum_posts.append((thread_id, content))
+
+        report = _run(
+            make_default_research_loop(
+                session=self._session_factory(),
+                message_text="prompt",
+                attachments=(),
+                channel=None,
+                collection_outcome=_StubCollectionOutcome(),
+                research_pack="<<pack>>",
+                role_for_research="engineering-agent/tech-lead",
+                thread_id=12345,
+                forum_publisher=self._publisher(posted=True),
+                post_to_forum_thread=post_to_forum_thread,
+                forum_comment_mode="member-bots",
+            )
+        )
+
+        msg = report.forum_status_message or ""
+        self.assertIn("운영-리서치 forum 게시 완료", msg)
+        self.assertIn("모드: member-bots", msg)
+        self.assertIn("open-call directive: 게시 완료", msg)
+        self.assertIn("후속 댓글은 운영-리서치 thread", msg)
+        # Gateway-mode-only wording must not leak into member-bots mode.
+        self.assertNotIn("역할별 댓글 0건", msg)
+        self.assertNotIn("역할별 댓글", msg)
+        # Mode metadata reaches the report fields too.
+        self.assertEqual(report.forum_comment_mode, "member-bots")
+        self.assertTrue(report.kickoff_posted)
+        self.assertIsNone(report.kickoff_error)
+
+    def test_kickoff_failure_in_member_bots_mode_surfaces_reason(self) -> None:
+        from yule_orchestrator.discord.engineering_channel_router import (
+            make_default_research_loop,
+        )
+
+        async def post_to_forum_thread(thread_id, content):
+            raise RuntimeError("rate limit 503")
+
+        report = _run(
+            make_default_research_loop(
+                session=self._session_factory(),
+                message_text="prompt",
+                attachments=(),
+                channel=None,
+                collection_outcome=_StubCollectionOutcome(),
+                research_pack="<<pack>>",
+                role_for_research="engineering-agent/tech-lead",
+                thread_id=12345,
+                forum_publisher=self._publisher(posted=True),
+                post_to_forum_thread=post_to_forum_thread,
+                forum_comment_mode="member-bots",
+            )
+        )
+
+        self.assertEqual(report.forum_comment_mode, "member-bots")
+        self.assertFalse(report.kickoff_posted)
+        self.assertIn("rate limit 503", report.kickoff_error or "")
+        # Error path must not regress the "역할별 댓글 N건" guard.
+        self.assertNotIn(
+            "역할별 댓글", report.forum_status_message or ""
+        )
+
+    def test_persist_research_forum_status_writes_canonical_keys(self) -> None:
+        """``persist_research_forum_status`` writes the Phase B keys
+        (research_open_call_*, forum_comment_mode, research_forum_thread_id)
+        plus legacy aliases for backward compat."""
+
+        try:
+            from tests._helpers import isolate_cache_for_test
+        except ImportError:  # pragma: no cover - bootstrap path
+            from _helpers import isolate_cache_for_test  # type: ignore
+
+        isolate_cache_for_test(self)
+
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            load_session,
+            save_session,
+        )
+        from yule_orchestrator.discord.engineering_channel_router import (
+            persist_research_forum_status,
+            EngineeringResearchLoopReport,
+        )
+
+        now = datetime(2026, 4, 30)
+        session = WorkflowSession(
+            session_id="sess-persist",
+            prompt="x",
+            task_type="research",
+            state=WorkflowState.IN_PROGRESS,
+            created_at=now,
+            updated_at=now,
+        )
+        save_session(session)
+
+        report = EngineeringResearchLoopReport(
+            forum_status_message="ok",
+            forum_thread_id=4242,
+            forum_thread_url="https://discord.test/4242",
+            forum_comment_mode="member-bots",
+            kickoff_posted=True,
+            kickoff_error=None,
+        )
+        persist_research_forum_status(session=session, report=report)
+
+        reloaded = load_session("sess-persist")
+        self.assertIsNotNone(reloaded)
+        extra = dict(reloaded.extra)
+        self.assertEqual(extra.get("forum_comment_mode"), "member-bots")
+        self.assertEqual(extra.get("research_forum_thread_id"), 4242)
+        self.assertEqual(
+            extra.get("research_forum_thread_url"), "https://discord.test/4242"
+        )
+        self.assertTrue(extra.get("research_open_call_posted"))
+        self.assertIsNone(extra.get("research_open_call_error"))
+        # Legacy aliases stay in sync for back-compat with existing
+        # diagnostic tests.
+        self.assertTrue(extra.get("forum_kickoff_posted"))
+        self.assertIsNone(extra.get("forum_kickoff_error"))
+
+    def test_persist_research_forum_status_records_kickoff_error(self) -> None:
+        try:
+            from tests._helpers import isolate_cache_for_test
+        except ImportError:  # pragma: no cover - bootstrap path
+            from _helpers import isolate_cache_for_test  # type: ignore
+
+        isolate_cache_for_test(self)
+
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            load_session,
+            save_session,
+        )
+        from yule_orchestrator.discord.engineering_channel_router import (
+            persist_research_forum_status,
+            EngineeringResearchLoopReport,
+        )
+
+        now = datetime(2026, 4, 30)
+        session = WorkflowSession(
+            session_id="sess-fail",
+            prompt="x",
+            task_type="research",
+            state=WorkflowState.IN_PROGRESS,
+            created_at=now,
+            updated_at=now,
+        )
+        save_session(session)
+
+        report = EngineeringResearchLoopReport(
+            forum_thread_id=99,
+            forum_comment_mode="member-bots",
+            kickoff_posted=False,
+            kickoff_error="forum kickoff 게시 실패: rate limit",
+        )
+        persist_research_forum_status(session=session, report=report)
+
+        reloaded = load_session("sess-fail")
+        extra = dict(reloaded.extra)
+        self.assertFalse(extra.get("research_open_call_posted"))
+        self.assertIn("rate limit", extra.get("research_open_call_error") or "")
+        self.assertEqual(extra.get("forum_comment_mode"), "member-bots")
+
+
+class RoleRuntimePrefaceTests(unittest.TestCase):
+    """Phase B role-runtime MVP: the open-call handler must produce a
+    take whose body covers all 5 sections (이해한 작업 / 역할 관점의
+    판단 / 참고 자료 / 리스크 / 다음 행동) and threads the role policy
+    through the runtime input.
+
+    The deterministic deliberation render already covers 관점 / 근거 /
+    리스크 / 다음 행동, so the preface only needs to add 이해한 작업 +
+    role policy stamping.
+    """
+
+    def setUp(self) -> None:
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            reset_handled_turns_for_tests,
+        )
+
+        reset_handled_turns_for_tests()
+        self.addCleanup(reset_handled_turns_for_tests)
+
+    def _session(self):
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+        )
+
+        return WorkflowSession(
+            session_id="sess-rt",
+            prompt=(
+                "운영-리서치 게시 흐름에서 멤버 봇이 진짜 자기 역할로 "
+                "응답했는지 확인할 수 있는 진단 흐름을 설계해줘"
+            ),
+            task_type="landing-page",
+            state=WorkflowState.APPROVED,
+            created_at=datetime(2026, 4, 30),
+            updated_at=datetime(2026, 4, 30),
+            # Include the engineering roles the runtime tests exercise so
+            # the open-call handler accepts them as participants.
+            role_sequence=(
+                "tech-lead",
+                "ai-engineer",
+                "backend-engineer",
+                "qa-engineer",
+            ),
+        )
+
+    def test_open_call_take_includes_runtime_preface_and_role_policy(self) -> None:
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            handle_research_turn_message,
+        )
+
+        outcome = handle_research_turn_message(
+            role="ai-engineer",
+            text="[research-open:sess-rt]",
+            session_loader=lambda _sid: self._session(),
+        )
+
+        self.assertIsNotNone(outcome)
+        msg = outcome.message
+        # 5-section contract — 이해한 작업 / 판단 근거 / 참고 자료 (or
+        # research_pack) / 리스크 / 다음 행동. The deterministic role
+        # take rendered by deliberation_role_turn already gives 근거 /
+        # 리스크 / 다음 행동; the runtime preface contributes 이해한
+        # 작업 + role-policy-driven 판단 근거 line.
+        self.assertIn("역할 runtime 결과", msg)
+        self.assertIn("이해한 작업:", msg)
+        self.assertIn("내 역할 관점의 판단 근거", msg)
+        self.assertIn("리스크", msg)
+        self.assertIn("다음 행동", msg)
+        # Role policy short_name is stamped through the preface so a
+        # future runtime can swap to an LLM-backed take without losing
+        # the policy provenance.
+        self.assertIn("ai-engineer", msg)
+        # Existing open-call memo footer must still be present so the
+        # forum thread still distinguishes autonomous takes from
+        # gateway-driven turns.
+        self.assertIn("자율 조사 메모", msg)
+
+    def test_role_runtime_input_carries_role_policy(self) -> None:
+        """The runtime input fed into ``run_runtime_loop`` must carry the
+        role policy. Patches the loop entry to capture the input."""
+
+        from unittest.mock import patch
+
+        captured: dict = {}
+
+        def _capture(input_, **_kwargs):
+            captured["input"] = input_
+
+            class _NoopResult:
+                error = None
+
+            return _NoopResult()
+
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            handle_research_turn_message,
+        )
+
+        with patch(
+            "yule_orchestrator.agents.runtime.run_runtime_loop",
+            side_effect=_capture,
+        ):
+            outcome = handle_research_turn_message(
+                role="backend-engineer",
+                text="[research-open:sess-rt]",
+                session_loader=lambda _sid: self._session(),
+            )
+
+        self.assertIsNotNone(outcome)
+        runtime_input = captured.get("input")
+        self.assertIsNotNone(runtime_input)
+        self.assertEqual(runtime_input.role_id, "engineering-agent/backend-engineer")
+        # Policy carries the canonical short_name + memory filter so the
+        # take preface can stamp them deterministically.
+        policy = (runtime_input.policy or {}).get("role_policy") or {}
+        self.assertEqual(policy.get("short_name"), "backend-engineer")
+        self.assertEqual(policy.get("memory_role_filter"), "backend-engineer")
+        self.assertTrue(policy.get("description"))
+
+    def test_runtime_failure_falls_back_to_deterministic_render(self) -> None:
+        """Runtime errors must not block the post — the deterministic
+        role-turn render still serves as the fallback body."""
+
+        from unittest.mock import patch
+
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            handle_research_turn_message,
+        )
+
+        with patch(
+            "yule_orchestrator.agents.runtime.run_runtime_loop",
+            side_effect=RuntimeError("runtime down"),
+        ):
+            outcome = handle_research_turn_message(
+                role="ai-engineer",
+                text="[research-open:sess-rt]",
+                session_loader=lambda _sid: self._session(),
+            )
+
+        self.assertIsNotNone(outcome)
+        # Deterministic role take's 4-section body must still be there.
+        self.assertIn("**[ai-engineer]**", outcome.message)
+        self.assertIn("리스크", outcome.message)
+        self.assertIn("자율 조사 메모", outcome.message)
+
+
+class RecordRoleTurnEventTests(unittest.TestCase):
+    """``record_role_turn_event`` must persist a role-keyed event on
+    session.extra and never raise from caller-facing code paths."""
+
+    def setUp(self) -> None:
+        try:
+            from tests._helpers import isolate_cache_for_test
+        except ImportError:  # pragma: no cover
+            from _helpers import isolate_cache_for_test  # type: ignore
+
+        isolate_cache_for_test(self)
+
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            save_session,
+        )
+
+        now = datetime(2026, 4, 30)
+        self._WorkflowSession = WorkflowSession
+        self._WorkflowState = WorkflowState
+        self.session = WorkflowSession(
+            session_id="sess-evt",
+            prompt="hero 정리",
+            task_type="research",
+            state=WorkflowState.APPROVED,
+            created_at=now,
+            updated_at=now,
+        )
+        save_session(self.session)
+
+    def _reload(self):
+        from yule_orchestrator.agents.workflow_state import load_session
+
+        return load_session("sess-evt")
+
+    def test_posted_event_lands_in_role_turns(self) -> None:
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            ROLE_TURN_KIND_OPEN,
+            ROLE_TURN_STATUS_POSTED,
+            record_role_turn_event,
+        )
+
+        record_role_turn_event(
+            session_id="sess-evt",
+            role="ai-engineer",
+            kind=ROLE_TURN_KIND_OPEN,
+            status=ROLE_TURN_STATUS_POSTED,
+        )
+        reloaded = self._reload()
+        role_turns = dict((reloaded.extra or {}).get("role_turns") or {})
+        self.assertIn("ai-engineer", role_turns)
+        event = role_turns["ai-engineer"]
+        self.assertEqual(event["status"], "posted")
+        self.assertEqual(event["kind"], "open")
+        self.assertIn("posted_at", event)
+        self.assertNotIn("error", event)
+
+    def test_error_event_records_reason(self) -> None:
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            ROLE_TURN_KIND_TURN,
+            ROLE_TURN_STATUS_ERROR,
+            record_role_turn_event,
+        )
+
+        record_role_turn_event(
+            session_id="sess-evt",
+            role="qa-engineer",
+            kind=ROLE_TURN_KIND_TURN,
+            status=ROLE_TURN_STATUS_ERROR,
+            error="Discord 5xx",
+        )
+        reloaded = self._reload()
+        role_turns = dict((reloaded.extra or {}).get("role_turns") or {})
+        self.assertEqual(role_turns["qa-engineer"]["status"], "error")
+        self.assertEqual(role_turns["qa-engineer"]["error"], "Discord 5xx")
+
+    def test_record_failure_is_silent(self) -> None:
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            record_role_turn_event,
+        )
+
+        # No save_session for this id → load returns None → recorder
+        # silently no-ops (no raise).
+        record_role_turn_event(
+            session_id="ghost",
+            role="ai-engineer",
+            kind="open",
+            status="posted",
+        )
+
+    def test_repeated_event_overwrites_latest(self) -> None:
+        """We keep history-light: latest event per role wins so the
+        diagnostic surface stays compact."""
+
+        from yule_orchestrator.discord.engineering_team_runtime import (
+            record_role_turn_event,
+        )
+
+        record_role_turn_event(
+            session_id="sess-evt",
+            role="ai-engineer",
+            kind="open",
+            status="error",
+            error="first",
+        )
+        record_role_turn_event(
+            session_id="sess-evt",
+            role="ai-engineer",
+            kind="open",
+            status="posted",
+        )
+        role_turns = dict((self._reload().extra or {}).get("role_turns") or {})
+        self.assertEqual(role_turns["ai-engineer"]["status"], "posted")
+        self.assertNotIn("error", role_turns["ai-engineer"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/engineering/test_channel_router_runtime_preflight.py
+++ b/tests/engineering/test_channel_router_runtime_preflight.py
@@ -375,5 +375,284 @@ class PreflightWithoutInjectionTests(unittest.TestCase):
         self.assertEqual(called["conversation"], 1)
 
 
+class ThreadBoundContinuationTests(_PreflightRouteHarness):
+    """Phase A: when the user is sitting inside a work thread and
+    types a short continuation phrase like "기존 세션으로 진행", the
+    runtime preflight must join the thread's session without going
+    through conversation_fn / auto_collect."""
+
+    def _thread_message(
+        self,
+        text: str,
+        *,
+        thread_id: int,
+        parent_id: int = 111,
+    ):
+        # Discord threads expose ``parent_id`` (the channel they live
+        # under). The router uses that as the "channel is a thread"
+        # signal and feeds thread_id into recall's anchor lookup.
+        return FakeMessage(
+            content=text,
+            channel=FakeChannel(
+                channel_id=thread_id,
+                name="engineer-feature-abc",
+                parent_id=parent_id,
+            ),
+        )
+
+    def test_force_continue_phrase_joins_thread_session(self) -> None:
+        sessions = [
+            RuntimeFakeSession(
+                session_id="thread-bound",
+                prompt="결제 모듈 멱등성 검토",
+                thread_id=909090,
+                updated_at=_now(-5),
+            ),
+        ]
+        continuation_fn = AsyncMock(
+            return_value=EngineeringThreadContinuation(
+                session=LegacyFakeSession(session_id="thread-bound", task_type="feature"),
+                thread_id=909090,
+                message="thread에 이어 붙였습니다.",
+            )
+        )
+        message = self._thread_message("기존 세션으로 진행", thread_id=909090)
+
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=continuation_fn,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "thread-bound")
+        self.assertEqual(result.thread_id, 909090)
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+
+
+class ClarificationFollowUpSelectionTests(_PreflightRouteHarness):
+    """Phase A: gateway shows candidates → user replies "1번" /
+    "기존 세션으로 진행" / "이걸로" → preflight resolves the cached
+    candidate without calling conversation_fn again."""
+
+    def setUp(self) -> None:  # noqa: D401
+        super().setUp()
+        # The clarification cache is module-level state. Reset it so
+        # tests don't leak candidates across each other when run in
+        # the discovery order.
+        from yule_orchestrator.discord import engineering_channel_router as router
+
+        router._GATEWAY_CLARIFICATION_CONTEXT.clear()
+
+    def _trigger_clarification(self, message, sessions):
+        # First turn: user message classifies as continue/summarize but
+        # recall returns ambiguous → preflight stores candidates and
+        # sends the clarification template.
+        return self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=AsyncMock(),
+        )
+
+    def test_numeric_pick_after_clarification(self) -> None:
+        # Two ambiguous sessions both touching "hermes 학습" so the
+        # initial recall returns candidates without a confident match.
+        sessions = [
+            RuntimeFakeSession(
+                session_id="hermes-a",
+                prompt="hermes 학습 루프 구조 설계",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+            RuntimeFakeSession(
+                session_id="hermes-b",
+                prompt="hermes 학습 루프 구조 검증",
+                updated_at=_now(-60),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+        ]
+        first = FakeMessage(
+            content="hermes 학습 루프 정리해줘",
+            channel=FakeChannel(channel_id=111, name="업무-접수"),
+        )
+        # Author id matches in setUp's FakeMessage default; we set it
+        # explicitly so the cache key is deterministic.
+        first.author = type("A", (), {"id": 4242})()
+        first_result = self._trigger_clarification(first, sessions)
+        self.assertTrue(first_result.handled)
+        # Cache populated.
+        from yule_orchestrator.discord import engineering_channel_router as router
+        cached = router._GATEWAY_CLARIFICATION_CONTEXT.get((111, 4242))
+        self.assertIsNotNone(cached)
+        self.assertEqual(len(cached), 2)
+        # Sanity: gateway sent the clarification template.
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("어떤 작업을 가리키시는지", sent)
+
+        # Second turn: user picks "1번".
+        # Reset send_chunks to isolate second-turn output.
+        self.send_chunks.reset_mock()
+        # conversation_fn is still set to AssertionError — must not run.
+        second_continuation = AsyncMock(
+            return_value=EngineeringThreadContinuation(
+                session=LegacyFakeSession(session_id="hermes-a", task_type="research"),
+                thread_id=11,
+                message="hermes-a에 이어 붙였습니다.",
+            )
+        )
+        second = FakeMessage(
+            content="1번",
+            channel=FakeChannel(channel_id=111, name="업무-접수"),
+        )
+        second.author = type("A", (), {"id": 4242})()
+        second_result = self._route(
+            message=second,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=second_continuation,
+        )
+        self.assertTrue(second_result.handled)
+        self.assertEqual(second_result.session_id, "hermes-a")
+        # conversation_fn / intake_fn must NOT run on the selection turn.
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+        # Cache cleared after a successful selection.
+        self.assertNotIn((111, 4242), router._GATEWAY_CLARIFICATION_CONTEXT)
+
+    def test_korean_ordinal_pick(self) -> None:
+        sessions = [
+            RuntimeFakeSession(
+                session_id="hermes-a",
+                prompt="hermes 학습 루프 구조 설계",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+            RuntimeFakeSession(
+                session_id="hermes-b",
+                prompt="hermes 학습 루프 구조 검증",
+                updated_at=_now(-60),
+                extra={"research_pack": {"title": "hermes 학습 루프"}},
+            ),
+        ]
+        first = FakeMessage(
+            content="hermes 학습 루프 정리해줘",
+            channel=FakeChannel(channel_id=222, name="업무-접수"),
+        )
+        first.author = type("A", (), {"id": 7000})()
+        self._trigger_clarification(first, sessions)
+        self.send_chunks.reset_mock()
+
+        second_continuation = AsyncMock(
+            return_value=EngineeringThreadContinuation(
+                session=LegacyFakeSession(session_id="hermes-b", task_type="research"),
+                thread_id=12,
+                message="hermes-b에 이어 붙였습니다.",
+            )
+        )
+        second = FakeMessage(
+            content="두 번째 거",
+            channel=FakeChannel(channel_id=222, name="업무-접수"),
+        )
+        second.author = type("A", (), {"id": 7000})()
+        result = self._route(
+            message=second,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=second_continuation,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "hermes-b")
+
+    def test_demonstrative_phrase_picks_single_cached_candidate(self) -> None:
+        """Pre-seed the cache with one candidate and verify "기존 세션
+        으로 진행" / "이걸로" land on it without conversation_fn /
+        auto_collect running."""
+
+        from yule_orchestrator.discord import engineering_channel_router as router
+
+        scope_key = (333, 8000)
+        router._GATEWAY_CLARIFICATION_CONTEXT[scope_key] = (
+            {
+                "session_id": "solo",
+                "title": "결제 모듈 멱등성",
+                "score": 0.5,
+                "thread_id": 21,
+                "forum_thread_id": None,
+                "task_type": "feature",
+            },
+        )
+
+        continuation = AsyncMock(
+            return_value=EngineeringThreadContinuation(
+                session=LegacyFakeSession(session_id="solo", task_type="feature"),
+                thread_id=21,
+                message="solo에 이어 붙였습니다.",
+            )
+        )
+        # Empty session list — preflight falls back to no recall match,
+        # so the only thing that can resolve "기존 세션으로 진행" is the
+        # cached candidate selection path.
+        message = FakeMessage(
+            content="기존 세션으로 진행",
+            channel=FakeChannel(channel_id=333, name="업무-접수"),
+        )
+        message.author = type("A", (), {"id": 8000})()
+
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [],
+            thread_continuation_fn=continuation,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "solo")
+        self.assertEqual(result.thread_id, 21)
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+        # Cache cleared after the successful resolution.
+        self.assertNotIn(scope_key, router._GATEWAY_CLARIFICATION_CONTEXT)
+
+    def test_demonstrative_phrase_with_multi_candidates_does_not_pick(self) -> None:
+        """``_try_select_candidate`` must NOT silently resolve "이걸로"
+        when the cache has multiple candidates — the user has to be
+        more specific. Exercise the helper directly so the harness's
+        "conversation_fn must not run" guard isn't tripped by the
+        legacy fallthrough that follows in the live router."""
+
+        from yule_orchestrator.discord import engineering_channel_router as router
+
+        candidates = (
+            {"session_id": "a", "title": "A", "score": 0.4,
+             "thread_id": None, "forum_thread_id": None, "task_type": "research"},
+            {"session_id": "b", "title": "B", "score": 0.35,
+             "thread_id": None, "forum_thread_id": None, "task_type": "research"},
+        )
+        self.assertIsNone(router._try_select_candidate("이걸로", candidates))
+        self.assertIsNone(router._try_select_candidate("기존 세션으로 진행", candidates))
+        # Numeric pick, on the other hand, IS unambiguous — sanity
+        # check the same helper for the positive path.
+        chosen = router._try_select_candidate("1번", candidates)
+        self.assertIsNotNone(chosen)
+        self.assertEqual(chosen["session_id"], "a")
+
+    def test_existing_session_phrase_without_cache_or_match_clarifies(self) -> None:
+        # No prior clarification, no matching open sessions: "기존
+        # 세션으로 진행" must NOT create a fresh session — it asks for
+        # clarification because the runtime can't tell which existing
+        # work the user means.
+        message = FakeMessage(
+            content="기존 세션으로 진행",
+            channel=FakeChannel(channel_id=444, name="업무-접수"),
+        )
+        message.author = type("A", (), {"id": 9000})()
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [],
+            thread_continuation_fn=AsyncMock(),
+        )
+        self.assertTrue(result.handled)
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("어떤 작업을 가리키시는지", sent)
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/engineering/test_channel_router_runtime_preflight.py
+++ b/tests/engineering/test_channel_router_runtime_preflight.py
@@ -1,0 +1,379 @@
+"""Phase 4B — runtime preflight tests for ``route_engineering_message``.
+
+Pin the auto_collect-first regression: when the user's message is a
+back-reference / status-style request, the router must not call
+``conversation_fn`` (which is the only place ``auto_collect=True`` is
+applied). The runtime preflight either joins the matched session or
+asks for clarification — and only ``new_work_request`` falls through
+to the legacy intake flow.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Optional
+from unittest.mock import AsyncMock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from tests._helpers import (
+    FakeChannel,
+    FakeMessage,
+    FakeIntakeResult,
+    FakePlan,
+    FakeSession as LegacyFakeSession,
+    extract_prompt as _extract_prompt,
+    isolate_cache_for_test as _isolate_cache_for_test,
+    run as _run,
+)
+
+from yule_orchestrator.discord.engineering_channel_router import (
+    EngineeringConversationOutcome,
+    EngineeringResearchLoopReport,
+    EngineeringRouteContext,
+    EngineeringThreadContinuation,
+    EngineeringThreadKickoff,
+    route_engineering_message,
+)
+
+
+@dataclass
+class RuntimeFakeSession:
+    """Recall-friendly session shape (more fields than the legacy
+    FakeSession used by the older router tests)."""
+
+    session_id: str
+    prompt: str = ""
+    task_type: str = "research"
+    state: str = "in_progress"
+    summary: Optional[str] = None
+    channel_id: Optional[int] = None
+    thread_id: Optional[int] = None
+    updated_at: Optional[datetime] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    executor_role: Optional[str] = "tech-lead"
+    executor_runner: Optional[str] = "claude-code"
+
+
+def _now(offset_minutes: int = 0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+def _channel(channel_id: int = 111, name: str = "업무-접수") -> FakeChannel:
+    return FakeChannel(channel_id=channel_id, name=name)
+
+
+class _PreflightRouteHarness(unittest.TestCase):
+    def setUp(self) -> None:  # noqa: D401 - test setup
+        self.context = EngineeringRouteContext(
+            intake_channel_id=111, intake_channel_name="업무-접수"
+        )
+        self.send_chunks = AsyncMock()
+        self.conversation_fn = AsyncMock(
+            side_effect=AssertionError(
+                "conversation_fn must NOT run when preflight handles the message"
+            )
+        )
+        self.intake_fn = AsyncMock(
+            side_effect=AssertionError("intake must NOT run for non-new-work intents")
+        )
+        self.kickoff_fn = AsyncMock(
+            side_effect=AssertionError("kickoff must NOT run for non-new-work intents")
+        )
+
+    def _route(
+        self,
+        *,
+        message,
+        list_sessions_fn,
+        thread_continuation_fn=None,
+    ):
+        return _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=self.context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=self.conversation_fn,
+                intake_fn=self.intake_fn,
+                thread_kickoff_fn=self.kickoff_fn,
+                send_chunks=self.send_chunks,
+                research_loop_fn=None,
+                thread_continuation_fn=thread_continuation_fn,
+                list_sessions_fn=list_sessions_fn,
+            )
+        )
+
+
+class SummarizeYesterdayPreflightTests(_PreflightRouteHarness):
+    def test_summarize_with_match_joins_existing_thread(self) -> None:
+        sessions = [
+            RuntimeFakeSession(
+                session_id="recent-1",
+                prompt="onboarding flow 검토",
+                updated_at=_now(-30),
+            ),
+        ]
+        existing = LegacyFakeSession(session_id="recent-1", task_type="research")
+        continuation = EngineeringThreadContinuation(
+            session=existing,
+            thread_id=4242,
+            message="기존 thread에 이어 붙였습니다.",
+        )
+        continuation_fn = AsyncMock(return_value=continuation)
+
+        message = FakeMessage(content="어제 작업 이어서 요약해줘", channel=_channel())
+
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=continuation_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "recent-1")
+        self.assertEqual(result.thread_id, 4242)
+        # auto_collect-first guard
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+        # The clarification prompt was NOT sent — we joined cleanly.
+        sent = "\n".join(str(call.args[1]) for call in self.send_chunks.await_args_list)
+        self.assertNotIn("어떤 작업을 가리키시는지", sent)
+        self.assertIn("기존 thread에 이어 붙였습니다.", sent)
+
+
+class HermesContinuePreflightTests(_PreflightRouteHarness):
+    def test_named_project_continue_routes_to_match(self) -> None:
+        sessions = [
+            RuntimeFakeSession(
+                session_id="hermes-session",
+                prompt="헤르메스 RAG 학습 루프 구조",
+                updated_at=_now(-30),
+                extra={"research_pack": {"title": "헤르메스 학습 루프"}},
+            ),
+            RuntimeFakeSession(
+                session_id="other",
+                prompt="결제 모듈 멱등성 검토",
+                updated_at=_now(-90),
+            ),
+        ]
+        continuation_fn = AsyncMock(
+            return_value=EngineeringThreadContinuation(
+                session=LegacyFakeSession(session_id="hermes-session", task_type="research"),
+                thread_id=8888,
+                message="hermes thread 이어 붙였습니다.",
+            )
+        )
+        message = FakeMessage(content="헤르메스 작업 이어서 가자", channel=_channel())
+
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions,
+            thread_continuation_fn=continuation_fn,
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "hermes-session")
+        self.assertEqual(result.thread_id, 8888)
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+
+
+class ExecuteStepWithoutMatchTests(_PreflightRouteHarness):
+    def test_obsidian_request_without_session_asks_clarification(self) -> None:
+        message = FakeMessage(content="Obsidian에 정리해줘", channel=_channel())
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [],  # no open sessions
+            thread_continuation_fn=AsyncMock(),
+        )
+        self.assertTrue(result.handled)
+        self.conversation_fn.assert_not_awaited()
+        self.intake_fn.assert_not_awaited()
+        sent = "\n".join(str(call.args[1]) for call in self.send_chunks.await_args_list)
+        self.assertIn("어떤 작업을 가리키시는지", sent)
+        self.assertIn("기존 작업 후속 실행", sent)
+
+
+class AppendContextWithoutMatchTests(_PreflightRouteHarness):
+    def test_append_context_without_session_asks_clarification(self) -> None:
+        message = FakeMessage(
+            content="이 자료만 기존 작업에 참고로 붙여줘",
+            channel=_channel(),
+        )
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [],
+            thread_continuation_fn=AsyncMock(),
+        )
+        self.assertTrue(result.handled)
+        self.conversation_fn.assert_not_awaited()
+        sent = "\n".join(str(call.args[1]) for call in self.send_chunks.await_args_list)
+        self.assertIn("기존 작업에 자료 첨부", sent)
+
+
+class NewWorkFallthroughTests(unittest.TestCase):
+    """Preflight must NOT take over for new-work / confirm / status /
+    diagnostic / general chat — those keep flowing through
+    conversation_fn so the existing intake + kickoff + research loop
+    behave exactly as before."""
+
+    def setUp(self) -> None:  # noqa: D401
+        # The legacy fallthrough path runs decide_routing which reads
+        # the workflow cache. Other tests in the suite may have written
+        # sessions there; isolate so this test's CREATE flow isn't
+        # accidentally promoted to JOIN by a stale match.
+        _isolate_cache_for_test(self)
+        self.context = EngineeringRouteContext(
+            intake_channel_id=111, intake_channel_name="업무-접수"
+        )
+        self.send_chunks = AsyncMock()
+
+    def _route_with_outcome(self, message, outcome, *, list_sessions_fn):
+        intake_fn = AsyncMock(
+            return_value=FakeIntakeResult(
+                session=LegacyFakeSession(session_id="new-1", task_type="feature"),
+                plan=FakePlan(),
+                message="**[engineering-agent] 새 작업 접수**",
+            )
+        )
+        kickoff_fn = AsyncMock(
+            return_value=EngineeringThreadKickoff(thread_id=7777, message="kickoff")
+        )
+
+        async def loop_fn(**_kwargs):
+            return EngineeringResearchLoopReport()
+
+        return _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=self.context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=lambda **_: outcome,
+                intake_fn=intake_fn,
+                thread_kickoff_fn=kickoff_fn,
+                send_chunks=self.send_chunks,
+                research_loop_fn=loop_fn,
+                thread_continuation_fn=None,
+                list_sessions_fn=list_sessions_fn,
+            )
+        ), intake_fn, kickoff_fn
+
+    def test_typical_new_work_flows_through_intake(self) -> None:
+        message = FakeMessage(
+            content="결제 모듈 멱등성 검증 흐름 백엔드에 추가해줘",
+            channel=_channel(),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="요약은 이렇습니다.",
+            confirmed=True,
+            intake_prompt="결제 모듈 멱등성 검증 흐름 백엔드에 추가해줘",
+        )
+        result, intake_fn, kickoff_fn = self._route_with_outcome(
+            message, outcome, list_sessions_fn=lambda **_kw: []
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "new-1")
+        intake_fn.assert_awaited_once()
+        kickoff_fn.assert_awaited_once()
+
+    def test_explicit_new_work_phrase_flows_through_intake(self) -> None:
+        message = FakeMessage(
+            content="새 작업으로 진행 결제 모듈 추가",
+            channel=_channel(),
+        )
+        outcome = EngineeringConversationOutcome(
+            content="요약",
+            confirmed=True,
+            intake_prompt="결제 모듈 추가",
+        )
+        result, intake_fn, _kickoff = self._route_with_outcome(
+            message, outcome, list_sessions_fn=lambda **_kw: []
+        )
+        self.assertTrue(result.handled)
+        intake_fn.assert_awaited_once()
+
+    def test_status_question_falls_through_to_conversation(self) -> None:
+        message = FakeMessage(content="지금 뭐 하는 중이야?", channel=_channel())
+        captured: dict = {}
+
+        def conversation_fn(**kwargs):
+            captured.update(kwargs)
+            return EngineeringConversationOutcome(
+                content="현재 상태입니다.",
+                is_status_query=True,
+            )
+
+        result = _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=self.context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=conversation_fn,
+                intake_fn=AsyncMock(
+                    side_effect=AssertionError("status query must not intake")
+                ),
+                thread_kickoff_fn=AsyncMock(
+                    side_effect=AssertionError("status query must not kickoff")
+                ),
+                send_chunks=self.send_chunks,
+                research_loop_fn=None,
+                thread_continuation_fn=None,
+                list_sessions_fn=lambda **_kw: [],
+            )
+        )
+        self.assertTrue(result.handled)
+        # conversation_fn was called — the status diagnostic responder
+        # lives there. Important: ``auto_collect=True`` is still in the
+        # legacy path but engineering_conversation short-circuits on
+        # status_query before it runs.
+        self.assertEqual(captured["message_text"], "지금 뭐 하는 중이야?")
+
+
+class PreflightWithoutInjectionTests(unittest.TestCase):
+    """When ``list_sessions_fn`` is not provided the runtime preflight
+    is fully disabled and the legacy flow stays intact — every existing
+    routing test depends on this contract."""
+
+    def test_no_list_sessions_fn_means_no_short_circuit(self) -> None:
+        context = EngineeringRouteContext(
+            intake_channel_id=111, intake_channel_name="업무-접수"
+        )
+        send_chunks = AsyncMock()
+        called = {"conversation": 0}
+
+        def conversation_fn(**_kwargs):
+            called["conversation"] += 1
+            return EngineeringConversationOutcome(content="hi")
+
+        message = FakeMessage(content="어제 작업 이어서 요약해줘", channel=_channel())
+
+        result = _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=conversation_fn,
+                intake_fn=AsyncMock(),
+                thread_kickoff_fn=AsyncMock(),
+                send_chunks=send_chunks,
+                research_loop_fn=None,
+                thread_continuation_fn=None,
+                # NO list_sessions_fn — preflight is disabled.
+            )
+        )
+        self.assertTrue(result.handled)
+        # conversation_fn was called because preflight didn't run.
+        self.assertEqual(called["conversation"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_research_loop_hook.py
+++ b/tests/engineering/test_research_loop_hook.py
@@ -235,6 +235,119 @@ class MemberBotsModeSummaryTestCase(unittest.TestCase):
         self.assertIsNone(report.kickoff_error)
 
 
+class PersistForumCommentModeTestCase(unittest.TestCase):
+    """``_persist_forum_comment_mode_to_session`` writes member-bots
+    vs gateway mode signals into ``session.extra`` so the status
+    diagnostic responder can describe the live setup later. Uses real
+    WorkflowSession + isolated cache to round-trip through SQLite."""
+
+    def setUp(self) -> None:  # noqa: D401
+        try:
+            from tests._helpers import isolate_cache_for_test
+        except ImportError:  # pragma: no cover - bootstrap path
+            from _helpers import isolate_cache_for_test  # type: ignore
+        isolate_cache_for_test(self)
+
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            save_session,
+        )
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        self._WorkflowSession = WorkflowSession
+        self._WorkflowState = WorkflowState
+        self._save_session = save_session
+        self.session = WorkflowSession(
+            session_id="abc123def456",
+            prompt="Stripe pricing 페이지 hero copy",
+            task_type="research",
+            state=WorkflowState.IN_PROGRESS,
+            created_at=now,
+            updated_at=now,
+            extra={"research_pack": {"title": "x"}},
+        )
+        save_session(self.session)
+
+    def _reload(self):
+        from yule_orchestrator.agents.workflow_state import load_session
+
+        return load_session(self.session.session_id)
+
+    def test_member_bots_kickoff_posted_writes_extra(self) -> None:
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=True),
+        )
+        bot_module._persist_forum_comment_mode_to_session(
+            session=self.session, publish=publish
+        )
+
+        reloaded = self._reload()
+        self.assertIsNotNone(reloaded)
+        extra = dict(reloaded.extra)
+        self.assertEqual(extra["forum_comment_mode"], "member-bots")
+        self.assertTrue(extra["forum_kickoff_posted"])
+        self.assertIsNone(extra["forum_kickoff_error"])
+
+    def test_member_bots_kickoff_failed_writes_error(self) -> None:
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=False, error="rate limit 503"),
+        )
+        bot_module._persist_forum_comment_mode_to_session(
+            session=self.session, publish=publish
+        )
+
+        reloaded = self._reload()
+        extra = dict(reloaded.extra)
+        self.assertEqual(extra["forum_comment_mode"], "member-bots")
+        self.assertFalse(extra["forum_kickoff_posted"])
+        self.assertEqual(extra["forum_kickoff_error"], "rate limit 503")
+
+    def test_gateway_mode_writes_only_mode_key(self) -> None:
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            role_comments={"product-designer": _CommentOutcome()},
+            decision_comment=_CommentOutcome(),
+            # No kickoff_comment → gateway mode.
+        )
+        bot_module._persist_forum_comment_mode_to_session(
+            session=self.session, publish=publish
+        )
+
+        reloaded = self._reload()
+        extra = dict(reloaded.extra)
+        self.assertEqual(extra["forum_comment_mode"], "gateway")
+        self.assertNotIn("forum_kickoff_posted", extra)
+        self.assertNotIn("forum_kickoff_error", extra)
+
+    def test_idempotent_overwrite_clears_stale_error(self) -> None:
+        # First publish failed.
+        publish_failed = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=False, error="initial error"),
+        )
+        bot_module._persist_forum_comment_mode_to_session(
+            session=self.session, publish=publish_failed
+        )
+        # Retry succeeds — the second persist must clear the stale error.
+        reloaded = self._reload()
+        publish_ok = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=True),
+        )
+        bot_module._persist_forum_comment_mode_to_session(
+            session=reloaded, publish=publish_ok
+        )
+
+        final = self._reload()
+        extra = dict(final.extra)
+        self.assertTrue(extra["forum_kickoff_posted"])
+        self.assertIsNone(extra["forum_kickoff_error"])
+
+
 class FormatResearchForumDisabledStatusTestCase(unittest.TestCase):
     def test_disabled_status_includes_role_hints_when_sequence_known(self) -> None:
         outcome = _outcome_with_designer_landing()

--- a/tests/engineering/test_research_loop_hook.py
+++ b/tests/engineering/test_research_loop_hook.py
@@ -80,6 +80,7 @@ class _PublishOutcome:
     role_comments: dict = field(default_factory=dict)
     decision_comment: Optional[_CommentOutcome] = None
     skipped_reason: Optional[str] = None
+    kickoff_comment: Optional[_CommentOutcome] = None
 
 
 def _outcome_with_designer_landing() -> _Outcome:
@@ -159,6 +160,79 @@ class ResearchLoopReportFromPublishTestCase(unittest.TestCase):
         self.assertIn("forum 게시 실패", report.forum_status_message)
         self.assertIn("# Research", report.forum_status_message)
         self.assertEqual(report.error, "discord api boom")
+
+
+class MemberBotsModeSummaryTestCase(unittest.TestCase):
+    """member-bots mode signals: the gateway only posted the
+    ``[research-open:<session_id>]`` directive; per-role comments come
+    from each member bot. Summary must reflect that — and never mention
+    the gateway-mode "역할별 댓글 N건" line, which would look like a
+    failure to operators."""
+
+    def test_kickoff_posted_in_member_bots_mode_renders_directive_status(self) -> None:
+        outcome = _outcome_with_designer_landing()
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=True),
+        )
+
+        report = bot_module._research_loop_report_from_publish(outcome, publish)
+
+        msg = report.forum_status_message or ""
+        self.assertIn("운영-리서치 forum 게시 완료", msg)
+        self.assertIn("모드: member-bots", msg)
+        self.assertIn("open-call directive: 게시 완료", msg)
+        self.assertIn("후속 댓글은 운영-리서치 thread", msg)
+        # Gateway-mode wording must not appear.
+        self.assertNotIn("역할별 댓글 0건", msg)
+        self.assertNotIn("tech-lead 종합 미기록", msg)
+        # Mode metadata reaches the report fields too.
+        self.assertEqual(report.forum_comment_mode, "member-bots")
+        self.assertTrue(report.kickoff_posted)
+        self.assertIsNone(report.kickoff_error)
+
+    def test_kickoff_failed_in_member_bots_mode_surfaces_reason(self) -> None:
+        outcome = _outcome_with_designer_landing()
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            kickoff_comment=_CommentOutcome(posted=False, error="rate limit 503"),
+        )
+
+        report = bot_module._research_loop_report_from_publish(outcome, publish)
+
+        msg = report.forum_status_message or ""
+        self.assertIn("모드: member-bots", msg)
+        self.assertIn("open-call directive: 게시 실패", msg)
+        self.assertIn("rate limit 503", msg)
+        # Gateway-mode wording must still not leak.
+        self.assertNotIn("역할별 댓글", msg)
+        self.assertEqual(report.forum_comment_mode, "member-bots")
+        self.assertFalse(report.kickoff_posted)
+        self.assertEqual(report.kickoff_error, "rate limit 503")
+
+    def test_gateway_mode_keeps_role_comment_summary(self) -> None:
+        outcome = _outcome_with_designer_landing()
+        publish = _PublishOutcome(
+            thread=_ThreadOutcome(),
+            role_comments={
+                "product-designer": _CommentOutcome(),
+                "frontend-engineer": _CommentOutcome(),
+            },
+            decision_comment=_CommentOutcome(),
+            # No kickoff_comment → gateway mode.
+        )
+
+        report = bot_module._research_loop_report_from_publish(outcome, publish)
+
+        msg = report.forum_status_message or ""
+        self.assertIn("역할별 댓글 2건", msg)
+        self.assertIn("tech-lead 종합 기록", msg)
+        # member-bots-only wording must not appear in gateway mode.
+        self.assertNotIn("모드: member-bots", msg)
+        self.assertNotIn("open-call directive", msg)
+        self.assertEqual(report.forum_comment_mode, "gateway")
+        self.assertIsNone(report.kickoff_posted)
+        self.assertIsNone(report.kickoff_error)
 
 
 class FormatResearchForumDisabledStatusTestCase(unittest.TestCase):

--- a/tests/engineering/test_session_status.py
+++ b/tests/engineering/test_session_status.py
@@ -1,0 +1,314 @@
+"""Phase E tests — session-state diagnostic helper.
+
+These exercise :mod:`yule_orchestrator.agents.session_status` so the
+detect/report/propose rules stay pinned. Each test maps to one of the
+operator-facing complaints from Phase E:
+
+- research_pack 있음 but open-call 없음
+- open-call 있음 but role_turn 없음
+- role_turn 있음 but synthesis 없음
+- synthesis 있음 but Obsidian proposal 없음
+- pending Obsidian approval
+- Obsidian write failed
+
+All inputs are synthesized in-memory — the helper does not touch the
+SQLite cache, Discord, or the network.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from typing import Any
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.session_status import (
+    FORUM_PUBLISH_FAILED,
+    OBSIDIAN_PENDING_APPROVAL,
+    OBSIDIAN_PROPOSAL_MISSING,
+    OBSIDIAN_WRITE_FAILED,
+    OPEN_CALL_FAILED,
+    OPEN_CALL_MISSING,
+    RESEARCH_LOOP_ERROR,
+    RESEARCH_PACK_MISSING,
+    ROLE_TURN_MISSING,
+    SESSION_CLOSED,
+    SYNTHESIS_MISSING,
+    diagnose_session,
+    render_diagnostic_summary,
+    render_member_bot_summary,
+)
+from yule_orchestrator.agents.workflow_state import WorkflowSession, WorkflowState
+
+
+def _session(**overrides: Any) -> WorkflowSession:
+    base = dict(
+        session_id="abc123def456",
+        prompt="운영 리서치 검토 작업",
+        task_type="research",
+        state=WorkflowState.IN_PROGRESS,
+        created_at=datetime(2026, 5, 5, 10, 0),
+        updated_at=datetime(2026, 5, 6, 9, 0),
+        channel_id=1001,
+        user_id=2002,
+        thread_id=3003,
+    )
+    base.update(overrides)
+    return WorkflowSession(**base)
+
+
+class SignalCodesTests(unittest.TestCase):
+    """Each Phase E condition gets a stable code that the supervisor /
+    discord layer can match without depending on Korean phrasing."""
+
+    def test_no_research_pack_emits_info_signal(self) -> None:
+        report = diagnose_session(_session())
+        self.assertTrue(report.has_signal(RESEARCH_PACK_MISSING))
+        self.assertEqual(
+            report.signal(RESEARCH_PACK_MISSING).severity, "info"
+        )
+
+    def test_research_pack_without_open_call_is_stale(self) -> None:
+        session = _session(
+            extra={"research_pack": {"title": "Stripe pricing"}},
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(OPEN_CALL_MISSING))
+        signal = report.signal(OPEN_CALL_MISSING)
+        self.assertEqual(signal.severity, "stale")
+        self.assertIn("publisher", signal.propose or "")
+
+    def test_forum_publish_error_promotes_to_failed(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "forum_publish_error": "starter 4000자 초과",
+            }
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(FORUM_PUBLISH_FAILED))
+        # OPEN_CALL_MISSING must NOT also fire — the explicit failure
+        # supersedes the generic "is the publisher even running?" hint.
+        self.assertFalse(report.has_signal(OPEN_CALL_MISSING))
+
+    def test_member_bots_kickoff_failure_emits_open_call_failed(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": False,
+                "forum_kickoff_error": "rate limit 503",
+            }
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(OPEN_CALL_FAILED))
+        signal = report.signal(OPEN_CALL_FAILED)
+        self.assertEqual(signal.severity, "failed")
+        self.assertIn("rate limit 503", signal.detail or "")
+
+    def test_open_call_active_without_role_turn_is_stale(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+            }
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(ROLE_TURN_MISSING))
+        # No synthesis-missing yet because no role spoke at all.
+        self.assertFalse(report.has_signal(SYNTHESIS_MISSING))
+
+    def test_role_turn_without_synthesis_is_stale(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+                "team_conversation": {
+                    "played_roles": ["tech-lead", "ai-engineer"],
+                },
+            }
+        )
+        report = diagnose_session(session)
+        self.assertFalse(report.has_signal(ROLE_TURN_MISSING))
+        self.assertTrue(report.has_signal(SYNTHESIS_MISSING))
+        self.assertEqual(
+            report.signal(SYNTHESIS_MISSING).severity, "stale"
+        )
+
+    def test_synthesis_without_obsidian_proposal_is_stale(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+                "team_conversation": {
+                    "played_roles": ["tech-lead", "ai-engineer"],
+                },
+                "research_synthesis": {"summary": "ok"},
+            }
+        )
+        report = diagnose_session(session)
+        self.assertFalse(report.has_signal(SYNTHESIS_MISSING))
+        self.assertTrue(report.has_signal(OBSIDIAN_PROPOSAL_MISSING))
+        signal = report.signal(OBSIDIAN_PROPOSAL_MISSING)
+        self.assertIn("yule obsidian sync", signal.propose or "")
+
+    def test_pending_obsidian_approval_is_blocked(self) -> None:
+        session = _session(
+            write_requested=True,
+            write_blocked_reason="작성 승인이 필요합니다",
+            extra={
+                "research_pack": {"title": "x"},
+                "research_synthesis": {"summary": "ok"},
+            },
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(OBSIDIAN_PENDING_APPROVAL))
+        signal = report.signal(OBSIDIAN_PENDING_APPROVAL)
+        self.assertEqual(signal.severity, "blocked")
+        self.assertIn("승인", signal.detail or "")
+
+    def test_obsidian_write_failed_is_failed(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_synthesis": {"summary": "ok"},
+                "obsidian_write_error": "Permission denied at /vault",
+            }
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(OBSIDIAN_WRITE_FAILED))
+        # When a write failed we should NOT also nag about a missing
+        # proposal — the failure already implies the proposal flow ran.
+        self.assertFalse(report.has_signal(OBSIDIAN_PROPOSAL_MISSING))
+
+    def test_research_loop_error_surfaces(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_loop_report": {"error": "forum starter 게시 실패"},
+            }
+        )
+        report = diagnose_session(session)
+        self.assertTrue(report.has_signal(RESEARCH_LOOP_ERROR))
+        self.assertIn(
+            "forum starter", report.signal(RESEARCH_LOOP_ERROR).detail or ""
+        )
+
+    def test_closed_session_emits_only_session_closed(self) -> None:
+        session = _session(
+            state=WorkflowState.COMPLETED,
+            summary="done",
+            extra={"research_pack": {"title": "x"}},
+        )
+        report = diagnose_session(session)
+        codes = {signal.code for signal in report.signals}
+        self.assertEqual(codes, {SESSION_CLOSED})
+
+    def test_no_session_returns_empty_report(self) -> None:
+        report = diagnose_session(None)
+        self.assertIsNone(report.session_id)
+        self.assertEqual(report.signals, ())
+        self.assertEqual(report.played_roles, ())
+
+    def test_primary_signal_picks_highest_severity_actionable(self) -> None:
+        # Pack missing (info), AND obsidian write failed (failed) → the
+        # primary signal must be the failed one.
+        session = _session(
+            extra={
+                "obsidian_write_error": "vault offline",
+            }
+        )
+        report = diagnose_session(session)
+        primary = report.primary_signal()
+        self.assertIsNotNone(primary)
+        self.assertEqual(primary.severity, "failed")
+        self.assertEqual(primary.code, OBSIDIAN_WRITE_FAILED)
+
+
+class RenderDiagnosticSummaryTests(unittest.TestCase):
+    def test_no_session_uses_safe_fallback(self) -> None:
+        body = render_diagnostic_summary(diagnose_session(None))
+        self.assertIn("열린 engineering-agent 세션이 보이지 않아요", body)
+
+    def test_summary_includes_session_header_and_actionable_tag(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "forum_publish_error": "starter 4000자 초과",
+            }
+        )
+        body = render_diagnostic_summary(diagnose_session(session))
+        self.assertIn("`abc123def456`", body)
+        self.assertIn("[FAILED]", body)
+        self.assertIn("starter 4000자 초과", body)
+
+    def test_pure_info_session_skips_actionable_block(self) -> None:
+        session = _session()
+        body = render_diagnostic_summary(diagnose_session(session))
+        # Only info-level signals fire so the supervisor block is omitted.
+        self.assertNotIn("감지된 다음 단계:", body)
+
+    def test_no_op_safe_for_minimal_session(self) -> None:
+        # No extra dict, no progress, no role sequence — the helper
+        # must not raise and must not emit blocked/failed signals.
+        session = _session(extra={})
+        report = diagnose_session(session)
+        for signal in report.signals:
+            self.assertIn(signal.severity, ("info", "stale", "blocked", "failed"))
+        body = render_diagnostic_summary(report)
+        self.assertTrue(body.startswith("현재 engineering-agent 세션 상태"))
+
+
+class RenderMemberBotSummaryTests(unittest.TestCase):
+    def test_member_bot_summary_with_kickoff_failure(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": False,
+                "forum_kickoff_error": "rate limit 503",
+            }
+        )
+        report = diagnose_session(session)
+        body = render_member_bot_summary(report)
+        self.assertIn("멤버 봇 진행 상태", body)
+        self.assertIn("게시 실패", body)
+        self.assertIn("rate limit 503", body)
+        self.assertIn("후속 댓글은 운영-리서치 thread", body)
+
+    def test_member_bot_summary_with_no_thread(self) -> None:
+        session = _session(extra={"research_pack": {"title": "x"}})
+        body = render_member_bot_summary(diagnose_session(session))
+        self.assertIn("운영-리서치 forum이 아직 열리지 않아", body)
+
+    def test_member_bot_summary_with_played_roles(self) -> None:
+        session = _session(
+            extra={
+                "research_pack": {"title": "x"},
+                "research_forum_thread_id": 4242,
+                "forum_comment_mode": "member-bots",
+                "forum_kickoff_posted": True,
+                "team_conversation": {
+                    "played_roles": ["tech-lead", "ai-engineer"],
+                },
+            }
+        )
+        body = render_member_bot_summary(diagnose_session(session))
+        self.assertIn("응답한 역할(2)", body)
+        self.assertIn("tech-lead", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/obsidian/test_approval.py
+++ b/tests/obsidian/test_approval.py
@@ -1,0 +1,512 @@
+"""Phase D — Discord-driven Obsidian save approval flow.
+
+Pins the contract between :mod:`yule_orchestrator.agents.obsidian_approval`
+and the engineering channel router:
+
+- "Obsidian에 정리해줘" never creates a new session — the runtime
+  preflight builds a preview against the matched session and stores a
+  pending proposal on ``session.extra``.
+- "저장 승인" / "이대로 저장" with a pending proposal calls the writer
+  exactly once.
+- Approval phrases without a pending proposal degrade to a clarification
+  message rather than intaking a brand-new session.
+- Vault-path / writer failures surface as friendly chat lines, not
+  tracebacks.
+- The collision-safe suffix policy from :mod:`obsidian_writer` is
+  preserved through the approval flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from tests._helpers import (
+    FakeChannel,
+    FakeMessage,
+    extract_prompt as _extract_prompt,
+    isolate_cache_for_test as _isolate_cache_for_test,
+    run as _run,
+)
+
+from yule_orchestrator.agents.obsidian_approval import (
+    ObsidianApprovalError,
+    build_save_proposal,
+    execute_pending_proposal,
+    get_pending_proposal,
+    is_obsidian_approval,
+    is_obsidian_save_request,
+    store_pending_proposal,
+)
+from yule_orchestrator.agents.obsidian_export import ExportPath, ObsidianNote
+from yule_orchestrator.agents.obsidian_writer import (
+    ENV_VAULT_PATH,
+    ObsidianWriteError,
+    ObsidianWriteResult,
+)
+from yule_orchestrator.agents.research_pack import (
+    ResearchAttachment,
+    ResearchPack,
+    ResearchSource,
+    SourceType,
+    pack_to_dict,
+)
+from yule_orchestrator.agents.workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    save_session,
+)
+from yule_orchestrator.discord.engineering_channel_router import (
+    EngineeringRouteContext,
+    route_engineering_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_pack() -> ResearchPack:
+    return ResearchPack(
+        title="결제 모듈 멱등성 검증",
+        summary="결제 PG 응답 재시도에서 idempotency-key 사용 패턴 정리.",
+        primary_url="https://stripe.com/docs/idempotency",
+        sources=(
+            ResearchSource(
+                source_url="https://stripe.com/docs/idempotency",
+                title="Stripe — Idempotency",
+                source_type=SourceType.OFFICIAL_DOCS,
+                collected_by_role="engineering-agent/backend-engineer",
+                why_relevant="공식 문서 기준 패턴",
+            ),
+        ),
+        tags=("payment", "idempotency"),
+        created_at=datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc),
+    )
+
+
+def _make_session(
+    *,
+    session_id: str = "abc123session",
+    channel_id: int = 1001,
+    user_id: int = 4242,
+    thread_id: int = 8000,
+    with_pack: bool = True,
+    extra: dict | None = None,
+) -> WorkflowSession:
+    base_extra: dict[str, Any] = {}
+    if with_pack:
+        base_extra["research_pack"] = pack_to_dict(_make_pack())
+    if extra:
+        base_extra.update(extra)
+    now = datetime(2026, 5, 6, 9, 0, tzinfo=timezone.utc)
+    return WorkflowSession(
+        session_id=session_id,
+        prompt="결제 모듈 멱등성 검증 흐름을 백엔드에 추가해줘",
+        task_type="research",
+        state=WorkflowState.IN_PROGRESS,
+        created_at=now - timedelta(hours=2),
+        updated_at=now,
+        channel_id=channel_id,
+        user_id=user_id,
+        thread_id=thread_id,
+        extra=base_extra,
+    )
+
+
+def _channel(channel_id: int = 1001, name: str = "업무-접수") -> FakeChannel:
+    return FakeChannel(channel_id=channel_id, name=name)
+
+
+def _route_context() -> EngineeringRouteContext:
+    return EngineeringRouteContext(
+        intake_channel_id=1001,
+        intake_channel_name="업무-접수",
+    )
+
+
+class _FakeWriter:
+    """Capture a single write_note() call without touching disk."""
+
+    def __init__(
+        self,
+        *,
+        result: ObsidianWriteResult | None = None,
+        raise_error: Exception | None = None,
+    ) -> None:
+        self.calls: list[dict] = []
+        self._result = result
+        self._raise = raise_error
+
+    def __call__(self, note, vault_root, *, overwrite=False, dry_run=False):
+        self.calls.append(
+            {
+                "note": note,
+                "vault_root": vault_root,
+                "overwrite": overwrite,
+                "dry_run": dry_run,
+            }
+        )
+        if self._raise is not None:
+            raise self._raise
+        if self._result is not None:
+            return self._result
+        target = vault_root / note.path.full
+        return ObsidianWriteResult(
+            target_path=target,
+            written=True,
+            dry_run=False,
+            overwrite=False,
+            original_target_path=target,
+            suffix_applied=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phrase detectors
+# ---------------------------------------------------------------------------
+
+
+class PhraseDetectorTests(unittest.TestCase):
+    def test_save_request_detects_korean_and_english(self) -> None:
+        self.assertTrue(is_obsidian_save_request("Obsidian에 정리해줘"))
+        self.assertTrue(is_obsidian_save_request("옵시디언에 저장해 줘"))
+        self.assertTrue(is_obsidian_save_request("이 세션 기준으로 저장해줘"))
+        self.assertTrue(is_obsidian_save_request("토의 기록 obsidian에 남겨줘"))
+        self.assertTrue(is_obsidian_save_request("save to obsidian please"))
+
+    def test_save_request_ignores_unrelated_text(self) -> None:
+        self.assertFalse(is_obsidian_save_request("결제 모듈에 멱등성 추가"))
+        self.assertFalse(is_obsidian_save_request(""))
+
+    def test_approval_detects_korean_phrases(self) -> None:
+        self.assertTrue(is_obsidian_approval("저장 승인"))
+        self.assertTrue(is_obsidian_approval("이대로 저장"))
+        self.assertTrue(is_obsidian_approval("이대로 저장해줘"))
+        self.assertTrue(is_obsidian_approval("네, 저장 승인합니다"))
+
+    def test_approval_does_not_fire_on_unrelated_messages(self) -> None:
+        self.assertFalse(is_obsidian_approval("결제 모듈 멱등성 추가"))
+        self.assertFalse(is_obsidian_approval(""))
+        # Bare "승인" requires a pending proposal — gated by the router.
+        self.assertFalse(is_obsidian_approval("승인"))
+
+    def test_bare_approval_token_with_pending_proposal(self) -> None:
+        self.assertTrue(is_obsidian_approval("승인", has_pending_proposal=True))
+        self.assertTrue(is_obsidian_approval("approve", has_pending_proposal=True))
+
+
+# ---------------------------------------------------------------------------
+# Build proposal
+# ---------------------------------------------------------------------------
+
+
+class BuildSaveProposalTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _isolate_cache_for_test(self)
+
+    def test_builds_preview_with_path_summary_and_sections(self) -> None:
+        session = _make_session()
+        proposal = build_save_proposal(session)
+        self.assertIn("`abc123session`", proposal.preview_message)
+        self.assertIn(proposal.vault_relative_path, proposal.preview_message)
+        self.assertIn("저장 승인", proposal.preview_message)
+        self.assertIn("결제 PG", proposal.preview_message)
+        self.assertGreater(len(proposal.sections), 0)
+        self.assertEqual(proposal.payload["session_id"], "abc123session")
+        self.assertEqual(proposal.payload["channel_id"], 1001)
+        self.assertEqual(proposal.payload["thread_id"], 8000)
+        self.assertEqual(proposal.payload["user_id"], 4242)
+
+    def test_missing_research_pack_raises_friendly_error(self) -> None:
+        session = _make_session(with_pack=False)
+        with self.assertRaises(ObsidianApprovalError) as ctx:
+            build_save_proposal(session)
+        self.assertIn("research_pack", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Execute pending proposal
+# ---------------------------------------------------------------------------
+
+
+class ExecutePendingProposalTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _isolate_cache_for_test(self)
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.vault_root = Path(self.tmpdir.name)
+        os.environ[ENV_VAULT_PATH] = str(self.vault_root)
+        self.addCleanup(lambda: os.environ.pop(ENV_VAULT_PATH, None))
+
+    def _session_with_proposal(self) -> WorkflowSession:
+        session = _make_session()
+        save_session(session)
+        proposal = build_save_proposal(session)
+        return store_pending_proposal(session, proposal)
+
+    def test_no_pending_proposal_raises(self) -> None:
+        session = _make_session(extra={"research_pack": None})
+        save_session(session)
+        with self.assertRaises(ObsidianApprovalError):
+            execute_pending_proposal(session)
+
+    def test_writer_invoked_once_with_resolved_vault(self) -> None:
+        session = self._session_with_proposal()
+        writer = _FakeWriter()
+        updated, outcome = execute_pending_proposal(session, writer_fn=writer)
+        self.assertTrue(outcome.success)
+        self.assertEqual(len(writer.calls), 1)
+        call = writer.calls[0]
+        self.assertEqual(call["overwrite"], False)
+        self.assertEqual(call["dry_run"], False)
+        self.assertEqual(call["vault_root"], self.vault_root.resolve())
+        self.assertIsNone(get_pending_proposal(updated))
+        # session.extra carries last write event
+        events = (updated.extra or {}).get("obsidian", {}).get("events") or []
+        self.assertEqual(events[-1]["status"], "written")
+        self.assertIn("`", outcome.message)
+
+    def test_vault_missing_returns_friendly_error(self) -> None:
+        session = self._session_with_proposal()
+        os.environ.pop(ENV_VAULT_PATH, None)
+        writer = _FakeWriter()
+        updated, outcome = execute_pending_proposal(session, writer_fn=writer)
+        self.assertFalse(outcome.success)
+        self.assertEqual(writer.calls, [])
+        # Pending proposal preserved so the operator can retry.
+        self.assertIsNotNone(get_pending_proposal(updated))
+        events = (updated.extra or {}).get("obsidian", {}).get("events") or []
+        self.assertEqual(events[-1]["status"], "vault_unavailable")
+        self.assertIn(ENV_VAULT_PATH, outcome.message)
+
+    def test_writer_failure_is_wrapped(self) -> None:
+        session = self._session_with_proposal()
+        writer = _FakeWriter(raise_error=ObsidianWriteError("permission denied"))
+        updated, outcome = execute_pending_proposal(session, writer_fn=writer)
+        self.assertFalse(outcome.success)
+        self.assertIn("permission denied", outcome.message)
+        # Pending proposal preserved on failure.
+        self.assertIsNotNone(get_pending_proposal(updated))
+        events = (updated.extra or {}).get("obsidian", {}).get("events") or []
+        self.assertEqual(events[-1]["status"], "write_failed")
+
+    def test_collision_safe_suffix_surfaces_in_outcome(self) -> None:
+        session = self._session_with_proposal()
+        original = self.vault_root / "10-projects" / "yule-studio-agent" / "knowledge" / "x.md"
+        suffixed = self.vault_root / "10-projects" / "yule-studio-agent" / "knowledge" / "x_2.md"
+        writer = _FakeWriter(
+            result=ObsidianWriteResult(
+                target_path=suffixed,
+                written=True,
+                dry_run=False,
+                overwrite=False,
+                original_target_path=original,
+                suffix_applied=True,
+            )
+        )
+        _updated, outcome = execute_pending_proposal(session, writer_fn=writer)
+        self.assertTrue(outcome.success)
+        self.assertTrue(outcome.suffix_applied)
+        self.assertIn("자동으로", outcome.message)
+
+
+# ---------------------------------------------------------------------------
+# Router integration
+# ---------------------------------------------------------------------------
+
+
+class RouterApprovalFlowTests(unittest.TestCase):
+    """End-to-end: the router intercepts save / approval phrases instead
+    of falling through to the legacy intake or research-loop path."""
+
+    def setUp(self) -> None:
+        _isolate_cache_for_test(self)
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.vault_root = Path(self.tmpdir.name)
+        os.environ[ENV_VAULT_PATH] = str(self.vault_root)
+        self.addCleanup(lambda: os.environ.pop(ENV_VAULT_PATH, None))
+
+        self.context = _route_context()
+        self.send_chunks = AsyncMock()
+        # These callables must NOT fire when the Obsidian flow takes over.
+        self.intake_fn = AsyncMock(
+            side_effect=AssertionError("intake must not run for save/approval")
+        )
+        self.kickoff_fn = AsyncMock(
+            side_effect=AssertionError("kickoff must not run for save/approval")
+        )
+        self.conversation_fn = AsyncMock(
+            side_effect=AssertionError(
+                "conversation_fn must not run for save/approval"
+            )
+        )
+
+    def _route(
+        self,
+        *,
+        message,
+        list_sessions_fn,
+        writer_fn=None,
+    ):
+        return _run(
+            route_engineering_message(
+                message=message,
+                bot_user=object(),
+                route_context=self.context,
+                extract_prompt=_extract_prompt,
+                conversation_fn=self.conversation_fn,
+                intake_fn=self.intake_fn,
+                thread_kickoff_fn=self.kickoff_fn,
+                send_chunks=self.send_chunks,
+                research_loop_fn=None,
+                thread_continuation_fn=None,
+                list_sessions_fn=list_sessions_fn,
+                obsidian_writer_fn=writer_fn,
+            )
+        )
+
+    def test_save_request_in_thread_builds_preview_and_stores_proposal(self) -> None:
+        session = _make_session(thread_id=8000)
+        save_session(session)
+        sessions = [session]
+        # Message is in the working thread (channel.id == thread_id) — recall
+        # uses thread anchor to match.
+        thread_channel = FakeChannel(
+            channel_id=8000,
+            name="작업-thread",
+            parent_id=1001,
+            parent_name="업무-접수",
+        )
+        message = FakeMessage(content="Obsidian에 정리해줘", channel=thread_channel)
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(result.session_id, "abc123session")
+        # Conversation / intake / kickoff didn't fire.
+        self.intake_fn.assert_not_awaited()
+        self.kickoff_fn.assert_not_awaited()
+        self.conversation_fn.assert_not_awaited()
+        # Preview surfaced via send_chunks.
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("Obsidian 저장 미리보기", sent)
+        self.assertIn("`abc123session`", sent)
+        self.assertIn("저장 승인", sent)
+        # Pending proposal landed on the persisted session.
+        reloaded = load_session("abc123session")
+        self.assertIsNotNone(reloaded)
+        pending = get_pending_proposal(reloaded)
+        self.assertIsNotNone(pending)
+
+    def test_approval_with_pending_proposal_invokes_writer(self) -> None:
+        session = _make_session(thread_id=8000)
+        save_session(session)
+        proposal = build_save_proposal(session)
+        store_pending_proposal(session, proposal)
+        sessions_with_proposal = [load_session("abc123session")]
+
+        writer = _FakeWriter()
+        thread_channel = FakeChannel(
+            channel_id=8000,
+            name="작업-thread",
+            parent_id=1001,
+            parent_name="업무-접수",
+        )
+        message = FakeMessage(content="저장 승인", channel=thread_channel)
+
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions_with_proposal,
+            writer_fn=writer,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(len(writer.calls), 1)
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("Obsidian 저장 완료", sent)
+
+    def test_approval_without_pending_proposal_clarifies(self) -> None:
+        # Session exists but no pending proposal stashed.
+        session = _make_session(thread_id=8000)
+        save_session(session)
+        thread_channel = FakeChannel(
+            channel_id=8000,
+            name="작업-thread",
+            parent_id=1001,
+            parent_name="업무-접수",
+        )
+        message = FakeMessage(content="저장 승인", channel=thread_channel)
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [session],
+        )
+        self.assertTrue(result.handled)
+        self.intake_fn.assert_not_awaited()
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("대기 중인 Obsidian 저장 제안이 없어요", sent)
+
+    def test_save_request_without_session_match_keeps_clarification(self) -> None:
+        # Mirrors the existing preflight contract from
+        # ``tests/engineering/test_channel_router_runtime_preflight.py``:
+        # no open session ⇒ runtime preflight asks for clarification, no
+        # preview is built (the preview branch needs a matched session).
+        thread_channel = FakeChannel(
+            channel_id=9999,
+            name="다른-thread",
+            parent_id=1001,
+            parent_name="업무-접수",
+        )
+        message = FakeMessage(content="Obsidian에 정리해줘", channel=thread_channel)
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: [],
+        )
+        self.assertTrue(result.handled)
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn("어떤 작업을 가리키시는지", sent)
+        self.assertIn("기존 작업 후속 실행", sent)
+
+    def test_approval_with_missing_vault_surfaces_friendly_error(self) -> None:
+        session = _make_session(thread_id=8000)
+        save_session(session)
+        proposal = build_save_proposal(session)
+        store_pending_proposal(session, proposal)
+        sessions_with_proposal = [load_session("abc123session")]
+        os.environ.pop(ENV_VAULT_PATH, None)
+
+        writer = _FakeWriter()
+        thread_channel = FakeChannel(
+            channel_id=8000,
+            name="작업-thread",
+            parent_id=1001,
+            parent_name="업무-접수",
+        )
+        message = FakeMessage(content="이대로 저장", channel=thread_channel)
+        result = self._route(
+            message=message,
+            list_sessions_fn=lambda **_kw: sessions_with_proposal,
+            writer_fn=writer,
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(writer.calls, [])
+        sent = "\n".join(str(c.args[1]) for c in self.send_chunks.await_args_list)
+        self.assertIn(ENV_VAULT_PATH, sent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/obsidian/test_knowledge_writer.py
+++ b/tests/obsidian/test_knowledge_writer.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.deliberation import (
+    BackendEngineerTake,
+    ProductDesignerTake,
+    TechLeadOpening,
+    TechLeadSynthesis,
+)
+from yule_orchestrator.agents.knowledge_writer import (
+    KNOWLEDGE_CONTRACT_VERSION,
+    KNOWLEDGE_KIND,
+    KNOWLEDGE_SUBDIR,
+    KnowledgeNote,
+    build_knowledge_note,
+    derive_knowledge_title,
+    render_knowledge_note,
+    scrub_title_text,
+)
+from yule_orchestrator.agents.obsidian_export import (
+    DEFAULT_PROJECT,
+    PROJECTS_BASE,
+    render_research_note,
+)
+from yule_orchestrator.agents.research_pack import (
+    ResearchAttachment,
+    ResearchPack,
+    ResearchSource,
+    pack_from_discord_message,
+)
+from yule_orchestrator.agents.workflow_state import WorkflowSession, WorkflowState
+
+
+def _session(**overrides) -> WorkflowSession:
+    base = dict(
+        session_id="abc12345",
+        prompt="Hermes 코드베이스를 우리 에이전트 런타임에 통합할 수 있는지 검토",
+        task_type="research",
+        state=WorkflowState.APPROVED,
+        created_at=datetime(2026, 5, 5, 9, 0),
+        updated_at=datetime(2026, 5, 5, 9, 5),
+        executor_role="ai-engineer",
+    )
+    base.update(overrides)
+    return WorkflowSession(**base)
+
+
+class ScrubTitleTextTests(unittest.TestCase):
+    def test_strips_research_prefix_and_bold(self) -> None:
+        self.assertEqual(
+            scrub_title_text("[Research] **Hermes 통합 검토**"),
+            "Hermes 통합 검토",
+        )
+
+    def test_strips_url_and_filler(self) -> None:
+        # Real-world failure mode: the title was being generated as the
+        # body's "자료 링크" header followed by the first URL — scrub
+        # must produce a clean, semantic phrase.
+        cleaned = scrub_title_text("자료 링크 https://github.com/example/hermes")
+        self.assertNotIn("https://", cleaned)
+        self.assertNotIn("자료 링크", cleaned)
+        self.assertEqual(cleaned, "")
+
+    def test_strips_korean_filler_prefixes(self) -> None:
+        cleaned = scrub_title_text("오늘은 Hermes 통합을 검토합니다")
+        self.assertNotIn("오늘은", cleaned)
+        self.assertIn("Hermes 통합", cleaned)
+
+
+class DeriveKnowledgeTitleTests(unittest.TestCase):
+    def test_explicit_session_topic_wins(self) -> None:
+        session = _session(extra={"topic": "Hermes 에이전트 통합 리서치"})
+        title = derive_knowledge_title(session=session)
+        self.assertEqual(title, "Hermes 에이전트 통합 리서치")
+
+    def test_url_only_pack_title_does_not_become_title(self) -> None:
+        # Regression: prior behaviour produced "자료 링크 https://..."
+        # as the H1 because the URL bled in from the body.
+        pack = ResearchPack(
+            title="자료 링크 https://github.com/example/hermes",
+            summary="",
+        )
+        session = _session(prompt="")
+        title = derive_knowledge_title(pack=pack, session=session)
+        self.assertNotIn("https://", title)
+        self.assertNotIn("자료 링크", title)
+        # Falls all the way through to the task_type fallback because no
+        # other usable signal exists.
+        self.assertTrue(title.endswith("작업 정리"), title)
+
+    def test_hermes_prompt_yields_short_semantic_title(self) -> None:
+        session = _session(
+            prompt=(
+                "Hermes 에이전트 통합 리서치 — 우리 코드베이스에 어떻게 적용할 수 "
+                "있을지 살펴보고, 다음 단계로 무엇을 정리할지 고민해보려 합니다."
+            ),
+        )
+        title = derive_knowledge_title(session=session)
+        self.assertLessEqual(len(title), 60)
+        self.assertIn("Hermes", title)
+        # Filler suffixes are gone.
+        self.assertNotIn("고민해보려", title)
+        self.assertNotIn("https://", title)
+
+    def test_synthesis_title_used_when_pack_and_prompt_empty(self) -> None:
+        synthesis = TechLeadSynthesis(
+            consensus="Claude Code 기반 에이전트 런타임 참고 자료를 정리한다",
+        )
+        title = derive_knowledge_title(
+            session=_session(prompt=""), synthesis=synthesis
+        )
+        self.assertIn("Claude Code", title)
+
+    def test_pack_title_is_used_when_intentional(self) -> None:
+        pack = ResearchPack(title="Stripe Pricing 패턴", summary="")
+        title = derive_knowledge_title(
+            pack=pack, session=_session(prompt="")
+        )
+        self.assertEqual(title, "Stripe Pricing 패턴")
+
+    def test_task_type_fallback_when_nothing_useful(self) -> None:
+        title = derive_knowledge_title(session=_session(prompt=""))
+        self.assertTrue(title.endswith("작업 정리"))
+        self.assertIn("research", title)
+
+
+class BuildKnowledgeNoteTests(unittest.TestCase):
+    def _pack(self) -> ResearchPack:
+        return pack_from_discord_message(
+            title="Hermes 통합 자료",
+            content=(
+                "Hermes 코드베이스 https://github.com/example/hermes 참고. "
+                "우리 런타임에 적용 가능성 검토."
+            ),
+            author_role="engineering-agent/ai-engineer",
+            channel_id=999,
+            thread_id=888,
+            message_id=777,
+            posted_at=datetime(2026, 5, 5, 9, 0),
+            attachments=[
+                ResearchAttachment(
+                    kind="image",
+                    url="https://cdn/hermes.png",
+                    filename="hermes-arch.png",
+                )
+            ],
+            tags=("research",),
+        )
+
+    def test_minimal_pack_only_produces_well_formed_note(self) -> None:
+        # research_pack alone is enough — synthesis and role turns are
+        # optional and the note still surfaces every required section.
+        note = build_knowledge_note(pack=self._pack(), session=_session())
+        self.assertIsInstance(note, KnowledgeNote)
+        # Title is short and free of URL noise.
+        self.assertLessEqual(len(note.title), 60)
+        self.assertNotIn("https://", note.title)
+        # Required sections all present, in contract order.
+        section_names = [name for name, _ in note.body_sections]
+        self.assertEqual(
+            section_names,
+            [
+                "작업 목적",
+                "원문 요청",
+                "현재 결론",
+                "수집 자료",
+                "역할별 검토",
+                "Tech Lead 종합",
+                "결정 / 제안",
+                "다음 액션",
+                "관련 세션",
+            ],
+        )
+        # Frontmatter contract.
+        for key in (
+            "title",
+            "topic",
+            "original_prompt",
+            "session_id",
+            "kind",
+            "status",
+            "roles",
+            "sources",
+            "created_at",
+            "task_type",
+            "project",
+        ):
+            self.assertIn(key, note.frontmatter, key)
+        self.assertEqual(note.frontmatter["kind"], KNOWLEDGE_KIND)
+        self.assertEqual(note.frontmatter["contract"], KNOWLEDGE_CONTRACT_VERSION)
+        # Path lands under the knowledge subdir.
+        self.assertTrue(
+            note.vault_folder.endswith(f"/{KNOWLEDGE_SUBDIR}"),
+            note.vault_folder,
+        )
+        self.assertTrue(note.vault_filename.startswith("2026-05-05_knowledge-"))
+
+    def test_original_prompt_preserved_in_frontmatter_and_body(self) -> None:
+        session = _session(
+            prompt="Hermes 에이전트 통합 리서치 — 우리 코드베이스에 어떻게 적용할지 검토"
+        )
+        note = build_knowledge_note(pack=self._pack(), session=session)
+        self.assertEqual(
+            note.frontmatter["original_prompt"], session.prompt
+        )
+        body_map = dict(note.body_sections)
+        self.assertIn(session.prompt, body_map["원문 요청"])
+
+    def test_role_turns_included_in_review_section(self) -> None:
+        pack = self._pack()
+        opening = TechLeadOpening(
+            task_breakdown=("Hermes 코드 구조 파악",),
+            decisions_needed=("적용 범위 결정",),
+            perspective="우선 architecture 파악이 필요",
+            evidence=("hermes README 확인",),
+            risks=("scope creep",),
+            next_actions=("핵심 모듈 정리",),
+        )
+        designer = ProductDesignerTake(
+            ux_direction="UX 영향 적음",
+            perspective="에이전트 UX는 동일 유지",
+            risks=("학습 곡선",),
+            next_actions=("도큐먼트 다이어그램 추가",),
+        )
+        backend = BackendEngineerTake(
+            data_impact="런타임 메모리 사용량 증가 가능",
+            api_impact="dispatcher 인터페이스 영향",
+            perspective="dispatcher 통합점 설계 필요",
+            risks=("동시성",),
+            next_actions=("dispatcher adapter 프로토타입",),
+        )
+        note = build_knowledge_note(
+            pack=pack,
+            session=_session(),
+            role_turns=(opening, designer, backend),
+        )
+        body_map = dict(note.body_sections)
+        review = body_map["역할별 검토"]
+        self.assertIn("tech-lead", review)
+        self.assertIn("product-designer", review)
+        self.assertIn("backend-engineer", review)
+        self.assertIn("Hermes 코드 구조 파악", review)
+        next_actions = body_map["다음 액션"]
+        self.assertIn("핵심 모듈 정리", next_actions)
+        self.assertIn("dispatcher adapter 프로토타입", next_actions)
+        decisions = body_map["결정 / 제안"]
+        self.assertIn("적용 범위 결정", decisions)
+
+    def test_synthesis_renders_into_tech_lead_section(self) -> None:
+        synthesis = TechLeadSynthesis(
+            consensus="Hermes의 dispatcher 패턴을 부분 적용",
+            todos=("dispatcher adapter 시제품", "런타임 회귀 검증"),
+            open_research=("성능 측정 baseline",),
+            user_decisions_needed=("적용 범위 확정",),
+            approval_required=False,
+        )
+        note = build_knowledge_note(
+            pack=self._pack(), session=_session(), synthesis=synthesis
+        )
+        body_map = dict(note.body_sections)
+        tech_lead = body_map["Tech Lead 종합"]
+        self.assertIn("Hermes의 dispatcher 패턴을 부분 적용", tech_lead)
+        self.assertIn("dispatcher adapter 시제품", tech_lead)
+        self.assertIn("성능 측정 baseline", tech_lead)
+        self.assertIn("승인 필요:** no", tech_lead)
+        # Decisions section pulls from synthesis user_decisions_needed.
+        self.assertIn("적용 범위 확정", body_map["결정 / 제안"])
+
+    def test_status_reflects_synthesis_and_session(self) -> None:
+        # Approval-pending wins.
+        note = build_knowledge_note(
+            pack=self._pack(),
+            session=_session(),
+            synthesis=TechLeadSynthesis(
+                consensus="x",
+                approval_required=True,
+                approval_reason="쓰기 승인",
+            ),
+        )
+        self.assertEqual(note.frontmatter["status"], "approval-pending")
+        # Decided when not pending.
+        decided = build_knowledge_note(
+            pack=self._pack(),
+            session=_session(),
+            synthesis=TechLeadSynthesis(consensus="x", approval_required=False),
+        )
+        self.assertEqual(decided.frontmatter["status"], "decided")
+        # Captured when no synthesis and intake state.
+        captured = build_knowledge_note(
+            pack=self._pack(),
+            session=_session(state=WorkflowState.INTAKE),
+        )
+        self.assertEqual(captured.frontmatter["status"], "captured")
+
+
+class RenderKnowledgeNoteTests(unittest.TestCase):
+    def _pack(self) -> ResearchPack:
+        return pack_from_discord_message(
+            title="Hermes 통합 자료",
+            content=(
+                "Hermes 코드 https://github.com/example/hermes 참고. "
+                "우리 런타임에 적용 가능성 검토."
+            ),
+            author_role="engineering-agent/ai-engineer",
+            channel_id=10,
+            thread_id=20,
+            message_id=30,
+            posted_at=datetime(2026, 5, 5, 9, 0),
+            tags=("research",),
+        )
+
+    def test_render_research_note_with_kind_knowledge_routes_to_writer(self) -> None:
+        # Public surface: the existing render_research_note() entry point
+        # opt-ins to the knowledge writer when ``kind="knowledge"`` is
+        # passed, so callers don't need to import knowledge_writer.
+        session = _session(
+            prompt="Hermes 에이전트 통합 리서치 — 우리 코드베이스에 어떻게 적용할지 검토"
+        )
+        synthesis = TechLeadSynthesis(
+            consensus="Hermes의 dispatcher 패턴을 부분 적용",
+            todos=("dispatcher adapter 프로토타입",),
+            open_research=("성능 baseline",),
+            user_decisions_needed=("적용 범위 확정",),
+        )
+        note = render_research_note(
+            self._pack(),
+            session=session,
+            synthesis=synthesis,
+            kind="knowledge",
+            env={},
+        )
+        self.assertIn(
+            f"{PROJECTS_BASE}/{DEFAULT_PROJECT}/{KNOWLEDGE_SUBDIR}",
+            note.path.folder,
+        )
+        for header in (
+            "## 작업 목적",
+            "## 원문 요청",
+            "## 현재 결론",
+            "## 수집 자료",
+            "## 역할별 검토",
+            "## Tech Lead 종합",
+            "## 결정 / 제안",
+            "## 다음 액션",
+            "## 관련 세션",
+        ):
+            self.assertIn(header, note.content)
+        self.assertIn("kind: knowledge", note.content)
+        self.assertIn("Hermes", note.content)
+        # Original prompt survives into the body.
+        self.assertIn("Hermes 에이전트 통합 리서치", note.content)
+        # No URL leaks into the H1.
+        h1 = note.content.split("\n#", 1)[0]
+        self.assertNotIn("https://", h1.split("---", 2)[2] if h1.count("---") >= 2 else h1)
+
+    def test_render_writes_under_session_project_when_set(self) -> None:
+        session = _session(extra={"project": "yule-studio-agent"})
+        note = render_knowledge_note(
+            pack=self._pack(),
+            session=session,
+            env={},
+        )
+        self.assertIn(
+            f"{PROJECTS_BASE}/yule-studio-agent/{KNOWLEDGE_SUBDIR}",
+            note.path.folder,
+        )
+        self.assertIn("project: yule-studio-agent", note.content)
+
+    def test_render_filename_basename_caps_at_100_chars(self) -> None:
+        long_pack = ResearchPack(
+            title=(
+                "Hermes 에이전트 통합 리서치를 위한 매우 긴 후보 제목 "
+                "정리 작업의 모든 세부 단계를 한 줄로 적어둔 케이스"
+            ),
+            summary="",
+            created_at=datetime(2026, 5, 5),
+        )
+        note = render_knowledge_note(pack=long_pack, session=_session(prompt=""))
+        self.assertLessEqual(len(note.path.filename), 100)
+        self.assertTrue(note.path.filename.endswith(".md"))
+
+
+class KnowledgeNoteSectionFormatTests(unittest.TestCase):
+    def test_empty_role_turns_section_renders_with_explanatory_marker(self) -> None:
+        note = build_knowledge_note(
+            pack=ResearchPack(title="간단 메모", summary=""),
+            session=_session(),
+        )
+        body_map = dict(note.body_sections)
+        self.assertIn("기록되지 않았습니다", body_map["역할별 검토"])
+
+    def test_decisions_and_actions_dedup_across_inputs(self) -> None:
+        # Same decision/action coming from multiple sources should not
+        # appear twice in the rendered list.
+        opening = TechLeadOpening(decisions_needed=("적용 범위 결정",))
+        synthesis = TechLeadSynthesis(
+            consensus="x",
+            user_decisions_needed=("적용 범위 결정",),
+            todos=("dispatcher adapter",),
+        )
+        backend = BackendEngineerTake(
+            next_actions=("dispatcher adapter",),
+        )
+        note = build_knowledge_note(
+            pack=None,
+            session=_session(),
+            synthesis=synthesis,
+            role_turns=(opening, backend),
+        )
+        body_map = dict(note.body_sections)
+        self.assertEqual(body_map["결정 / 제안"].count("적용 범위 결정"), 1)
+        self.assertEqual(body_map["다음 액션"].count("dispatcher adapter"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #56 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
Engineering Agent가 단순 템플릿 응답 봇이 아니라, 기존 작업을 기억하고 이어가며 역할별 에이전트가 독립적으로 상태를 판단할 수 있도록 conversational runtime 기반을 추가했습니다.

이번 작업은 Discord 기반 팀 운영을 위해 다음 흐름의 기반을 마련합니다.

`Observe → Understand → Recall → Research → Decide → Act → Record`

주요 변경 사항:
- Role agent runtime model / loop 추가
- deterministic intent classifier 추가
- 기존 session recall / memory adapter 연결
- gateway router preflight 추가
  - 기존 작업 이어가기
  - 이전 작업 요약
  - 기존 작업 후속 실행
  - context append
- confirm / continuation / clarification 흐름 보강
- member-bots open-call 상태 및 role turn 기록 보강
- status diagnostic 응답 개선
- Obsidian KnowledgeNote export 추가
- Obsidian preview → approval → local vault write 흐름 추가
- `yule supervisor run --once` 상태 진단 CLI 추가
- 관련 unittest 추가

## ✅ 테스트
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `yule obsidian sync --help`
- `yule obsidian sync --session <session_id> --kind knowledge --dry-run`
- `yule supervisor run --once --limit 5`

확인한 내용:
- `--kind knowledge` CLI 인식
- KnowledgeNote가 `10-projects/<project>/knowledge/` 아래로 렌더링됨
- Obsidian 저장 전 preview / approval flow 동작
- supervisor가 session 상태, forum/open-call, role turn, synthesis, Obsidian proposal 상태를 진단함

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
이번 PR은 “실제 회사처럼 동작하는 Discord 에이전트 팀”을 만들기 위한 기반 작업입니다.

남은 후속 과제:
- LLM-backed conversational runner 연결
- role별 장기 memory retrieval 품질 개선
- Discord live 환경에서 member-bot retry / stale turn 정책 보강
- Obsidian vault git commit / push 승인 플로우 분리
- gateway와 member bot의 자유 대화 능력 강화