### PR TITLE
[Feat] Hermes Agent 흡수 — memory/recall/compression/self-improvement/scheduled-automation 정책 5종 (#59)

### DIFF
--- a/agents/engineering-agent/agent.json
+++ b/agents/engineering-agent/agent.json
@@ -30,7 +30,12 @@
     "policies/runtime/agents/engineering-agent/message-protocol.md",
     "policies/runtime/agents/engineering-agent/version-control.md",
     "policies/runtime/agents/engineering-agent/workflow.md",
-    "policies/runtime/agents/engineering-agent/testing.md"
+    "policies/runtime/agents/engineering-agent/testing.md",
+    "policies/runtime/agents/engineering-agent/memory-policy.md",
+    "policies/runtime/agents/engineering-agent/recall-policy.md",
+    "policies/runtime/agents/engineering-agent/context-compression.md",
+    "policies/runtime/agents/engineering-agent/self-improvement-flow.md",
+    "policies/runtime/agents/engineering-agent/scheduled-automation.md"
   ],
   "write_policy": {
     "max_write_executors_per_run": 1,

--- a/policies/runtime/agents/engineering-agent/context-compression.md
+++ b/policies/runtime/agents/engineering-agent/context-compression.md
@@ -1,0 +1,122 @@
+# Engineering Agent — Context compression policy (Hermes-inspired, issue #59)
+
+본 정책은 Yule 의 **context / trajectory compression** 을 정한다. Hermes Agent 의 `agent/context_compressor.py` 가 보여주는 token threshold + 보호 영역 + tool output 압축 패턴을 Yule 의 lifecycle 안에 결합하되, **원문 prompt / decision / synthesis 본문은 절대 압축 / 삭제하지 않는다.**
+
+이 문서는 issue #59 ([Hermes 흡수 결정 D-4](#)) 의 구현물이다.
+
+## 1. 핵심 원칙
+
+1. **audit traceability 는 모든 효율보다 우선.** 원문 prompt / synthesis consensus / decision body / agent_ops_audit entries 는 압축 / 요약 / 절단 대상이 아니다.
+2. **압축은 *전송 비용* 통제 수단**. SQLite / Obsidian 영속 저장은 원본을 그대로. 압축은 LLM runner 입력 / `work_report.executive_summary` / Discord 메시지 표시 영역에만 적용.
+3. **threshold 는 모델 context window 비율로 정의** — 절대 토큰 수가 아니라 모델별 비율. 모델 교체 시 자동으로 따라감.
+4. **운영자 명시 압축이 최우선** — `/compress <topic>` 같은 명령 흐름 (Hermes 패턴) 이 정책에 들어와야 자동 압축이 잘못 가도 수동 복구 가능.
+
+## 2. 압축 적용 영역 (4 surface)
+
+| surface | 압축 적용? | 무엇이 압축되나 | 보호 영역 |
+|---|---|---|---|
+| **role-runner dispatch input** | 적용 — token threshold 시 | prior turns 의 middle 영역 | 첫 N=3 메시지 + 가장 최근 `tail_token_budget` 메시지 |
+| **`work_report.executive_summary`** (already-final) | 적용 — `len > 1500` 시 자동 head + tail (knowledge writer 패턴) | 본문 중간 | 헤더 + 첫 단락 + 마지막 단락 |
+| **Discord 메시지 표시** | 적용 — `> DISCORD_MESSAGE_LENGTH_LIMIT` 시 starter + reply chunks | 일부 | 구분 표시 (`(continued in reply)`) |
+| **Obsidian export 파일 본문** | **압축 금지** — 영속 저장은 원본 | (해당 없음) | 전체 |
+| **session.extra (SQLite)** | **압축 금지** — JSON-safe round-trip 필요 | (해당 없음) | 전체 |
+| **agent_ops_audit entries** | **압축 금지** — 200 entries cap 만 | (해당 없음) | 전체 |
+
+## 3. role-runner dispatch input 압축 (정책)
+
+[M11b RoleRunner dispatcher](../../../../src/yule_orchestrator/agents/runners/role_runner.py) 가 `RoleRunnerInput.previous_decisions` 를 받아 LLM runner 에 보낼 때.
+
+### 3.1 threshold
+
+| 모델 family | context window (입력 한도) | threshold | 비고 |
+|---|---|---|---|
+| Claude Sonnet 4.x | 200K | 50% (100K input) | Hermes 기본값과 동일 |
+| Claude Opus 4.x | 200K | 50% (100K input) | |
+| Codex / GPT-5.x | 128K | 40% (51K input) | 출력 budget 여유 확보 |
+| Ollama 로컬 (qwen-72b 등) | 32K~128K | 35% | 로컬 latency 고려 |
+| **Yule deterministic fallback** | (해당 없음) | 압축 안 함 | template-driven, prompt 가 짧음 |
+
+threshold 도달 시 LLM 기반 자동 요약 발동. **Yule deterministic fallback 은 본 정책에서 제외** — 정해진 짧은 template 만 사용.
+
+### 3.2 보호 영역
+
+압축 시 다음은 절대 손대지 않는다:
+
+- 첫 3 개 메시지 (system prompt + 원문 prompt + 첫 합의 메시지)
+- 가장 최근 5 개 메시지 (last 5 turns)
+- 모든 `kind=decision` 또는 `role=tech-lead` synthesis 메시지
+- Yule 의 `RoleProfile.output_sections` 가 박은 헤더 (`핵심 판단` / `다음 액션` 등)
+
+### 3.3 압축된 turn 표현 형태
+
+middle turn → 한 줄 placeholder:
+
+```
+[role-take@<role>] <문장 요약 ≤ 80자> (생략된 본문 N자, audit_id=<id>)
+```
+
+audit_id 는 `agent_ops_audit` 의 entry_id 를 가리킴. 압축 후에도 원문 retrieval 가능.
+
+### 3.4 압축 트리거 (read-side only)
+
+압축은 *전송 시점에만* — SQLite / Obsidian 의 영속 저장 본문은 원본 그대로.
+
+## 4. work_report 압축 (정책)
+
+`agents/work_report.py` 의 `executive_summary` 는 이미 부분 요약 — 하지만 long body 는 그대로 들고 다님.
+
+| 단계 | 본문 처리 |
+|---|---|
+| `compute_report_status() == INSUFFICIENT` | 본문 불생성 — placeholder 만 |
+| `compute_report_status() == INTERIM` | `executive_summary` (≤ 800자) + 정해진 섹션 |
+| `compute_report_status() == READY` | full body 생성 — 압축 없음 |
+| `compute_report_status() == FINAL` | full body + audit reference 부착 |
+
+본 정책은 *INTERIM 단계의 800자 cap* 을 명시 source of truth 로 삼는다. 코드 (`work_report.py`) 와 본 정책이 같은 한계를 본다.
+
+## 5. Discord 메시지 압축 (이미 구현됨)
+
+`discord/research_forum.py` 의 `truncate_for_starter_message` + `split_forum_starter_and_replies` 가 이미 처리. 본 정책은 *원본 보존* 만 재확인:
+
+- starter 가 limit 초과 시 reply chunk 로 분할.
+- 원본은 Obsidian export 에 그대로 들어감.
+- forum-starter 안 truncation marker (`_본문이 길어 ...`) 는 사용자 가시 표식 — 원본은 vault.
+
+## 6. 절대 금지 (압축 대상 제외)
+
+다음은 어느 단계에서도 압축 / 절단 / 요약하지 않는다:
+
+| 영역 | 이유 |
+|---|---|
+| `WorkflowSession.prompt` 원문 | audit 의 root |
+| `TechLeadSynthesis.consensus` | 결정 본문 |
+| `TechLeadSynthesis.user_decisions_needed` | 사용자 승인 표면 |
+| Obsidian frontmatter 의 `original_prompt` | session.prompt 의 vault mirror |
+| `agent_ops_audit[].outcome` / `summary` | 의사결정 traceability |
+| approval card body | 운영자 승인 게이트의 가시성 |
+| commit message | git 의 truth |
+| PR description body (G3 `render_pr_body`) | GitHub 의 contract |
+
+위 영역에 압축이 들어가면 lifecycle gate 자체가 의미를 잃는다.
+
+## 7. 운영자 명시 압축 (Hermes /compress 패턴)
+
+수동 복구 / 명시 압축이 가능해야 자동 압축이 잘못 가도 운영 가능.
+
+후속 milestone 의 CLI 후보:
+- `yule engineer compress --session <id> --topic <topic>` — 특정 세션의 prior turns 를 LLM 으로 명시 요약 + 보고. 영속 저장은 새 task-log note 로.
+- `yule engineer usage --session <id>` — 현재 세션의 token / cost 누적량 표시 (Hermes `/usage` 대응).
+
+본 phase 는 정책까지. 코드는 별도 issue.
+
+## 8. 후속 milestone
+
+1. **role-runner dispatch input 압축 wiring** — `agents/runners/bootstrap.py` 가 `previous_decisions` 길이를 보고 [§3.1 threshold](#31-threshold) 도달 시 LLM 압축 호출. 우선순위 P1.
+2. **`yule engineer compress` / `yule engineer usage` CLI** — 우선순위 P2.
+3. **work_report INTERIM cap 코드화** — 800자 cap 을 `agents/work_report.py` 상수로 박고 본 정책과 cross-link. 우선순위 P3.
+
+## 9. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-08 | 초기 작성 — issue #59 의 Hermes 흡수 결정 D-4 구현물. 4 surface 별 압축 적용 / 모델별 threshold / 보호 영역 / 절대 금지 영역 / 후속 milestone 정리 |

--- a/policies/runtime/agents/engineering-agent/memory-policy.md
+++ b/policies/runtime/agents/engineering-agent/memory-policy.md
@@ -1,0 +1,96 @@
+# Engineering Agent — Memory policy (Hermes-inspired, issue #59)
+
+본 정책은 Yule 의 **persistent memory 운영 규칙** 을 정한다. Hermes Agent 의 `memory_manager` 가 보여주는 "어떤 산출물이 향후 작업의 1 차 input 인가" 의 hint 흐름을 Yule 의 lifecycle gate 안에 결합하되, **자율 memory write 는 절대 도입하지 않는다.**
+
+이 문서는 issue #59 ([Hermes 흡수 결정 D-2](#)) 의 구현물이다. 단일 source-of-truth — supervisor / status / `yule memory search` 가 본 정책을 따른다.
+
+## 1. 핵심 원칙
+
+1. **자율 memory write 금지.** 모든 memory write 는 lifecycle gate (`agents/lifecycle_status.can_write_obsidian_record`) 를 통과한 산출물만 한다. agent 가 자기 결정으로 SQLite/Obsidian 에 새 항목을 만들지 못한다.
+2. **재사용성 hint 는 운영자 가시성 영역에 둔다.** "이 산출물이 향후 작업 input 으로 유용하다" 는 표식은 *retrieval 우선순위 boost* 형태로만 작동 — write 트리거가 아니다.
+3. **원문 prompt / decision / synthesis 는 절대 압축 / 삭제하지 않는다.** audit traceability 가 모든 효율보다 우선.
+4. **multi-tenant memory 도입 안 함.** Yule 은 single-operator 환경 — Hermes 의 `MemoryProvider` 추상화 같은 다중 백엔드 안 둔다.
+
+## 2. 메모리 영역 (Yule 의 4 surface)
+
+| surface | 위치 | 책임 |
+|---|---|---|
+| **session.extra** (workflow_sessions row) | SQLite `.cache/yule/cache.sqlite3` | 진행 중 lifecycle 상태 — `active_research_roles` / `research_pack` / `work_report` / `coding_proposal` / `agent_ops_audit` 등 |
+| **memory FTS5 index** | SQLite `documents` table | `yule memory reindex` 가 `policies/` + Obsidian vault 를 SOURCE_POLICY / SOURCE_KNOWLEDGE 로 인덱싱 |
+| **Obsidian vault** | 운영자 vault root (절대경로 `OBSIDIAN_VAULT_PATH`) | 사람 가독 자산 — research / decisions / task-logs / reports / knowledge / retrospectives |
+| **topic ledger** | session.extra `research_topic` 키 | `agents/lifecycle/research_topic.py` 가 thread/topic 단위 dedup + status transition |
+
+위 4 surface 를 동시에 갖는 게 Hermes 와 Yule 의 차이 — Hermes 는 `memory_manager` 가 단일 추상화로 묶지만, Yule 은 surface 별 책임 분리.
+
+## 3. memory write trigger (단일 source)
+
+**모든 memory write 는 다음 trigger 만 인정한다**:
+
+| Trigger | source code | 영향받는 surface |
+|---|---|---|
+| `persist_research_artifacts` (intake / forum hook) | `agents/research_persistence.py` | session.extra `research_pack` / `research_synthesis` |
+| `merge_session_extra` (lifecycle persistence) | `agents/lifecycle_persistence.py` | session.extra (lifecycle keys) |
+| `yule obsidian sync` (사용자 명시 + lifecycle gate 통과) | `cli/obsidian.py` | Obsidian vault file |
+| `yule memory reindex` (사용자 명시) | `cli/memory.py` | memory FTS5 index |
+| `transition_topic_ledger` (sync 후) | `agents/lifecycle/research_topic.py` | session.extra `research_topic` |
+| `append_agent_ops_audit` (의사결정 record) | `agents/lifecycle/agent_ops_log.py` | session.extra `agent_ops_audit` |
+
+**위 6 가지 외의 자율 write 는 금지.** 새 trigger 추가는 본 정책 §7 절차 따라 PR + decision note.
+
+## 4. 재사용성 hint 정책 (read-side boost only)
+
+특정 산출물이 향후 작업의 1 차 input 으로 자주 쓰일 때 *retrieval 우선순위* 를 올린다. **새 write 트리거가 아니다 — 이미 영속화된 데이터의 검색 가중치 변경.**
+
+| 표식 | 어디서 박힘 | retrieval boost |
+|---|---|---|
+| `kind=decision` (frontmatter) | obsidian_export 자동 | 기본 +1 — 결정은 다음 작업의 가장 강한 input |
+| `status=decided` 또는 `status=approval-pending` | obsidian_export 자동 | 기본 +0.5 |
+| `frontmatter.reusable=true` | 운영자 명시 | +1 — "이 자료는 같은 영역 작업에 자주 쓰임" 운영자 표식 |
+| `frontmatter.canonical=true` | 운영자 명시 | +2 — "이 영역의 1 차 source" 운영자 표식 (회고 / runbook) |
+| `kind=retrospective` | obsidian_export 자동 | +0.5 — 다음 작업의 input 후보 |
+
+`yule memory search` / role-runner retrieval 이 본 boost 를 적용. 본 정책은 *어떤 boost 가 어떤 표식에서 오는지* 의 단일 source — 코드 구현은 [후속 milestone — `agents/memory/retrieval.py` boost wiring](#7-후속-milestone) 에서.
+
+## 5. memory 만료 / pruning 정책
+
+| 영역 | 만료 정책 | 근거 |
+|---|---|---|
+| `session.extra` (SQLite) | 무기한 — explicit `delete-session` 만 | audit traceability 우선 |
+| memory FTS5 index | `yule memory reindex` 가 **stale path 자동 제거** | 파일 삭제 후 재인덱싱 시 자동 정리 |
+| Obsidian vault | 만료 없음 — 운영자가 git 으로 관리 | vault 가 git repo 인 경우 history 보존 |
+| `research_topic` ledger | 무기한 — `STATUS_SUPERSEDED` 표식만 | 후속 revision 추적 가능하도록 |
+| `agent_ops_audit` | session.extra 안 — 200 entries cap | 이미 구현됨 (`agent_ops_log._max_entries`) |
+
+**Hermes 의 curator 가 하는 자동 archive / consolidation 은 도입하지 않는다.** 운영자 명시 commit 만 vault 변경.
+
+## 6. supervisor / status 노출 형태
+
+session 진단 시 (`yule supervisor run --once` 또는 `yule status`) 본 정책 영역의 신호:
+
+- session.extra 에 *재사용성 hint* 표식이 있는 산출물은 status 출력에서 별표 / `📌` 마커.
+- `yule memory search "query"` 가 retrieval 결과를 boost 순으로 정렬 (boost 값 함께 출력 — 운영자가 왜 그 순서인지 확인 가능).
+- topic ledger 의 `STATUS_SAVED` + `revision > 1` 산출물은 supervisor 진단에서 "revision 누적 중 — 회고 후보" 신호.
+
+## 7. 후속 milestone
+
+본 정책 적용을 위한 코드 작업 — 본 phase 범위 밖, 명시적으로 다음 milestone:
+
+1. **retrieval boost wiring** — `agents/memory/retrieval.py` 에 frontmatter 기반 boost 적용. 우선순위 P1.
+2. **status surface 의 hint 마커** — `agents/session_status.py` 가 frontmatter `reusable=true` / `canonical=true` 산출물을 별도 라인으로 노출. 우선순위 P2.
+3. **`yule memory search` boost 출력** — 검색 결과에 boost 값 표시. 우선순위 P2.
+
+각 milestone 은 별도 issue + decision note 로 관리.
+
+## 8. 변경 절차
+
+본 정책 변경 시:
+1. issue + decision note 작성.
+2. memory write trigger §3 추가 / 변경은 보안 영향 검토 — 자율 write 가 새로 들어가면 반드시 lifecycle gate 와 결합 증명.
+3. `yule memory reindex` 실행하여 vault 인덱스 갱신.
+4. supervisor 진단 출력 변경 시 회귀 테스트 (`tests/engineering/test_session_status.py` 또는 신규).
+
+## 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-08 | 초기 작성 — issue #59 의 Hermes 흡수 결정 D-2 구현물. memory write trigger / 재사용성 hint / 만료 정책 / supervisor 노출 / 후속 milestone 정리 |

--- a/policies/runtime/agents/engineering-agent/recall-policy.md
+++ b/policies/runtime/agents/engineering-agent/recall-policy.md
@@ -1,0 +1,109 @@
+# Engineering Agent — Recall policy (Hermes-inspired, issue #59)
+
+본 정책은 Yule 의 **cross-session recall** 을 정한다. Hermes Agent 의 `agent/insights.py` 가 보여주는 "지난 N 일 동안 어떤 작업을 했고 어떤 자료를 봤는지" 의 일자별 회상 흐름을 Yule lifecycle 안에 결합한다.
+
+이 문서는 issue #59 ([Hermes 흡수 결정 D-3](#)) 의 구현물이다.
+
+## 1. 핵심 원칙
+
+1. **recall 은 이미 영속화된 자산을 다시 꺼내 쓰는 행위다.** 새로 인덱스를 만들지 않고, [memory-policy](./memory-policy.md) §3 의 6 가지 trigger 가 만든 자산만 본다.
+2. **session 단위 recall 은 이미 잘 됨** — `agents/session_status.py` + topic ledger 가 단일 세션 내부 진행/막힘 을 답한다. 본 정책은 *cross-session* 영역.
+3. **운영자 정량 보고와 정성 진단을 분리한다.** Hermes insights 는 token / cost / 빈도 (정량). Yule supervisor 는 어디까지 했고 무엇이 막혔나 (정성). 둘 다 의미 있고 상호 보완.
+4. **recall 결과는 새 작업의 input 후보**. 자동 input 주입은 *명시적 인용* 만 — `yule engineer intake` 가 자동으로 어제의 결정을 prompt 에 끼워 넣지 않는다.
+
+## 2. recall 영역 (3 종)
+
+| 영역 | 답하는 질문 | source |
+|---|---|---|
+| **session-internal** (이미 구현됨) | 이 세션은 어디까지 진행했나 / 무엇이 막혔나 | `session_status.diagnose_session()` + topic ledger |
+| **cross-session 일자별 회고** (본 정책 신규) | 지난 N 일 동안 어떤 결정 / 자료 / 작업이 있었나 | task-logs / decisions / research / agent_ops_audit |
+| **topic 횡단 recall** (본 정책 신규) | 같은 주제로 한 작업이 여러 세션 / 여러 thread 에 흩어져 있을 때 한 곳에서 보기 | topic ledger `topic_key` + Obsidian frontmatter `topic` 키 |
+
+## 3. cross-session 일자별 회고
+
+### 3.1 입력 source
+
+운영자가 `yule insights --days 7` (후속 milestone) 또는 본 정책에 따라 수동 grep 하면 다음 source 를 본다:
+
+| source | 위치 | 무엇을 보나 |
+|---|---|---|
+| Obsidian `task-logs/` | vault `10-projects/<project>/task-logs/` | 일자별 작업 진행 로그 |
+| Obsidian `decisions/` | vault `10-projects/<project>/decisions/` | TechLeadSynthesis 기반 결정 노트 |
+| Obsidian `research/` | vault `10-projects/<project>/research/` | ResearchPack 자료 노트 |
+| Obsidian `retrospectives/` | vault `10-projects/<project>/retrospectives/` | 회고 노트 ([self-improvement-flow](./self-improvement-flow.md)) |
+| `session.extra.agent_ops_audit` | SQLite | 의사결정 / dispatch / handoff 로그 |
+| `session.extra.research_topic` | SQLite | topic ledger transitions |
+
+### 3.2 출력 형태 (보고서 contract)
+
+후속 milestone 의 `yule insights` 가 만들 보고서 형태:
+
+```markdown
+# 지난 7 일 회고 — 2026-05-01 ~ 2026-05-08
+
+## 활동 요약
+- 신규 세션: N 건
+- 종료 세션: N 건
+- decisions 신규: N 건
+- research 신규: N 건
+- retrospectives 신규: N 건
+
+## 영역별 활동 (top 5)
+| topic_key | 세션 수 | 결정 수 | 마지막 활동 |
+
+## 막힌 작업 (in-flight)
+| session_id | thread | 마지막 lifecycle | stop_reason |
+
+## 회고 후보
+| topic | 회고 미작성 결정 | hint |
+
+## audit 빈도 분석
+| action | 빈도 | 마지막 발생 |
+```
+
+본 정책은 *contract* 를 정한다. 코드는 [§5 후속 milestone](#5-후속-milestone) 에서.
+
+## 4. topic 횡단 recall
+
+같은 topic 으로 한 작업이 여러 세션에 흩어져 있는 경우의 recall.
+
+### 4.1 매칭 키
+
+- 1 차: `session.extra.research_topic.topic_key` (topic ledger).
+- 2 차: Obsidian frontmatter `topic` 키.
+- 3 차 fallback: `kind=decision/research` 노트의 `slug` prefix 일치 (운영자 grep).
+
+### 4.2 사용 시나리오
+
+- 사용자: "Hermes 통합 관련 자료 다 보여줘"
+  - 검색 키: `topic=hermes-yule-integration`
+  - 결과: research / decision / task-log 모두 묶어서 반환.
+
+- 사용자: "지난 달 결제 모듈 작업한 거"
+  - 검색 키: `topic prefix payment-` AND created_at within 30 days.
+
+### 4.3 retrieval boost (memory-policy §4 와 결합)
+
+topic 횡단 recall 결과는 [memory-policy §4](./memory-policy.md#4-재사용성-hint-정책-read-side-boost-only) 의 boost 를 따른다 — `kind=decision` + `frontmatter.canonical=true` 가 가장 위.
+
+## 5. 후속 milestone
+
+본 정책의 코드 구현 — 본 phase 범위 밖:
+
+1. **`yule insights` CLI** (`cli/insights.py`) — `--days N` / `--topic` 옵션, 보고서 §3.2 contract 준수. 우선순위 P1.
+2. **topic 횡단 검색** — `cli/memory.py` 에 `--topic` filter 추가. 우선순위 P2.
+3. **supervisor 의 회고 후보 안내** — `agents/session_status.py` 가 *회고 미작성 + decision 존재* 세션을 별도 신호로 노출. 우선순위 P2.
+
+각 milestone 은 별도 issue + decision note 로.
+
+## 6. 안전 가드
+
+- recall 보고서는 **읽기 전용**. recall 결과를 본 작업이 새 산출물을 자동 만들지 않는다.
+- recall 결과의 인용은 운영자가 명시적으로 prompt 에 붙임. 자동 prompt 주입 금지.
+- secret / private key / Authorization 헤더가 task-logs / agent_ops_audit 안에 들어 있을 가능성 → recall 결과 출력 시 [audit redact_secrets](../../../../docs/github-agent-workos.md#5-hard-rails) 패턴 동일 적용.
+
+## 7. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-08 | 초기 작성 — issue #59 의 Hermes 흡수 결정 D-3 구현물. cross-session 회고 contract / topic 횡단 recall / 후속 milestone 정리 |

--- a/policies/runtime/agents/engineering-agent/scheduled-automation.md
+++ b/policies/runtime/agents/engineering-agent/scheduled-automation.md
@@ -1,0 +1,167 @@
+# Engineering Agent — Scheduled automation policy (Hermes-inspired, issue #59)
+
+본 정책은 Yule 의 **반복 작업 / scheduled work** 운영 규칙을 정한다. Hermes Agent 의 `cron/scheduler.py` + `jobs.json` 패턴을 Yule 환경에 맞게 흡수하되, secret 노출 표면 / destructive 작업 / multi-platform 안전 가드를 강하게 둔다.
+
+이 문서는 issue #59 ([Hermes 흡수 결정 D-6](#)) 의 구현물이다.
+
+## 1. 핵심 원칙
+
+1. **destructive 작업 금지.** push to main / merge / deploy / `rm -rf` / git reset 류는 어떤 scheduled job 도 호출 못한다.
+2. **secret 미주입.** scheduled job 자체가 secret 을 들고 있지 않는다 — 인증된 Yule worker 환경 (`.env.local`) 만 secret 을 본다.
+3. **단일 platform.** Discord 외 새 messenger 로 결과 전송 금지 ([decision D-1 비도입](#)).
+4. **운영자 명시 등록.** scheduled job 은 운영자가 정책 따라 등록 — agent 자율 등록 금지.
+5. **결과 audit 가시.** 모든 job 실행은 `agent_ops_audit` row 1 건 + supervisor 진단 노출.
+
+## 2. 적용 영역
+
+| 영역 | 도입 형태 | 비고 |
+|---|---|---|
+| **반복 작업 (cron-style)** | 본 정책 신규 | Hermes `jobs.json` 패턴 흡수 |
+| 일 단위 briefing (이미 구현) | `discord/bot.py._run_daily_briefing_loop` 그대로 유지 | 본 정책의 special case |
+| 일 단위 preparation (이미 구현) | `discord/bot.py._run_daily_preparation_loop` 그대로 | 본 정책의 special case |
+| checkpoint notification (이미 구현) | `discord/bot.py._run_checkpoint_notification_loop` 그대로 | 본 정책의 special case |
+| systemd timer / `yule run-service` (always-on worker) | 별도 — worker pool, 본 정책 영역 아님 | `docs/operations.md` |
+
+## 3. job storage 형태 (contract)
+
+후속 milestone 의 storage 는 다음 contract 를 따른다 — Hermes `jobs.json` 패턴 + Yule 안전 가드.
+
+### 3.1 storage 경로
+
+`.cache/yule/scheduled-jobs.json` (gitignored, `.env*` 와 같은 디렉토리 정책)
+또는 SQLite `scheduled_jobs` table — 후속 milestone 에서 결정. 본 정책은 *contract* 만.
+
+### 3.2 job entry schema
+
+```json
+{
+  "job_id": "<stable id, 12 hex>",
+  "name": "<운영자 친화 이름>",
+  "schedule": {
+    "kind": "interval | weekly | monthly | once",
+    "spec": "...",
+    "tz": "Asia/Seoul"
+  },
+  "trigger": {
+    "kind": "engineer_intake | research_collect | retrospective_check | memory_reindex | obsidian_sync_check",
+    "payload": { "...": "..." }
+  },
+  "deliver": {
+    "channel": "discord:<channel_id_env_key>",
+    "format": "summary"
+  },
+  "safety": {
+    "destructive_allowed": false,
+    "max_runtime_seconds": 600,
+    "approval_required": false,
+    "approval_action": null
+  },
+  "audit": {
+    "owner": "engineering-agent/tech-lead",
+    "registered_by": "<operator>",
+    "registered_at": "<ISO>",
+    "last_run_at": "<ISO|null>",
+    "last_outcome": "ok | failed | skipped | denied"
+  }
+}
+```
+
+### 3.3 trigger.kind whitelist
+
+다음 5 가지만 인정. 새 trigger 는 본 정책 §8 절차 따라.
+
+| trigger.kind | 의미 | safety constraint |
+|---|---|---|
+| `engineer_intake` | `yule engineer intake --prompt "..."` 와 동일 — 새 세션 생성 | `--write` 자동 부여 금지. write 는 항상 운영자 승인 |
+| `research_collect` | 특정 topic 으로 자료 수집만 — 결과 영속화 yes | 코드 변경 / git commit 금지 |
+| `retrospective_check` | 회고 후보 안내 ([self-improvement-flow §3.1](./self-improvement-flow.md#31-lifecycle-단계--회고-후보-알림)) — supervisor 진단으로 surface | read-only |
+| `memory_reindex` | `yule memory reindex` — vault 인덱싱 갱신 | secret 영역 인덱싱 안 함 (이미 구현됨) |
+| `obsidian_sync_check` | 미동기화 세션 안내 — 실제 sync 자동 실행 안 함 | read-only — sync 는 사용자 명시 |
+
+## 4. safety 가드 (필수)
+
+### 4.1 destructive 작업 금지 (코드 차원에서 차단)
+
+후속 milestone 의 scheduler 는 다음을 *호출 자체* 가 안 되게 만든다:
+
+- `git push` / `git reset --hard` / `git checkout --` / `git rebase -i` / `git commit --amend`
+- `gh pr merge` / `gh pr close --delete-branch`
+- `rm -rf` / `find -delete` / DB drop 류
+- `yule github smoke-pr --live` (운영자 명시만)
+- secret rotation 류
+
+위 호출이 trigger.payload 안에 들어 있어도 scheduler 가 실행 거부 + audit "denied: destructive_command_in_payload" 기록.
+
+### 4.2 max runtime cap
+
+job entry `safety.max_runtime_seconds` (기본 600 = 10 분) 초과 시 strict timeout. timeout 은 `last_outcome=failed` 로 기록.
+
+### 4.3 secret 미주입
+
+scheduled job payload 에 `${ENV_VAR}` 같은 expansion 은 허용하지 않는다 — payload 는 plain string 만. secret 이 필요한 작업(예: GitHub App write) 은 *Yule worker 환경* 에서만 실행되고 worker 가 자기 env 에서 secret 을 읽는다.
+
+### 4.4 approval 필요한 작업
+
+`safety.approval_required: true` 인 job 은 trigger 직후 `#승인-대기` 카드 게시까지만 — 실행은 운영자 승인 후 (G6 approval routed runner 와 동일 path).
+
+## 5. delivery — Discord 단일
+
+`deliver.channel` 은 다음 형태만 인정:
+- `discord:<env_key>` — `.env.local` 의 channel_id env key 이름. 직접 hardcode 금지.
+
+새 platform (Telegram / Slack / Email) 추가는 본 정책 §8 절차 + decision note + secret 정책 검토 필수.
+
+`deliver.format`:
+- `summary` — 한 줄 요약 + 자세한 내용은 supervisor 진단 / Obsidian.
+- `full` — 결과 markdown 그대로 (max 2000 chars per Discord 메시지 — `discord/research_forum.split_forum_starter_and_replies` 패턴).
+
+## 6. audit 흐름
+
+모든 scheduled job 실행은 1 건의 `agent_ops_audit` entry:
+
+```json
+{
+  "action": "scheduled_job",
+  "autonomy_level": "L1",
+  "summary": "job=<job_id> name=<name> outcome=<ok|failed|denied> duration=<ms>",
+  "outcome": "ok | failed | denied",
+  "references": ["<vault path or url if any>"],
+  "actor": "engineering-agent/scheduler"
+}
+```
+
+`yule supervisor run --once` 가 본 entry 를 cross-section 으로 노출 — "지난 7 일 scheduled jobs" 라인.
+
+## 7. Hermes vs Yule 차이 (명시)
+
+| Hermes | Yule |
+|---|---|
+| `jobs.json` 운영자 + LLM agent 모두 등록 가능 | 운영자만 등록 — agent 자율 등록 금지 |
+| `deliver: "telegram:chat_id"` | `deliver: "discord:<env_key>"` 만 |
+| 자연어 schedule parse | 명시 schedule.kind + spec 만 (운영자 명시) |
+| LLM 으로 자체 prompt 실행 | trigger.kind whitelist 5 종 |
+| script 필드로 임의 Python 실행 | script 필드 없음 — trigger.kind 로만 |
+| in-process tick() | systemd timer 또는 Yule worker (후속 결정) |
+
+Yule 은 single-operator 환경 + audit-traceable 정책 — 본 차이가 안전 가드의 핵심.
+
+## 8. 후속 milestone
+
+1. **scheduler 코드** — `agents/lifecycle/scheduler.py` (정책 §3 contract 구현). 우선순위 P1.
+2. **CLI** — `yule engineer schedule add | list | remove` — 운영자 등록 / 조회 / 해제. 우선순위 P1.
+3. **`#봇-상태` 자동 보고** — 매일 1 회 scheduled job summary. 우선순위 P2.
+4. **systemd timer 통합** — Yule run-service 와 결합. 우선순위 P3.
+
+각 milestone 별 issue + decision note.
+
+## 9. 변경 절차
+
+1. 새 trigger.kind 추가 — issue + decision note + 본 정책 §3.3 갱신.
+2. 새 platform delivery 추가 — issue + decision note + secret 정책 검토 + 본 정책 §5 갱신.
+3. destructive 작업 가드 변경 — 회사 정책 / supervisor 검토 필수. 본 정책 §4.1 의 차단 목록은 단일 source-of-truth.
+
+## 10. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-08 | 초기 작성 — issue #59 의 Hermes 흡수 결정 D-6 구현물. job storage contract / trigger whitelist 5 종 / safety 가드 / Discord 단일 delivery / audit 흐름 / 후속 milestone 정리 |

--- a/policies/runtime/agents/engineering-agent/self-improvement-flow.md
+++ b/policies/runtime/agents/engineering-agent/self-improvement-flow.md
@@ -1,0 +1,123 @@
+# Engineering Agent — Self-improvement flow (Hermes-inspired, issue #59)
+
+본 정책은 Yule 의 **회고 → 다음 작업 input 자동 흐름** 을 정한다. Hermes Agent 의 `agent/curator.py` 가 보여주는 "스킬 라이브러리 자동 정리" 의 컨셉 중 *명시적 회고 흐름* 만 흡수하고, **자율 LLM-driven consolidation 은 도입하지 않는다.**
+
+이 문서는 issue #59 ([Hermes 흡수 결정 D-5](#)) 의 구현물이다.
+
+## 1. 핵심 원칙
+
+1. **자동 LLM consolidation 금지.** Yule 의 정책 / role profile / lifecycle 은 단일 source-of-truth 가 되어야 한다 — agent 가 자기 결정으로 운영자 변경 없이 정책 / 자산을 갱신하지 못한다.
+2. **회고는 *자산* 이지 *코드 변경 트리거* 가 아니다.** 회고가 다음 작업의 input 이 되는 path 는 정책으로 박지만, 회고 본문 자체가 코드 / 정책을 자동 수정하지 않는다.
+3. **회고 자동화는 *생성 시점 알림* 까지**. session 종료 시 회고 작성 후보를 운영자에게 안내하는 데까지가 정책 — 본문은 운영자가 작성 (또는 명시적 LLM 요약).
+4. **회고 자산이 다음 작업 input 으로 들어가는 통로는 명시적**. `yule engineer intake` 가 회고를 자동 첨부하지 않는다 — 운영자가 영역을 알면 명시 인용.
+
+## 2. retrospective note kind
+
+회고 본문은 `kind=retrospective` Obsidian note. 이미 [obsidian-memory.md](./obsidian-memory.md) §2 path layout 에서 `10-projects/<project>/retrospectives/` 폴더가 정의되어 있고, 본 정책이 그 contract 의 추가 서약을 둔다.
+
+### 2.1 frontmatter 필수 필드
+
+```yaml
+---
+title: "<영역> 회고 — <YYYY-MM-DD>"
+topic: <topic_key>
+kind: retrospective
+project: yule-studio-agent
+session_id: <원본 세션 id>
+related_decisions: [path1, path2]   # 다음 작업 input 후보로 다시 인용될 결정 노트들
+related_research: [path1, path2]
+status: captured                     # 작성 직후 / decided 로 promote 가능
+canonical: <true|false>              # 영역의 "1 차 source" 표식 (memory-policy boost +2)
+reusable: <true|false>               # 다른 작업에서 자주 인용 (boost +1)
+created_at: <ISO>
+---
+```
+
+### 2.2 필수 본문 섹션 (8 개)
+
+```
+# <영역> 회고
+
+## 무엇을 시도했나
+## 어떤 결과가 나왔나
+## 무엇이 잘 되었나 (keep)
+## 무엇이 안 되었나 (problem)
+## 다음에 다르게 할 것 (try)
+## 영역의 1 차 source 후보       (canonical 표식 후보)
+## 다음 작업 input 후보           (다음 intake 에서 인용 후보 noun-phrase)
+## 운영자 액션
+```
+
+본 8 개 섹션이 비어 있어도 헤더는 유지 — `_(없음)_` placeholder 표시 (knowledge-writer 패턴).
+
+## 3. 회고 생성 트리거 (운영자 명시 안내)
+
+### 3.1 lifecycle 단계 — 회고 후보 알림
+
+`agents/lifecycle_status.py` 가 다음 조건일 때 *회고 작성 후보* 신호를 supervisor 진단에 노출:
+
+| 조건 | 신호 |
+|---|---|
+| `work_report.status == FINAL` AND 같은 topic 의 retrospective 미작성 | "이 작업 회고 작성 후보" |
+| `topic_ledger.status == STATUS_SAVED` AND `revision >= 2` | "revision 누적 — 회고 후보" |
+| coding_job 종료 (성공 / 실패) | "coding 결과 회고 후보" |
+
+신호는 **알림** 일 뿐 — 회고 본문 자동 생성 없음. 운영자가 결정.
+
+### 3.2 명시 명령 후보 (후속 milestone)
+
+후속 milestone 의 CLI 후보:
+- `yule engineer retrospective --session <id>` — §2.2 8 섹션 template 으로 회고 note 자동 scaffold (본문은 빈 placeholder, 운영자가 채움). 우선순위 P2.
+- `yule engineer retrospective --session <id> --auto-summarize` — LLM 으로 keep/problem/try 부분 초안 (사람 검수 필수). 우선순위 P3.
+
+본 phase 는 정책까지.
+
+## 4. 회고 → 다음 작업 input path
+
+### 4.1 retrieval boost (memory-policy §4 와 결합)
+
+retrospective note 는 [memory-policy §4](./memory-policy.md#4-재사용성-hint-정책-read-side-boost-only) 의 boost 를 받는다:
+- `kind=retrospective` → +0.5
+- `frontmatter.canonical=true` → +2 (위 boost 와 합산 → +2.5)
+- `frontmatter.reusable=true` → +1 (합산 → +1.5)
+
+`yule memory search` 결과에서 회고 note 가 다른 `research` / `task-log` 보다 위에 노출됨.
+
+### 4.2 명시 인용 흐름
+
+운영자가 새 작업 intake 시:
+1. `yule memory search "<영역 keyword>"` 로 같은 영역 회고 후보 확인.
+2. 회고에서 인용할 부분을 prompt 에 명시 — "지난 X 작업의 retrospective 의 *try* 부분을 따라 진행" 형태.
+3. session.extra `references_used` 키에 명시 인용 표식 (이미 구현됨).
+
+### 4.3 자동 input 주입 금지
+
+`yule engineer intake` 가 회고 본문을 자동으로 prompt 에 끼워 넣지 않는다 — 운영자가 영역을 알고 명시 인용해야 한다. 자동 주입은 prompt 노이즈 + 잘못된 input 위험.
+
+## 5. Hermes curator 흡수 / 비흡수 비교
+
+| Hermes curator 영역 | Yule 적용 | 이유 |
+|---|---|---|
+| 활성 / stale / archived state transition | **비도입** | Yule vault 는 git 으로 관리 — 사용자 명시 commit 만 변경 |
+| 좁은 스킬 → umbrella 스킬 LLM consolidation | **비도입** | 단일 source-of-truth 자동 갱신 위험 |
+| `run.json` + `REPORT.md` 감사 로그 | **부분 도입** | retrospective note 가 본 역할 — kind=retrospective + 8 섹션 |
+| cron job reference 자동 갱신 | **비도입** | scheduled-automation 정책에서 별도 다룸 |
+| LLM review agent (자기 자신 review) | **비도입** | 운영자 가시성 우선 |
+
+## 6. 안전 가드
+
+- 회고 본문 작성은 **운영자만**. agent 가 본문을 직접 쓰지 않는다.
+- LLM 보조 요약 (--auto-summarize) 후속 milestone 도 **사람 검수 필수** — frontmatter `status: captured` 로 작성, 운영자가 검수 후 `decided` 로 promote.
+- canonical / reusable 표식은 운영자만 박는다 — agent 자율 표식 금지.
+
+## 7. 후속 milestone
+
+1. **lifecycle status 회고 후보 신호** — `agents/lifecycle_status.py` + `agents/session_status.py` 가 §3.1 조건을 진단에 노출. 우선순위 P1.
+2. **`yule engineer retrospective` CLI** — §3.2. 우선순위 P2.
+3. **memory retrieval boost wiring** — kind=retrospective + canonical/reusable 표식 boost 적용 (memory-policy §4 와 동시 진행). 우선순위 P1.
+
+## 8. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-08 | 초기 작성 — issue #59 의 Hermes 흡수 결정 D-5 구현물. retrospective note contract / 회고 trigger / 다음 input path / 자율 consolidation 금지 정리 |


### PR DESCRIPTION
## 어떤 기능인가요?

issue #59 (헤르메스 에이전트 오픈소스 코드 참고 후 장점 반영) 의 1 차 결과물 — 정책 5 종 + agent.json 등록까지. Hermes Agent (NousResearch/hermes-agent) 의 8 개 영역을 Yule 의 Discord/Obsidian/GitHub App 흐름과 비교해 **diff 기반** 으로 부족한 영역만 흡수.

본 PR 의 작성 / 결정 / 문서화 주체는 모두 `engineering-agent/tech-lead` 단일 주체.

closes 없음 — issue #59 는 본 PR 머지 후에도 후속 milestone 으로 이어진다.

## 작업 상세 내용

### 도입 (5 영역)

- [x] **memory-policy.md** — 자율 memory write 금지 + 6 trigger 단일 source + frontmatter `reusable=true/canonical=true` retrieval boost
- [x] **recall-policy.md** — cross-session 일자별 회고 contract + topic 횡단 recall + 자동 prompt 주입 금지
- [x] **context-compression.md** — 4 surface 별 압축 적용 + 압축 금지 영역 (원문 prompt / decision / synthesis / agent_ops_audit) + 모델별 threshold 비율
- [x] **self-improvement-flow.md** — retrospective note kind contract (8 섹션) + 자율 LLM consolidation 금지 + 회고→다음 input path
- [x] **scheduled-automation.md** — job storage contract + trigger.kind whitelist 5 종 + destructive 차단 + Discord 단일 delivery

### 비도입 (3 영역)

- D-1 messaging gateway → single-operator 환경 / Discord 만 운영
- D-7 subagent / parallel workstream → role 모델 + worker pool 이 다른 문제를 더 잘 풂
- D-8 workspace migration → use case 부재 (OpenClaw → Hermes 같은 brand switch 시나리오 없음)

각 비도입 사유는 [decision note](https://github.com/yule-studio/yule-studio-agent/issues/59) 의 D-1 / D-7 / D-8 절에 단일 source.

### 변경 파일

```
agents/engineering-agent/agent.json                                            |   7 ++-
policies/runtime/agents/engineering-agent/context-compression.md     | 122 ++++++
policies/runtime/agents/engineering-agent/memory-policy.md           |  96 +++++
policies/runtime/agents/engineering-agent/recall-policy.md           | 109 ++++++
policies/runtime/agents/engineering-agent/scheduled-automation.md    | 167 +++++++++
policies/runtime/agents/engineering-agent/self-improvement-flow.md   | 123 +++++++
6 files changed, 623 insertions(+), 1 deletion(-)
```

### 검증

- [x] `python3 -m unittest tests.engineering.test_role_profiles_doc_integration tests.engineering.test_role_profiles tests.engineering.test_role_profiles_v2` → 26 OK
- [x] `python3 -m unittest tests.engineering.test_role_selection tests.engineering.test_role_output_template tests.memory.test_retrieval tests.memory.test_index` → 45 OK
- [x] `agents/engineering-agent/agent.json` — JSON valid + 5 신규 정책 경로 모두 등록 확인 (20 entries)
- [x] 5 정책 본문 self-check — 각 정책 §"후속 milestone" 절에 코드 후속 작업 명시
- [x] secret / token / private key 출력 없음 — `.env.local` / pem / Authorization 헤더 미참조
- [x] `git status` / `git diff --stat --cached` — 정확히 6 개 파일만 변경, 인터리빙 사고 없음

### Hermes 흡수 매핑표 (요약)

| 영역 | Hermes | Yule 현재 | 결정 | 정책 산출물 |
|---|---|---|---|---|
| messaging gateway | `gateway/` 6 platform | Discord only | **비도입** | (없음) |
| persistent memory | `memory_manager.py` | SQLite + Obsidian | **부분 도입** | memory-policy.md |
| cross-session recall | `insights.py` (FTS5+LLM) | thread-scoped | **부분 도입** | recall-policy.md |
| context compression | `context_compressor.py` (50% threshold) | 없음 | **부분 도입** | context-compression.md |
| skill self-improvement | `curator.py` (auto consolidation) | skeleton | **부분 도입** | self-improvement-flow.md |
| scheduled automation | `cron/scheduler.py` + jobs.json | daily loop only | **부분 도입** | scheduled-automation.md |
| subagent / parallel | `delegate_tool.py` | role × 7 + worker pool | **비도입** | (없음) |
| workspace migration | OpenClaw import | use case 없음 | **비도입** | (없음) |

전체 분석 + WHY/WHERE/WHAT-NOT 은 Obsidian:
- `10-projects/yule-studio-agent/research/2026-05-08_hermes-agent-architecture-deep-dive.md`
- `10-projects/yule-studio-agent/decisions/2026-05-08_hermes-yule-integration-decisions.md`
- `10-projects/yule-studio-agent/task-logs/2026-05-08_59-hermes-tech-lead.md`

### 안전 가드 / 범위 가드

- **#25 (foundation 변경) 본문 미수정** — 신규 정책 추가만, `lifecycle-mvp.md` / `obsidian-memory.md` / `role-profiles.md` 본문 손대지 않음.
- **#48 (팀 아키텍처 일반론) 영역 회피** — Hermes 의 *gateway / memory / evolution / automation* 관점에 한정, 일반 team-structure 손대지 않음.
- **destructive reset / force push / auto merge / production deploy 없음**.
- **secret / token / private key 출력 없음**.
- 코드 변경 0 건 — 정책 + agent.json 등록까지로 limit.

### 후속 milestone (각 정책에 박힘)

- memory-policy.md §7 — retrieval boost wiring (P1) / status hint marker (P2) / `yule memory search` boost 출력 (P2)
- recall-policy.md §5 — `yule insights` CLI (P1) / topic 횡단 검색 (P2) / supervisor 회고 후보 안내 (P2)
- context-compression.md §8 — role-runner dispatch input 압축 (P1) / `yule engineer compress|usage` (P2) / work_report INTERIM cap 코드화 (P3)
- self-improvement-flow.md §7 — lifecycle 회고 후보 신호 (P1) / `yule engineer retrospective` (P2) / retrieval boost wiring (P1)
- scheduled-automation.md §8 — scheduler 코드 (P1) / `yule engineer schedule` CLI (P1) / `#봇-상태` 자동 보고 (P2) / systemd 통합 (P3)

후속 milestone 별로 별도 issue + decision note 가 만들어진다.

## 참고할만한 자료

- 외부 레퍼런스: https://github.com/NousResearch/hermes-agent
- 분석 module: `gateway/` / `agent/memory_manager.py` / `agent/curator.py` / `agent/context_compressor.py` / `agent/insights.py` / `cron/scheduler.py`
- issue: #59
- decision note: Obsidian vault `10-projects/yule-studio-agent/decisions/2026-05-08_hermes-yule-integration-decisions.md`

⚠️ Merge 금지 — draft PR 검토 후 사용자 승인이 끝나면 일반 merge. force push / auto merge / production deploy 절대 없음.