### PR TITLE
✨ #73 structured knowledge loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,10 +252,19 @@ DISCORD_GUILD_ID=
 # manual transport 는 ProviderAvailability.MANUAL_ONLY 슬롯이며 운영자가
 # 직접 vault 에 등록하는 경로다 — 라이브 호출이 존재하지 않는다.
 #
-# 현재 코드베이스 상태: 모든 transport 가 NO_LIVE_IMPL 상태다. 별도 PR
-# (live fetcher) 에서 implementation 이 등록될 때까지 fake 가 항상 사용된다.
+# 현재 코드베이스 상태:
+#   - rss / atom / github_releases_atom: parser 가 결정적으로 land 됨
+#     (feed_parser.parse_feed_bytes). 라이브 전환은 urllib 기반
+#     BytesFetcher 한 조각만 별도 PR 에서 등록하면 된다 — 그 PR 이
+#     register_safe_feed_providers() 한 번 호출하면 세 transport 가
+#     동시에 AVAILABLE 로 전환된다.
+#   - sitemap / html_list / html_detail / github_api_repo_activity:
+#     아직 NO_LIVE_IMPL. 별도 PR 에서 register_live(transport=...) 로
+#     채운다.
+#   - manual: ProviderAvailability.MANUAL_ONLY (라이브 호출 없음).
 # 아래 플래그는 운영자가 cost-budget / rate-limit 검토를 마친 뒤 켜는
-# "준비 완료 시 활성화" 스위치 역할이다.
+# "준비 완료 시 활성화" 스위치 역할이다. 셋업 상태는
+# KnowledgeProviderRegistry.availability_summary(env) 로 한눈에 본다.
 
 # 모든 transport 가 공유하는 user-agent (provider_spec_for 의 기본값과 동일)
 # YULE_KNOWLEDGE_USER_AGENT=yule-engineering-intelligence/0.1 (+contact: operator)

--- a/.env.example
+++ b/.env.example
@@ -236,3 +236,42 @@ DISCORD_GUILD_ID=
 # YULE_DECISION_OLLAMA_TIMEOUT=20
 # YULE_DECISION_ANTHROPIC_ENABLED=false
 # YULE_DECISION_OPENAI_ENABLED=false
+
+# =====================================================================
+# #73 — Engineering knowledge provider env (background ingestion 루프)
+#
+# `engineering_intelligence` 패키지는 역할별 source 를 background 로 수집한다.
+# 각 transport(rss / atom / sitemap / html_list / html_detail /
+# github_releases_atom / github_api_repo_activity / manual)에는 provider 가
+# 하나씩 등록되어 있고, decision classifier 와 동일한 dual-gate 정책을 따른다:
+#   1. transport 가 요구하는 env 키가 모두 채워져 있음.
+#   2. transport 의 ``YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED`` 플래그가
+#      true 로 셋업되어 있음.
+# 둘 중 하나라도 빠지면 결정적 FakeKnowledgeProvider 가 사용된다.
+#
+# manual transport 는 ProviderAvailability.MANUAL_ONLY 슬롯이며 운영자가
+# 직접 vault 에 등록하는 경로다 — 라이브 호출이 존재하지 않는다.
+#
+# 현재 코드베이스 상태: 모든 transport 가 NO_LIVE_IMPL 상태다. 별도 PR
+# (live fetcher) 에서 implementation 이 등록될 때까지 fake 가 항상 사용된다.
+# 아래 플래그는 운영자가 cost-budget / rate-limit 검토를 마친 뒤 켜는
+# "준비 완료 시 활성화" 스위치 역할이다.
+
+# 모든 transport 가 공유하는 user-agent (provider_spec_for 의 기본값과 동일)
+# YULE_KNOWLEDGE_USER_AGENT=yule-engineering-intelligence/0.1 (+contact: operator)
+
+# 인증 불필요 (public feed) — 활성화 = enable flag 만 true.
+# YULE_KNOWLEDGE_RSS_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_ATOM_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_GITHUB_RELEASES_ATOM_LIVE_ENABLED=false
+
+# Sitemap / HTML — public 이지만 cadence/parse 부담이 있다. 운영자가 명시
+# 활성화. Tier 1 docs 사이트맵은 24h cadence 가 표준이다.
+# YULE_KNOWLEDGE_SITEMAP_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_HTML_LIST_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_HTML_DETAIL_LIVE_ENABLED=false
+
+# GitHub API repo activity — 기존 GitHub App env 3종(YULE_GITHUB_APP_*) 를
+# 그대로 재사용한다. 셋이 모두 채워지지 않으면 ProviderAvailability.MISSING_ENV
+# 로 떨어져 fake 로 폴백한다.
+# YULE_KNOWLEDGE_GITHUB_API_REPO_ACTIVITY_LIVE_ENABLED=false

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -290,10 +290,17 @@ Round 4-bis 에서 추가된 구현 (provider 측 강화):
 - [provider_routing.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `route_refresh_plan(plan, *, role_id, registry, env)` 가 `RefreshPlan` 의 due/skipped 각 entry 에 transport / provider_id / availability / axes 를 붙여 `RoutedRefreshCandidate` 로 변환. `axis_priority_order(...)` 가 `overdue_axes_for_role` 결과를 받아 SECURITY 같이 비어 있는 axis 를 가진 candidate 를 우선 큐 앞으로 보낸다 (tier / availability / source_id 가 tie-breaker). `select_routed_due(...)` 한 번 호출로 plan→route→axis priority→tick quota 까지 처리.
 - [.env.example #73 — Engineering knowledge provider env](../.env.example) — `YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED` 8개와 `YULE_GITHUB_APP_*` 재사용 정책 명시. 모든 플래그 기본값은 false (cost-budget 검토 후 운영자가 켠다).
 
+Round 4-ter 에서 추가된 구현 (live-ready parser + 운영 가시성):
+
+- [feed_parser.py](../src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py) — `parse_atom_bytes` / `parse_rss_bytes` / `parse_feed_bytes` 결정적 parser (xml.etree + email.utils 만 사용, urllib 무관). RSS-mode 소스가 실제로 Atom 페이로드를 내려주는 edge case 까지 sniff 로 dispatch. summary 는 `_SUMMARY_LIMIT=500` 자로 자동 truncate 되어 content_policy ("link + 짧은 인용") 자동 준수. `BytesFetcher` Protocol + `make_feed_live_factory` glue 가 별도 PR 에서 작성할 urllib 한 조각을 그대로 받아 `LiveFetcherFactory` 로 변환. `register_safe_feed_providers(registry, bytes_fetcher_factory=...)` 한 번 호출로 RSS / ATOM / GITHUB_RELEASES_ATOM 세 transport 가 동시에 라이브 전환된다.
+- [provider_registry.py — availability_summary](../src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py) — `ProviderAvailabilityRow` (transport / provider_id / availability / has_live_impl / manual / env_keys / enable_flag / missing_env_keys / enable_flag_set / description / notes) + `ProviderAvailabilitySummary` (`by_state` / `states_count` / `needs_attention` / `to_payload`). 운영자 대시보드는 `registry.availability_summary(env).to_payload()` 한 번 호출로 "5 transports live, 2 missing_env, 1 disabled_by_flag" 를 그대로 그릴 수 있다.
+- [provider_routing.py — reasoning trail](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `RoutedRefreshCandidate` 가 `transport_reason` (왜 이 transport 가 선택됐는지: `rss + atom URL heuristic`, `manual (collection_mode=manual)` 등) 와 `availability_reason` (왜 이 availability state 가 됐는지: `missing env keys: YULE_GITHUB_APP_ID, ...`, `flag YULE_KNOWLEDGE_RSS_LIVE_ENABLED not truthy` 등) 두 필드를 추가로 가진다. `routing_reason` property 로 한 줄 요약 (`transport=…; availability=…`) 도 노출. `RefreshPlanStatus` 와 `refresh_plan_status(plan, *, role_id, registry, env)` 헬퍼는 routed candidates + registry availability_summary 를 한 번에 묶어서 background refresh planner 가 tick 마다 JSON 한 덩어리로 dump 할 수 있게 만든다.
+
 남은 일 (별도 worktree / PR):
 
-- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API). `KnowledgeProviderRegistry.register_live(transport, live_factory=...)` 한 번 호출로 활성화된다.
-- runtime service spawn (`eng-research-collector`) — scheduler tick → `select_routed_due` → registry fetcher → adapter → vault writer.
+- urllib 기반 `BytesFetcher` 한 조각 (timeout / user-agent / 30x 처리). `register_safe_feed_providers(registry, bytes_fetcher_factory=...)` 한 번 호출로 RSS / Atom / GitHub releases atom 이 동시에 live 전환된다.
+- sitemap / html_list / html_detail / github_api_repo_activity 의 live fetcher (parser 까지 미구현; 본 PR 시점에서 NO_LIVE_IMPL).
+- runtime service spawn (`eng-research-collector`) — scheduler tick → `refresh_plan_status` 로 가시성 dump → `select_routed_due` → registry fetcher → adapter → vault writer.
 - `SourceRefreshState` persistence (sqlite or vault sidecar).
 - discussion synthesizer 가 `relevant_knowledge` slot 을 prompt 에 어떻게 짜 넣을지.
 

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -458,6 +458,52 @@ Claude는 UI 자동조작 대상으로 쓰지 않는다. runtime이 `claude` 명
 - secret / token / pem 출력 금지
 - 기존 사용자 변경 덮어쓰기 금지
 
+## 16-bis. Coding executor 라이브 와이어링 (Round 3)
+
+Phase 3 ~ 4 의 실제 코드 경로는 다음과 같이 land 했다 — 어느 모듈이 어느 책임을 가지는지 한눈에 보이게 둔다.
+
+### 16-bis.1 producer (gateway 승인 → coding_execute 큐)
+
+- `agents/coding/authorization.py` — 사용자 요청 → `CodingAuthorizationProposal`.
+- `agents/coding/job.py` + Discord 라우터 — 승인 phrase 도착 시 `CodingJob(status=ready)` 를 `session.extra["coding_job"]` 에 영속.
+- `agents/job_queue/coding_execute_dispatcher.py` (Round 3 신규) — `iter_ready_coding_jobs` / `dispatch_ready_coding_jobs` 가 `coding_job=ready` 세션을 스캔해 `coding_execute` 행을 큐에 enqueue, `session.extra["coding_execute_dispatch"]` marker 로 dedup.
+- `agents/job_queue/coding_execute_dispatcher.WorkflowSessionState` — `next_task_selector` 의 `SessionStateLike` 구현. selector 의 우선순위 체인에 production 세션 데이터를 연결.
+
+### 16-bis.2 executor (worktree → tests → commit → push → draft PR)
+
+- `agents/job_queue/coding_executor_worker.py` — Protocol seam 6 종 (worktree / editor / tests / committer / pusher / draft PR). protected branch / force push 가드.
+- `agents/job_queue/coding_executor_live.py` — `build_live_executor`: 로컬 worktree + RecordOnly editor + subprocess 테스트 + LocalGitCommitter + GithubAppPusher + GithubAppDraftPRCreator. LLM editor 는 여전히 명시적 blocker.
+- `runtime/run_service.py::build_coding_executor_bundle` (Round 3 신규) — env 매트릭스 평가, GitHub App env 3종 모두 갖춰진 경우에만 LiveGithubAppClient 시도. 부분 설정으로는 절대 활성화되지 않음.
+- `runtime/run_service.py::_build_process_job(CODING_EXECUTOR)` (Round 3 신규) — 서비스 등록, dispatcher 틱 → consumer pick → process_job → progress recorder 순서.
+
+### 16-bis.3 CI 결과 → 4-state 표준화 + retry 가드
+
+- `agents/job_queue/ci_status.py` (Round 2) — `CIStatus` / `decide_retry` / `CIRetryPolicy` (max_attempts=3 기본, ×2 backoff, 30 분 cap). pure decider.
+- `agents/job_queue/ci_retry_orchestrator.py` (Round 3 신규) — `orchestrate_ci_retry` 가 GithubAppCheckRunFetcher 로 CI 조회 → `decide_retry` → retry 시 새 `coding_execute` 행 enqueue (branch_hint 에 `-attemptN` suffix 로 dedup 회피) → terminal 시 `completion_hook.record_completion` 호출 → `session.extra` 갱신.
+- `github_app/live_client.py::list_check_runs` / `get_pull_request` (Round 3 신규) — orchestrator 가 의존하는 GitHub Checks API 어댑터.
+- `agents/job_queue/next_task_selector.py::select_next_task_with_ci_retry_guard` (Round 2) — selector 가 max_attempts 초과 PR 을 자동으로 skip + `payload['ci_retry_escalated']` 로 surface.
+
+### 16-bis.4 결과 surface (Obsidian + GitHub PR)
+
+- `agents/job_queue/coding_execute_progress.py` (Round 3 신규) — `record_coding_execute_progress` 가 (1) `session.extra["coding_execute_progress"]` 50 행 capped history 에 entry 추가, (2) `obsidian_write` 큐에 `task-log` 노트 enqueue (approval 게이트 없는 kind), (3) GitHub PR comment 발사 (poster 부재 시 silent skip).
+- `runtime/run_service.py::_record_coding_progress_after_outcome` — coding_execute 종료 outcome 마다 자동 호출. workflow_state 로드 실패 / GitHub 502 모두 swallow.
+
+### 16-bis.5 환경 contract
+
+- `YULE_CODING_EXECUTOR_AUTOSPAWN=true` — `runtime up` 이 `eng-coding-executor` 를 자동 spawn 할지 결정. 기본값은 opt-in 비활성.
+- `YULE_CODING_EXECUTOR_DRY_RUN={true|false}` — dispatcher 가 만드는 request 의 dry_run override. 기본값은 metadata > env > true. `false` 명시 + GitHub App env 갖춤 = 실제 push 까지 진행.
+- `YULE_CODING_EXECUTOR_REPO` / `YULE_CODING_EXECUTOR_BASE_BRANCH` — repo / base branch 기본값.
+- `YULE_GITHUB_APP_ID` + `YULE_GITHUB_APP_INSTALLATION_ID` + `YULE_GITHUB_APP_PRIVATE_KEY_PATH` — 모두 갖춰져야 LiveGithubAppClient 시도.
+- `YULE_CODING_EXECUTOR_REPO_ROOT` / `YULE_CODING_EXECUTOR_WORKTREE_ROOT` — worktree 위치 override (기본 `YULE_REPO_ROOT` + `/tmp/yule-coding-executor-worktrees`).
+
+### 16-bis.6 운영 hard rails (Round 3 시점 재확인)
+
+- protected branch (main / master / develop / dev / prod / release / release\\* / hotfix\\*) 직접 push 차단 — `coding_executor_worker.is_protected_branch`.
+- force push 차단 — Pusher Protocol 에 force flag 자체가 존재하지 않음.
+- LLM editor 비활성 — `RecordOnlyCodeEditor` 가 plan markdown 만 작성, 실제 source 변경 없음. 활성화는 별도 PR + 운영자 승인.
+- 무한 retry 차단 — `decide_retry` 가 max_attempts 초과 시 즉시 `blocked` 로 escalate, orchestrator 는 그 verdict 그대로 신뢰.
+- 부분 GitHub App env → 절대 LiveGithubAppClient 시도 안 함 (3 키 중 하나라도 비면 dry-run blocker 로 degrade).
+
 ## 17. 최종 판단
 
 지금의 1순위는 `tech-lead` 완성이다.

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -1,0 +1,470 @@
+# Engineering Company Runtime Master Plan
+
+> 목적: Yule Studio Agent를 단순한 업무 접수 봇이 아니라, Discord에서 기술 토의와 구현을 이어가고, GitHub/CI/Obsidian을 통해 계속 일하는 `tech-lead` 중심 개발 회사형 runtime으로 완성하기 위한 기준 문서.
+>
+> 이 문서는 "다음에 무엇을 만들지"보다 먼저 "무엇을 어떤 순서로, 어디까지 완성해야 하는지"를 고정한다.
+
+## 1. 최종 목표
+
+Yule가 도달해야 하는 최종 상태는 아래와 같다.
+
+1. Discord에서 업무 접수뿐 아니라 기술 토의가 가능하다.
+2. `tech-lead`가 긴 문맥을 유지하며 설계/조사/구현/질문 필요 여부를 판단한다.
+3. 구현이 필요하면 승인 후 실제 코드 수정, 테스트, push, draft PR까지 이어진다.
+4. CI 결과를 다시 읽고 retry / clarification / done / blocked 로 이어진다.
+5. 모든 과정은 Obsidian에 운영 메모리로 기록된다.
+6. 작업이 하나 끝나면 runtime이 다음 작업을 자동으로 선택한다.
+7. 역할별 자료 수집/정형화 루프가 상시 돌아서, 요청이 오기 전에도 지식이 축적된다.
+
+핵심 원칙: **Claude는 이 시스템을 만드는 도구이고, 완성 후에는 runtime이 Claude를 필요할 때 호출하며 계속 돌아야 한다.**
+
+## 2. 현재 기준선
+
+현재 레포는 아래 기초를 이미 갖고 있다.
+
+- Discord intake / gateway 흐름
+- research / role deliberation / approval 뼈대
+- Obsidian export / note 정책의 일부
+- GitHub App 기반 issue / draft PR 흐름 일부
+- always-on runtime skeleton
+- queue worker 구조
+- CI 기초 설정
+
+하지만 아직 아래는 미완성이다.
+
+- 자유로운 기술 토의 모드
+- 실제 live code editing executor
+- CI failure → retry / re-plan 루프
+- 상시 role-based research ingestion live wiring
+- 작업 완료 후 next-task auto handoff
+
+## 3. 현재 완성도 평가
+
+이 수치는 운영 판단 기준으로 유지한다.
+
+| 영역 | 현재 추정 |
+| --- | --- |
+| 운영 골격 | 65~75% |
+| Discord 기술 토의 능력 | 40~50% |
+| 완전 자율 코딩 루프 | 45~55% |
+| 역할별 자료 수집/정형화 루프 | 25~35% |
+| 실제 회사처럼 굴러가는 종합 수준 | 45~55% |
+
+이 문서의 목표는 위 4개 축이 서로 충돌하지 않게 나누어 100%에 수렴하도록 만드는 것이다.
+
+## 4. `gateway` 와 `tech-lead` 경계
+
+이 경계를 분명히 하지 않으면 외부 surface와 내부 조율이 섞여 시스템이 불안정해진다.
+
+### 4.1 gateway 책임
+
+`gateway`는 외부 surface 담당이다.
+
+- Discord `#업무-접수` 첫 응답
+- thread / session 생성
+- intake metadata 정리
+- `#봇-상태` / kickoff / closure 같은 운영 surface
+- 외부 사용자에게 보이는 상태 전달
+- 내부 runtime으로 job enqueue
+
+정리하면: **gateway는 받는 입구와 바깥쪽 상태판이다.**
+
+### 4.2 tech-lead 책임
+
+`tech-lead`는 coordinator이자 부서장이다.
+
+- 긴 문맥 유지
+- 토의 진행
+- role 관점 종합
+- 설계/조사/구현 여부 판단
+- 승인 요청과 handoff
+- 구현 이후 결과 해석
+- 다음 작업 선택
+
+정리하면: **tech-lead는 생각하고 조율하고 이어가는 두뇌다.**
+
+### 4.3 경계 규칙
+
+1. 외부 사용자의 첫 접점은 gateway다.
+2. 기술 토의가 시작되면 주체는 tech-lead다.
+3. status/post/kickoff/closure는 gateway-mediated가 우선이다.
+4. cross-role decision / 합의 / conflict resolution 은 tech-lead-mediated다.
+5. 다른 role bot 확장 전까지는 실제 구현 실행도 tech-lead가 대표 주체다.
+
+## 5. 운영 구조의 5개 레이어
+
+### 5.1 Surface Layer
+
+- Discord
+- GitHub Issue / PR
+- CI 알림
+- Obsidian 기록
+
+### 5.2 Coordination Layer
+
+- gateway
+- tech-lead runtime
+- approval gate
+- completion hook
+- next-task selector
+
+### 5.3 Intelligence Layer
+
+- deterministic fast-path
+- Claude classifier
+- Claude discussion synthesizer
+- Claude executor
+- context pack builder
+- relevant memory selector
+
+### 5.4 Execution Layer
+
+- worktree
+- shell / git / gh
+- test runner
+- draft PR generation
+- CI result consumption
+
+### 5.5 Memory Layer
+
+- research note
+- decision note
+- task-log
+- report / retrospective
+- role knowledge / collected references
+
+## 6. 전체 루프 구조
+
+이 시스템은 4개의 루프가 합쳐져야 한다.
+
+### 6.1 Background Knowledge Loop
+
+상시 돌아야 하는 루프.
+
+- 역할별 자료 수집
+- dedup / importance score
+- source registry 기반 분류
+- Obsidian / role knowledge 저장
+- 요청 시 retrieval 가능한 상태로 유지
+
+### 6.2 Discussion Loop
+
+Discord thread 안에서 도는 루프.
+
+- 사용자의 질문 이해
+- context pack 구성
+- 관련 note / issue / PR / code / sources retrieval
+- 설계/조사/구현 여부 판단
+- 필요하면 clarification
+
+### 6.3 Execution Loop
+
+구현이 필요할 때 도는 루프.
+
+- approval
+- worktree
+- code edit
+- tests
+- commit / push
+- draft PR
+
+### 6.4 Improvement Loop
+
+끝난 뒤 돌아야 하는 루프.
+
+- CI success/failure 해석
+- blocked reason 정리
+- retry / re-plan
+- retrospective
+- next action 생성
+
+## 7. 기술 토의 모드의 필수 요구사항
+
+이 시스템은 단순 업무 접수로 끝나면 안 된다. 아래 같은 대화가 가능해야 한다.
+
+- "이 구조 맞아?"
+- "이건 devops 관점에서 어떻게 풀지?"
+- "일단 조사만 할까?"
+- "구현 전에 리스크부터 정리하자"
+
+이를 위해 `discussion_mode` 가 필요하다.
+
+### 7.1 discussion mode의 최소 상태
+
+- `discussion`
+- `research_only`
+- `implementation_candidate`
+- `clarification_needed`
+
+### 7.2 discussion mode의 최소 입력
+
+- 최근 Discord thread 요약
+- session state
+- 관련 Obsidian notes
+- 관련 issue / PR
+- 관련 코드 힌트
+- role profile
+- role research profile
+
+### 7.3 discussion mode의 최소 출력
+
+- 현재 판단 모드
+- 왜 그렇게 판단했는지
+- 구현 필요 여부
+- 추가 질문이 필요한지
+- next action
+
+## 8. 문맥을 넓게 이해하게 만드는 핵심
+
+문맥 이해는 모델 자체보다 입력 구조가 더 중요하다.
+
+### 8.1 Context Pack Builder
+
+각 요청마다 아래를 묶는다.
+
+- current user message
+- recent thread summary
+- session.extra summary
+- linked issue / PR summary
+- relevant Obsidian notes
+- related file hints
+- role profile
+- role research profile
+
+### 8.2 Relevant Memory Selector
+
+모든 note를 넣지 않는다. 요청과 관련된 note만 뽑는다.
+
+- 동일 topic
+- 같은 부서/역할
+- 최근 실패/회고
+- 관련 PR / issue
+- 같은 domain / 같은 task_type
+
+### 8.3 Fast-path + LLM 조합
+
+- 명확한 요청은 deterministic path
+- 애매한 요청만 Claude classifier
+- 토의 중 ambiguity가 커지면 재분류
+
+## 9. 자료 수집/정형화 루프는 필수
+
+이 항목은 선택이 아니다. 회사처럼 굴러가려면 요청 전부터 지식이 쌓여야 한다.
+
+### 9.1 역할별 상시 수집 대상
+
+- backend: official docs, API, schema, auth 흐름, migration 패턴
+- frontend: MDN, framework docs, accessibility, design system, browser compatibility
+- qa: regression, test plan, bug pattern, edge case, acceptance criteria
+- devops: CI/CD, infra, observability, rollout, rollback, runtime 운영 패턴
+- tech-lead: architecture, ADR, tradeoff, dependency, risk, rollout plan
+
+### 9.2 수집 루프의 두 단계
+
+1. 요청 이전의 background ingestion
+2. 요청 이후의 request-time retrieval
+
+즉 "계속 수집"과 "요청 맞춤 retrieval"은 둘 다 필요하다.
+
+### 9.3 구현 기준선
+
+이미 존재하는 정책/코드:
+
+- [research-collector.md](../policies/runtime/agents/engineering-agent/research-collector.md)
+- [research-profiles.md](../policies/runtime/agents/engineering-agent/research-profiles.md)
+- [collector.py](../src/yule_orchestrator/agents/engineering_intelligence/collector.py)
+
+남은 일:
+
+- live source adapters
+- schedule / interval
+- 저장 루프
+- retrieval 통합
+
+## 10. CI와 CD의 관계
+
+현재는 PR CI가 1순위고, CD는 후순위다.
+
+### 10.1 지금 꼭 할 것
+
+- PR에서 테스트
+- package smoke
+- Discord success/failure 알림
+- CI 결과를 runtime 상태로 반영
+
+### 10.2 지금 하지 않을 것
+
+- production deploy
+- auto merge
+- main push 배포
+- 완전한 zero-downtime CD
+
+### 10.3 왜 분리하나
+
+CI는 품질 게이트고, CD는 운영 위험과 직결된다. 지금은 runtime이 로컬에서 완결 루프를 먼저 완성해야 한다.
+
+## 11. Obsidian 운영 메모리 정책
+
+Obsidian은 로그 저장소가 아니라 운영 메모리다.
+
+### 11.1 note 종류
+
+- research
+- decision
+- task-log
+- report / retrospective
+
+### 11.2 note 규칙
+
+- `## 관련 문서` 필수
+- wikilink 이름은 실제 basename과 일치
+- 민감정보/secret/실제 key는 저장 금지
+- 공유 가능한 것과 로컬 전용 것을 분리
+
+### 11.3 저장해야 할 내용
+
+- 어떤 자료를 참고했는지
+- 어떤 판단을 했는지
+- 어떤 구현이 진행됐는지
+- 실패 원인이 무엇인지
+- 다음 액션이 무엇인지
+
+## 12. PR를 나누는 원칙
+
+하나의 PR에서 모든 걸 끝내려 하지 않는다. 섹션과 milestone을 나눠서 간다.
+
+### 12.1 PR 분리 원칙
+
+1. 운영 골격
+2. Discord 기술 토의
+3. 완전 자율 코딩 루프
+4. 자료 수집/정형화 루프
+
+한 PR 안에서는 하나의 중심 목표만 다룬다. foundation PR이 크더라도 "하나의 단계 완료" 단위여야 한다.
+
+### 12.2 worktree 원칙
+
+하나의 initiative 아래에서도 worktree는 나눈다.
+
+예시:
+
+- `feature/company-runtime-discussion`
+- `feature/company-runtime-execution`
+- `feature/company-runtime-research-loop`
+- `feature/company-runtime-autonomy`
+
+## 13. 다음 구현 우선순위
+
+지금부터의 실제 순서는 아래가 맞다.
+
+### Phase 1. Discussion Mode
+
+완료 기준:
+
+- Discord에서 기술 토의 가능
+- context pack 구성
+- implementation 여부 판단
+
+### Phase 2. Claude Decision Layer
+
+완료 기준:
+
+- ambiguous request만 `claude` 호출
+- deterministic fast-path 유지
+- discussion / research / implementation / clarification 분류
+
+### Phase 3. Coding Executor Live Wiring
+
+완료 기준:
+
+- 승인 후 실제 code edit
+- test
+- commit/push/draft PR
+
+### Phase 4. CI Failure → Retry Loop
+
+완료 기준:
+
+- CI 실패 읽기
+- retry guard
+- blocked / retry_ready / done 반영
+
+### Phase 5. Background Research Ingestion
+
+완료 기준:
+
+- 역할별 수집이 background로 동작
+- 정형화된 자료가 role knowledge로 저장
+
+### Phase 6. Next Task Auto-Handoff
+
+완료 기준:
+
+- 작업 하나 끝나면 selector가 다음 작업 선택
+- runtime이 계속 이어서 일함
+
+## 14. 완료 조건
+
+아래 시나리오가 end-to-end로 가능해야 "회사형 runtime" 완성으로 본다.
+
+1. Discord에서 요청 또는 기술 토의 시작
+2. tech-lead가 긴 문맥으로 대화
+3. 관련 자료와 note를 자동 retrieval
+4. 조사/구현/질문 필요 여부 판단
+5. 구현이면 승인 요청
+6. 승인 후 실제 코드 수정과 draft PR 생성
+7. PR CI 결과 수신
+8. 실패면 retry / clarification / blocked 처리
+9. 성공/실패/차단 상태를 Obsidian + GitHub에 기록
+10. 다음 작업을 자동 선택
+
+## 15. Claude 실행 프로토콜
+
+Claude는 UI 자동조작 대상으로 쓰지 않는다. runtime이 `claude` 명령을 호출하는 도구로 쓴다.
+
+### 15.1 역할
+
+- classifier
+- discussion synthesizer
+- executor
+
+### 15.2 원칙
+
+- 작은 단위로 호출
+- structured output 우선
+- fast-path가 애매할 때만 호출
+- 실패하면 blocked reason 남기고 deterministic fallback
+
+### 15.3 handoff 규칙
+
+세션이 끊겨도 다음 세션이 이어갈 수 있어야 한다.
+
+반드시 남길 것:
+
+- 현재 phase
+- 현재 branch / worktree / PR / issue
+- 현재 blocker
+- 남은 next actions
+- 관련 note 링크
+
+## 16. 운영 가드
+
+아래는 영구 hard rail이다.
+
+- protected branch 직접 push 금지
+- force push 금지
+- auto merge 금지
+- production deploy 자동화 금지
+- secret / token / pem 출력 금지
+- 기존 사용자 변경 덮어쓰기 금지
+
+## 17. 최종 판단
+
+지금의 1순위는 `tech-lead` 완성이다.
+
+- multi-bot 확장은 후순위
+- CI는 이미 1차 기반이므로 유지
+- CD는 로컬 완결 루프 후 검토
+- discussion + research + execution + retry를 한 흐름으로 묶는 것이 핵심
+
+이 문서를 기준으로 앞으로의 구현 판단을 고정한다.

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -283,10 +283,17 @@ Round 4 에서 추가된 구현:
 - [retrieval.py](../src/yule_orchestrator/agents/engineering_intelligence/retrieval.py) — `KnowledgeRecord` (lightweight projection), `score_knowledge_record` (role × axis × topic × importance × freshness), `KnowledgeRetriever` (`with_signals` 로 score 노출).
 - [discussion/context_pack.py](../src/yule_orchestrator/agents/discussion/context_pack.py) — `EngineeringKnowledgeRef` slot + `knowledge_loader` / `knowledge_retriever` seam 추가. ContextPack.relevant_knowledge 가 자동으로 채워진다.
 
+Round 4-bis 에서 추가된 구현 (provider 측 강화):
+
+- [provider_registry.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py) — 8 transport (rss / atom / sitemap / html_list / html_detail / github_releases_atom / github_api_repo_activity / manual) 각각에 한 줄씩 등록되는 `KnowledgeProviderRegistration` (provider_id / auth / fake_fetcher / live_factory / manual flag). `ProviderAuthRequirement` 가 decision classifier 와 동일한 dual gate (env_keys + enable_flag) 를 쓴다. `ProviderAvailability` 5 상태 (available / disabled_by_flag / missing_env / no_live_impl / manual_only) 가 운영자 대시보드에 그대로 노출. `default_registry()` 가 시드한 8 row 의 .env contract 가 `.env.example` 에 명시되어 있다.
+- [providers.py — FakeKnowledgeProvider](../src/yule_orchestrator/agents/engineering_intelligence/providers.py) — `StubLiveSourceFetcher` (records, returns empty) 와 별도로 `source_id → items` fixture 기반의 결정적 fake. 라이브 PR 이 들어오기 전까지 모든 transport 의 fallback fetcher 로 사용된다.
+- [provider_routing.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `route_refresh_plan(plan, *, role_id, registry, env)` 가 `RefreshPlan` 의 due/skipped 각 entry 에 transport / provider_id / availability / axes 를 붙여 `RoutedRefreshCandidate` 로 변환. `axis_priority_order(...)` 가 `overdue_axes_for_role` 결과를 받아 SECURITY 같이 비어 있는 axis 를 가진 candidate 를 우선 큐 앞으로 보낸다 (tier / availability / source_id 가 tie-breaker). `select_routed_due(...)` 한 번 호출로 plan→route→axis priority→tick quota 까지 처리.
+- [.env.example #73 — Engineering knowledge provider env](../.env.example) — `YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED` 8개와 `YULE_GITHUB_APP_*` 재사용 정책 명시. 모든 플래그 기본값은 false (cost-budget 검토 후 운영자가 켠다).
+
 남은 일 (별도 worktree / PR):
 
-- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
-- runtime service spawn (`eng-research-collector`) — scheduler tick → fetcher → adapter → vault writer.
+- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API). `KnowledgeProviderRegistry.register_live(transport, live_factory=...)` 한 번 호출로 활성화된다.
+- runtime service spawn (`eng-research-collector`) — scheduler tick → `select_routed_due` → registry fetcher → adapter → vault writer.
 - `SourceRefreshState` persistence (sqlite or vault sidecar).
 - discussion synthesizer 가 `relevant_knowledge` slot 을 prompt 에 어떻게 짜 넣을지.
 

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -274,12 +274,21 @@ Discord thread 안에서 도는 루프.
 - [research-profiles.md](../policies/runtime/agents/engineering-agent/research-profiles.md)
 - [collector.py](../src/yule_orchestrator/agents/engineering_intelligence/collector.py)
 
-남은 일:
+Round 4 에서 추가된 구현:
 
-- live source adapters
-- schedule / interval
-- 저장 루프
-- retrieval 통합
+- [models.SourceAxis](../src/yule_orchestrator/agents/engineering_intelligence/models.py) — 10종 axis enum (official_docs / api_schema_auth / web_platform_framework / regression_test_plan / ci_cd_infra_observability / architecture_adr_tradeoff / ai_framework / design_system / security / release_notes_changelog).
+- [source_registry](../src/yule_orchestrator/agents/engineering_intelligence/source_registry.py) — 모든 seed 가 `axes` tag 부여, `required_axes_for_role` / `axes_for_role` / `sources_for_axis` / `axis_hints_for_task_type` helper 추가.
+- [scheduler.py](../src/yule_orchestrator/agents/engineering_intelligence/scheduler.py) — `compute_refresh_plan` (never / due / fresh / backoff / quota / review_required / auto_collect_disabled 7-state classifier), exponential backoff (×1/×2/×4/×8, 24h cap), `record_refresh_outcome`, `overdue_axes_for_role`.
+- [providers.py](../src/yule_orchestrator/agents/engineering_intelligence/providers.py) — `LiveProviderSpec` (transport / endpoint / parser / rate_limit / requires_auth_env), `provider_spec_for(SourceEntry)` 디스패치, `LiveSourceFetcher` Protocol + `StubLiveSourceFetcher` 결정적 fake.
+- [retrieval.py](../src/yule_orchestrator/agents/engineering_intelligence/retrieval.py) — `KnowledgeRecord` (lightweight projection), `score_knowledge_record` (role × axis × topic × importance × freshness), `KnowledgeRetriever` (`with_signals` 로 score 노출).
+- [discussion/context_pack.py](../src/yule_orchestrator/agents/discussion/context_pack.py) — `EngineeringKnowledgeRef` slot + `knowledge_loader` / `knowledge_retriever` seam 추가. ContextPack.relevant_knowledge 가 자동으로 채워진다.
+
+남은 일 (별도 worktree / PR):
+
+- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
+- runtime service spawn (`eng-research-collector`) — scheduler tick → fetcher → adapter → vault writer.
+- `SourceRefreshState` persistence (sqlite or vault sidecar).
+- discussion synthesizer 가 `relevant_knowledge` slot 을 prompt 에 어떻게 짜 넣을지.
 
 ## 10. CI와 CD의 관계
 

--- a/notes/vault-mirror/10-projects/yule-studio-agent/task-logs/2026-05-09_issue-73-task-log-tech-lead-runtime-loop.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/task-logs/2026-05-09_issue-73-task-log-tech-lead-runtime-loop.md
@@ -37,6 +37,11 @@ tags: [task-log, tech-lead-runtime, foundation]
 | 2026-05-09 commit-8 | Round 2 — C. auto-spawn opt-in (`YULE_CODING_EXECUTOR_AUTOSPAWN` env flag) | 완료, runtime up 연결 |
 | 2026-05-09 commit-9 | Round 2 — D. CI failure → retry loop (`ci_status.py` + selector 가드) | 완료, 무한 재시도 차단 |
 | 2026-05-09 commit-10 | Round 2 — task-log + governance 회귀 + PR body 갱신 | 본 commit |
+| 2026-05-09 round-3 kickoff | live wiring 4 종 (dispatcher / 서비스 spawn / CI orchestrator / progress hook) — 같은 PR / 같은 branch | |
+| 2026-05-09 commit-11 | Round 3 — A. coding_execute_dispatcher (`coding_execute_dispatcher.py` + tests) | 완료 |
+| 2026-05-09 commit-12 | Round 3 — B. eng-coding-executor 서비스 spawn + LiveGithubAppClient.list_check_runs / get_pull_request | 완료 |
+| 2026-05-09 commit-13 | Round 3 — C. CI retry orchestrator + Obsidian/GitHub progress hook | 완료 |
+| 2026-05-09 commit-14 | Round 3 — D. 마스터 플랜 16-bis 섹션 + 본 task-log Round 3 갱신 | 본 commit |
 
 # 변경 / 산출물 (계획)
 
@@ -135,3 +140,47 @@ tags: [task-log, tech-lead-runtime, foundation]
 - [[2026-05-09_issue-73-decision-tech-lead-runtime-loop]]
 - [[2026-05-08_issue-69-research-engineering-agent-governance-synthesis]]
 - [[2026-05-08_issue-69-decision-engineering-agent-authoring-policy]]
+
+# Round 3 — 종료 시점 갱신 (2026-05-09)
+
+## 결과 요약
+
+같은 PR / 같은 branch 위에서 commit 11~14 추가. Round 1 의 protocol foundation, Round 2 의 live executor + CI policy 위에 producer / 서비스 spawn / orchestrator / progress hook 4 영역을 한 번에 land — 회사형 runtime 의 execution + improvement 루프가 처음으로 end-to-end deterministic.
+
+## 산출물 (Round 3)
+
+| 영역 | 위치 | 비고 |
+| --- | --- | --- |
+| A. coding_execute dispatcher | `src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py` (480 라인) | iter_ready_coding_jobs / build_coding_execute_request / dispatch_ready_coding_jobs / WorkflowSessionState. session.extra["coding_execute_dispatch"] marker + worker.find_active 양쪽으로 dedup. |
+| A. tests | `tests/job_queue/test_coding_execute_dispatcher.py` (23 케이스) | iter 필터 / env 우선순위 / 큐 wiring / idempotency / loader 실패 가드. |
+| B. 서비스 spawn | `src/yule_orchestrator/runtime/run_service.py` | _build_process_job 의 CODING_EXECUTOR 분기 + build_coding_executor_bundle + dispatcher 틱 + progress recorder hook. |
+| B. CI 조회 endpoint | `src/yule_orchestrator/github_app/live_client.py` | list_check_runs / get_pull_request 추가, /repos/{repo}/commits/{sha}/check-runs 결과를 ci_status.from_check_runs 와 직접 호환되는 dict 로 투영. |
+| B. tests | `tests/runtime/test_run_service_coding_executor.py` (8 케이스), `tests/github_app/test_live_client_check_runs.py` (5 케이스) | env matrix / factory 실패 / 클로저 wiring / dispatcher 틱 / GET endpoint round-trip. |
+| C. CI retry orchestrator | `src/yule_orchestrator/agents/job_queue/ci_retry_orchestrator.py` (480 라인) | orchestrate_ci_retry / GithubAppCheckRunFetcher / CIRetryDecision. retry 시 branch_hint 에 -attemptN suffix 붙여 새 행 enqueue, terminal 시 completion_hook funnel. |
+| C. progress hook | `src/yule_orchestrator/agents/job_queue/coding_execute_progress.py` (430 라인) | record_coding_execute_progress / make_github_pr_comment_fn. task-log obsidian_write 큐 + 선택적 PR comment + 50 행 capped history. |
+| C. tests | `tests/job_queue/test_ci_retry_orchestrator.py` (9 케이스), `tests/job_queue/test_coding_execute_progress.py` (11 케이스) | success / under-budget / over-budget / unknown / pending / GitHub failure / dry-run skip / collaborator 부재. |
+
+## 회귀 검증
+
+- `python3 -m unittest discover -s tests -t .` → **3117/3117 OK** (skip 5).
+- 신규 테스트만 56 케이스 (Round 1+2 기준 +56).
+
+## Hard rails 보존 확인 (Round 3)
+
+- 보호 브랜치 push 차단: 그대로.
+- LLM 코드 편집기 비활성: 그대로 (RecordOnlyCodeEditor).
+- live GitHub push: GitHub App env 3 종 모두 갖춰진 경우만, 부분 설정으로는 절대 활성화 안 됨.
+- 무한 재시도: decide_retry max_attempts 그대로, orchestrator 는 verdict 신뢰.
+- task-log 노트만 자동 enqueue (knowledge / decision-record 같은 approval-required kind 는 제외).
+- progress poster 실패 swallowed — verdict 무결성 보존.
+
+## 본 PR 비범위 → 후속 PR 매핑 (Round 3 갱신)
+
+- live LLM 코드 편집기 활성화 → 별도 PR. operator 승인 + cost 검토.
+- CI orchestrator 의 supervisor watch loop 자동 호출 (현재는 명시적 호출 / 테스트 inject 까지만 — 후속 PR 에서 지정 인터벌 polling).
+- Discord 봇 alert (escalated PR / blocked job 운영자 알림) → 별도 PR.
+
+## 외부 blocker
+
+- 없음. Round 3 4 영역 모두 hard-rail 안에서 land. live LLM editor 만 명시적 별도 PR.
+

--- a/policies/runtime/agents/engineering-agent/research-collector.md
+++ b/policies/runtime/agents/engineering-agent/research-collector.md
@@ -153,3 +153,87 @@ API 응답을 ResearchSource로 변환하는 `_result_dict_to_source`는 다음 
 3. Tavily/Brave 실 호출 검증 — 실제 API key 환경에서 응답 shape이 `_result_dict_to_source`와 일치하는지 확인.
 4. provider별 rate limit / 비용 관리 정책.
 5. 자동 수집 결과의 `confidence` 보강 — provider score / domain trust / role profile 일치도를 합쳐 high/medium/low 결정.
+
+## 12. Background ingestion scheduler (engineering_intelligence)
+
+본 §1~§11은 **요청이 들어왔을 때** intake 가 부르는 collector를 다룬다. master plan §6.1의 background knowledge loop는 별개 모듈이며, 코드 진실 소스는 `src/yule_orchestrator/agents/engineering_intelligence/scheduler.py`.
+
+### 12.1 흐름
+
+```
+runtime tick (every N minutes)
+   │
+   ▼
+compute_refresh_plan(role_id, now, states, tick_quota)
+   │
+   ├── never attempted        → due (reason=never_attempted)
+   ├── interval 경과           → due (reason=due 혹은 retry_after_X_failures)
+   ├── interval 미경과         → skipped_fresh (next_eligible_at 명시)
+   ├── failure backoff 미경과  → skipped_backoff (×1 / ×2 / ×4 / ×8, 24h cap)
+   ├── review_required=True   → skipped_review_required
+   ├── auto_collect=False     → skipped_auto_collect_disabled
+   └── tick quota 초과        → skipped_quota
+   ▼
+RefreshPlan(role, due, skipped, tick_quota)
+   │
+   ▼
+collect_for_role_with_schedule(role_id, adapter, states, now)
+   │
+   ├── plan.due_source_ids() 만 adapter 호출
+   ├── adapter 실패 → record_refresh_outcome(success=False, notes=...)
+   ├── adapter 성공 → record_refresh_outcome(success=True, items_collected)
+   └── returns (CollectionRunResult, updated_states)
+```
+
+### 12.2 운영 의도
+
+- **per-tick quota = role daily limit (5)** 가 기본. 한 번의 tick이 한 역할의 모든 source를 동시에 때리지 않게 하려는 가드.
+- **exponential backoff**는 source 자체 interval에 anchor 한다. 6h 주기 RSS는 두 번 실패하면 12h를 기다리고, 30분 주기 보안 advisory는 1h 만 기다린다 — 신선도 우선순위가 작동한다.
+- **state persistence는 본 모듈 책임이 아니다.** `SourceRefreshState` 가 caller가 sqlite/vault 사이드카에 직렬화해 보관하고 다음 tick에 다시 넣어준다. 본 모듈은 pure function.
+- `overdue_axes_for_role(role, states, grace_factor=2.0)` 는 "이 역할의 어떤 axis가 통째로 새 자료가 안 들어오고 있는가" 를 surface한다. 운영자 dashboard에 그대로 노출하면 되고, alert 임계값은 운영자가 결정.
+
+### 12.3 운영 환경변수 (Round 4 예약)
+
+scheduler 자체는 env를 읽지 않는다. 다만 **runtime 가 본 모듈을 부를 때** 다음 env가 의미를 가지게 될 예정이다 (현 commit 시점에는 wiring 부재).
+
+| 키 | 의미 |
+| --- | --- |
+| `YULE_ENG_INTEL_REFRESH_TICK_INTERVAL_MINUTES` | scheduler tick 간격. 기본 15분 권장. |
+| `YULE_ENG_INTEL_REFRESH_GLOBAL_QUOTA` | 한 tick에서 모든 역할 합쳐 호출할 수 있는 source 상한. dispatcher 부하 방지용. |
+| `YULE_ENG_INTEL_REFRESH_DRY_RUN` | true면 plan만 계산하고 adapter 호출은 하지 않는다. 운영자가 cadence를 검증할 때 사용. |
+
+이 env는 후속 PR에서 runtime side에 wire한다 — 본 PR scope에는 포함되지 않는다.
+
+## 13. Live provider seam (engineering_intelligence)
+
+코드 진실 소스: `src/yule_orchestrator/agents/engineering_intelligence/providers.py`.
+
+### 13.1 디스패치
+
+`provider_spec_for(SourceEntry) -> LiveProviderSpec` 가 단일 진입점이다. `SourceEntry.collection_mode` + base_url heuristic으로 transport를 결정한다.
+
+| CollectionMode | URL hint | ProviderTransport | parser | rate_limit_per_minute |
+| --- | --- | --- | --- | --- |
+| `MANUAL` | 무관 | `manual` | `manual` | 0 (호출 안 함) |
+| `GITHUB_API` | `github.com/...` | `github_api_repo_activity` | `github_api` | 30 |
+| `RSS` | `github.com/.../releases` | `github_releases_atom` | `atom` | 20 |
+| `RSS` | `*.atom` | `atom` | `atom` | 30 |
+| `RSS` | 그 외 | `rss` | `rss` | 30 |
+| `SITEMAP` | — | `sitemap` | `sitemap` | 10 |
+| `HTML_LIST` | — | `html_list` | `html_list` | 15 |
+| `HTML_DETAIL` | — | `html_detail` | `html_detail` | 5 |
+
+### 13.2 보안/secret 정책
+
+- `LiveProviderSpec.requires_auth_env` 는 **env key 이름**만 든다 — 실제 토큰 값은 절대 들어가지 않는다.
+- GitHub API spec의 `requires_auth_env=("YULE_GITHUB_APP_ID",)` 는 "App env 3종 중 하나라도 비어 있으면 fetch 시도 자체를 차단해야 한다" 는 신호다. fetcher impl 가 아직 land 하지 않았으므로, 본 PR scope 에서는 `StubLiveSourceFetcher` 만 제공한다.
+- request_headers_seed에는 token 헤더가 없다. fetcher impl 가 env를 읽어 별도로 합성해야 한다.
+
+### 13.3 후속 wiring (별도 PR)
+
+1. `providers_live.py` — urllib 기반 fetcher 구현 (RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
+2. fetcher rate limiter — `LiveProviderSpec.rate_limit_per_minute` 를 token bucket으로 강제.
+3. fetcher → adapter 어댑터 — `SourceCollectorAdapter` Protocol 에 fit하도록 (spec, source) → items 형태를 (source) → items 로 변환.
+4. runtime service 등록 — `eng-research-collector` 서비스가 본 PR 의 scheduler + 별도 fetcher 를 합쳐 tick 마다 돌도록.
+
+위 4번의 runtime wiring 은 본 worktree 의 write scope 밖이다. 본 PR 는 데이터 모델 + 정책 + 스케줄러 + 어댑터 seam 까지만 land 한다.

--- a/policies/runtime/agents/engineering-agent/research-collector.md
+++ b/policies/runtime/agents/engineering-agent/research-collector.md
@@ -229,7 +229,29 @@ scheduler 자체는 env를 읽지 않는다. 다만 **runtime 가 본 모듈을 
 - GitHub API spec의 `requires_auth_env=("YULE_GITHUB_APP_ID",)` 는 "App env 3종 중 하나라도 비어 있으면 fetch 시도 자체를 차단해야 한다" 는 신호다. fetcher impl 가 아직 land 하지 않았으므로, 본 PR scope 에서는 `StubLiveSourceFetcher` 만 제공한다.
 - request_headers_seed에는 token 헤더가 없다. fetcher impl 가 env를 읽어 별도로 합성해야 한다.
 
-### 13.3 후속 wiring (별도 PR)
+### 13.3 share_scope — 외부 surface 인용 boundary
+
+`engineering_intelligence.KnowledgeShareScope` 가 한 자료 항목이 어디까지 외부 surface(Discord digest, PR body, 합성 응답)에 인용 가능한지를 결정한다. 코드 진실 소스: `models.KnowledgeShareScope` + `obsidian.shareable_external_payload` + `discord_summary._format_line`.
+
+| share_scope | 외부 surface 노출 | Obsidian note 본문 | 사용 예 |
+| --- | --- | --- | --- |
+| `public` | 제목 + 요약 + source link 인용 가능 | 14 섹션 전부 렌더 | 공식 docs / release notes / 엔지니어링 블로그 |
+| `team_internal` | 제목 + source link 만 노출 (요약 차단) | 14 섹션 전부 렌더, 다만 외부 합성 응답에 본문은 사용 금지 | 사내 ADR / private repo 의 PR / 사내 advisory |
+| `restricted` | "🔒 공개 제한된 자료" 신호만 노출 | 학습 본문 섹션은 placeholder, 메타데이터 + share_scope_reason 만 보존 | 보안 incident / 고객 데이터가 섞인 자료 |
+
+규칙:
+
+- 기본값은 `public`. collector 가 명시하지 않으면 `public` 으로 처리한다.
+- `restricted` 자료는 반드시 `share_scope_reason` 을 채워야 한다 — quality gate 가 막는다 (`missing:share_scope_reason_for_restricted`).
+- `team_internal` 자료는 chat 합성 응답의 본문 인용에 사용하지 않는다. ContextPack `relevant_knowledge` 의 `summary` 가 `team_internal` 인 경우 evidence 블록은 자동으로 요약 라인을 생략한다.
+- `restricted` 자료는 ContextPack evidence 블록에서도 제목/링크가 모두 마스킹되고 `topic_key` + `share_scope_reason` 만 surface 에 남는다.
+
+운영자 관점:
+
+- vault 안에서는 share_scope 와 무관하게 본문(자료 형태에 따라 placeholder 가 박힌 채로) 이 다 보인다 — Obsidian 은 운영 채널이지 외부 surface 가 아니다.
+- 외부 surface 로 보낼 페이로드를 만들 때는 `obsidian.shareable_external_payload(item)` 결과만 사용한다. raw `EngineeringKnowledgeItem.to_payload()` 는 vault 전용.
+
+### 13.4 후속 wiring (별도 PR)
 
 1. `providers_live.py` — urllib 기반 fetcher 구현 (RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
 2. fetcher rate limiter — `LiveProviderSpec.rate_limit_per_minute` 를 token bucket으로 강제.

--- a/policies/runtime/agents/engineering-agent/research-profiles.md
+++ b/policies/runtime/agents/engineering-agent/research-profiles.md
@@ -159,3 +159,39 @@ discussion request-time retrieval은 위의 `_ROLE_RESEARCH_PROFILES` 가중치 
 | (그 외 / `unknown` / `None`) | (없음 — 기본 role 가중치만 사용) |
 
 이 표를 변경하면 해당 매트릭스를 코드(`_TASK_TYPE_AXIS_HINTS`)와 함께 업데이트해야 한다 — 두 위치가 따로 놀면 retrieval에서 생기는 미스매치를 디버그하기가 까다로워진다.
+
+## 부록 C — knowledge note share_scope 와 evidence surface
+
+`engineering_intelligence.KnowledgeShareScope` 는 한 knowledge note 가 외부 surface(Discord digest, PR body, 합성 응답)에 어디까지 인용될 수 있는지를 결정하는 boundary 플래그다. 본 부록은 retrieval surface 에 share_scope 가 어떻게 노출되는지를 정리한다 — 운영자 관점에서 "이 자료가 chat 응답에 그대로 인용되어도 되는가?" 를 빠르게 판단하기 위한 표.
+
+### C.1 share_scope 별 surface 동작
+
+| share_scope | retrieval surface (`relevant_knowledge` 블록) | Discord 일별 digest |
+| --- | --- | --- |
+| `public` | 제목 + 출처 링크 + 요약 1줄 + 점수/근거 표시 | 제목 + importance badge + source link |
+| `team_internal` | 제목 + 출처 링크 + 점수/근거 표시 (요약 자동 차단) + `🔒 team-internal` 라벨 | 제목 + source link + `🔒 team-internal` 라벨 |
+| `restricted` | `🔒 공개 제한된 자료` + `share_scope_reason` 만 노출 (제목/URL/요약 모두 마스킹) | `🔒 공개 제한된 자료 (topic_key)` 라벨만 |
+
+코드 진실 소스: `discussion.context_pack.format_knowledge_evidence_block` + `engineering_intelligence.discord_summary._format_line`.
+
+### C.2 retrieval evidence 라벨
+
+`KnowledgeMatch.evidence_labels()` 가 score signal 토큰을 사람이 읽을 수 있는 한국어 라벨로 변환한다. 합성 응답이나 Obsidian decision note 의 "근거 자료" 블록은 본 라벨을 그대로 사용한다.
+
+| signal token | 한국어 라벨 |
+| --- | --- |
+| `role_primary_match` | 요청 역할과 정확히 일치 |
+| `role_secondary_match` | 요청 역할이 보조 역할로 등록됨 |
+| `axis_overlap:<axes>` | task_type 축 일치 (`<axes>`) |
+| `topic_overlap:<n>` | 질문 토큰 겹침 (+`n`) |
+| `importance_critical` / `importance_high` | 중요도 critical / high |
+| `importance_low` | 중요도 low (감점) |
+| `fresh_7d` / `fresh_30d` | 최근 7일 / 30일 이내 수집 |
+| `empty_body_penalty` | 본문/태그 비어 있음 (감점) |
+
+새 signal 을 추가하면 `engineering_intelligence.retrieval._KNOWN_SIGNAL_LABELS` 에 한국어 라벨을 함께 넣을 것 — 비어 있으면 surface 가 raw token 을 그대로 노출한다.
+
+### C.3 운영 가드
+
+- ContextPack 빌더는 retriever 가 `with_signals` 를 노출하면 우선 사용해서 score + signals 를 surface 에 끌고 들어온다. 라이트한 fallback retriever 만 줘도 되지만 score/signal 트레이스가 없으면 evidence 블록은 점수/근거 없이 제목/요약만 보인다.
+- `share_scope=restricted` 자료가 `relevant_knowledge` 에 들어 있으면 합성 응답은 자동으로 본문을 마스킹한다. 운영자가 직접 본문을 합성 응답에 넣는 코드를 추가할 일이 생기면 `format_knowledge_evidence_block` 결과만 사용하거나 `obsidian.shareable_external_payload` 페이로드만 사용한다 — raw `EngineeringKnowledgeRef.summary` 를 직접 인용하지 않는다.

--- a/policies/runtime/agents/engineering-agent/research-profiles.md
+++ b/policies/runtime/agents/engineering-agent/research-profiles.md
@@ -125,3 +125,37 @@ RoleQueryHints(
 - ResearchPack과 본 프로필의 연결: 자료가 들어올 때 `collected_by_role`과 `source_type`을 보고 본 프로필 가중치로 자동 정렬.
 - 사용자 task 신호(예: prompt에 "moodboard", "API reference" 같은 단어)가 있을 때 task_type 분류 외에 추가 가중치를 주는 보정.
 - 가중치를 외부 정책 JSON으로 빼서 운영자가 코드 수정 없이 조정 가능하게.
+
+## 부록 A — 역할별 SourceAxis 매트릭스 (engineering_intelligence)
+
+`engineering_intelligence.SourceAxis`는 master plan §9.1에서 명시한 역할별 상시 수집 대상을 enum으로 굳힌 것이다. 위 §역할별 기본 프로필은 사용자 발화 직후 retrieval에서 `source_type` 가중치를 결정하지만, 본 부록은 background ingestion이 어떤 axis를 항상 채워두어야 하는지를 결정한다. 코드 진실 소스는 `source_registry.required_axes_for_role(role_id)` + `axes_for_role(role_id)`.
+
+| 역할 | 필수 SourceAxis (operational seed) | 핵심 source 종류 |
+| --- | --- | --- |
+| tech-lead | `architecture_adr_tradeoff`, `official_docs` | RFC editor, ISO/IEC 25010, ADR repo, Cloudflare/Stripe engineering blog |
+| backend-engineer | `official_docs`, `api_schema_auth`, `release_notes_changelog`, `security` | Spring docs/blog, FastAPI/PostgreSQL/Redis release, OWASP Top 10, NIST CVE |
+| frontend-engineer | `web_platform_framework`, `official_docs`, `release_notes_changelog` | React blog, Next.js releases, TypeScript what's new, web.dev, MDN, WCAG |
+| devops-engineer | `ci_cd_infra_observability`, `release_notes_changelog`, `security` | Docker/Kubernetes/Argo CD/Terraform release, GitHub Actions changelog, NIST CVE |
+| qa-engineer | `regression_test_plan`, `security` | Playwright/Testing Library/Cypress, ISO 29119, Google Testing Blog, NIST CVE |
+| ai-engineer | `ai_framework` | OpenAI/Anthropic news, Hugging Face blog, LangChain blog, pgvector, Ragas |
+| product-designer | `design_system` | Apple HIG, Material Design, Fluent, Atlassian, Carbon, GOV.UK Patterns |
+
+축가 하나라도 빠지면 `tests/engineering_intelligence/test_source_registry.py::AxisCoverageTests::test_every_role_meets_required_axes` 가 실패한다. 새 source seed를 추가하거나 기존 seed에서 axis tag를 빼면 본 표와 `_ROLE_REQUIRED_AXES` 둘 다 같이 갱신할 것.
+
+## 부록 B — task_type → axis hint matrix
+
+discussion request-time retrieval은 위의 `_ROLE_RESEARCH_PROFILES` 가중치 외에 task_type에서 유도한 axis hint를 추가 보너스로 사용한다. 코드 진실 소스는 `source_registry.axis_hints_for_task_type(task_type)`.
+
+| task_type | 부스트되는 axis |
+| --- | --- |
+| `backend-feature` | `api_schema_auth`, `official_docs`, `security` |
+| `frontend-feature` | `web_platform_framework`, `official_docs` |
+| `landing-page` | `design_system`, `web_platform_framework` |
+| `onboarding-flow` | `design_system`, `web_platform_framework` |
+| `visual-polish` | `design_system` |
+| `email-campaign` | `design_system` |
+| `qa-test` | `regression_test_plan`, `security` |
+| `platform-infra` | `ci_cd_infra_observability`, `architecture_adr_tradeoff` |
+| (그 외 / `unknown` / `None`) | (없음 — 기본 role 가중치만 사용) |
+
+이 표를 변경하면 해당 매트릭스를 코드(`_TASK_TYPE_AXIS_HINTS`)와 함께 업데이트해야 한다 — 두 위치가 따로 놀면 retrieval에서 생기는 미스매치를 디버그하기가 까다로워진다.

--- a/src/yule_orchestrator/agents/discussion/__init__.py
+++ b/src/yule_orchestrator/agents/discussion/__init__.py
@@ -32,6 +32,7 @@ from .mode import (
 from .context_pack import (
     ContextPack,
     ContextPackBuilder,
+    EngineeringKnowledgeRef,
     ObsidianNoteRef,
     GithubIssueRef,
     GithubPRRef,
@@ -61,6 +62,7 @@ __all__ = (
     "classify_discussion_mode",
     "ContextPack",
     "ContextPackBuilder",
+    "EngineeringKnowledgeRef",
     "ObsidianNoteRef",
     "GithubIssueRef",
     "GithubPRRef",

--- a/src/yule_orchestrator/agents/discussion/__init__.py
+++ b/src/yule_orchestrator/agents/discussion/__init__.py
@@ -1,0 +1,78 @@
+"""Discussion mode v1 — tech-lead 토의/조사/구현/질문 분류 + 응답 합성.
+
+이 패키지는 engineering-agent gateway가 받은 자유 발화를 단순한 intake
+파이프라인이 아니라 tech-lead가 끌고 갈 토의 흐름으로 옮길 때 쓴다.
+gateway는 외부 surface(채널 응답·status·closure)만 책임지고, 본 모듈은
+긴 문맥을 들고 다음 행동을 판단하는 두뇌 역할이다.
+
+핵심 진입점:
+
+- :class:`DiscussionMode` — 4가지 판단 모드.
+- :func:`classify_discussion_mode` — deterministic fast-path + LLM seam.
+- :class:`ContextPack` / :class:`ContextPackBuilder` — 한 요청에 들어가는
+  최근 thread 요약 / session.extra / 관련 issue·PR / Obsidian note 후보 /
+  코드 힌트 / role profile 묶음.
+- :class:`RelevantMemorySelector` — 후보 note/issue 중 이 요청과 관련 있는
+  것만 골라 ``ContextPack``에 끼워 넣는 보조 단계.
+- :class:`DiscussionSynthesis` / :func:`synthesize_discussion` — 위 분류와
+  pack을 받아 토의/설계 논의/조사/구현 후보 응답 텍스트 + 다음 행동을
+  생산한다.
+- :func:`build_implementation_handoff` — synthesis가 구현 후보로 넘어갈
+  때 ``CodingAuthorizationProposal``로 이어주는 얇은 어댑터.
+
+I/O는 하지 않는다. Discord/GitHub/Obsidian에 실제로 기록하는 일은 호출자
+(gateway 채널 라우터, forum hook 등)의 책임으로 둔다.
+"""
+
+from .mode import (
+    DiscussionMode,
+    DiscussionModeMatch,
+    classify_discussion_mode,
+)
+from .context_pack import (
+    ContextPack,
+    ContextPackBuilder,
+    ObsidianNoteRef,
+    GithubIssueRef,
+    GithubPRRef,
+    CodeHint,
+    ThreadMessage,
+)
+from .memory_selector import (
+    MemoryCandidate,
+    RelevantMemorySelector,
+    score_memory_candidate,
+)
+from .synthesizer import (
+    DiscussionSynthesis,
+    DiscussionTemplate,
+    synthesize_discussion,
+)
+from .handoff import (
+    DiscussionHandoff,
+    HandoffBlocker,
+    build_implementation_handoff,
+)
+
+
+__all__ = (
+    "DiscussionMode",
+    "DiscussionModeMatch",
+    "classify_discussion_mode",
+    "ContextPack",
+    "ContextPackBuilder",
+    "ObsidianNoteRef",
+    "GithubIssueRef",
+    "GithubPRRef",
+    "CodeHint",
+    "ThreadMessage",
+    "MemoryCandidate",
+    "RelevantMemorySelector",
+    "score_memory_candidate",
+    "DiscussionSynthesis",
+    "DiscussionTemplate",
+    "synthesize_discussion",
+    "DiscussionHandoff",
+    "HandoffBlocker",
+    "build_implementation_handoff",
+)

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -107,6 +107,16 @@ class EngineeringKnowledgeRef:
     동일하지만, 본 모듈은 engineering_intelligence 를 import 하지 않는다
     (서로 독립적으로 import-able 해야 한다는 운영 원칙). 합성 어댑터는
     ``ContextPackBuilder._coerce_knowledge_ref`` 가 담당.
+
+    ``share_scope`` / ``share_scope_reason`` 는 외부 surface (Discord,
+    합성 응답, PR 본문) 가 어디까지 인용해도 되는지를 결정하는 boundary
+    플래그다. 값이 없으면 ``"public"`` 으로 간주한다 — collector 가
+    명시하지 않은 자료는 운영자 합의로 PUBLIC default 로 처리한다.
+
+    ``score`` / ``signals`` / ``evidence_labels`` 은 retrieval 이 왜 이
+    자료를 골랐는지를 사람이 읽을 수 있는 형태로 surface 에 남기기
+    위한 슬롯이다. 합성 응답 / Obsidian decision note 가 "근거 자료"
+    블록을 만들 때 그대로 사용한다.
     """
 
     title: str
@@ -122,6 +132,9 @@ class EngineeringKnowledgeRef:
     note_path: Optional[str] = None
     score: Optional[float] = None
     signals: Sequence[str] = field(default_factory=tuple)
+    evidence_labels: Sequence[str] = field(default_factory=tuple)
+    share_scope: str = "public"
+    share_scope_reason: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +243,9 @@ class ContextPack:
                     "note_path": k.note_path,
                     "score": k.score,
                     "signals": list(k.signals),
+                    "evidence_labels": list(k.evidence_labels),
+                    "share_scope": k.share_scope,
+                    "share_scope_reason": k.share_scope_reason,
                 }
                 for k in self.relevant_knowledge
             ],
@@ -249,6 +265,40 @@ class ContextPack:
             "blockers": list(self.blockers),
             "extra": dict(self.extra),
         }
+
+    def format_knowledge_evidence_block(
+        self,
+        *,
+        max_items: int = 5,
+        heading: str = "근거 자료 (engineering_intelligence)",
+    ) -> str:
+        """``relevant_knowledge`` 를 마크다운 evidence 블록으로 렌더한다.
+
+        합성 응답 / Obsidian decision note / PR body footer 가 "이번
+        토의에서 어떤 사내 자료가 근거로 쓰였는가" 를 사람에게 보여주기
+        위한 구조화된 출력이다. 빈 리스트일 때는 빈 문자열을 반환해
+        호출자가 if-string-truthy 로 분기할 수 있다.
+
+        규칙:
+
+        - ``share_scope=public`` — 제목 + 출처 링크 + summary 한 줄.
+        - ``share_scope=team_internal`` — 제목 + 출처 링크 + 'team-
+          internal' 라벨, summary 는 의도적으로 생략. vault 외부에서는
+          본문 합성에 인용하지 않는다는 정책을 따른다.
+        - ``share_scope=restricted`` — 제목/링크/summary 모두 가리고
+          topic_key + share_scope_reason 만 노출. 외부에 자료가 있다는
+          신호만 남긴다.
+
+        retrieval 점수 / signal 은 ``evidence_labels`` 가 채워져 있으면
+        한국어 라벨로, 아니면 raw signal 문자열로 노출한다.
+        """
+
+        if not self.relevant_knowledge:
+            return ""
+        lines: list[str] = [f"### {heading}"]
+        for ref in list(self.relevant_knowledge)[: max(max_items, 0)]:
+            lines.extend(_format_knowledge_evidence_lines(ref))
+        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +609,34 @@ class ContextPackBuilder:
             picked = (same_role + other)[: self.max_knowledge]
             return tuple(picked)
 
+        # Prefer the retriever's ``with_signals`` form so we can carry
+        # the score + signals through to the surface. The plain
+        # ``__call__`` form just returns records and loses the "왜 이
+        # 자료가 골라졌는가" trace, which is exactly what this PR is
+        # trying to surface.
+        with_signals = getattr(self.knowledge_retriever, "with_signals", None)
+        if callable(with_signals):
+            try:
+                matches = with_signals(
+                    candidates=raw,
+                    query=query,
+                    role=role,
+                    task_type=task_type,
+                    limit=self.max_knowledge,
+                )
+            except Exception:  # noqa: BLE001
+                matches = ()
+            normalized: list[EngineeringKnowledgeRef] = []
+            for match in matches:
+                ref = self._coerce_knowledge_ref(match)
+                if ref is not None:
+                    normalized.append(ref)
+            if normalized:
+                return tuple(normalized[: self.max_knowledge])
+            # Fall through to the plain retriever — sometimes
+            # ``with_signals`` returns nothing while the plain call
+            # would, and we'd rather show *something* than nothing.
+
         try:
             picked = self.knowledge_retriever(
                 candidates=raw,
@@ -583,12 +661,49 @@ class ContextPackBuilder:
 
     @staticmethod
     def _coerce_knowledge_ref(value: Any) -> Optional[EngineeringKnowledgeRef]:
-        """Best-effort projection of vault row / KnowledgeRecord / dict."""
+        """Best-effort projection of vault row / KnowledgeRecord / dict.
+
+        Accepts:
+
+        - ``EngineeringKnowledgeRef`` — passthrough.
+        - ``KnowledgeMatch`` (duck-typed: has ``record`` / ``score`` /
+          ``signals`` attrs; bonus: ``evidence_labels()`` method) — the
+          score / signal trace is unpacked onto the resulting ref so
+          the synthesizer can show "왜 이 자료가 골라졌는가" without a
+          second lookup.
+        - ``KnowledgeRecord`` / ``EngineeringKnowledgeItem`` — flat
+          attribute walk.
+        - Plain mapping — the dict carries the same field names.
+        """
 
         if value is None:
             return None
         if isinstance(value, EngineeringKnowledgeRef):
             return value
+
+        # KnowledgeMatch duck-typing: unwrap into (record, score, signals).
+        score: Optional[float] = None
+        signals_seq: tuple[str, ...] = ()
+        evidence_labels_seq: tuple[str, ...] = ()
+        record_attr = getattr(value, "record", None)
+        if (
+            record_attr is not None
+            and not isinstance(value, Mapping)
+            and hasattr(value, "signals")
+        ):
+            try:
+                score = float(getattr(value, "score"))
+            except (TypeError, ValueError):
+                score = None
+            signals_seq = tuple(getattr(value, "signals", ()) or ())
+            label_method = getattr(value, "evidence_labels", None)
+            if callable(label_method):
+                try:
+                    evidence_labels_seq = tuple(label_method())
+                except Exception:  # noqa: BLE001
+                    evidence_labels_seq = ()
+            value = record_attr
+
         # KnowledgeRecord 와 EngineeringKnowledgeItem (engineering_intelligence
         # 패키지) 둘 다 있으면 직접 import 하지 않고 duck typing 으로 처리.
         title = getattr(value, "title", None)
@@ -602,6 +717,9 @@ class ContextPackBuilder:
                     axes_seq.append(str(axis_value))
             importance_attr = getattr(value, "importance", None)
             importance_value = getattr(importance_attr, "value", importance_attr)
+            share_attr = getattr(value, "share_scope", None)
+            share_value = getattr(share_attr, "value", share_attr)
+            share_scope = str(share_value) if share_value else "public"
             return EngineeringKnowledgeRef(
                 title=str(title),
                 role=str(role),
@@ -614,6 +732,13 @@ class ContextPackBuilder:
                 importance=str(importance_value) if importance_value else None,
                 collected_at=getattr(value, "collected_at", None) or None,
                 note_path=getattr(value, "note_path", None),
+                score=score if score is not None else getattr(value, "score", None),
+                signals=signals_seq,
+                evidence_labels=evidence_labels_seq,
+                share_scope=share_scope,
+                share_scope_reason=str(
+                    getattr(value, "share_scope_reason", "") or ""
+                ),
             )
         if isinstance(value, Mapping):
             title_v = str(value.get("title") or "").strip()
@@ -622,6 +747,9 @@ class ContextPackBuilder:
                 return None
             axes_raw = value.get("axes") or ()
             axes_seq = [str(a) for a in axes_raw if a]
+            mapping_signals = tuple(value.get("signals") or ()) or signals_seq
+            mapping_labels = tuple(value.get("evidence_labels") or ()) or evidence_labels_seq
+            mapping_score = value.get("score")
             return EngineeringKnowledgeRef(
                 title=title_v,
                 role=role_v,
@@ -634,8 +762,11 @@ class ContextPackBuilder:
                 importance=value.get("importance"),
                 collected_at=value.get("collected_at"),
                 note_path=value.get("note_path"),
-                score=value.get("score"),
-                signals=tuple(value.get("signals") or ()),
+                score=mapping_score if mapping_score is not None else score,
+                signals=mapping_signals,
+                evidence_labels=mapping_labels,
+                share_scope=str(value.get("share_scope") or "public"),
+                share_scope_reason=str(value.get("share_scope_reason") or ""),
             )
         return None
 
@@ -694,6 +825,50 @@ class ContextPackBuilder:
         if not bits:
             return None
         return ", ".join(bits)
+
+
+_RESTRICTED_LINE_FALLBACK = "🔒 공개 제한된 자료"
+
+
+def _format_knowledge_evidence_lines(ref: EngineeringKnowledgeRef) -> list[str]:
+    """Format one ``EngineeringKnowledgeRef`` as evidence bullet lines.
+
+    Splits into a heading bullet + an optional indented signal bullet
+    so the operator can scan title-first and only drop into "왜 이
+    자료가 골라졌는가" details when needed.
+    """
+
+    scope = (ref.share_scope or "public").lower()
+    lines: list[str] = []
+    if scope == "restricted":
+        marker = _RESTRICTED_LINE_FALLBACK
+        if ref.share_scope_reason:
+            marker = f"{marker} — {ref.share_scope_reason}"
+        else:
+            marker = f"{marker} (`{ref.topic_key}`)"
+        lines.append(f"- {marker}")
+    else:
+        title = ref.title or "(제목 없음)"
+        if ref.source_url:
+            head = f"- **{title}** — [{ref.source_name or '출처'}]({ref.source_url})"
+        else:
+            head = f"- **{title}**"
+        if scope == "team_internal":
+            head = f"{head} · 🔒 team-internal"
+        lines.append(head)
+        if scope == "public" and ref.summary:
+            lines.append(f"  - 요약: {ref.summary}")
+    detail_bits: list[str] = []
+    if ref.role:
+        detail_bits.append(f"role={ref.role}")
+    if ref.score is not None:
+        detail_bits.append(f"score={ref.score:.1f}")
+    labels = list(ref.evidence_labels) if ref.evidence_labels else list(ref.signals)
+    if labels:
+        detail_bits.append("근거: " + ", ".join(labels))
+    if detail_bits:
+        lines.append(f"  - {' · '.join(detail_bits)}")
+    return lines
 
 
 def _summarize_thread(messages: Sequence[ThreadMessage]) -> str:

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -300,6 +300,69 @@ class ContextPack:
             lines.extend(_format_knowledge_evidence_lines(ref))
         return "\n".join(lines)
 
+    def share_boundary_breakdown(self) -> Mapping[str, int]:
+        """``relevant_knowledge`` 항목 수를 share_scope 별로 집계한다.
+
+        외부 surface (Discord 다이제스트 / 합성 응답 / PR body) 가
+        "이번 응답에 인용한 자료가 어떤 boundary 안에 있는지" 를
+        한 눈에 보여줄 때 쓴다. 키는 항상 4 종 (`public`,
+        `team_internal`, `restricted`, `total`) 이 모두 들어 있고
+        값은 정수다 — 호출자가 dict[k] 접근으로 바로 쓸 수 있다.
+        """
+
+        counts = {"public": 0, "team_internal": 0, "restricted": 0}
+        for ref in self.relevant_knowledge:
+            scope = (ref.share_scope or "public").lower()
+            if scope not in counts:
+                scope = "public"
+            counts[scope] += 1
+        counts["total"] = sum(counts.values())
+        return counts
+
+    def knowledge_short_summary(self, *, max_topics: int = 2) -> str:
+        """근거 자료를 한 줄로 요약한다 — 합성 응답 / 운영 dashboard 용.
+
+        - 총 건수 + share_scope 별 카운트 (0 인 scope 는 생략).
+        - 상위 ``max_topics`` 건의 제목 / topic_key — share_scope 정책을
+          그대로 따른다 (restricted 는 topic_key 만, team_internal/public
+          은 제목).
+        - relevant_knowledge 가 비어 있으면 빈 문자열.
+
+        예시 출력:
+        ``"근거 자료 3건 (public 2 · team_internal 1) — Spring Security 인증 흐름 외 1건"``
+        """
+
+        refs = list(self.relevant_knowledge)
+        if not refs:
+            return ""
+        breakdown = self.share_boundary_breakdown()
+        scope_bits: list[str] = []
+        for scope_key in ("public", "team_internal", "restricted"):
+            value = breakdown.get(scope_key, 0)
+            if value:
+                scope_bits.append(f"{scope_key} {value}")
+        scope_part = f" ({' · '.join(scope_bits)})" if scope_bits else ""
+        topic_labels: list[str] = []
+        for ref in refs[: max(max_topics, 0)]:
+            scope = (ref.share_scope or "public").lower()
+            if scope == "restricted":
+                topic_labels.append(f"🔒 `{ref.topic_key or 'restricted'}`")
+            else:
+                title = (ref.title or "(제목 없음)").strip()
+                if scope == "team_internal":
+                    topic_labels.append(f"{title} (🔒 team-internal)")
+                else:
+                    topic_labels.append(title)
+        topic_part = ""
+        if topic_labels:
+            extra = max(len(refs) - len(topic_labels), 0)
+            preview = ", ".join(topic_labels)
+            if extra:
+                topic_part = f" — {preview} 외 {extra}건"
+            else:
+                topic_part = f" — {preview}"
+        return f"근거 자료 {breakdown['total']}건{scope_part}{topic_part}"
+
 
 # ---------------------------------------------------------------------------
 # Builder — 외부 source는 callable seam으로 주입

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -1,0 +1,536 @@
+"""ContextPack — discussion mode가 사용하는 입력 묶음.
+
+마스터 플랜 §7.2 / §8.1을 그대로 따른다. 하나의 사용자 메시지가 들어오면
+tech-lead는 다음 묶음을 본다:
+
+- 현재 user message
+- 최근 thread 요약
+- session.extra 요약 (research_pack 메타, coding_proposal 등)
+- 관련 issue / PR 요약
+- 관련 Obsidian note (RelevantMemorySelector가 골라준 것)
+- 관련 코드/파일 힌트
+- role profile + role research profile
+
+본 모듈은 순수 dataclass + builder만 둔다. 외부 fetch는 호출자(주로
+gateway 채널 라우터, forum hook)가 책임진다 — issue/PR/Obsidian/코드
+어디서 끌어오는지는 환경에 따라 다르고, builder는 받은 입력을 묶어 주는
+얇은 합성기 역할만 한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence
+
+
+# ---------------------------------------------------------------------------
+# 작은 reference dataclass — 모두 frozen, 외부 fetch 결과를 그대로 받는다.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThreadMessage:
+    """thread 내 발화 한 줄.
+
+    ``role``은 ``user`` / ``tech-lead`` / ``backend-engineer`` 등 자유 라벨.
+    ``content``는 단일 문자열. 길이는 builder가 cap한다.
+    """
+
+    role: str
+    content: str
+    posted_at: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ObsidianNoteRef:
+    """Obsidian vault에서 retrieval된 note 한 건의 메타데이터."""
+
+    title: str
+    path: Optional[str] = None
+    summary: Optional[str] = None
+    tags: Sequence[str] = field(default_factory=tuple)
+    kind: Optional[str] = None  # research / decision / reference / task-log
+    project: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class GithubIssueRef:
+    """GitHub issue 한 건. issue body는 별도 fetch 후 ``summary``로 줄여서."""
+
+    number: int
+    title: str
+    state: Optional[str] = None  # open / closed
+    summary: Optional[str] = None
+    url: Optional[str] = None
+    labels: Sequence[str] = field(default_factory=tuple)
+    repo: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class GithubPRRef:
+    """GitHub PR 한 건. ``state``는 open / closed / merged."""
+
+    number: int
+    title: str
+    state: Optional[str] = None
+    summary: Optional[str] = None
+    url: Optional[str] = None
+    branch: Optional[str] = None
+    repo: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CodeHint:
+    """관련 파일/심볼 힌트.
+
+    실제 코드 본문을 들고 다니지는 않는다 — 경로 + 심볼 이름 + 한 줄
+    이유만. 본문이 필요하면 호출자가 별도로 가져온다.
+    """
+
+    path: str
+    symbol: Optional[str] = None
+    summary: Optional[str] = None
+    line: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# ContextPack
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContextPack:
+    """tech-lead가 한 요청을 판단할 때 사용하는 입력 묶음.
+
+    어떤 슬롯도 비어 있을 수 있다 — 외부 source가 미설정이면 비운 채로
+    들어와서 ``DiscussionSynthesizer``가 "이 부분은 비어 있다"를 명시
+    적으로 출력한다.
+    """
+
+    current_message: str
+    session_id: Optional[str] = None
+    task_type: Optional[str] = None
+    suggested_task_type: Optional[str] = None
+    role_for_research: str = "engineering-agent/tech-lead"
+    recent_thread: Sequence[ThreadMessage] = field(default_factory=tuple)
+    thread_summary: Optional[str] = None
+    session_extra_summary: Optional[str] = None
+    related_issues: Sequence[GithubIssueRef] = field(default_factory=tuple)
+    related_prs: Sequence[GithubPRRef] = field(default_factory=tuple)
+    relevant_notes: Sequence[ObsidianNoteRef] = field(default_factory=tuple)
+    code_hints: Sequence[CodeHint] = field(default_factory=tuple)
+    role_profile_summary: Optional[str] = None
+    role_research_profile_summary: Optional[str] = None
+    write_requested: bool = False
+    write_blocked_reason: Optional[str] = None
+    blockers: Sequence[str] = field(default_factory=tuple)
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Mapping[str, Any]:
+        """LLM seam / 디버그 dump용 직렬화. dataclass는 평면 dict로."""
+
+        return {
+            "current_message": self.current_message,
+            "session_id": self.session_id,
+            "task_type": self.task_type,
+            "suggested_task_type": self.suggested_task_type,
+            "role_for_research": self.role_for_research,
+            "recent_thread": [
+                {
+                    "role": m.role,
+                    "content": m.content,
+                    "posted_at": m.posted_at,
+                }
+                for m in self.recent_thread
+            ],
+            "thread_summary": self.thread_summary,
+            "session_extra_summary": self.session_extra_summary,
+            "related_issues": [
+                {
+                    "number": i.number,
+                    "title": i.title,
+                    "state": i.state,
+                    "summary": i.summary,
+                    "url": i.url,
+                    "labels": list(i.labels),
+                    "repo": i.repo,
+                }
+                for i in self.related_issues
+            ],
+            "related_prs": [
+                {
+                    "number": p.number,
+                    "title": p.title,
+                    "state": p.state,
+                    "summary": p.summary,
+                    "url": p.url,
+                    "branch": p.branch,
+                    "repo": p.repo,
+                }
+                for p in self.related_prs
+            ],
+            "relevant_notes": [
+                {
+                    "title": n.title,
+                    "path": n.path,
+                    "summary": n.summary,
+                    "tags": list(n.tags),
+                    "kind": n.kind,
+                    "project": n.project,
+                    "updated_at": n.updated_at,
+                }
+                for n in self.relevant_notes
+            ],
+            "code_hints": [
+                {
+                    "path": h.path,
+                    "symbol": h.symbol,
+                    "summary": h.summary,
+                    "line": h.line,
+                }
+                for h in self.code_hints
+            ],
+            "role_profile_summary": self.role_profile_summary,
+            "role_research_profile_summary": self.role_research_profile_summary,
+            "write_requested": self.write_requested,
+            "write_blocked_reason": self.write_blocked_reason,
+            "blockers": list(self.blockers),
+            "extra": dict(self.extra),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Builder — 외부 source는 callable seam으로 주입
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ContextPackBuilder:
+    """ContextPack 합성기.
+
+    외부 source는 모두 콜러블 seam으로 받는다. 각 seam은 실패해도 builder
+    가 멈추면 안 된다 — 실패 시 해당 슬롯을 비우고 ``blockers``에 사람이
+    읽기 쉬운 한 줄을 남긴다.
+
+    seam 시그니처:
+
+    - ``thread_loader(session_id) -> Iterable[ThreadMessage]``
+    - ``issue_loader(query) -> Iterable[GithubIssueRef]``
+    - ``pr_loader(query) -> Iterable[GithubPRRef]``
+    - ``note_loader(query) -> Iterable[ObsidianNoteRef]``
+    - ``code_hint_loader(query) -> Iterable[CodeHint]``
+    - ``role_profile_loader(role) -> Optional[str]`` (역할 프로필 요약 한 단락)
+    - ``role_research_profile_loader(role) -> Optional[str]`` (research 프로필 요약)
+
+    ``memory_selector``는 ``RelevantMemorySelector`` 호환 콜러블. 받은
+    note 후보를 추려서 돌려준다. 없으면 raw note 결과를 그대로 사용한다.
+    """
+
+    thread_loader: Optional[Any] = None
+    issue_loader: Optional[Any] = None
+    pr_loader: Optional[Any] = None
+    note_loader: Optional[Any] = None
+    code_hint_loader: Optional[Any] = None
+    role_profile_loader: Optional[Any] = None
+    role_research_profile_loader: Optional[Any] = None
+    memory_selector: Optional[Any] = None
+    max_thread_messages: int = 12
+    max_issues: int = 5
+    max_prs: int = 5
+    max_notes: int = 5
+    max_code_hints: int = 6
+    max_thread_message_chars: int = 280
+
+    def build(
+        self,
+        *,
+        message_text: str,
+        session: Optional[Any] = None,
+        suggested_task_type: Optional[str] = None,
+        role_for_research: str = "engineering-agent/tech-lead",
+        retrieval_query: Optional[str] = None,
+    ) -> ContextPack:
+        """주어진 메시지 + 선택적 :class:`WorkflowSession`로 pack을 만든다.
+
+        *retrieval_query*는 issue/PR/note/code 검색용 쿼리. 비어 있으면
+        message_text를 그대로 쓴다. 호출자가 더 정제된 쿼리(예: 토픽
+        키워드만)를 만들었다면 넘겨주면 된다.
+        """
+
+        query = (retrieval_query or message_text or "").strip()
+        blockers: list[str] = []
+
+        # 1. session 정보
+        session_id = getattr(session, "session_id", None)
+        task_type = getattr(session, "task_type", None)
+        write_requested = bool(getattr(session, "write_requested", False))
+        write_blocked_reason = getattr(session, "write_blocked_reason", None)
+        extra = dict(getattr(session, "extra", {}) or {}) if session else {}
+        session_extra_summary = self._summarize_session_extra(extra)
+
+        # 2. thread loader
+        recent_thread, thread_summary, thread_blocker = self._collect_thread(
+            session_id=session_id,
+            session=session,
+        )
+        if thread_blocker:
+            blockers.append(thread_blocker)
+
+        # 3. issue / PR loader
+        related_issues, issue_blocker = self._collect_with_seam(
+            self.issue_loader, query, self.max_issues, "issue_loader"
+        )
+        if issue_blocker:
+            blockers.append(issue_blocker)
+        related_prs, pr_blocker = self._collect_with_seam(
+            self.pr_loader, query, self.max_prs, "pr_loader"
+        )
+        if pr_blocker:
+            blockers.append(pr_blocker)
+
+        # 4. note loader + memory selector
+        raw_notes, note_blocker = self._collect_with_seam(
+            self.note_loader, query, self.max_notes * 4, "note_loader"
+        )
+        if note_blocker:
+            blockers.append(note_blocker)
+        relevant_notes = self._select_relevant_notes(
+            raw_notes,
+            query=query,
+            task_type=task_type or suggested_task_type,
+            role=role_for_research,
+        )
+
+        # 5. code hint loader
+        code_hints, code_blocker = self._collect_with_seam(
+            self.code_hint_loader, query, self.max_code_hints, "code_hint_loader"
+        )
+        if code_blocker:
+            blockers.append(code_blocker)
+
+        # 6. role profile + research profile
+        role_profile_summary = self._safe_call(
+            self.role_profile_loader, role_for_research, "role_profile_loader", blockers
+        )
+        role_research_profile_summary = self._safe_call(
+            self.role_research_profile_loader,
+            role_for_research,
+            "role_research_profile_loader",
+            blockers,
+        )
+
+        return ContextPack(
+            current_message=message_text or "",
+            session_id=session_id,
+            task_type=task_type,
+            suggested_task_type=suggested_task_type,
+            role_for_research=role_for_research,
+            recent_thread=tuple(recent_thread),
+            thread_summary=thread_summary,
+            session_extra_summary=session_extra_summary,
+            related_issues=tuple(related_issues),
+            related_prs=tuple(related_prs),
+            relevant_notes=tuple(relevant_notes),
+            code_hints=tuple(code_hints),
+            role_profile_summary=role_profile_summary,
+            role_research_profile_summary=role_research_profile_summary,
+            write_requested=write_requested,
+            write_blocked_reason=write_blocked_reason,
+            blockers=tuple(blockers),
+            extra={"session_extra_keys": sorted(extra.keys())} if extra else {},
+        )
+
+    # ---- 내부 helpers ------------------------------------------------------
+
+    def _collect_thread(
+        self,
+        *,
+        session_id: Optional[str],
+        session: Optional[Any],
+    ) -> tuple[list[ThreadMessage], Optional[str], Optional[str]]:
+        if self.thread_loader is None:
+            return [], None, None
+        try:
+            raw = self.thread_loader(session_id) if session_id else []
+        except TypeError:
+            try:
+                raw = self.thread_loader()
+            except Exception as exc:  # noqa: BLE001
+                return [], None, f"thread_loader 호출 실패: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            return [], None, f"thread_loader 호출 실패: {exc}"
+        messages: list[ThreadMessage] = []
+        for item in raw or ():
+            if isinstance(item, ThreadMessage):
+                msg = item
+            elif isinstance(item, Mapping):
+                msg = ThreadMessage(
+                    role=str(item.get("role") or "user"),
+                    content=str(item.get("content") or ""),
+                    posted_at=item.get("posted_at"),
+                )
+            else:
+                continue
+            content = msg.content
+            if len(content) > self.max_thread_message_chars:
+                content = content[: self.max_thread_message_chars - 1].rstrip() + "…"
+                msg = ThreadMessage(role=msg.role, content=content, posted_at=msg.posted_at)
+            messages.append(msg)
+        if len(messages) > self.max_thread_messages:
+            messages = messages[-self.max_thread_messages :]
+        summary = _summarize_thread(messages) if messages else None
+        return messages, summary, None
+
+    def _collect_with_seam(
+        self,
+        seam: Optional[Any],
+        query: str,
+        cap: int,
+        seam_name: str,
+    ) -> tuple[list[Any], Optional[str]]:
+        if seam is None:
+            return [], None
+        try:
+            raw = seam(query)
+        except TypeError:
+            try:
+                raw = seam()
+            except Exception as exc:  # noqa: BLE001
+                return [], f"{seam_name} 호출 실패: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            return [], f"{seam_name} 호출 실패: {exc}"
+        items = list(raw or ())
+        return items[:cap], None
+
+    def _select_relevant_notes(
+        self,
+        raw_notes: Sequence[Any],
+        *,
+        query: str,
+        task_type: Optional[str],
+        role: Optional[str],
+    ) -> Sequence[ObsidianNoteRef]:
+        notes: list[ObsidianNoteRef] = []
+        for item in raw_notes:
+            if isinstance(item, ObsidianNoteRef):
+                notes.append(item)
+            elif isinstance(item, Mapping):
+                notes.append(
+                    ObsidianNoteRef(
+                        title=str(item.get("title") or "(제목 없음)"),
+                        path=item.get("path"),
+                        summary=item.get("summary"),
+                        tags=tuple(item.get("tags") or ()),
+                        kind=item.get("kind"),
+                        project=item.get("project"),
+                        updated_at=item.get("updated_at"),
+                    )
+                )
+        if not notes:
+            return []
+        if self.memory_selector is None:
+            return notes[: self.max_notes]
+        try:
+            picked = self.memory_selector(
+                candidates=notes,
+                query=query,
+                task_type=task_type,
+                role=role,
+                limit=self.max_notes,
+            )
+        except TypeError:
+            try:
+                picked = self.memory_selector(notes)
+            except Exception:  # noqa: BLE001
+                picked = notes[: self.max_notes]
+        except Exception:  # noqa: BLE001
+            picked = notes[: self.max_notes]
+        return tuple(picked)[: self.max_notes]
+
+    def _safe_call(
+        self,
+        seam: Optional[Any],
+        argument: Any,
+        seam_name: str,
+        blockers: list[str],
+    ) -> Optional[str]:
+        if seam is None:
+            return None
+        try:
+            value = seam(argument)
+        except TypeError:
+            try:
+                value = seam()
+            except Exception as exc:  # noqa: BLE001
+                blockers.append(f"{seam_name} 호출 실패: {exc}")
+                return None
+        except Exception as exc:  # noqa: BLE001
+            blockers.append(f"{seam_name} 호출 실패: {exc}")
+            return None
+        if value is None:
+            return None
+        return str(value).strip() or None
+
+    @staticmethod
+    def _summarize_session_extra(extra: Mapping[str, Any]) -> Optional[str]:
+        """session.extra에서 toi 판단에 도움되는 키만 추려 한 줄 요약.
+
+        세부 payload는 절대 dump하지 않는다 — secret이 섞일 위험. 키 존재
+        여부만 체크해서 "research_pack: 있음, coding_proposal: 없음" 식.
+        """
+
+        if not extra:
+            return None
+        relevant_keys = (
+            "research_pack",
+            "research_synthesis",
+            "coding_proposal",
+            "coding_job",
+            "work_report",
+            "research_loop_report",
+            "active_research_roles",
+            "role_research_results",
+            "forum_thread_id",
+            "research_forum_thread_id",
+        )
+        bits: list[str] = []
+        for key in relevant_keys:
+            value = extra.get(key)
+            if value is None or (hasattr(value, "__len__") and len(value) == 0):
+                continue
+            bits.append(f"{key}: 있음")
+        if not bits:
+            return None
+        return ", ".join(bits)
+
+
+def _summarize_thread(messages: Sequence[ThreadMessage]) -> str:
+    """thread 요약 — 발화 횟수 + 가장 최근 user 발화 한 줄.
+
+    매우 단순한 휴리스틱. 본격적인 LLM 요약은 후속 단계에서.
+    """
+
+    if not messages:
+        return ""
+    last_user = next(
+        (m for m in reversed(messages) if "user" in m.role.lower()), None
+    )
+    last_user_text = last_user.content.strip() if last_user else ""
+    if len(last_user_text) > 160:
+        last_user_text = last_user_text[:157] + "…"
+    summary = f"최근 thread 발화 {len(messages)}건"
+    if last_user_text:
+        summary += f" · 마지막 user 발화: \"{last_user_text}\""
+    return summary
+
+
+__all__ = (
+    "ContextPack",
+    "ContextPackBuilder",
+    "ObsidianNoteRef",
+    "GithubIssueRef",
+    "GithubPRRef",
+    "CodeHint",
+    "ThreadMessage",
+)

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -94,6 +94,36 @@ class CodeHint:
     line: Optional[int] = None
 
 
+@dataclass(frozen=True)
+class EngineeringKnowledgeRef:
+    """`engineering_intelligence` 가 vault 에 쌓아둔 knowledge 한 건.
+
+    ContextPackBuilder 가 retrieval seam 으로 받아서 ``ContextPack``의
+    ``relevant_knowledge`` 슬롯에 그대로 끼워 넣는다. 외부 fetch는
+    호출자(주로 vault index loader)가 책임지고, 본 dataclass 는 뷰
+    전용 — 합성기/디버그 dump 가 사용한다.
+
+    필드 의미는 :class:`engineering_intelligence.KnowledgeRecord` 와
+    동일하지만, 본 모듈은 engineering_intelligence 를 import 하지 않는다
+    (서로 독립적으로 import-able 해야 한다는 운영 원칙). 합성 어댑터는
+    ``ContextPackBuilder._coerce_knowledge_ref`` 가 담당.
+    """
+
+    title: str
+    role: str
+    topic_key: str = ""
+    source_url: str = ""
+    source_name: str = ""
+    summary: Optional[str] = None
+    axes: Sequence[str] = field(default_factory=tuple)
+    rag_tags: Sequence[str] = field(default_factory=tuple)
+    importance: Optional[str] = None
+    collected_at: Optional[str] = None
+    note_path: Optional[str] = None
+    score: Optional[float] = None
+    signals: Sequence[str] = field(default_factory=tuple)
+
+
 # ---------------------------------------------------------------------------
 # ContextPack
 # ---------------------------------------------------------------------------
@@ -119,6 +149,9 @@ class ContextPack:
     related_issues: Sequence[GithubIssueRef] = field(default_factory=tuple)
     related_prs: Sequence[GithubPRRef] = field(default_factory=tuple)
     relevant_notes: Sequence[ObsidianNoteRef] = field(default_factory=tuple)
+    relevant_knowledge: Sequence[EngineeringKnowledgeRef] = field(
+        default_factory=tuple
+    )
     code_hints: Sequence[CodeHint] = field(default_factory=tuple)
     role_profile_summary: Optional[str] = None
     role_research_profile_summary: Optional[str] = None
@@ -182,6 +215,24 @@ class ContextPack:
                 }
                 for n in self.relevant_notes
             ],
+            "relevant_knowledge": [
+                {
+                    "title": k.title,
+                    "role": k.role,
+                    "topic_key": k.topic_key,
+                    "source_url": k.source_url,
+                    "source_name": k.source_name,
+                    "summary": k.summary,
+                    "axes": list(k.axes),
+                    "rag_tags": list(k.rag_tags),
+                    "importance": k.importance,
+                    "collected_at": k.collected_at,
+                    "note_path": k.note_path,
+                    "score": k.score,
+                    "signals": list(k.signals),
+                }
+                for k in self.relevant_knowledge
+            ],
             "code_hints": [
                 {
                     "path": h.path,
@@ -235,10 +286,13 @@ class ContextPackBuilder:
     role_profile_loader: Optional[Any] = None
     role_research_profile_loader: Optional[Any] = None
     memory_selector: Optional[Any] = None
+    knowledge_loader: Optional[Any] = None
+    knowledge_retriever: Optional[Any] = None
     max_thread_messages: int = 12
     max_issues: int = 5
     max_prs: int = 5
     max_notes: int = 5
+    max_knowledge: int = 5
     max_code_hints: int = 6
     max_thread_message_chars: int = 280
 
@@ -309,6 +363,22 @@ class ContextPackBuilder:
         if code_blocker:
             blockers.append(code_blocker)
 
+        # 5b. engineering_intelligence knowledge loader + retriever.
+        raw_knowledge, knowledge_blocker = self._collect_with_seam(
+            self.knowledge_loader,
+            query,
+            self.max_knowledge * 5,
+            "knowledge_loader",
+        )
+        if knowledge_blocker:
+            blockers.append(knowledge_blocker)
+        relevant_knowledge = self._select_relevant_knowledge(
+            raw_knowledge,
+            query=query,
+            task_type=task_type or suggested_task_type,
+            role=role_for_research,
+        )
+
         # 6. role profile + research profile
         role_profile_summary = self._safe_call(
             self.role_profile_loader, role_for_research, "role_profile_loader", blockers
@@ -332,6 +402,7 @@ class ContextPackBuilder:
             related_issues=tuple(related_issues),
             related_prs=tuple(related_prs),
             relevant_notes=tuple(relevant_notes),
+            relevant_knowledge=tuple(relevant_knowledge),
             code_hints=tuple(code_hints),
             role_profile_summary=role_profile_summary,
             role_research_profile_summary=role_research_profile_summary,
@@ -447,6 +518,126 @@ class ContextPackBuilder:
         except Exception:  # noqa: BLE001
             picked = notes[: self.max_notes]
         return tuple(picked)[: self.max_notes]
+
+    def _select_relevant_knowledge(
+        self,
+        raw: Sequence[Any],
+        *,
+        query: str,
+        task_type: Optional[str],
+        role: Optional[str],
+    ) -> Sequence[EngineeringKnowledgeRef]:
+        """Score + truncate engineering knowledge candidates.
+
+        Two paths:
+
+        1. ``knowledge_retriever`` is provided — call it with the
+           coerced :class:`EngineeringKnowledgeRef` candidates so the
+           caller's deterministic scoring (typically
+           :class:`engineering_intelligence.KnowledgeRetriever`) drives
+           ordering. We forward ``KnowledgeRecord`` style objects when
+           we have them so the retriever can use its own score
+           signals.
+        2. No retriever — fall back to "first ``max_knowledge`` items
+           after coercion / role match filter".
+        """
+
+        coerced = [self._coerce_knowledge_ref(item) for item in raw]
+        coerced = [ref for ref in coerced if ref is not None]
+        if not coerced:
+            return ()
+        if self.knowledge_retriever is None:
+            # Lightweight fallback: prefer same-role refs, then keep
+            # registry order, capped by ``max_knowledge``.
+            normalized_role = (role or "").strip().lower().split("/")[-1]
+            same_role = [
+                r for r in coerced if r.role.lower() == normalized_role
+            ]
+            other = [
+                r for r in coerced if r.role.lower() != normalized_role
+            ]
+            picked = (same_role + other)[: self.max_knowledge]
+            return tuple(picked)
+
+        try:
+            picked = self.knowledge_retriever(
+                candidates=raw,
+                query=query,
+                role=role,
+                task_type=task_type,
+                limit=self.max_knowledge,
+            )
+        except TypeError:
+            try:
+                picked = self.knowledge_retriever(raw)
+            except Exception:  # noqa: BLE001
+                picked = coerced[: self.max_knowledge]
+        except Exception:  # noqa: BLE001
+            picked = coerced[: self.max_knowledge]
+        normalized: list[EngineeringKnowledgeRef] = []
+        for item in picked:
+            ref = self._coerce_knowledge_ref(item)
+            if ref is not None:
+                normalized.append(ref)
+        return tuple(normalized[: self.max_knowledge])
+
+    @staticmethod
+    def _coerce_knowledge_ref(value: Any) -> Optional[EngineeringKnowledgeRef]:
+        """Best-effort projection of vault row / KnowledgeRecord / dict."""
+
+        if value is None:
+            return None
+        if isinstance(value, EngineeringKnowledgeRef):
+            return value
+        # KnowledgeRecord 와 EngineeringKnowledgeItem (engineering_intelligence
+        # 패키지) 둘 다 있으면 직접 import 하지 않고 duck typing 으로 처리.
+        title = getattr(value, "title", None)
+        role = getattr(value, "role", None)
+        if title and role and not isinstance(value, Mapping):
+            axes_attr = getattr(value, "axes", ())
+            axes_seq: list[str] = []
+            for axis in axes_attr or ():
+                axis_value = getattr(axis, "value", axis)
+                if axis_value:
+                    axes_seq.append(str(axis_value))
+            importance_attr = getattr(value, "importance", None)
+            importance_value = getattr(importance_attr, "value", importance_attr)
+            return EngineeringKnowledgeRef(
+                title=str(title),
+                role=str(role),
+                topic_key=str(getattr(value, "topic_key", "") or ""),
+                source_url=str(getattr(value, "source_url", "") or ""),
+                source_name=str(getattr(value, "source_name", "") or ""),
+                summary=getattr(value, "summary", None) or None,
+                axes=tuple(axes_seq),
+                rag_tags=tuple(getattr(value, "rag_tags", ()) or ()),
+                importance=str(importance_value) if importance_value else None,
+                collected_at=getattr(value, "collected_at", None) or None,
+                note_path=getattr(value, "note_path", None),
+            )
+        if isinstance(value, Mapping):
+            title_v = str(value.get("title") or "").strip()
+            role_v = str(value.get("role") or "").strip()
+            if not (title_v and role_v):
+                return None
+            axes_raw = value.get("axes") or ()
+            axes_seq = [str(a) for a in axes_raw if a]
+            return EngineeringKnowledgeRef(
+                title=title_v,
+                role=role_v,
+                topic_key=str(value.get("topic_key") or ""),
+                source_url=str(value.get("source_url") or ""),
+                source_name=str(value.get("source_name") or ""),
+                summary=value.get("summary") or None,
+                axes=tuple(axes_seq),
+                rag_tags=tuple(value.get("rag_tags") or ()),
+                importance=value.get("importance"),
+                collected_at=value.get("collected_at"),
+                note_path=value.get("note_path"),
+                score=value.get("score"),
+                signals=tuple(value.get("signals") or ()),
+            )
+        return None
 
     def _safe_call(
         self,

--- a/src/yule_orchestrator/agents/discussion/handoff.py
+++ b/src/yule_orchestrator/agents/discussion/handoff.py
@@ -1,0 +1,164 @@
+"""discussion → coding authorization handoff.
+
+토의가 ``IMPLEMENTATION_CANDIDATE``로 결론났을 때 그 자리에서 곧바로
+:func:`recommend_authorization`을 부르고, 실제 ``CodingJob`` build는
+사용자 승인 phrase 도착 후로 미루기 위한 얇은 어댑터.
+
+본 모듈은 다음을 보장한다:
+
+1. ``DiscussionSynthesis``의 ``implementation_ready=False``이거나 모드가
+   ``IMPLEMENTATION_CANDIDATE``가 아니면 :class:`HandoffBlocker`를 돌려
+   주고 절대 proposal을 만들지 않는다.
+2. ``user_request``는 pack의 ``current_message``를 사용하되, 비어 있으면
+   thread summary로 fallback. 둘 다 비면 blocker.
+3. ``recommend_authorization``이 research-only로 떨어뜨리면 그 결과를
+   그대로 사용하지 않고 blocker로 보고한다 — 토의 단계에서 이미 구현
+   후보로 분류했는데 권한 추천이 research-only면 신호가 충돌하므로
+   사용자에게 다시 물어야 한다.
+
+destructive 동작은 절대 없다. proposal은 단순 dataclass이고, 사용자
+승인 phrase + 별도 ``build_coding_job_from_proposal`` 호출이 있어야만
+실제 ``CodingJob``이 만들어진다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional
+
+from ..coding.authorization import (
+    CodingAuthorizationProposal,
+    LIFECYCLE_MODE_RESEARCH_ONLY,
+    recommend_authorization,
+)
+from .context_pack import ContextPack
+from .mode import DiscussionMode
+from .synthesizer import DiscussionSynthesis
+
+
+@dataclass(frozen=True)
+class HandoffBlocker:
+    """handoff를 만들지 못한 사유.
+
+    blocker는 사용자에게 그대로 노출 가능 — gateway가 "권한 제안을 만들
+    수 없습니다: <reason>"이라고 답한다.
+    """
+
+    reason: str
+    detail: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DiscussionHandoff:
+    """discussion → coding authorization handoff payload.
+
+    proposal이 채워져 있으면 gateway가 그대로 ``format_authorization_message``
+    로 렌더해 사용자에게 보여주고 승인 phrase를 기다린다. ``follow_up_text``
+    는 토의 본문 뒤에 한 줄 덧붙이기 좋은 안내다.
+    """
+
+    proposal: Optional[CodingAuthorizationProposal]
+    follow_up_text: str
+    blocker: Optional[HandoffBlocker] = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+def build_implementation_handoff(
+    *,
+    synthesis: DiscussionSynthesis,
+    pack: ContextPack,
+    department_dir: Optional[Path] = None,
+    role_profile_loader: Optional[Mapping[str, Mapping[str, object]]] = None,
+) -> DiscussionHandoff:
+    """``synthesis``가 구현 후보일 때 ``CodingAuthorizationProposal``을 만든다.
+
+    실패 시에도 예외를 던지지 않고 :class:`HandoffBlocker`로 감싼 결과를
+    돌려준다 — 토의 흐름은 handoff 실패로 멈추면 안 된다.
+    """
+
+    if synthesis.mode != DiscussionMode.IMPLEMENTATION_CANDIDATE or not synthesis.implementation_ready:
+        return DiscussionHandoff(
+            proposal=None,
+            follow_up_text=(
+                "_지금 turn은 구현 후보가 아니라 토의/조사 단계라서 권한 제안은 만들지 않습니다._"
+            ),
+            blocker=HandoffBlocker(
+                reason="discussion mode가 구현 후보가 아님",
+                detail=f"현재 모드: {synthesis.mode.value}",
+            ),
+        )
+
+    user_request = (pack.current_message or "").strip()
+    if not user_request and pack.thread_summary:
+        user_request = pack.thread_summary.strip()
+    if not user_request:
+        return DiscussionHandoff(
+            proposal=None,
+            follow_up_text=(
+                "_요청 본문이 비어 있어 권한 제안을 만들 수 없습니다. "
+                "어떤 변경을 원하시는지 한두 문장으로 알려 주세요._"
+            ),
+            blocker=HandoffBlocker(
+                reason="user_request가 비어 있음",
+                detail="ContextPack.current_message와 thread_summary 모두 빈 값",
+            ),
+        )
+
+    try:
+        proposal = recommend_authorization(
+            user_request=user_request,
+            session_id=pack.session_id,
+            department_dir=department_dir,
+            role_profile_loader=role_profile_loader,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return DiscussionHandoff(
+            proposal=None,
+            follow_up_text=(
+                "_권한 제안 생성 중 내부 오류가 발생했습니다. "
+                "tech-lead에게 다시 요청해 주세요._"
+            ),
+            blocker=HandoffBlocker(
+                reason="recommend_authorization 호출 실패",
+                detail=str(exc),
+            ),
+        )
+
+    if proposal.lifecycle_mode == LIFECYCLE_MODE_RESEARCH_ONLY:
+        return DiscussionHandoff(
+            proposal=None,
+            follow_up_text=(
+                "_권한 추천이 research-only로 떨어졌습니다 — 토의에서는 구현 후보로 보였지만 "
+                "본문 신호가 약합니다. `수정 권한 제안`이라고 다시 답해 주시거나, "
+                "조사 단계로 받아들이실지 알려 주세요._"
+            ),
+            blocker=HandoffBlocker(
+                reason="권한 추천이 research-only",
+                detail=(
+                    "분류기는 implementation_candidate로 봤지만 "
+                    "recommend_authorization는 코드 변경 신호를 약하다고 판단함"
+                ),
+            ),
+        )
+
+    follow_up_text = (
+        "_권한 제안을 만들었습니다. 이대로 진행하려면 "
+        "`수정 승인` / `이대로 구현 진행` / `구현 시작` 중 하나로 답해 주세요._"
+    )
+    return DiscussionHandoff(
+        proposal=proposal,
+        follow_up_text=follow_up_text,
+        metadata={
+            "mode": synthesis.mode.value,
+            "rationale": synthesis.rationale,
+            "suggested_handoff_role": synthesis.suggested_handoff_role,
+        },
+    )
+
+
+__all__ = (
+    "DiscussionHandoff",
+    "HandoffBlocker",
+    "build_implementation_handoff",
+)

--- a/src/yule_orchestrator/agents/discussion/memory_selector.py
+++ b/src/yule_orchestrator/agents/discussion/memory_selector.py
@@ -16,6 +16,12 @@
 
 I/O 없음. note retrieval(외부 source 호출)은 builder의 ``note_loader``가
 하고, 본 모듈은 그 결과만 정렬한다.
+
+본 모듈은 **Obsidian note** 만 다룬다. engineering_intelligence 가 vault 에
+쌓아둔 ``EngineeringKnowledgeItem`` (= 역할별 학습 자료) 의 retrieval 은
+:mod:`yule_orchestrator.agents.engineering_intelligence.retrieval` 의
+``KnowledgeRetriever`` 가 책임지고, ContextPackBuilder 는 두 selector
+를 별개 슬롯 (``relevant_notes`` / ``relevant_knowledge``) 에 채운다.
 """
 
 from __future__ import annotations

--- a/src/yule_orchestrator/agents/discussion/memory_selector.py
+++ b/src/yule_orchestrator/agents/discussion/memory_selector.py
@@ -1,0 +1,200 @@
+"""RelevantMemorySelector — 한 요청에 관련 있는 note만 골라 반환.
+
+마스터 플랜 §8.2를 따른다. 모든 note를 들고 들어가지 않는다.
+
+기본 점수 규칙 (deterministic):
+
+- 같은 topic (title/summary/tags에 query 키워드 매칭): +3
+- 같은 task_type (note.tags / note.kind): +2
+- 같은 부서/역할 (note.tags에 role 토큰): +2
+- 최근 회고/실패 note (note.kind이 ``retrospective`` / ``decision``): +1
+- 관련 PR/issue 언급 (note.summary에 ``#<n>`` 또는 ``PR <n>``): +1
+- 본문이 비어 있는 note는 −2 (시그널이 약함)
+
+점수가 0 이하인 note는 잘라낸다. 같은 점수면 ``updated_at``이 최근일수록
+앞으로. ``limit``만큼 자른다.
+
+I/O 없음. note retrieval(외부 source 호출)은 builder의 ``note_loader``가
+하고, 본 모듈은 그 결과만 정렬한다.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+from .context_pack import ObsidianNoteRef
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    """note 한 건과 함께 계산된 점수/매치 신호.
+
+    호출자(synthesizer / 디버그 dump)가 왜 이 note가 골라졌는지 보일 때
+    사용한다. ``RelevantMemorySelector``는 직접 :class:`ObsidianNoteRef`를
+    돌려주지만, ``score_memory_candidate``는 :class:`MemoryCandidate`를
+    개별 단위로 노출한다.
+    """
+
+    note: ObsidianNoteRef
+    score: float
+    signals: Sequence[str]
+
+
+_TOKEN_PATTERN = re.compile(r"[\w가-힣]+", re.UNICODE)
+
+
+def _tokens(text: Optional[str]) -> set[str]:
+    if not text:
+        return set()
+    return {tok.lower() for tok in _TOKEN_PATTERN.findall(text) if len(tok) >= 2}
+
+
+def _shared_tokens(left: Optional[str], right: Optional[str]) -> set[str]:
+    return _tokens(left) & _tokens(right)
+
+
+_RETRO_KINDS = {"retrospective", "decision", "task-log", "report"}
+_ROLE_TOKENS = {
+    "tech-lead",
+    "product-designer",
+    "backend-engineer",
+    "frontend-engineer",
+    "qa-engineer",
+    "ai-engineer",
+    "devops-engineer",
+}
+
+
+def score_memory_candidate(
+    note: ObsidianNoteRef,
+    *,
+    query: Optional[str],
+    task_type: Optional[str],
+    role: Optional[str],
+) -> MemoryCandidate:
+    """단일 note의 관련도 점수.
+
+    점수는 0~10 범위에 머무는 게 보통이지만 수학적으로 강제하지는 않는다.
+    상한 cap이 필요하면 호출자가 ``min(score, cap)``로 잘라 쓰면 된다.
+    """
+
+    score = 0.0
+    signals: list[str] = []
+
+    haystack = " ".join(
+        filter(
+            None,
+            [
+                note.title or "",
+                note.summary or "",
+                " ".join(note.tags or ()),
+            ],
+        )
+    )
+
+    shared = _shared_tokens(query, haystack)
+    if shared:
+        score += 3.0
+        signals.append(f"topic_overlap:{len(shared)}")
+
+    if task_type:
+        normalized_task = task_type.strip().lower()
+        if normalized_task and (
+            normalized_task in {t.lower() for t in (note.tags or ())}
+            or (note.kind or "").lower() == normalized_task
+        ):
+            score += 2.0
+            signals.append("task_type_match")
+
+    role_normalized = (role or "").lower()
+    role_short = role_normalized.split("/")[-1] if role_normalized else ""
+    note_tags_lower = {str(t).lower() for t in (note.tags or ())}
+    role_hits = (
+        {role_short, role_normalized}
+        & (note_tags_lower | {(note.kind or "").lower()})
+    ) - {""}
+    if role_hits:
+        score += 2.0
+        signals.append("role_match")
+    # 일반 role 토큰도 가산
+    elif note_tags_lower & _ROLE_TOKENS:
+        score += 0.5
+        signals.append("any_role_tag")
+
+    if (note.kind or "").lower() in _RETRO_KINDS:
+        score += 1.0
+        signals.append("retrospective_or_decision")
+
+    if note.summary and re.search(r"#\d+|pr\s*\d+|issue\s*\d+", note.summary, re.IGNORECASE):
+        score += 1.0
+        signals.append("references_pr_or_issue")
+
+    if not (note.summary or note.tags):
+        score -= 2.0
+        signals.append("body_empty")
+
+    return MemoryCandidate(note=note, score=score, signals=tuple(signals))
+
+
+@dataclass
+class RelevantMemorySelector:
+    """note 후보 목록 → 추려진 ``ObsidianNoteRef`` 시퀀스.
+
+    ``min_score`` 미만은 잘라낸다 (default 0.5 — 약한 신호 1개도 통과).
+    callable로 직접 호출 가능: ``selector(candidates=..., query=..., ...)``.
+    """
+
+    min_score: float = 0.5
+
+    def __call__(
+        self,
+        *,
+        candidates: Iterable[ObsidianNoteRef],
+        query: Optional[str] = None,
+        task_type: Optional[str] = None,
+        role: Optional[str] = None,
+        limit: int = 5,
+    ) -> Sequence[ObsidianNoteRef]:
+        scored: list[tuple[float, int, ObsidianNoteRef]] = []
+        for idx, note in enumerate(candidates):
+            if not isinstance(note, ObsidianNoteRef):
+                continue
+            cand = score_memory_candidate(
+                note, query=query, task_type=task_type, role=role
+            )
+            if cand.score < self.min_score:
+                continue
+            # 정렬: 점수 desc, updated_at desc, idx asc (안정).
+            scored.append((cand.score, idx, note))
+        scored.sort(
+            key=lambda triplet: (
+                -triplet[0],
+                _updated_at_sort_key(triplet[2].updated_at),
+                triplet[1],
+            )
+        )
+        return tuple(note for _, _, note in scored[:limit])
+
+
+def _updated_at_sort_key(value: Optional[str]) -> str:
+    """ISO 시각 문자열은 그대로 비교 가능 — 없는 값은 가장 오래된 취급."""
+
+    if not value:
+        return ""
+    # desc 정렬을 위해 음수 변환 대신 reverse 문자열 (z-prefix) 트릭.
+    # 단순화를 위해 정상 문자열을 쓰고 호출부에서 reverse 정렬은 위에서
+    # 음수 점수와 같이 묶어 처리. 여기서는 빈 문자열을 가장 오래된 것으로
+    # 취급하기 위해 그대로 반환하고, 호출부 sort에서는 desc 가산을 위해
+    # 0 위치 음수 점수에 맞춰 두 번째 키는 asc — 따라서 큰 ISO 시각이
+    # asc 정렬에서 뒤로 가는 문제가 있다. 이를 보정하기 위해 ASCII chr
+    # 보수치를 만든다.
+    return "".join(chr(255 - ord(c)) if ord(c) < 255 else c for c in value)
+
+
+__all__ = (
+    "MemoryCandidate",
+    "RelevantMemorySelector",
+    "score_memory_candidate",
+)

--- a/src/yule_orchestrator/agents/discussion/mode.py
+++ b/src/yule_orchestrator/agents/discussion/mode.py
@@ -1,0 +1,362 @@
+"""DiscussionMode — 4-state classifier with deterministic fast-path + LLM seam.
+
+분류 모드는 마스터 플랜 §7.1을 그대로 따른다:
+
+- ``discussion`` — 자유 토의 / 설계 토의 / 의견 묻기
+- ``research_only`` — 조사/리서치만 진행
+- ``implementation_candidate`` — 구현 후보 (코드 변경 의도 명확)
+- ``clarification_needed`` — 추가 질문 없이는 위 셋 중 어느 것도 확정 못 함
+
+원칙:
+
+1. 명확한 신호는 ``classify_discussion_mode``가 deterministic 단계에서
+   바로 결정한다 (토큰 매칭 + 휴리스틱).
+2. deterministic이 결정 못 하면 ``llm_classifier`` 콜러블이 있으면 호출,
+   결과가 4 모드 중 하나가 아니면 fallback ``DiscussionMode.DISCUSSION``.
+3. 콜러블이 없으면 곧바로 fallback. 토의 모드를 default로 두는 이유는
+   "분류 못 함 → 일단 새 작업 등록"보다 "분류 못 함 → 일단 토의로 받음"이
+   덜 위험하고, 사용자가 토의 안에서 다음 단계를 안내받을 수 있기 때문.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+
+class DiscussionMode(str, Enum):
+    """tech-lead가 한 요청에 대해 가질 수 있는 4가지 판단 모드."""
+
+    DISCUSSION = "discussion"
+    RESEARCH_ONLY = "research_only"
+    IMPLEMENTATION_CANDIDATE = "implementation_candidate"
+    CLARIFICATION_NEEDED = "clarification_needed"
+
+
+@dataclass(frozen=True)
+class DiscussionModeMatch:
+    """분류 결과.
+
+    ``mode``는 결정된 모드이고, ``rationale``는 사람이 읽기 위한 한 줄
+    이유, ``signals``는 어떤 휴리스틱/키워드가 매치됐는지를 디버깅과
+    상태 진단용으로 보존한다. ``source``는 ``deterministic`` /
+    ``llm`` / ``fallback`` 중 하나.
+    """
+
+    mode: DiscussionMode
+    rationale: str
+    signals: Sequence[str] = field(default_factory=tuple)
+    source: str = "deterministic"
+    confidence: str = "medium"
+
+
+# ---------------------------------------------------------------------------
+# 신호 사전 — 의도적으로 짧게. 새 신호 추가 시 본 모듈 docstring + tests
+# 양쪽을 같이 갱신해야 한다.
+# ---------------------------------------------------------------------------
+
+
+_RESEARCH_ONLY_PHRASES: tuple[str, ...] = (
+    "조사만",
+    "리서치만",
+    "정리까지만",
+    "정리 까지만",
+    "코드 수정 없이",
+    "코드 수정없이",
+    "코드 수정 안 하고",
+    "코드 수정안 하고",
+    "수정하지 말고 조사",
+    "수정 하지 말고 조사",
+    "수정하지 말고 리서치",
+    "자료 수집만",
+    "자료수집만",
+    "자료 모으기만",
+    "research only",
+    "research-only",
+    "no code change",
+    "리서치해줘",
+    "리서치 해줘",
+    "조사해줘",
+    "조사 해줘",
+    "일단 조사",
+    "일단 리서치",
+    "조사부터",
+    "리서치부터",
+)
+
+
+_IMPLEMENTATION_PHRASES: tuple[str, ...] = (
+    "구현해",
+    "구현 해",
+    "구현 시작",
+    "구현 진행",
+    "구현 부탁",
+    "고쳐줘",
+    "고쳐 줘",
+    "고치자",
+    "수정해줘",
+    "수정 해줘",
+    "수정해주세요",
+    "패치해줘",
+    "패치 해줘",
+    "리팩",
+    "refactor",
+    "implement",
+    "build it",
+    "fix this",
+    "fix the",
+    "patch this",
+    "패치 작성",
+    "코드 작성",
+    "코드 짜",
+    "pr 올려",
+    "pr을 올려",
+    "pr 만들",
+    "pr을 만들",
+    "pull request",
+    "draft pr",
+    "이슈로 만들",
+    "이슈 만들어",
+    "기능 구현",
+    "기능을 구현",
+)
+
+# 검토/분석 신호 — 있으면 implementation으로 가지 않게 막는다.
+_REVIEW_BLOCKERS: tuple[str, ...] = (
+    "어떻게 생각",
+    "이 구조 맞아",
+    "이 구조가 맞",
+    "이 설계 맞",
+    "이 접근 맞",
+    "리뷰 부탁",
+    "리뷰해줘",
+    "리뷰 해줘",
+    "검토 부탁",
+    "검토해줘",
+    "검토 해줘",
+    "분석 부탁",
+    "분석해줘",
+    "review this",
+    "review please",
+    "what do you think",
+)
+
+
+_DISCUSSION_PHRASES: tuple[str, ...] = (
+    "어떻게 생각",
+    "어떻게 푸",
+    "어떻게 풀",
+    "이 구조 맞",
+    "이 구조가 맞",
+    "이 설계 맞",
+    "이 접근이 맞",
+    "이 접근 맞",
+    "관점에서",
+    "관점에 대해",
+    "관점에서 보면",
+    "리스크부터",
+    "리스크 먼저",
+    "리스크 정리",
+    "tradeoff",
+    "트레이드오프",
+    "어디서부터 봐",
+    "어디부터 봐",
+    "토의",
+    "디스커션",
+    "discussion",
+    "의견 좀",
+    "의견 부탁",
+    "어떻게 봐",
+    "어떻게 보",
+    "이게 맞아",
+    "이게 맞을까",
+    "이게 맞나",
+    "이게 옳",
+    "어떤 방식이 좋",
+    "어떤 게 좋",
+    "어느 쪽이 좋",
+    "방향이 맞",
+    "전략 좀",
+    "design discussion",
+    "architecture discussion",
+)
+
+
+_CLARIFICATION_TOKENS: tuple[str, ...] = (
+    "도와줘",
+    "도와 줘",
+    "할 일",
+    "할일",
+    "작업 있",
+    "뭐 해야",
+    "뭐해야",
+)
+
+
+def _normalize(text: str) -> str:
+    return " ".join((text or "").lower().split())
+
+
+def _matches_any(haystack: str, phrases: Sequence[str]) -> tuple[str, ...]:
+    return tuple(p for p in phrases if p and p in haystack)
+
+
+def _looks_too_vague(normalized: str) -> bool:
+    """clarification_needed로 떨어뜨릴 만큼 모호한지.
+
+    매우 짧거나 (3자 이하), 한 단어이거나, 모호 토큰만 들어 있는 경우.
+    """
+
+    if not normalized:
+        return True
+    if len(normalized) <= 3:
+        return True
+    word_count = len(normalized.split())
+    if word_count == 1:
+        return True
+    if word_count <= 3 and any(token in normalized for token in _CLARIFICATION_TOKENS):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 메인 분류기
+# ---------------------------------------------------------------------------
+
+
+def classify_discussion_mode(
+    message_text: str,
+    *,
+    context_pack: Optional[Mapping[str, Any]] = None,
+    llm_classifier: Optional[Callable[..., Any]] = None,
+) -> DiscussionModeMatch:
+    """deterministic 단계 → 필요 시 LLM seam → fallback 순으로 모드 결정.
+
+    *context_pack*은 :class:`ContextPack`를 ``as_dict``로 직렬화한 것을
+    그대로 넘기면 된다 (또는 :class:`ContextPack` 자체). LLM seam에 같이
+    전달돼서 더 넓은 문맥으로 분류할 수 있게 한다.
+
+    *llm_classifier*는 ``(message_text, normalized, context_pack) -> Any``
+    형태의 콜러블. 반환값이 ``DiscussionMode``이거나 그 value 문자열이면
+    채택, 아니면 fallback. 예외도 fallback으로 흡수한다 — 토의 흐름은
+    LLM 장애로 멈추면 안 된다.
+    """
+
+    normalized = _normalize(message_text)
+
+    # 1. clarification — 가장 먼저. 빈/매우 짧은/단어 1개는 다른 신호가
+    #    있어도 기본적으로 추가 질문이 필요하다.
+    if _looks_too_vague(normalized):
+        return DiscussionModeMatch(
+            mode=DiscussionMode.CLARIFICATION_NEEDED,
+            rationale="요청이 비어 있거나 너무 짧아 의도를 확정할 수 없다",
+            signals=("too_vague",),
+            source="deterministic",
+            confidence="high",
+        )
+
+    # 2. research_only — 사용자가 명시적으로 "조사/리서치만"이라고 했을 때.
+    research_signals = _matches_any(normalized, _RESEARCH_ONLY_PHRASES)
+    if research_signals:
+        return DiscussionModeMatch(
+            mode=DiscussionMode.RESEARCH_ONLY,
+            rationale=(
+                "사용자가 명시적으로 조사/리서치만 진행해 달라고 요청했다"
+            ),
+            signals=research_signals,
+            source="deterministic",
+            confidence="high",
+        )
+
+    # 3. discussion — 검토/분석 신호 또는 design/structure 토의 신호가 있다.
+    review_signals = _matches_any(normalized, _REVIEW_BLOCKERS)
+    discussion_signals = _matches_any(normalized, _DISCUSSION_PHRASES)
+    union_signals = tuple(sorted(set(review_signals + discussion_signals)))
+    if union_signals:
+        return DiscussionModeMatch(
+            mode=DiscussionMode.DISCUSSION,
+            rationale=(
+                "설계/접근 검토를 요청하는 표현이 포함되어 있다 — "
+                "구현보다 토의로 받는 것이 안전하다"
+            ),
+            signals=union_signals,
+            source="deterministic",
+            confidence="high",
+        )
+
+    # 4. implementation_candidate — 검토 신호 없이 구현 동사가 있다.
+    impl_signals = _matches_any(normalized, _IMPLEMENTATION_PHRASES)
+    if impl_signals and not review_signals:
+        return DiscussionModeMatch(
+            mode=DiscussionMode.IMPLEMENTATION_CANDIDATE,
+            rationale=(
+                "구현/수정/PR 동사가 직접 등장 — 코드 변경 의도가 강하게 보인다"
+            ),
+            signals=impl_signals,
+            source="deterministic",
+            confidence="high",
+        )
+
+    # 5. ambiguous — LLM seam으로 보낸다.
+    if llm_classifier is not None:
+        try:
+            verdict = llm_classifier(
+                message_text=message_text,
+                normalized=normalized,
+                context_pack=context_pack,
+            )
+        except Exception:  # noqa: BLE001 - never let LLM crash the gateway
+            verdict = None
+        mode = _coerce_mode(verdict)
+        if mode is not None:
+            rationale = "LLM classifier 결정"
+            signals: tuple[str, ...] = ("llm_classified",)
+            if isinstance(verdict, Mapping):
+                rationale = str(verdict.get("rationale") or rationale)
+                raw_signals = verdict.get("signals") or ()
+                if isinstance(raw_signals, (list, tuple)):
+                    signals = tuple(str(s) for s in raw_signals if s)
+            return DiscussionModeMatch(
+                mode=mode,
+                rationale=rationale,
+                signals=signals,
+                source="llm",
+                confidence="medium",
+            )
+
+    # 6. 최종 fallback — discussion으로 받는다. 새 작업 등록보다 안전하다.
+    return DiscussionModeMatch(
+        mode=DiscussionMode.DISCUSSION,
+        rationale=(
+            "deterministic 신호 부족이고 LLM 결정도 없음 — "
+            "토의로 받아 다음 단계를 함께 정한다"
+        ),
+        signals=("fallback",),
+        source="fallback",
+        confidence="low",
+    )
+
+
+def _coerce_mode(value: Any) -> Optional[DiscussionMode]:
+    """LLM seam이 돌려주는 다양한 모양을 :class:`DiscussionMode`로 정규화."""
+
+    if value is None:
+        return None
+    if isinstance(value, DiscussionMode):
+        return value
+    if isinstance(value, Mapping):
+        return _coerce_mode(value.get("mode"))
+    if isinstance(value, str):
+        try:
+            return DiscussionMode(value.strip().lower())
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = (
+    "DiscussionMode",
+    "DiscussionModeMatch",
+    "classify_discussion_mode",
+)

--- a/src/yule_orchestrator/agents/discussion/synthesizer.py
+++ b/src/yule_orchestrator/agents/discussion/synthesizer.py
@@ -64,6 +64,16 @@ class DiscussionSynthesis:
     - ``role_perspectives``: 영역별 관점 (backend/frontend/...) — 설계
       논의 출력에 사용.
     - ``blockers``: pack의 blocker + synthesizer가 발견한 blocker.
+    - ``knowledge_evidence_block``: ``ContextPack.format_knowledge_evidence_block``
+      결과를 미리 만들어 둔 마크다운 블록. operator-facing surface 가
+      response_text 외에 따로 PR body / Obsidian decision note 등에
+      그대로 끼워 넣을 수 있도록 노출한다.
+    - ``knowledge_short_summary``: 한 줄 요약 ("근거 자료 N건 (public ...) — ...").
+      운영자가 본문 펼치기 전에 share_scope 분포 + 상위 자료를 한 눈에
+      보게 하는 용도. response_text 안에도 같은 한 줄이 포함된다.
+    - ``share_boundary``: ``ContextPack.share_boundary_breakdown()`` 결과
+      그대로. 외부 publisher (status poster / digest hook) 가 이 turn 의
+      자료 boundary 분포를 그대로 쓸 수 있도록 carries through.
     """
 
     mode: DiscussionMode
@@ -76,6 +86,9 @@ class DiscussionSynthesis:
     role_perspectives: Mapping[str, str] = field(default_factory=dict)
     blockers: Sequence[str] = field(default_factory=tuple)
     suggested_handoff_role: Optional[str] = None
+    knowledge_evidence_block: str = ""
+    knowledge_short_summary: str = ""
+    share_boundary: Mapping[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> Mapping[str, object]:
         return {
@@ -89,6 +102,9 @@ class DiscussionSynthesis:
             "role_perspectives": dict(self.role_perspectives),
             "blockers": list(self.blockers),
             "suggested_handoff_role": self.suggested_handoff_role,
+            "knowledge_evidence_block": self.knowledge_evidence_block,
+            "knowledge_short_summary": self.knowledge_short_summary,
+            "share_boundary": dict(self.share_boundary),
         }
 
 
@@ -167,6 +183,7 @@ def _synthesize_clarification(
             "정보가 충분해지면 다시 분류",
         ),
         blockers=tuple(pack.blockers),
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -179,15 +196,24 @@ def _synthesize_research(
     followups = _research_followups(pack)
     body_lines = [
         f"좋아요. \"{topic}\"는 코드 변경 전에 자료부터 모으는 단계로 받겠습니다.",
-        "",
-        "모을 자료 후보:",
     ]
+    short_summary = pack.knowledge_short_summary()
+    if short_summary:
+        body_lines.append(f"_이미 모인 자료: {short_summary}_")
+    body_lines.append("")
+    body_lines.append("모을 자료 후보:")
     if followups:
         body_lines.extend(f"- {item}" for item in followups)
     else:
         body_lines.append(
             "- 우선 사용자 메시지의 키워드로 1차 검색을 돌리고, 결과를 함께 보면서 좁혀 갈게요."
         )
+    evidence_block = pack.format_knowledge_evidence_block(
+        heading="이미 vault 에 있는 근거 자료"
+    )
+    if evidence_block:
+        body_lines.append("")
+        body_lines.append(evidence_block)
     body_lines.append("")
     body_lines.append(
         "정리한 결과는 운영-리서치 thread와 Obsidian에 남기고, 그때 구현 여부를 다시 결정하시면 됩니다."
@@ -209,6 +235,9 @@ def _synthesize_research(
         research_followups=tuple(followups),
         blockers=tuple(pack_blockers),
         suggested_handoff_role=None,
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -221,11 +250,16 @@ def _synthesize_discussion(
     next_actions = _discussion_next_actions(pack)
     research_followups = _research_followups(pack)
 
+    short_summary = pack.knowledge_short_summary()
+    evidence_block = pack.format_knowledge_evidence_block()
+
     body_lines = [
         f"좋아요. \"{topic}\"는 토의로 받아 다음 단계를 함께 정해 보겠습니다.",
     ]
     rationale_short = _truncate(classification.rationale, 140)
     body_lines.append(f"_분류 근거: {rationale_short}_")
+    if short_summary:
+        body_lines.append(f"_{short_summary}_")
     body_lines.append("")
 
     if perspectives:
@@ -254,6 +288,10 @@ def _synthesize_discussion(
             )
         body_lines.append("")
 
+    if evidence_block:
+        body_lines.append(evidence_block)
+        body_lines.append("")
+
     body_lines.append("다음에 할 수 있는 선택:")
     for action in next_actions:
         body_lines.append(f"- {action}")
@@ -266,6 +304,9 @@ def _synthesize_discussion(
         research_followups=tuple(research_followups),
         role_perspectives=dict(perspectives),
         blockers=tuple(pack.blockers),
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -274,15 +315,25 @@ def _synthesize_implementation(
     classification: DiscussionModeMatch,
 ) -> DiscussionSynthesis:
     topic = _short_topic(pack.current_message)
+    short_summary = pack.knowledge_short_summary()
+    evidence_block = pack.format_knowledge_evidence_block(
+        heading="이번 결정 근거 자료"
+    )
     body_lines = [
         f"\"{topic}\"는 구현 후보로 보입니다. 곧바로 코드를 만지지는 않고, "
         "권한 제안을 먼저 만들어 보여 드릴게요.",
-        "",
-        "다음 단계:",
-        "- tech-lead가 어느 역할(executor)이 맞을지 추천",
-        "- 사용자가 `수정 승인` 또는 `이대로 구현 진행`이라 답하면 코딩 작업으로 넘김",
-        "- 그 전까지는 어떤 파일도 수정하지 않습니다",
     ]
+    if short_summary:
+        body_lines.append(f"_결정 근거 요약: {short_summary}_")
+    body_lines.extend(
+        [
+            "",
+            "다음 단계:",
+            "- tech-lead가 어느 역할(executor)이 맞을지 추천",
+            "- 사용자가 `수정 승인` 또는 `이대로 구현 진행`이라 답하면 코딩 작업으로 넘김",
+            "- 그 전까지는 어떤 파일도 수정하지 않습니다",
+        ]
+    )
     if pack.write_blocked_reason:
         body_lines.append("")
         body_lines.append(f"_쓰기 차단 사유: {pack.write_blocked_reason}_")
@@ -291,6 +342,9 @@ def _synthesize_implementation(
     if suggested_role:
         body_lines.append("")
         body_lines.append(f"_초기 추천 executor: `{suggested_role}` (권한 제안 단계에서 재계산)_")
+    if evidence_block:
+        body_lines.append("")
+        body_lines.append(evidence_block)
     return DiscussionSynthesis(
         mode=DiscussionMode.IMPLEMENTATION_CANDIDATE,
         rationale=classification.rationale,
@@ -303,6 +357,9 @@ def _synthesize_implementation(
         implementation_ready=True,
         blockers=tuple(blockers),
         suggested_handoff_role=suggested_role,
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 

--- a/src/yule_orchestrator/agents/discussion/synthesizer.py
+++ b/src/yule_orchestrator/agents/discussion/synthesizer.py
@@ -1,0 +1,526 @@
+"""tech-lead discussion synthesizer.
+
+마스터 플랜 §7.3을 따른다. ``ContextPack`` + ``DiscussionModeMatch``를
+받아 다음을 만들어 준다:
+
+- 사용자에게 보여줄 응답 텍스트
+- 어떤 next_actions가 따라붙는지
+- 추가 질문이 필요하면 무엇을 물어야 하는지
+- 구현 후보로 넘어갔을 때 handoff 메타가 채워지는지
+
+출력 정책:
+
+- 자유 토의 (``DISCUSSION``): 관점 제안 + 사용자 의견 요청 + 필요 시 조사
+  로 회수하거나 구현 후보로 끌어올리는 다음 단계 옵션.
+- 설계 논의 (``DISCUSSION`` 중에서도 reviewer 키워드 매칭): 영역별 관점
+  요약 (backend/frontend/devops 등) + 결정 필요 항목 + tradeoff.
+- 조사 단계 (``RESEARCH_ONLY``): 어떤 source/role profile에 따라 무엇을
+  더 모을지를 명시. 구현은 별도 요청 전까지 유보.
+- 구현 후보 (``IMPLEMENTATION_CANDIDATE``): handoff blob을 채워 두고,
+  사용자에게는 "권한 제안을 만들 수 있다"라고 안내.
+- clarification (``CLARIFICATION_NEEDED``): 단순 reset — 어디서/무엇을
+  알려달라는 짧은 질문.
+
+한 turn의 결과만 담는다. 채널/사용자 단위 stash는 호출자가 한다.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Sequence
+
+from .context_pack import ContextPack
+from .mode import DiscussionMode, DiscussionModeMatch
+
+
+@dataclass(frozen=True)
+class DiscussionTemplate:
+    """한 모드의 응답 템플릿 — 메시지 + 다음 단계 셋.
+
+    호출자가 응답 본문 + ``next_actions`` 리스트를 그대로 노출할 수 있게
+    분리해 둔다. 본문 어휘는 한국어이며, gateway가 그대로 Discord에 게시
+    한다.
+    """
+
+    body: str
+    next_actions: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class DiscussionSynthesis:
+    """tech-lead가 한 turn에서 생산하는 토의 합성 결과.
+
+    - ``mode``: 이 turn의 판단 모드
+    - ``rationale``: 왜 그 모드인지 한 줄 — gateway가 status diagnostic
+      에 그대로 가져다 쓸 수 있다.
+    - ``response_text``: Discord에 그대로 게시할 본문 (header/menu 포함).
+    - ``next_actions``: 다음에 사용자/시스템이 취해야 할 행동 bullet.
+    - ``open_questions``: clarification 필요 시 사용자에게 물을 항목들.
+    - ``implementation_ready``: 구현 후보 모드일 때만 True. handoff
+      payload가 별도 :func:`build_implementation_handoff`로 전달된다.
+    - ``research_followups``: research_only / discussion 모드에서 추가로
+      모아야 할 자료 항목.
+    - ``role_perspectives``: 영역별 관점 (backend/frontend/...) — 설계
+      논의 출력에 사용.
+    - ``blockers``: pack의 blocker + synthesizer가 발견한 blocker.
+    """
+
+    mode: DiscussionMode
+    rationale: str
+    response_text: str
+    next_actions: Sequence[str] = field(default_factory=tuple)
+    open_questions: Sequence[str] = field(default_factory=tuple)
+    implementation_ready: bool = False
+    research_followups: Sequence[str] = field(default_factory=tuple)
+    role_perspectives: Mapping[str, str] = field(default_factory=dict)
+    blockers: Sequence[str] = field(default_factory=tuple)
+    suggested_handoff_role: Optional[str] = None
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "mode": self.mode.value,
+            "rationale": self.rationale,
+            "response_text": self.response_text,
+            "next_actions": list(self.next_actions),
+            "open_questions": list(self.open_questions),
+            "implementation_ready": self.implementation_ready,
+            "research_followups": list(self.research_followups),
+            "role_perspectives": dict(self.role_perspectives),
+            "blockers": list(self.blockers),
+            "suggested_handoff_role": self.suggested_handoff_role,
+        }
+
+
+# ---------------------------------------------------------------------------
+# 메인 entry point
+# ---------------------------------------------------------------------------
+
+
+def synthesize_discussion(
+    *,
+    pack: ContextPack,
+    classification: DiscussionModeMatch,
+    llm_synthesizer: Optional[object] = None,
+) -> DiscussionSynthesis:
+    """``pack`` + ``classification``으로 한 turn의 합성 결과를 만든다.
+
+    ``llm_synthesizer``가 주어지면 deterministic 합성을 거쳐 그 결과를
+    LLM에 한 번 더 통과시켜 본문을 다듬을 수 있다. 본 모듈에서는 seam만
+    노출하고 실제 호출은 향후 milestone에서 연결한다 — LLM이 미설정이거
+    나 실패하면 deterministic 결과가 그대로 노출된다.
+    """
+
+    mode = classification.mode
+
+    if mode == DiscussionMode.CLARIFICATION_NEEDED:
+        synthesis = _synthesize_clarification(pack, classification)
+    elif mode == DiscussionMode.RESEARCH_ONLY:
+        synthesis = _synthesize_research(pack, classification)
+    elif mode == DiscussionMode.IMPLEMENTATION_CANDIDATE:
+        synthesis = _synthesize_implementation(pack, classification)
+    else:  # DISCUSSION (default)
+        synthesis = _synthesize_discussion(pack, classification)
+
+    if llm_synthesizer is None:
+        return synthesis
+    try:
+        polished = llm_synthesizer(synthesis=synthesis, pack=pack)
+    except Exception:  # noqa: BLE001 - never let LLM crash the gateway
+        return synthesis
+    if isinstance(polished, DiscussionSynthesis):
+        return polished
+    return synthesis
+
+
+# ---------------------------------------------------------------------------
+# 모드별 합성기 — deterministic
+# ---------------------------------------------------------------------------
+
+
+def _synthesize_clarification(
+    pack: ContextPack,
+    classification: DiscussionModeMatch,
+) -> DiscussionSynthesis:
+    questions = [
+        "어느 화면 / 흐름 / 모듈을 다루고 싶은지",
+        "지금 막혀 있는 지점이나 원하는 결과",
+        "참고할 수 있는 링크 / PR / 스크린샷이 있는지",
+    ]
+    body_lines = [
+        "받았어요. 다만 지금 내용만으로는 어디부터 봐야 할지 잡히지 않아 한 번만 더 여쭐게요.",
+        "",
+        "다음 중 한두 가지만 알려 주시면 충분합니다:",
+    ]
+    body_lines.extend(f"- {q}" for q in questions)
+    body_lines.append("")
+    body_lines.append(
+        "추가 정보가 정리되면 토의로 이어 갈지, 바로 조사로 보낼지를 함께 정해 보겠습니다."
+    )
+    return DiscussionSynthesis(
+        mode=DiscussionMode.CLARIFICATION_NEEDED,
+        rationale=classification.rationale,
+        response_text="\n".join(body_lines),
+        open_questions=tuple(questions),
+        next_actions=(
+            "사용자 추가 정보 대기",
+            "정보가 충분해지면 다시 분류",
+        ),
+        blockers=tuple(pack.blockers),
+    )
+
+
+def _synthesize_research(
+    pack: ContextPack,
+    classification: DiscussionModeMatch,
+) -> DiscussionSynthesis:
+    topic = _short_topic(pack.current_message)
+    role_short = _role_short_name(pack.role_for_research)
+    followups = _research_followups(pack)
+    body_lines = [
+        f"좋아요. \"{topic}\"는 코드 변경 전에 자료부터 모으는 단계로 받겠습니다.",
+        "",
+        "모을 자료 후보:",
+    ]
+    if followups:
+        body_lines.extend(f"- {item}" for item in followups)
+    else:
+        body_lines.append(
+            "- 우선 사용자 메시지의 키워드로 1차 검색을 돌리고, 결과를 함께 보면서 좁혀 갈게요."
+        )
+    body_lines.append("")
+    body_lines.append(
+        "정리한 결과는 운영-리서치 thread와 Obsidian에 남기고, 그때 구현 여부를 다시 결정하시면 됩니다."
+    )
+    pack_blockers = list(pack.blockers)
+    if not pack.role_research_profile_summary:
+        pack_blockers.append(
+            f"{role_short} research profile 미주입 — 우선순위는 기본 휴리스틱으로 진행"
+        )
+    return DiscussionSynthesis(
+        mode=DiscussionMode.RESEARCH_ONLY,
+        rationale=classification.rationale,
+        response_text="\n".join(body_lines),
+        next_actions=(
+            "research collector 호출",
+            "결과 정리 후 사용자에게 검토 요청",
+            "구현 필요 시 사용자에게 권한 제안 다시 요청",
+        ),
+        research_followups=tuple(followups),
+        blockers=tuple(pack_blockers),
+        suggested_handoff_role=None,
+    )
+
+
+def _synthesize_discussion(
+    pack: ContextPack,
+    classification: DiscussionModeMatch,
+) -> DiscussionSynthesis:
+    topic = _short_topic(pack.current_message)
+    perspectives = _role_perspectives(pack)
+    next_actions = _discussion_next_actions(pack)
+    research_followups = _research_followups(pack)
+
+    body_lines = [
+        f"좋아요. \"{topic}\"는 토의로 받아 다음 단계를 함께 정해 보겠습니다.",
+    ]
+    rationale_short = _truncate(classification.rationale, 140)
+    body_lines.append(f"_분류 근거: {rationale_short}_")
+    body_lines.append("")
+
+    if perspectives:
+        body_lines.append("관련 관점 후보:")
+        for role, text in perspectives.items():
+            body_lines.append(f"- **{role}** — {text}")
+        body_lines.append("")
+
+    if pack.relevant_notes:
+        body_lines.append("참고할 만한 메모:")
+        for note in pack.relevant_notes[:3]:
+            label = note.title or "(제목 없음)"
+            location = f" · `{note.path}`" if note.path else ""
+            body_lines.append(f"- {label}{location}")
+        body_lines.append("")
+
+    if pack.related_issues or pack.related_prs:
+        body_lines.append("연결된 GitHub:")
+        for issue in pack.related_issues[:3]:
+            body_lines.append(
+                f"- issue #{issue.number} {issue.title} ({issue.state or '?'})"
+            )
+        for pr in pack.related_prs[:3]:
+            body_lines.append(
+                f"- PR #{pr.number} {pr.title} ({pr.state or '?'})"
+            )
+        body_lines.append("")
+
+    body_lines.append("다음에 할 수 있는 선택:")
+    for action in next_actions:
+        body_lines.append(f"- {action}")
+
+    return DiscussionSynthesis(
+        mode=DiscussionMode.DISCUSSION,
+        rationale=classification.rationale,
+        response_text="\n".join(body_lines),
+        next_actions=tuple(next_actions),
+        research_followups=tuple(research_followups),
+        role_perspectives=dict(perspectives),
+        blockers=tuple(pack.blockers),
+    )
+
+
+def _synthesize_implementation(
+    pack: ContextPack,
+    classification: DiscussionModeMatch,
+) -> DiscussionSynthesis:
+    topic = _short_topic(pack.current_message)
+    body_lines = [
+        f"\"{topic}\"는 구현 후보로 보입니다. 곧바로 코드를 만지지는 않고, "
+        "권한 제안을 먼저 만들어 보여 드릴게요.",
+        "",
+        "다음 단계:",
+        "- tech-lead가 어느 역할(executor)이 맞을지 추천",
+        "- 사용자가 `수정 승인` 또는 `이대로 구현 진행`이라 답하면 코딩 작업으로 넘김",
+        "- 그 전까지는 어떤 파일도 수정하지 않습니다",
+    ]
+    if pack.write_blocked_reason:
+        body_lines.append("")
+        body_lines.append(f"_쓰기 차단 사유: {pack.write_blocked_reason}_")
+    blockers = list(pack.blockers)
+    suggested_role = _suggest_executor_hint(pack)
+    if suggested_role:
+        body_lines.append("")
+        body_lines.append(f"_초기 추천 executor: `{suggested_role}` (권한 제안 단계에서 재계산)_")
+    return DiscussionSynthesis(
+        mode=DiscussionMode.IMPLEMENTATION_CANDIDATE,
+        rationale=classification.rationale,
+        response_text="\n".join(body_lines),
+        next_actions=(
+            "build_implementation_handoff 호출",
+            "권한 제안을 사용자에게 표시",
+            "사용자 승인 phrase 대기",
+        ),
+        implementation_ready=True,
+        blockers=tuple(blockers),
+        suggested_handoff_role=suggested_role,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 보조 helpers
+# ---------------------------------------------------------------------------
+
+
+def _short_topic(text: Optional[str], max_chars: int = 60) -> str:
+    if not text:
+        return "(요청 본문 없음)"
+    head = text.strip().splitlines()[0].strip()
+    if not head:
+        return "(요청 본문 없음)"
+    if len(head) <= max_chars:
+        return head
+    return head[: max_chars - 1].rstrip() + "…"
+
+
+def _truncate(text: Optional[str], max_chars: int) -> str:
+    if not text:
+        return ""
+    cleaned = " ".join(text.split())
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return cleaned[: max_chars - 1].rstrip() + "…"
+
+
+_PERSPECTIVE_TRIGGERS = {
+    "backend-engineer": (
+        "backend",
+        "back-end",
+        "api",
+        "schema",
+        "db",
+        "database",
+        "auth",
+        "인증",
+        "권한",
+        "마이그레이션",
+        "migration",
+        "queue",
+        "transaction",
+        "트랜잭션",
+        "백엔드",
+    ),
+    "frontend-engineer": (
+        "frontend",
+        "front-end",
+        "ui",
+        "컴포넌트",
+        "component",
+        "react",
+        "next.js",
+        "vue",
+        "css",
+        "접근성",
+        "accessibility",
+        "프론트",
+    ),
+    "devops-engineer": (
+        "devops",
+        "ci",
+        "cd",
+        "deploy",
+        "docker",
+        "k8s",
+        "kubernetes",
+        "terraform",
+        "supervisor",
+        "runtime",
+        "observability",
+        "monitor",
+        "infra",
+        "github action",
+        "rollout",
+    ),
+    "qa-engineer": (
+        "qa",
+        "회귀",
+        "regression",
+        "테스트",
+        "test plan",
+        "acceptance",
+        "edge case",
+    ),
+    "ai-engineer": (
+        "ai",
+        "rag",
+        "llm",
+        "prompt",
+        "agent",
+        "memory",
+        "evaluation",
+        "embedding",
+    ),
+    "product-designer": (
+        "designer",
+        "design",
+        "디자이너",
+        "ux",
+        "디자인",
+        "moodboard",
+        "wireframe",
+        "톤",
+        "user flow",
+    ),
+}
+
+
+_PERSPECTIVE_HINTS = {
+    "backend-engineer": "데이터/인증/마이그레이션 영향 — 어디까지 손이 가는지부터 합의",
+    "frontend-engineer": "컴포넌트/상태/접근성 — UX와 어떤 상태가 깨지는지 점검",
+    "devops-engineer": "배포/CI/runtime/관측성 — 운영 사고 가능 지점부터 정리",
+    "qa-engineer": "회귀/엣지 케이스 — 어떤 시나리오가 깨지면 안 되는지 정의",
+    "ai-engineer": "LLM/RAG/agent runtime — 비용·지연·hallucination 트레이드오프 정리",
+    "product-designer": "UX/디자인 톤 — 사용자 흐름과 일관성 어디서 갈리는지 정리",
+}
+
+
+def _role_perspectives(pack: ContextPack) -> Mapping[str, str]:
+    text = " ".join(
+        filter(
+            None,
+            [
+                pack.current_message or "",
+                pack.thread_summary or "",
+                pack.session_extra_summary or "",
+            ],
+        )
+    ).lower()
+    if not text:
+        return {}
+    matched: dict[str, str] = {}
+    for role, keywords in _PERSPECTIVE_TRIGGERS.items():
+        if any(kw in text for kw in keywords):
+            matched[role] = _PERSPECTIVE_HINTS[role]
+    if not matched:
+        # 기본: tech-lead 자기 관점만 노출.
+        matched["tech-lead"] = (
+            "구조/의존성/리스크/롤아웃 — 다른 역할 신호가 약하면 우선 tech-lead가 정리"
+        )
+    return matched
+
+
+def _discussion_next_actions(pack: ContextPack) -> Sequence[str]:
+    """토의 다음 단계 옵션을 다음 우선순위로 만든다.
+
+    1. 자료가 부족하다고 판단되면 조사로 회수.
+    2. 시그널이 명확해지면 구현 후보로 끌어올릴 수 있다는 옵션.
+    3. 추가 질문/확인이 필요한지.
+    """
+
+    options: list[str] = [
+        "구체화된 결정이 필요한 부분이 있으면 알려 주세요 — 한 항목씩 합의",
+        "조사가 더 필요하면 `조사만 진행`이라고 말씀해 주세요",
+        "방향이 정해지면 `수정 권한 제안`이라고 답해 권한 제안으로 넘어갈 수 있습니다",
+    ]
+    if pack.write_requested and not pack.write_blocked_reason:
+        options.insert(0, "쓰기가 이미 승인된 상태이므로 합의 즉시 권한 제안으로 이어 갈 수 있습니다")
+    return tuple(options)
+
+
+def _research_followups(pack: ContextPack) -> Sequence[str]:
+    role_short = _role_short_name(pack.role_for_research)
+    base = [
+        f"{role_short} research profile 우선순위 source 1차 수집",
+        "관련 issue / PR 제목과 라벨 정리",
+    ]
+    if pack.suggested_task_type:
+        base.append(
+            f"task_type 힌트({pack.suggested_task_type})에 맞춘 reference 카테고리 보강"
+        )
+    if not pack.relevant_notes:
+        base.append("Obsidian 관련 note retrieval (현재 후보 없음 — 비어 있는 슬롯)")
+    return tuple(base)
+
+
+_EXECUTOR_KEYWORDS = {
+    "backend-engineer": ("api", "schema", "auth", "백엔드", "migration", "transaction", "queue"),
+    "frontend-engineer": ("ui", "react", "컴포넌트", "프론트", "css", "next.js", "vue"),
+    "devops-engineer": ("ci", "cd", "deploy", "docker", "k8s", "terraform", "supervisor", "infra"),
+    "qa-engineer": ("회귀", "regression", "테스트", "acceptance"),
+    "ai-engineer": ("rag", "llm", "prompt", "agent", "embedding"),
+    "product-designer": ("ux", "디자인", "moodboard", "wireframe"),
+}
+
+
+def _suggest_executor_hint(pack: ContextPack) -> Optional[str]:
+    text = " ".join(
+        filter(
+            None,
+            [
+                pack.current_message or "",
+                pack.thread_summary or "",
+            ],
+        )
+    ).lower()
+    if not text:
+        return None
+    best: Optional[str] = None
+    best_hits = 0
+    for role, keywords in _EXECUTOR_KEYWORDS.items():
+        hits = sum(1 for kw in keywords if kw in text)
+        if hits > best_hits:
+            best = role
+            best_hits = hits
+    return best
+
+
+def _role_short_name(role: str) -> str:
+    if not role:
+        return "tech-lead"
+    return role.split("/")[-1] if "/" in role else role
+
+
+__all__ = (
+    "DiscussionSynthesis",
+    "DiscussionTemplate",
+    "synthesize_discussion",
+)

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -67,11 +67,15 @@ from .provider_registry import (
     LiveFetcherFactory,
     ProviderAuthRequirement,
     ProviderAvailability,
+    ProviderAvailabilityRow,
+    ProviderAvailabilitySummary,
     default_registry,
 )
 from .provider_routing import (
+    RefreshPlanStatus,
     RoutedRefreshCandidate,
     axis_priority_order,
+    refresh_plan_status,
     route_refresh_plan,
     select_routed_due,
 )
@@ -182,10 +186,14 @@ __all__ = [
     "LiveFetcherFactory",
     "ProviderAuthRequirement",
     "ProviderAvailability",
+    "ProviderAvailabilityRow",
+    "ProviderAvailabilitySummary",
     "default_registry",
     # provider routing (refresh-plan → registry → fetch decision)
+    "RefreshPlanStatus",
     "RoutedRefreshCandidate",
     "axis_priority_order",
+    "refresh_plan_status",
     "route_refresh_plan",
     "select_routed_due",
     # retrieval

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -54,6 +54,7 @@ from .retrieval import (
     KnowledgeMatch,
     KnowledgeRecord,
     KnowledgeRetriever,
+    label_for_signal,
     score_knowledge_record,
 )
 from .scheduler import (
@@ -87,6 +88,7 @@ from .models import (
     ENGINEERING_KNOWLEDGE_CONTRACT,
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     KnowledgeStatus,
     LearningLevel,
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
@@ -103,6 +105,8 @@ from .obsidian import (
     build_engineering_knowledge_write_request,
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
+    shareable_external_payload,
+    vault_only_metadata,
 )
 from .renderer import (
     RendererError,
@@ -145,6 +149,7 @@ __all__ = [
     "KnowledgeMatch",
     "KnowledgeRecord",
     "KnowledgeRetriever",
+    "label_for_signal",
     "score_knowledge_record",
     # scheduler
     "RefreshPlan",
@@ -173,6 +178,7 @@ __all__ = [
     "ENGINEERING_KNOWLEDGE_CONTRACT",
     "EngineeringKnowledgeItem",
     "Importance",
+    "KnowledgeShareScope",
     "KnowledgeStatus",
     "LearningLevel",
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",
@@ -188,6 +194,8 @@ __all__ = [
     "build_engineering_knowledge_write_request",
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
+    "shareable_external_payload",
+    "vault_only_metadata",
     # renderer
     "RendererError",
     "render_engineering_knowledge_note",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -69,9 +69,11 @@ from .models import (
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
     PracticeVerification,
     ProjectApplicability,
+    SourceAxis,
     SourceEntry,
     SourceKind,
     SourceTier,
+    default_refresh_interval_for_kind,
 )
 from .obsidian import (
     QualityGateResult,
@@ -89,10 +91,15 @@ from .source_registry import (
     COMMON_CORE_SOURCES,
     SUPPORTED_ROLES,
     auto_collectable_sources,
+    axes_for_role,
+    axis_hints_for_task_type,
     daily_limit_for_role,
     find_source,
     prioritise_sources,
+    required_axes_for_role,
+    role_axis_coverage_report,
     role_sources,
+    sources_for_axis,
 )
 
 
@@ -128,9 +135,11 @@ __all__ = [
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",
     "PracticeVerification",
     "ProjectApplicability",
+    "SourceAxis",
     "SourceEntry",
     "SourceKind",
     "SourceTier",
+    "default_refresh_interval_for_kind",
     # obsidian
     "QualityGateResult",
     "build_engineering_knowledge_write_request",
@@ -145,8 +154,13 @@ __all__ = [
     "COMMON_CORE_SOURCES",
     "SUPPORTED_ROLES",
     "auto_collectable_sources",
+    "axes_for_role",
+    "axis_hints_for_task_type",
     "daily_limit_for_role",
     "find_source",
     "prioritise_sources",
+    "required_axes_for_role",
+    "role_axis_coverage_report",
     "role_sources",
+    "sources_for_axis",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -59,6 +59,12 @@ from .provider_registry import (
     ProviderAvailability,
     default_registry,
 )
+from .provider_routing import (
+    RoutedRefreshCandidate,
+    axis_priority_order,
+    route_refresh_plan,
+    select_routed_due,
+)
 from .retrieval import (
     KnowledgeMatch,
     KnowledgeRecord,
@@ -158,6 +164,11 @@ __all__ = [
     "ProviderAuthRequirement",
     "ProviderAvailability",
     "default_registry",
+    # provider routing (refresh-plan → registry → fetch decision)
+    "RoutedRefreshCandidate",
+    "axis_priority_order",
+    "route_refresh_plan",
+    "select_routed_due",
     # retrieval
     "KnowledgeMatch",
     "KnowledgeRecord",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -39,7 +39,24 @@ from .collector import (
     FakeSourceCollectorAdapter,
     SourceCollectorAdapter,
     collect_for_role,
+    collect_for_role_with_schedule,
     utc_now_iso,
+)
+from .providers import (
+    LiveProviderSpec,
+    LiveSourceFetcher,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+    specs_for_role,
+)
+from .scheduler import (
+    RefreshPlan,
+    RefreshPlanEntry,
+    SourceRefreshState,
+    compute_refresh_plan,
+    overdue_axes_for_role,
+    record_refresh_outcome,
 )
 from .dedup import (
     compute_dedup_key,
@@ -109,7 +126,22 @@ __all__ = [
     "FakeSourceCollectorAdapter",
     "SourceCollectorAdapter",
     "collect_for_role",
+    "collect_for_role_with_schedule",
     "utc_now_iso",
+    # providers
+    "LiveProviderSpec",
+    "LiveSourceFetcher",
+    "ProviderTransport",
+    "StubLiveSourceFetcher",
+    "provider_spec_for",
+    "specs_for_role",
+    # scheduler
+    "RefreshPlan",
+    "RefreshPlanEntry",
+    "SourceRefreshState",
+    "compute_refresh_plan",
+    "overdue_axes_for_role",
+    "record_refresh_outcome",
     # dedup
     "compute_dedup_key",
     "dedup_items",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -51,6 +51,16 @@ from .providers import (
     provider_spec_for,
     specs_for_role,
 )
+from .feed_parser import (
+    BytesFetcher,
+    FeedFetchOutcome,
+    FeedParserError,
+    make_feed_live_factory,
+    parse_atom_bytes,
+    parse_feed_bytes,
+    parse_rss_bytes,
+    register_safe_feed_providers,
+)
 from .provider_registry import (
     KnowledgeProviderRegistration,
     KnowledgeProviderRegistry,
@@ -157,6 +167,15 @@ __all__ = [
     "StubLiveSourceFetcher",
     "provider_spec_for",
     "specs_for_role",
+    # feed parser (live-ready RSS / Atom / GitHub releases atom)
+    "BytesFetcher",
+    "FeedFetchOutcome",
+    "FeedParserError",
+    "make_feed_live_factory",
+    "parse_atom_bytes",
+    "parse_feed_bytes",
+    "parse_rss_bytes",
+    "register_safe_feed_providers",
     # provider registry / auth contract
     "KnowledgeProviderRegistration",
     "KnowledgeProviderRegistry",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -43,12 +43,21 @@ from .collector import (
     utc_now_iso,
 )
 from .providers import (
+    FakeKnowledgeProvider,
     LiveProviderSpec,
     LiveSourceFetcher,
     ProviderTransport,
     StubLiveSourceFetcher,
     provider_spec_for,
     specs_for_role,
+)
+from .provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    LiveFetcherFactory,
+    ProviderAuthRequirement,
+    ProviderAvailability,
+    default_registry,
 )
 from .retrieval import (
     KnowledgeMatch,
@@ -135,12 +144,20 @@ __all__ = [
     "collect_for_role_with_schedule",
     "utc_now_iso",
     # providers
+    "FakeKnowledgeProvider",
     "LiveProviderSpec",
     "LiveSourceFetcher",
     "ProviderTransport",
     "StubLiveSourceFetcher",
     "provider_spec_for",
     "specs_for_role",
+    # provider registry / auth contract
+    "KnowledgeProviderRegistration",
+    "KnowledgeProviderRegistry",
+    "LiveFetcherFactory",
+    "ProviderAuthRequirement",
+    "ProviderAvailability",
+    "default_registry",
     # retrieval
     "KnowledgeMatch",
     "KnowledgeRecord",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -50,6 +50,12 @@ from .providers import (
     provider_spec_for,
     specs_for_role,
 )
+from .retrieval import (
+    KnowledgeMatch,
+    KnowledgeRecord,
+    KnowledgeRetriever,
+    score_knowledge_record,
+)
 from .scheduler import (
     RefreshPlan,
     RefreshPlanEntry,
@@ -135,6 +141,11 @@ __all__ = [
     "StubLiveSourceFetcher",
     "provider_spec_for",
     "specs_for_role",
+    # retrieval
+    "KnowledgeMatch",
+    "KnowledgeRecord",
+    "KnowledgeRetriever",
+    "score_knowledge_record",
     # scheduler
     "RefreshPlan",
     "RefreshPlanEntry",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -106,6 +106,7 @@ from .obsidian import (
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
     shareable_external_payload,
+    summarize_share_boundary,
     vault_only_metadata,
 )
 from .renderer import (
@@ -195,6 +196,7 @@ __all__ = [
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
     "shareable_external_payload",
+    "summarize_share_boundary",
     "vault_only_metadata",
     # renderer
     "RendererError",

--- a/src/yule_orchestrator/agents/engineering_intelligence/collector.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/collector.py
@@ -276,10 +276,152 @@ def utc_now_iso() -> str:
     return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# ---------------------------------------------------------------------------
+# Scheduler-aware sweep
+# ---------------------------------------------------------------------------
+
+
+def collect_for_role_with_schedule(
+    role_id: str,
+    *,
+    adapter: SourceCollectorAdapter,
+    states: Mapping[str, Any] = (),  # type: ignore[assignment]
+    now: Optional[datetime] = None,
+    already_stored: Sequence[EngineeringKnowledgeItem] = (),
+    daily_limit: Optional[int] = None,
+    tick_quota: Optional[int] = None,
+    warn: Optional[Callable[[str], None]] = None,
+) -> Tuple[CollectionRunResult, "Mapping[str, Any]"]:
+    """Run a single ingestion tick filtered by the refresh planner.
+
+    Returns ``(run_result, updated_states)`` so the caller can persist
+    the new ``SourceRefreshState`` map. The orchestrator is then free
+    to drop the result on the floor on dry-run, or enqueue
+    ObsidianWriteRequests for accepted items.
+
+    Behaviour mirrors :func:`collect_for_role` but only visits the
+    sources the planner marks as ``due`` for *this* tick. Sources
+    already fresh / under backoff / over the per-tick quota are left
+    untouched and produce no new state row.
+    """
+
+    if warn is None:
+        warn = lambda _msg: None  # noqa: E731
+
+    # Defer scheduler import so :mod:`.collector` stays importable even
+    # if the scheduler module had a parse error in development.
+    from .scheduler import (
+        SourceRefreshState,
+        compute_refresh_plan,
+        record_refresh_outcome,
+    )
+
+    state_map: dict[str, SourceRefreshState] = {
+        sid: state for sid, state in (states or {}).items()
+    }
+    plan = compute_refresh_plan(
+        role_id,
+        now=now,
+        states=state_map,
+        tick_quota=tick_quota,
+    )
+    due_ids = set(plan.due_source_ids())
+
+    sources = role_sources(role_id)
+    sources_by_id = {s.source_id: s for s in sources}
+
+    visited: List[str] = []
+    bag: List[EngineeringKnowledgeItem] = []
+    new_states: dict[str, SourceRefreshState] = dict(state_map)
+    for source_id in plan.due_source_ids():
+        source = sources_by_id.get(source_id)
+        if source is None:
+            continue
+        visited.append(source_id)
+        previous = new_states.get(source_id) or SourceRefreshState(
+            source_id=source_id
+        )
+        try:
+            produced = adapter(source) or ()
+        except Exception as exc:  # noqa: BLE001 — adapter must not crash run
+            warn(
+                f"adapter failed for source={source_id!r}: "
+                f"{type(exc).__name__}"
+            )
+            new_states[source_id] = record_refresh_outcome(
+                previous,
+                now=now,
+                success=False,
+                items_collected=0,
+                notes=type(exc).__name__,
+            )
+            continue
+        for item in produced:
+            if not item.dedup_key:
+                item = item.with_dedup_key(compute_dedup_key(item))
+            bag.append(item)
+        new_states[source_id] = record_refresh_outcome(
+            previous,
+            now=now,
+            success=True,
+            items_collected=len(produced),
+            notes="",
+        )
+
+    deduped, dedup_rejected = dedup_items(bag)
+    fresh, same_day_rejected = enforce_same_day_topic_uniqueness(
+        deduped, already_stored=already_stored
+    )
+
+    sources_lookup = {s.source_id: s for s in role_sources(role_id)}
+    ordered = tuple(
+        sorted(fresh, key=lambda item: _sort_key(item, sources=sources_lookup))
+    )
+    limit = (
+        daily_limit
+        if daily_limit is not None
+        else daily_limit_for_role(role_id)
+    )
+    accepted = ordered[: max(0, limit)]
+    overflow = ordered[max(0, limit):]
+    overflow_rejections: List[Mapping[str, Any]] = [
+        {
+            "reason": "daily_limit_exceeded",
+            "topic_key": item.topic_key,
+            "title": item.title,
+        }
+        for item in overflow
+    ]
+
+    rejected: List[Mapping[str, Any]] = (
+        list(dedup_rejected)
+        + list(same_day_rejected)
+        + overflow_rejections
+        + [
+            {
+                "reason": skipped.decision,
+                "source_id": skipped.source_id,
+                "next_eligible_at": skipped.next_eligible_at,
+            }
+            for skipped in plan.skipped
+        ]
+    )
+
+    result = CollectionRunResult(
+        role=role_id,
+        accepted=tuple(accepted),
+        rejected=tuple(rejected),
+        visited_source_ids=tuple(visited),
+        daily_limit=limit,
+    )
+    return result, new_states
+
+
 __all__ = [
     "CollectionRunResult",
     "FakeSourceCollectorAdapter",
     "SourceCollectorAdapter",
     "collect_for_role",
+    "collect_for_role_with_schedule",
     "utc_now_iso",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
@@ -6,6 +6,10 @@ Produces a short markdown block per role. Rules:
   * Each line carries title / importance / source name + URL.
   * Body refers the reader to the full Obsidian document — Discord
     is *not* where the long-form knowledge note lives.
+  * Each digest carries a share-boundary footer when any
+    `team_internal` or `restricted` items appear so the operator can
+    see "이 채널에 떠 있는 자료 5건 중 1건은 vault 안에서만 본다" 를
+    스크롤 없이 파악할 수 있다.
   * No actual Discord posting happens here. The post-side wiring
     (gateway / status-poster) is left for follow-up so the surface
     stays test-friendly and offline.
@@ -13,7 +17,7 @@ Produces a short markdown block per role. Rules:
 
 from __future__ import annotations
 
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Mapping, Sequence
 
 from .models import EngineeringKnowledgeItem, Importance, KnowledgeShareScope
 
@@ -62,6 +66,56 @@ def _format_line(index: int, item: EngineeringKnowledgeItem) -> str:
     )
 
 
+def share_boundary_breakdown(
+    items: Sequence[EngineeringKnowledgeItem],
+) -> Mapping[str, int]:
+    """Count digest items per ``share_scope``.
+
+    Returns a dict that always carries 4 keys (`public`,
+    `team_internal`, `restricted`, `total`) so callers can dispatch
+    on the value without a missing-key check. Sums to ``len(items)``
+    even when the digest's own daily-limit truncation would hide
+    items downstream — the caller controls truncation, this helper
+    just classifies what it received.
+    """
+
+    counts = {"public": 0, "team_internal": 0, "restricted": 0}
+    for item in items:
+        scope = item.share_scope
+        key = scope.value if isinstance(scope, KnowledgeShareScope) else str(scope or "public").lower()
+        if key not in counts:
+            key = "public"
+        counts[key] += 1
+    counts["total"] = sum(counts.values())
+    return counts
+
+
+def _share_boundary_footer(breakdown: Mapping[str, int]) -> str:
+    """One-line footer summarising the digest's share-boundary mix.
+
+    Empty when everything is `public` (no operator action needed).
+    Otherwise lists the non-public counts so the operator knows the
+    digest contains material that should not be copy-pasted out of
+    Discord verbatim.
+    """
+
+    bits: List[str] = []
+    for key, label in (
+        ("team_internal", "🔒 team-internal"),
+        ("restricted", "🔒 공개 제한"),
+    ):
+        value = breakdown.get(key, 0)
+        if value:
+            bits.append(f"{label} {value}건")
+    if not bits:
+        return ""
+    public_count = breakdown.get("public", 0)
+    return (
+        f"_share boundary — public {public_count}건 · {' · '.join(bits)}. "
+        "외부 채널 복사 시 vault link 로만 참조하세요._"
+    )
+
+
 def render_daily_role_summary(
     role_id: str,
     items: Sequence[EngineeringKnowledgeItem],
@@ -91,6 +145,10 @@ def render_daily_role_summary(
     lines.append(
         "_상세 문서와 실습 가이드는 Obsidian `engineering-knowledge` 노트를 참고하세요._"
     )
+    if visible:
+        footer = _share_boundary_footer(share_boundary_breakdown(visible))
+        if footer:
+            lines.append(footer)
     if extra_note:
         lines.append("")
         lines.append(extra_note)
@@ -117,4 +175,5 @@ def render_multi_role_summary(
 __all__ = [
     "render_daily_role_summary",
     "render_multi_role_summary",
+    "share_boundary_breakdown",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Iterable, List, Sequence
 
-from .models import EngineeringKnowledgeItem, Importance
+from .models import EngineeringKnowledgeItem, Importance, KnowledgeShareScope
 
 
 _IMPORTANCE_BADGES = {
@@ -29,11 +29,36 @@ _IMPORTANCE_BADGES = {
 _MAX_PER_ROLE = 5
 
 
+_SHARE_SCOPE_TAGS = {
+    KnowledgeShareScope.PUBLIC: "",
+    KnowledgeShareScope.TEAM_INTERNAL: " · 🔒 team-internal",
+    KnowledgeShareScope.RESTRICTED: " · 🔒 공개 제한",
+}
+
+
 def _format_line(index: int, item: EngineeringKnowledgeItem) -> str:
+    """Format a single digest line, honouring ``share_scope``.
+
+    - ``PUBLIC``: title + badge + source link, identical to the v0
+      output so existing assertions continue to pass.
+    - ``TEAM_INTERNAL``: same surface, plus a ``team-internal`` tag so
+      downstream readers know the body is Obsidian-only.
+    - ``RESTRICTED``: title and source replaced by an opaque
+      ``topic_key`` reference + the share-scope tag — no title, no
+      source URL, no body. The Obsidian footer line still tells the
+      reader where to look up the full record.
+    """
+
     badge = _IMPORTANCE_BADGES.get(item.importance, item.importance.value)
+    scope_tag = _SHARE_SCOPE_TAGS.get(item.share_scope, "")
+    if item.share_scope == KnowledgeShareScope.RESTRICTED:
+        return (
+            f"{index}. **🔒 공개 제한된 자료** "
+            f"(`{item.topic_key}`) — {badge}{scope_tag}"
+        )
     return (
         f"{index}. **{item.title}** — {badge} · "
-        f"[{item.source_name}]({item.source_url})"
+        f"[{item.source_name}]({item.source_url}){scope_tag}"
     )
 
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
@@ -1,0 +1,429 @@
+"""Deterministic feed parser — bytes → :class:`EngineeringKnowledgeItem`.
+
+Round 4-ter brings the safest provider class (public RSS / Atom /
+GitHub releases atom) one step closer to live without taking the
+network dependency yet. The transport seam (.providers.LiveSourceFetcher)
+still has no urllib import and no live impl in the registry — but the
+*parser half* lands here so a follow-up PR can ship a thin urllib
+``BytesFetcher`` and call ``register_safe_feed_providers`` instead of
+writing a full transport+parser.
+
+What ships now:
+
+  * :func:`parse_atom_bytes` / :func:`parse_rss_bytes` /
+    :func:`parse_feed_bytes` — pure functions over an XML byte
+    payload. Fill the required :class:`EngineeringKnowledgeItem`
+    fields from the source's metadata and the entry's title / link /
+    summary / published timestamp.
+  * :class:`BytesFetcher` — Protocol the live half satisfies once
+    the urllib client lands. Tests pass a closure returning canned
+    XML; production passes a small urllib wrapper.
+  * :func:`make_feed_live_factory` — glues a BytesFetcher to the
+    parser and returns a ``LiveFetcherFactory`` shaped exactly like
+    ``KnowledgeProviderRegistry.register_live`` expects.
+  * :func:`register_safe_feed_providers` — convenience: registers
+    RSS / ATOM / GITHUB_RELEASES_ATOM in one call so the operator
+    flips three transports at once when the urllib bytes_fetcher is
+    ready.
+
+Strict offline. Only stdlib ``xml.etree.ElementTree`` /
+``email.utils.parsedate_to_datetime`` are imported. No urllib /
+requests / socket. Tests pin the parser end-to-end against canned
+XML so the contract can't silently regress when the live PR plugs
+the BytesFetcher in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Callable, Mapping, Optional, Protocol, Tuple
+from xml.etree import ElementTree as ET
+
+from .models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceEntry,
+)
+from .providers import LiveProviderSpec, ProviderTransport
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+_SUMMARY_LIMIT = 500
+
+
+class FeedParserError(Exception):
+    """Raised when bytes are not a valid feed.
+
+    Distinct from a transport error: malformed XML usually means the
+    operator wired a wrong endpoint, not a transient blip. The live
+    factory swallows transport errors but logs / surfaces parse
+    failures so the dashboard can flag the bad source.
+    """
+
+
+class BytesFetcher(Protocol):
+    """The live half of a feed fetch — bytes only, no parsing."""
+
+    def __call__(self, spec: LiveProviderSpec) -> bytes:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _hash_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha1(
+        "|".join(parts).encode("utf-8", errors="replace")
+    ).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+def _coerce_iso(text: str) -> Optional[str]:
+    """ISO-8601 (atom) or RFC-822 (rss) → ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    Best-effort: parse with :func:`datetime.fromisoformat` first and
+    fall back to :func:`email.utils.parsedate_to_datetime` for the
+    RSS-2.0 ``Mon, 01 Jan 2026 00:00:00 GMT`` shape. Anything else
+    returns ``None`` — the item still flows through with no
+    ``published_at``; freshness scoring will rank it lower but the
+    pipeline doesn't drop it.
+    """
+
+    text = (text or "").strip()
+    if not text:
+        return None
+    iso_candidate = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(iso_candidate)
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(text)
+        except (TypeError, ValueError):
+            return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _text(elem: Optional[ET.Element]) -> str:
+    if elem is None or elem.text is None:
+        return ""
+    return elem.text.strip()
+
+
+def _trim(value: str, *, limit: int = _SUMMARY_LIMIT) -> str:
+    """Cap summary length per content_policy ("light quotation only")."""
+
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _build_item(
+    source: SourceEntry,
+    *,
+    title: str,
+    url: str,
+    summary: str,
+    published: Optional[str],
+) -> EngineeringKnowledgeItem:
+    """Compose one :class:`EngineeringKnowledgeItem` from parsed feed bits.
+
+    The collector / dedup layer takes over from here — it sets the
+    final ``dedup_key`` and may merge with prior items. We just have
+    to fill enough fields that those layers don't drop the row.
+    """
+
+    role = source.role_tags[0] if source.role_tags else "tech-lead"
+    final_title = title or url or source.name
+    final_url = url or source.base_url
+    item_id = _hash_id(source.source_id, final_title, final_url)
+    topic_key = _hash_id("topic", source.source_id, final_title.lower())
+    return EngineeringKnowledgeItem(
+        item_id=item_id,
+        topic_key=topic_key,
+        title=final_title,
+        role=role,
+        stack_tags=tuple(source.stack_tags),
+        source_name=source.name,
+        source_url=final_url,
+        source_kind=source.source_kind,
+        collected_at=_now_iso(),
+        published_at=published,
+        importance=Importance.MEDIUM,
+        summary=_trim(summary),
+        rag_tags=tuple(source.stack_tags),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atom 1.0 parser
+# ---------------------------------------------------------------------------
+
+
+def parse_atom_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Parse an Atom 1.0 feed into items for *source*.
+
+    Recognises the standard ``<feed><entry>...`` shape plus
+    ``<link rel="alternate" href="...">`` (preferred) with a
+    fallback to the first ``<link>``. ``updated`` is the canonical
+    timestamp; ``published`` is the fallback when ``updated`` is
+    absent.
+    """
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise FeedParserError(f"atom parse failed: {exc}") from exc
+
+    items: list[EngineeringKnowledgeItem] = []
+    for entry in root.findall(f"{_ATOM_NS}entry"):
+        title = _text(entry.find(f"{_ATOM_NS}title"))
+
+        link_elem = entry.find(f"{_ATOM_NS}link[@rel='alternate']")
+        if link_elem is None:
+            link_elem = entry.find(f"{_ATOM_NS}link")
+        url = (link_elem.get("href") if link_elem is not None else "") or ""
+
+        summary = _text(entry.find(f"{_ATOM_NS}summary"))
+        if not summary:
+            summary = _text(entry.find(f"{_ATOM_NS}content"))
+
+        published = _coerce_iso(_text(entry.find(f"{_ATOM_NS}updated")))
+        if not published:
+            published = _coerce_iso(_text(entry.find(f"{_ATOM_NS}published")))
+
+        items.append(
+            _build_item(
+                source,
+                title=title,
+                url=url,
+                summary=summary,
+                published=published,
+            )
+        )
+    return tuple(items)
+
+
+# ---------------------------------------------------------------------------
+# RSS 2.0 parser
+# ---------------------------------------------------------------------------
+
+
+def parse_rss_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Parse an RSS 2.0 (or RDF) feed into items for *source*.
+
+    Handles the ``<rss><channel><item>...`` shape. RDF (``<rdf:RDF>``)
+    falls back to scanning the root for ``<item>`` directly so older
+    feeds still parse without a namespace dance.
+    """
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise FeedParserError(f"rss parse failed: {exc}") from exc
+
+    channel = root.find("channel")
+    item_elements = (
+        channel.findall("item") if channel is not None else root.findall("item")
+    )
+
+    items: list[EngineeringKnowledgeItem] = []
+    for item in item_elements:
+        title = _text(item.find("title"))
+        url = _text(item.find("link"))
+        summary = _text(item.find("description"))
+        published = _coerce_iso(_text(item.find("pubDate")))
+        items.append(
+            _build_item(
+                source,
+                title=title,
+                url=url,
+                summary=summary,
+                published=published,
+            )
+        )
+    return tuple(items)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_atom_payload(payload: bytes) -> bool:
+    head = payload[:200].lower()
+    return b"<feed" in head and b"atom" in head
+
+
+def parse_feed_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+    transport: ProviderTransport,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Pick the right parser for *transport* and apply it to *payload*.
+
+    GitHub releases atom uses the same Atom 1.0 shape as a regular
+    atom feed, so they share a parser. RSS-mode sources sometimes
+    expose an Atom payload (we already do this URL heuristic at
+    spec-build time, but a misregistered source can leak through);
+    we sniff the head and dispatch to the atom parser when the bytes
+    say "feed/atom".
+    """
+
+    if transport in (
+        ProviderTransport.ATOM,
+        ProviderTransport.GITHUB_RELEASES_ATOM,
+    ):
+        return parse_atom_bytes(payload, source=source)
+    if transport is ProviderTransport.RSS:
+        if _looks_like_atom_payload(payload):
+            return parse_atom_bytes(payload, source=source)
+        return parse_rss_bytes(payload, source=source)
+    raise FeedParserError(
+        f"unsupported transport for feed parser: {transport.value}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live factory glue
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeedFetchOutcome:
+    """Diagnostic record the live factory can hand back per call.
+
+    Currently unused by the registry's :class:`LiveSourceFetcher`
+    callable contract (which returns items only) — kept around as a
+    lightweight pure-data shape so the future operator dashboard can
+    surface "fetch ok / parse failed / transport error" without
+    re-running the call.
+    """
+
+    source_id: str
+    transport: str
+    item_count: int
+    fetched_bytes: int
+    parse_ok: bool
+    note: str = ""
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "transport": self.transport,
+            "item_count": int(self.item_count),
+            "fetched_bytes": int(self.fetched_bytes),
+            "parse_ok": bool(self.parse_ok),
+            "note": self.note,
+        }
+
+
+def make_feed_live_factory(
+    bytes_fetcher_factory: Callable[[Mapping[str, str]], BytesFetcher],
+    *,
+    parser: Callable[
+        ..., Tuple[EngineeringKnowledgeItem, ...]
+    ] = parse_feed_bytes,
+) -> Callable[[Mapping[str, str]], Any]:
+    """Wrap *bytes_fetcher_factory* into a registry-shaped live factory.
+
+    The registered live factory must take ``env`` and return a
+    :class:`LiveSourceFetcher`. The bytes-fetcher factory takes the
+    same env and returns a :class:`BytesFetcher`. We glue them with
+    the parser and obey the LiveSourceFetcher Protocol contract:
+
+      * Never raise on transport errors — return ``()`` so the
+        scheduler can record the failure and back off.
+      * Empty payload → empty tuple. The collector treats this the
+        same as "feed has no new items".
+      * Parser failures are swallowed at this layer too (the live
+        factory's job is to be safe by default); callers that want
+        the explicit error observe it via :class:`FeedFetchOutcome`
+        once the dashboard lands.
+    """
+
+    def factory(env: Mapping[str, str]) -> Callable[..., Any]:
+        fetcher = bytes_fetcher_factory(env)
+
+        def fetch(spec: LiveProviderSpec, *, source: SourceEntry):
+            try:
+                payload = fetcher(spec)
+            except Exception:
+                return ()
+            if not payload:
+                return ()
+            try:
+                return parser(payload, source=source, transport=spec.transport)
+            except FeedParserError:
+                return ()
+
+        return fetch
+
+    return factory
+
+
+def register_safe_feed_providers(
+    registry: Any,
+    *,
+    bytes_fetcher_factory: Callable[[Mapping[str, str]], BytesFetcher],
+    transports: Tuple[ProviderTransport, ...] = (
+        ProviderTransport.RSS,
+        ProviderTransport.ATOM,
+        ProviderTransport.GITHUB_RELEASES_ATOM,
+    ),
+) -> Tuple[ProviderTransport, ...]:
+    """Register the parser-backed live factory on each of *transports*.
+
+    Returns the transports that were actually registered. Skips any
+    transport that is not in the registry rather than raising — the
+    operator can choose a subset (e.g. atom-only) without having to
+    pre-trim the registry.
+    """
+
+    factory = make_feed_live_factory(bytes_fetcher_factory)
+    registered: list[ProviderTransport] = []
+    for transport in transports:
+        if transport not in registry:
+            continue
+        registry.register_live(transport, live_factory=factory)
+        registered.append(transport)
+    return tuple(registered)
+
+
+__all__ = [
+    "BytesFetcher",
+    "FeedFetchOutcome",
+    "FeedParserError",
+    "make_feed_live_factory",
+    "parse_atom_bytes",
+    "parse_feed_bytes",
+    "parse_rss_bytes",
+    "register_safe_feed_providers",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/models.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/models.py
@@ -91,6 +91,56 @@ class SourceTier(str, Enum):
     TIER_4 = "tier_4_community"
 
 
+class SourceAxis(str, Enum):
+    """역할별 자료 축. 한 source는 여러 axis에 속할 수 있다.
+
+    이 enum은 master plan §9.1의 "역할별 상시 수집 대상" 항목들을
+    1:1로 흡수한다. 각 source가 어떤 axis를 cover하는지 태깅해두면
+    request-time retrieval에서 task_type → axes hint matrix로 정렬할
+    수 있고, scheduler는 한 axis가 누락되지 않도록 감시할 수 있다.
+    """
+
+    OFFICIAL_DOCS = "official_docs"
+    API_SCHEMA_AUTH = "api_schema_auth"
+    WEB_PLATFORM_FRAMEWORK = "web_platform_framework"
+    REGRESSION_TEST_PLAN = "regression_test_plan"
+    CI_CD_INFRA_OBSERVABILITY = "ci_cd_infra_observability"
+    ARCHITECTURE_ADR_TRADEOFF = "architecture_adr_tradeoff"
+    AI_FRAMEWORK = "ai_framework"
+    DESIGN_SYSTEM = "design_system"
+    SECURITY = "security"
+    RELEASE_NOTES_CHANGELOG = "release_notes_changelog"
+
+
+# 기본 refresh 주기 (분 단위). source_kind를 보고 상식적인 값을 박는다.
+# scheduler가 SourceEntry.refresh_interval_minutes 미설정인 경우의
+# fallback으로 사용한다.
+_DEFAULT_REFRESH_INTERVAL_MINUTES_BY_KIND: "Mapping[SourceKind, int]" = {
+    # 보안 권고는 신선도가 핵심 — 30분 cadence
+    SourceKind.SECURITY_ADVISORY: 30,
+    # 릴리스/체인지로그는 시간 단위
+    SourceKind.RELEASE_NOTES: 60,
+    SourceKind.CHANGELOG: 60,
+    # 엔지니어링 블로그는 6시간
+    SourceKind.ENGINEERING_BLOG: 360,
+    # 공식 문서는 사이트맵을 자주 돌릴 필요가 없다 — 24시간
+    SourceKind.DOCS: 1440,
+    SourceKind.DESIGN_SYSTEM: 1440,
+    # 깃허브 레포 watch는 1시간
+    SourceKind.REPO: 60,
+    SourceKind.ISSUE_TRACKER: 60,
+    # 표준 / 매뉴얼 검토 대상은 주 단위
+    SourceKind.STANDARD: 10080,
+    SourceKind.COMMUNITY: 720,
+}
+
+
+def default_refresh_interval_for_kind(kind: "SourceKind") -> int:
+    """``SourceKind`` 기준 기본 refresh interval (분)."""
+
+    return _DEFAULT_REFRESH_INTERVAL_MINUTES_BY_KIND.get(kind, 1440)
+
+
 # Note kind for vault writes — distinct from canonical "knowledge"
 # (which is the L3-approval long-term record). The L1 auto-saved
 # "collected & learning" note kind is "engineering-knowledge".
@@ -134,6 +184,11 @@ class SourceEntry:
         "link + short summary + light quotation only — no full-text reproduction"
     )
     max_items_per_day: int = 5
+    # 한 source가 여러 axis에 속할 수 있다. 비어 있으면 collector는 axis 정렬에서
+    # "not classified" bucket으로 본다 — retrieval에서는 보너스 점수 없음.
+    axes: Tuple["SourceAxis", ...] = ()
+    # 기본은 SourceKind 기반 fallback. 0/None은 fallback 사용 의도.
+    refresh_interval_minutes: int = 0
 
     def is_official(self) -> bool:
         return self.tier in (
@@ -141,6 +196,13 @@ class SourceEntry:
             SourceTier.TIER_2,
             SourceTier.TIER_3,
         )
+
+    def effective_refresh_interval_minutes(self) -> int:
+        """SourceEntry-level override가 있으면 그 값, 없으면 kind 기본값."""
+
+        if self.refresh_interval_minutes and self.refresh_interval_minutes > 0:
+            return self.refresh_interval_minutes
+        return default_refresh_interval_for_kind(self.source_kind)
 
     def to_payload(self) -> Mapping[str, Any]:
         return {
@@ -158,6 +220,8 @@ class SourceEntry:
             "review_required": self.review_required,
             "content_policy": self.content_policy,
             "max_items_per_day": self.max_items_per_day,
+            "axes": [axis.value for axis in self.axes],
+            "refresh_interval_minutes": self.effective_refresh_interval_minutes(),
         }
 
 
@@ -378,7 +442,9 @@ __all__ = [
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",
     "PracticeVerification",
     "ProjectApplicability",
+    "SourceAxis",
     "SourceEntry",
     "SourceKind",
     "SourceTier",
+    "default_refresh_interval_for_kind",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/models.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/models.py
@@ -81,6 +81,31 @@ class KnowledgeStatus(str, Enum):
     DEPRECATED = "deprecated"
 
 
+class KnowledgeShareScope(str, Enum):
+    """공유 가능 범위 — note/report 출력에 박혀 외부 노출 경계가 된다.
+
+    - ``PUBLIC``: 공식 문서·릴리스 노트·블로그처럼 외부 surface(Discord
+      digest, PR 본문, 합성 응답)에 본문 요약과 함께 그대로 인용해도
+      되는 자료. note 의 모든 섹션이 그대로 렌더된다.
+    - ``TEAM_INTERNAL``: 사내 repo/ADR/private security advisory 처럼
+      Obsidian vault 안에서는 전체 내용을 보지만 외부 surface 로는 제목
+      + 출처 링크 + share_scope 만 노출한다. 본문 요약은 chat 응답에
+      포함하지 말 것.
+    - ``RESTRICTED``: 보안 incident report, customer data 가 섞인 자료
+      처럼 본문은 vault 에도 압축 저장(요약 1~2줄)하고 외부에서는 "공개
+      제한된 자료" 라는 신호만 남긴다. 렌더된 note 의 본문은 link +
+      share_scope_reason 만 남고, common_mistakes / practice 같은 학습
+      섹션도 "내부 채널에서만 공유" 라는 한 줄로 대체된다.
+
+    기본값은 :data:`KnowledgeShareScope.PUBLIC`. 호출자(collector /
+    operator) 가 명시적으로 더 좁힐 수 있다.
+    """
+
+    PUBLIC = "public"
+    TEAM_INTERNAL = "team_internal"
+    RESTRICTED = "restricted"
+
+
 # Tier 1 = official spec/docs; Tier 4 = community. Auto collection
 # defaults to Tier 1~2; Tier 3~4 requires review_required=True or low
 # trust_weight.
@@ -351,6 +376,11 @@ class EngineeringKnowledgeItem:
     review_after_days: int = 90
     staleness_reason: str = ""
 
+    # Share boundary — note/report 출력 시 외부 surface(Discord digest,
+    # PR body, 합성 응답)에 어디까지 인용해도 되는지를 결정한다.
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC
+    share_scope_reason: str = ""
+
     # Project applicability
     project_applicability: Optional[ProjectApplicability] = None
 
@@ -415,6 +445,8 @@ class EngineeringKnowledgeItem:
             "knowledge_status": self.knowledge_status.value,
             "review_after_days": self.review_after_days,
             "staleness_reason": self.staleness_reason,
+            "share_scope": self.share_scope.value,
+            "share_scope_reason": self.share_scope_reason,
             "project_applicability": (
                 self.project_applicability.to_payload()
                 if self.project_applicability is not None
@@ -437,6 +469,7 @@ __all__ = [
     "ENGINEERING_KNOWLEDGE_CONTRACT",
     "EngineeringKnowledgeItem",
     "Importance",
+    "KnowledgeShareScope",
     "KnowledgeStatus",
     "LearningLevel",
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",

--- a/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
@@ -31,6 +31,7 @@ from typing import Any, List, Mapping, Optional, Tuple
 from .models import (
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
     EngineeringKnowledgeItem,
+    KnowledgeShareScope,
 )
 from .renderer import RendererError, render_engineering_knowledge_note
 
@@ -97,8 +98,106 @@ def evaluate_quality_gate(item: EngineeringKnowledgeItem) -> QualityGateResult:
         reasons.append("missing:practice_verification.expected_result")
     if item.review_after_days is None or int(item.review_after_days) <= 0:
         reasons.append("missing:review_after_days")
+    # Share boundary: scope is mandatory (default PUBLIC at the model
+    # layer is acceptable, but it must be a member of the enum). When
+    # an operator scopes an item down to RESTRICTED they must also
+    # explain why, so the operator-facing audit can pin the call.
+    if not isinstance(item.share_scope, KnowledgeShareScope):
+        reasons.append("missing:share_scope")
+    elif (
+        item.share_scope == KnowledgeShareScope.RESTRICTED
+        and not item.share_scope_reason.strip()
+    ):
+        reasons.append("missing:share_scope_reason_for_restricted")
 
     return QualityGateResult(passed=not reasons, reasons=tuple(reasons))
+
+
+# ---------------------------------------------------------------------------
+# Share boundary helpers
+# ---------------------------------------------------------------------------
+
+
+def shareable_external_payload(
+    item: EngineeringKnowledgeItem,
+) -> Mapping[str, Any]:
+    """Return the dict of fields safe to ship to an external surface.
+
+    External surfaces here = Discord digest, PR body, gateway response
+    text — anything that leaves the Obsidian vault. The payload is
+    intentionally minimal:
+
+    - ``PUBLIC``: title + summary + source name/url + topic_key +
+      share_scope (so consumers can label the citation).
+    - ``TEAM_INTERNAL``: title + source name/url + topic_key only —
+      summary deliberately omitted so a downstream copy-paste loop
+      can't accidentally leak the synthesised body to a public channel.
+    - ``RESTRICTED``: only the topic_key + share_scope marker. No
+      title, no source, no summary. Lets external surfaces show
+      "🔒 공개 제한된 자료 1건" without disclosing what topic.
+
+    The mapping is always a fresh dict (caller can mutate without
+    affecting the item). Missing optional fields stay absent rather
+    than carrying empty strings, so consumers can ``if "summary" in
+    payload`` rather than ``if payload["summary"]``.
+    """
+
+    scope = item.share_scope
+    base: dict[str, Any] = {
+        "topic_key": item.topic_key,
+        "share_scope": scope.value,
+    }
+    if scope == KnowledgeShareScope.PUBLIC:
+        base.update(
+            {
+                "title": item.title,
+                "summary": item.summary,
+                "source_name": item.source_name,
+                "source_url": item.source_url,
+            }
+        )
+    elif scope == KnowledgeShareScope.TEAM_INTERNAL:
+        base.update(
+            {
+                "title": item.title,
+                "source_name": item.source_name,
+                "source_url": item.source_url,
+                "internal_only": True,
+            }
+        )
+    else:  # RESTRICTED
+        base["restricted_marker"] = "🔒 공개 제한된 자료"
+        if item.share_scope_reason:
+            base["share_scope_reason"] = item.share_scope_reason
+    return base
+
+
+def vault_only_metadata(
+    item: EngineeringKnowledgeItem,
+) -> Mapping[str, Any]:
+    """Return the dict of fields that should stay inside Obsidian.
+
+    These are the body sections — practice steps, common mistakes,
+    learning extras, project applicability — plus the share_scope so
+    a vault tool can audit "this is internal even though it landed".
+    Used by callers that want to deposit *only* the vault-private
+    chunk into long-term storage without re-exporting body text.
+    """
+
+    return {
+        "share_scope": item.share_scope.value,
+        "share_scope_reason": item.share_scope_reason,
+        "summary": item.summary,
+        "why_it_matters": item.why_it_matters,
+        "what_changed": item.what_changed,
+        "practical_impact": item.practical_impact,
+        "recommended_action": item.recommended_action,
+        "practice_topic": item.practice_topic,
+        "practice_steps": list(item.practice_steps),
+        "practice_checklist": list(item.practice_checklist),
+        "common_mistakes": list(item.common_mistakes),
+        "expected_output": item.expected_output,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -153,8 +252,11 @@ def build_engineering_knowledge_write_request(
             "dedup_key": item.dedup_key,
             "importance": item.importance.value,
             "audience": item.audience.value,
+            "share_scope": item.share_scope.value,
+            "share_scope_reason": item.share_scope_reason,
         },
         "engineering_knowledge_item": dict(item.to_payload()),
+        "shareable_external_payload": dict(shareable_external_payload(item)),
     }
 
     return ObsidianWriteRequest(
@@ -197,4 +299,6 @@ __all__ = [
     "build_engineering_knowledge_write_request",
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
+    "shareable_external_payload",
+    "vault_only_metadata",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
@@ -26,7 +26,7 @@ here (note_kind ``engineering-knowledge`` is not in
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 from .models import (
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
@@ -172,6 +172,51 @@ def shareable_external_payload(
     return base
 
 
+def summarize_share_boundary(
+    items: Sequence[EngineeringKnowledgeItem],
+) -> Mapping[str, Any]:
+    """Operator-facing one-line summary of a digest's share-boundary mix.
+
+    Returns ``{"counts": {public, team_internal, restricted, total},
+    "summary": str}``. The ``summary`` is the same one-line shape used
+    by the Discord digest footer and the discussion synthesizer's
+    ``knowledge_short_summary`` so an operator dashboard / status
+    poster can stamp the same sentence regardless of surface.
+
+    Empty input returns a stable empty payload so the caller can
+    branch on ``payload["counts"]["total"] == 0``.
+    """
+
+    counts = {"public": 0, "team_internal": 0, "restricted": 0}
+    for item in items:
+        scope = item.share_scope
+        key = (
+            scope.value
+            if isinstance(scope, KnowledgeShareScope)
+            else str(scope or "public").lower()
+        )
+        if key not in counts:
+            key = "public"
+        counts[key] += 1
+    counts["total"] = sum(counts.values())
+    if counts["total"] == 0:
+        return {"counts": counts, "summary": ""}
+    bits: list[str] = []
+    for key in ("public", "team_internal", "restricted"):
+        if counts[key]:
+            bits.append(f"{key} {counts[key]}건")
+    summary = (
+        f"근거 자료 {counts['total']}건 ({' · '.join(bits)})."
+        if bits
+        else f"근거 자료 {counts['total']}건."
+    )
+    if counts["restricted"]:
+        summary += " 🔒 공개 제한 자료가 포함돼 있어 외부 채널 인용 금지."
+    elif counts["team_internal"]:
+        summary += " 🔒 team-internal 항목은 vault link 로만 참조."
+    return {"counts": counts, "summary": summary}
+
+
 def vault_only_metadata(
     item: EngineeringKnowledgeItem,
 ) -> Mapping[str, Any]:
@@ -300,5 +345,6 @@ __all__ = [
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
     "shareable_external_payload",
+    "summarize_share_boundary",
     "vault_only_metadata",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
@@ -1,0 +1,514 @@
+"""Auth + availability registry for live knowledge providers.
+
+The :mod:`.providers` module owns the *transport spec* — given a
+:class:`SourceEntry`, :func:`provider_spec_for` returns the
+:class:`LiveProviderSpec` describing how the bytes arrive (RSS / Atom
+/ Sitemap / HTML / GitHub Releases / GitHub API / Manual).
+
+This module owns the *registry* layer that complements that spec:
+
+  * Which provider implementations actually exist for each transport.
+  * What env contract each provider requires before it may dispatch
+    a live call (mirrors the decision-classifier dual gate — env keys
+    *and* an explicit enable flag must both be set).
+  * Whether the configured implementation is currently
+    ``available`` / ``disabled_by_flag`` / ``missing_env`` /
+    ``no_live_impl`` / ``manual_only`` for the operator's environment.
+  * A deterministic fake (:class:`FakeKnowledgeProvider`) that every
+    transport falls back to when live dispatch is not authorised.
+
+Strict offline. Live HTTP / API code lives in a follow-up — this
+module defines the *seam* without importing urllib / requests /
+socket / sqlite / vault. Tests pin the seam so the contract can't
+silently regress when the live impl lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from .models import EngineeringKnowledgeItem, SourceEntry
+from .providers import (
+    FakeKnowledgeProvider,
+    LiveProviderSpec,
+    LiveSourceFetcher,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth requirement
+# ---------------------------------------------------------------------------
+
+
+_TRUTHY = {"1", "true", "yes", "on", "y"}
+
+
+@dataclass(frozen=True)
+class ProviderAuthRequirement:
+    """Env contract a provider must satisfy before live dispatch.
+
+    Two-part dual gate, intentionally identical in shape to the
+    decision-classifier env policy:
+
+      1. ``env_keys`` — every key listed here must resolve to a
+         non-empty value in the operator env mapping.
+      2. ``enable_flag`` — the boolean flag that the operator flips
+         after manual cost / safety review. ``None`` means the
+         transport has no dedicated flag (e.g. ``MANUAL`` — there is
+         no live call to gate).
+
+    Both conditions are necessary; either alone leaves the registry
+    in fallback (fake / stub) mode. This matches the project's
+    "key found ≠ enabled" rule from .env.example §classifier.
+    """
+
+    env_keys: Tuple[str, ...] = ()
+    enable_flag: Optional[str] = None
+    notes: str = ""
+
+    def env_keys_present(self, env: Mapping[str, str]) -> bool:
+        """All required keys map to a non-blank value in *env*."""
+
+        for key in self.env_keys:
+            value = (env.get(key) or "").strip()
+            if not value:
+                return False
+        return True
+
+    def enable_flag_set(self, env: Mapping[str, str]) -> bool:
+        """The enable flag is explicitly truthy (or unset → True)."""
+
+        if not self.enable_flag:
+            return True
+        value = (env.get(self.enable_flag) or "").strip().lower()
+        return value in _TRUTHY
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "env_keys": list(self.env_keys),
+            "enable_flag": self.enable_flag,
+            "notes": self.notes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+class ProviderAvailability(str, Enum):
+    """Live-or-fallback decision for a provider entry.
+
+    Distinguishes the *reason* a provider isn't currently live so the
+    operator dashboard can call out exactly the env / flag / impl
+    that's missing instead of a generic "fake".
+    """
+
+    AVAILABLE = "available"
+    DISABLED_BY_FLAG = "disabled_by_flag"
+    MISSING_ENV = "missing_env"
+    NO_LIVE_IMPL = "no_live_impl"
+    MANUAL_ONLY = "manual_only"
+
+
+# ---------------------------------------------------------------------------
+# Registration row
+# ---------------------------------------------------------------------------
+
+
+# A live factory takes the env mapping and returns a fetcher.
+# Concretely the live impl needs to thread through user-agent +
+# rate-limit + auth headers, all of which depend on env. The factory
+# pattern keeps the registry purely declarative — no live object is
+# constructed unless availability resolves to AVAILABLE.
+LiveFetcherFactory = Callable[[Mapping[str, str]], LiveSourceFetcher]
+
+
+@dataclass(frozen=True)
+class KnowledgeProviderRegistration:
+    """One row in the provider registry — transport → provider seat.
+
+    The fake fetcher is required (offline default for tests + dev +
+    cost-safe operator); the live factory is optional and only fires
+    if availability resolves to ``AVAILABLE``. ``manual=True`` marks
+    the slot where there is no live call by design (the operator
+    enters items by hand) — availability collapses to
+    ``MANUAL_ONLY`` regardless of env.
+    """
+
+    provider_id: str
+    transport: ProviderTransport
+    auth: ProviderAuthRequirement
+    fake_fetcher: LiveSourceFetcher
+    live_factory: Optional[LiveFetcherFactory] = None
+    manual: bool = False
+    description: str = ""
+
+    def has_live_impl(self) -> bool:
+        return self.live_factory is not None and not self.manual
+
+    def evaluate_availability(
+        self, env: Mapping[str, str]
+    ) -> ProviderAvailability:
+        """Resolve the env into an availability state.
+
+        Order matters: ``manual=True`` short-circuits to
+        ``MANUAL_ONLY``; absence of a live impl is checked next so
+        that "no impl" is not masked by a fully-set env. Then env
+        keys, then enable flag. The first failing condition wins so
+        the operator dashboard can fix exactly that one thing.
+        """
+
+        if self.manual:
+            return ProviderAvailability.MANUAL_ONLY
+        if self.live_factory is None:
+            return ProviderAvailability.NO_LIVE_IMPL
+        if not self.auth.env_keys_present(env):
+            return ProviderAvailability.MISSING_ENV
+        if not self.auth.enable_flag_set(env):
+            return ProviderAvailability.DISABLED_BY_FLAG
+        return ProviderAvailability.AVAILABLE
+
+    def select_fetcher(self, env: Mapping[str, str]) -> LiveSourceFetcher:
+        """Return the fetcher to use right now for this transport.
+
+        ``AVAILABLE`` → live factory output; everything else → fake.
+        The caller never has to branch on availability when it just
+        needs a callable.
+        """
+
+        if self.evaluate_availability(env) is ProviderAvailability.AVAILABLE:
+            assert self.live_factory is not None  # narrowed by guard above
+            return self.live_factory(env)
+        return self.fake_fetcher
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "transport": self.transport.value,
+            "auth": self.auth.to_payload(),
+            "manual": self.manual,
+            "has_live_impl": self.has_live_impl(),
+            "description": self.description,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeProviderRegistry:
+    """Mutable provider registry keyed on :class:`ProviderTransport`.
+
+    Designed for explicit construction:
+
+      * :func:`default_registry` produces the baseline seed (one
+        registration per transport with ``fake`` only and the env
+        contract attached).
+      * Tests / a future live-wiring PR call ``register_live`` to
+        plug a factory for one transport. No global mutation —
+        callers thread the registry through.
+    """
+
+    def __init__(
+        self,
+        registrations: Iterable[KnowledgeProviderRegistration] = (),
+    ) -> None:
+        self._by_transport: dict[
+            ProviderTransport, KnowledgeProviderRegistration
+        ] = {}
+        for reg in registrations:
+            self._by_transport[reg.transport] = reg
+
+    # -- mutation ------------------------------------------------------
+
+    def register(self, registration: KnowledgeProviderRegistration) -> None:
+        """Replace any existing entry for ``registration.transport``."""
+
+        self._by_transport[registration.transport] = registration
+
+    def register_live(
+        self,
+        transport: ProviderTransport,
+        *,
+        live_factory: LiveFetcherFactory,
+    ) -> None:
+        """Attach a live factory to an existing registration.
+
+        Raises :class:`KeyError` if the transport is unknown — keeps
+        a typo from silently producing a registry that never goes
+        live. Reuses the existing auth contract / fake; the operator
+        only has to write the live factory in their PR.
+        """
+
+        existing = self._by_transport.get(transport)
+        if existing is None:
+            raise KeyError(
+                f"cannot attach live factory: transport "
+                f"{transport.value!r} not in registry"
+            )
+        if existing.manual:
+            raise ValueError(
+                f"transport {transport.value!r} is manual-only — "
+                f"refusing to attach live factory"
+            )
+        self._by_transport[transport] = replace(
+            existing, live_factory=live_factory
+        )
+
+    # -- read-only ----------------------------------------------------
+
+    def __contains__(self, transport: ProviderTransport) -> bool:
+        return transport in self._by_transport
+
+    def get(
+        self, transport: ProviderTransport
+    ) -> KnowledgeProviderRegistration:
+        try:
+            return self._by_transport[transport]
+        except KeyError as exc:  # pragma: no cover — defensive
+            raise KeyError(
+                f"no provider registered for transport "
+                f"{transport.value!r}"
+            ) from exc
+
+    def iter_registrations(
+        self,
+    ) -> Tuple[KnowledgeProviderRegistration, ...]:
+        # Sorted on transport.value for deterministic iteration in
+        # tests + audit dumps.
+        return tuple(
+            sorted(
+                self._by_transport.values(),
+                key=lambda r: r.transport.value,
+            )
+        )
+
+    def evaluate(
+        self,
+        transport: ProviderTransport,
+        *,
+        env: Mapping[str, str],
+    ) -> ProviderAvailability:
+        return self.get(transport).evaluate_availability(env)
+
+    def select_fetcher_for(
+        self,
+        source: SourceEntry,
+        *,
+        env: Mapping[str, str],
+    ) -> Tuple[LiveProviderSpec, LiveSourceFetcher, ProviderAvailability]:
+        """Resolve a :class:`SourceEntry` into (spec, fetcher, availability).
+
+        Encapsulates the "build spec + look up registration + decide
+        availability + pick fetcher" sequence so a future scheduler
+        runner just calls one helper per source.
+        """
+
+        spec = provider_spec_for(source)
+        registration = self.get(spec.transport)
+        availability = registration.evaluate_availability(env)
+        fetcher = (
+            registration.live_factory(env)
+            if availability is ProviderAvailability.AVAILABLE
+            and registration.live_factory is not None
+            else registration.fake_fetcher
+        )
+        return spec, fetcher, availability
+
+    def availability_report(
+        self, env: Mapping[str, str]
+    ) -> Mapping[str, str]:
+        """``transport.value → availability.value`` for the dashboard."""
+
+        return {
+            reg.transport.value: reg.evaluate_availability(env).value
+            for reg in self.iter_registrations()
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default registry seed
+# ---------------------------------------------------------------------------
+
+
+# Env contract per transport — keys are "necessary" and the flag is
+# the dual-gate "sufficient" half. None of these are read by the
+# registry; they're declared here so the operator dashboard + tests
+# pin the contract independently of the live impl.
+_KNOWLEDGE_LIVE_ENABLED_FLAG = "YULE_KNOWLEDGE_{transport}_LIVE_ENABLED"
+
+
+def _flag_for(transport: ProviderTransport) -> str:
+    return _KNOWLEDGE_LIVE_ENABLED_FLAG.format(
+        transport=transport.value.upper()
+    )
+
+
+def default_registry(
+    *,
+    fake_fixture: Optional[
+        Mapping[str, Sequence[EngineeringKnowledgeItem]]
+    ] = None,
+) -> KnowledgeProviderRegistry:
+    """Baseline registry: one entry per transport, fake-only by default.
+
+    *fake_fixture* — optional ``source_id → items`` map for the fake
+    fetcher. If ``None``, the registry uses :class:`StubLiveSourceFetcher`
+    everywhere (records calls, returns empty). Tests that want
+    deterministic items wired through the registry pass a fixture
+    once at construction.
+    """
+
+    fake = (
+        FakeKnowledgeProvider(fake_fixture)
+        if fake_fixture is not None
+        else StubLiveSourceFetcher()
+    )
+
+    rss = KnowledgeProviderRegistration(
+        provider_id="rss-feed",
+        transport=ProviderTransport.RSS,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.RSS),
+            notes="Public RSS — no auth, only the operator enable flag.",
+        ),
+        fake_fetcher=fake,
+        description="Generic RSS 2.0 / RDF feed parser.",
+    )
+    atom = KnowledgeProviderRegistration(
+        provider_id="atom-feed",
+        transport=ProviderTransport.ATOM,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.ATOM),
+            notes="Public Atom 1.0 — no auth, only the operator enable flag.",
+        ),
+        fake_fetcher=fake,
+        description="Atom 1.0 feed parser.",
+    )
+    github_releases = KnowledgeProviderRegistration(
+        provider_id="github-releases-atom",
+        transport=ProviderTransport.GITHUB_RELEASES_ATOM,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.GITHUB_RELEASES_ATOM),
+            notes=(
+                "Public Atom feed exposed by github.com/<owner>/<repo>/"
+                "releases.atom — keep cadence ≤ 20/min to stay under the "
+                "unauthenticated rate limit."
+            ),
+        ),
+        fake_fetcher=fake,
+        description="GitHub releases atom (no auth).",
+    )
+    sitemap = KnowledgeProviderRegistration(
+        provider_id="sitemap-walker",
+        transport=ProviderTransport.SITEMAP,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.SITEMAP),
+            notes="Sitemap walks are heavier; cadence pinned low in the spec.",
+        ),
+        fake_fetcher=fake,
+        description="sitemap.xml walker (lastmod-aware).",
+    )
+    html_list = KnowledgeProviderRegistration(
+        provider_id="html-list",
+        transport=ProviderTransport.HTML_LIST,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.HTML_LIST),
+            notes="Index-page scrape — link + summary only per content_policy.",
+        ),
+        fake_fetcher=fake,
+        description="HTML index / list page scraper.",
+    )
+    html_detail = KnowledgeProviderRegistration(
+        provider_id="html-detail",
+        transport=ProviderTransport.HTML_DETAIL,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.HTML_DETAIL),
+            notes="Detail page fetch — slowest path; called only when index missed.",
+        ),
+        fake_fetcher=fake,
+        description="HTML detail-page scraper.",
+    )
+    github_api = KnowledgeProviderRegistration(
+        provider_id="github-api-repo-activity",
+        transport=ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+        auth=ProviderAuthRequirement(
+            # Reuse the existing GitHub App env triple — no new secret
+            # surface area. Knowledge fetcher will share the App
+            # installation with the GitHub agent.
+            env_keys=(
+                "YULE_GITHUB_APP_ID",
+                "YULE_GITHUB_APP_INSTALLATION_ID",
+                "YULE_GITHUB_APP_PRIVATE_KEY_PATH",
+            ),
+            enable_flag=_flag_for(
+                ProviderTransport.GITHUB_API_REPO_ACTIVITY
+            ),
+            notes=(
+                "Backed by the existing GitHub App. Private repo "
+                "endpoints fail closed without the App env triple."
+            ),
+        ),
+        fake_fetcher=fake,
+        description="GitHub REST: issues / releases / commits via App.",
+    )
+    manual = KnowledgeProviderRegistration(
+        provider_id="manual",
+        transport=ProviderTransport.MANUAL,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=None,
+            notes=(
+                "MANUAL — no live call. Operator enters knowledge items "
+                "directly via the vault / Discord intake."
+            ),
+        ),
+        fake_fetcher=fake,
+        manual=True,
+        description="Manual entry slot — no transport.",
+    )
+
+    return KnowledgeProviderRegistry(
+        registrations=(
+            rss,
+            atom,
+            github_releases,
+            sitemap,
+            html_list,
+            html_detail,
+            github_api,
+            manual,
+        )
+    )
+
+
+__all__ = [
+    "FakeKnowledgeProvider",
+    "KnowledgeProviderRegistration",
+    "KnowledgeProviderRegistry",
+    "LiveFetcherFactory",
+    "ProviderAuthRequirement",
+    "ProviderAvailability",
+    "default_registry",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
@@ -340,6 +340,148 @@ class KnowledgeProviderRegistry:
             for reg in self.iter_registrations()
         }
 
+    def availability_summary(
+        self, env: Mapping[str, str]
+    ) -> "ProviderAvailabilitySummary":
+        """Structured ``transport → state + diagnostics`` summary.
+
+        Builds one :class:`ProviderAvailabilityRow` per registration —
+        the row includes the env contract (which keys, which flag),
+        which keys are still empty, and whether the flag is set.
+        Operators get a single object they can render as a table on
+        the dashboard or feed into the background refresh planner so
+        a tick log explains exactly *why* a transport fell back to
+        the fake.
+        """
+
+        rows = tuple(
+            ProviderAvailabilityRow.from_registration(reg, env=env)
+            for reg in self.iter_registrations()
+        )
+        return ProviderAvailabilitySummary(rows=rows)
+
+
+# ---------------------------------------------------------------------------
+# Operator-facing availability summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderAvailabilityRow:
+    """One transport's resolved availability + the diagnostics behind it.
+
+    Designed for "render as a table on the operator dashboard"
+    rather than for the runner — the runner already calls
+    :meth:`KnowledgeProviderRegistry.select_fetcher_for`. This row
+    answers *why* a transport is in its current state so the
+    operator can fix exactly the missing piece (env key vs flag vs
+    live impl).
+    """
+
+    transport: str
+    provider_id: str
+    availability: str
+    has_live_impl: bool
+    manual: bool
+    env_keys: Tuple[str, ...]
+    enable_flag: Optional[str]
+    missing_env_keys: Tuple[str, ...]
+    enable_flag_set: bool
+    description: str
+    notes: str
+
+    @classmethod
+    def from_registration(
+        cls,
+        registration: "KnowledgeProviderRegistration",
+        *,
+        env: Mapping[str, str],
+    ) -> "ProviderAvailabilityRow":
+        missing = tuple(
+            key
+            for key in registration.auth.env_keys
+            if not (env.get(key) or "").strip()
+        )
+        return cls(
+            transport=registration.transport.value,
+            provider_id=registration.provider_id,
+            availability=registration.evaluate_availability(env).value,
+            has_live_impl=registration.has_live_impl(),
+            manual=registration.manual,
+            env_keys=tuple(registration.auth.env_keys),
+            enable_flag=registration.auth.enable_flag,
+            missing_env_keys=missing,
+            enable_flag_set=registration.auth.enable_flag_set(env),
+            description=registration.description,
+            notes=registration.auth.notes,
+        )
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "transport": self.transport,
+            "provider_id": self.provider_id,
+            "availability": self.availability,
+            "has_live_impl": bool(self.has_live_impl),
+            "manual": bool(self.manual),
+            "env_keys": list(self.env_keys),
+            "enable_flag": self.enable_flag,
+            "missing_env_keys": list(self.missing_env_keys),
+            "enable_flag_set": bool(self.enable_flag_set),
+            "description": self.description,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderAvailabilitySummary:
+    """All :class:`ProviderAvailabilityRow` rows + small grouping helpers.
+
+    Pure data — no I/O. Three convenience views the dashboard /
+    background refresh planner reach for the most:
+
+      * :meth:`by_state` — ``state → rows`` for a "live / blocked /
+        manual" tabbed view.
+      * :meth:`states_count` — quick "5 available, 2 missing_env"
+        headline number.
+      * :meth:`needs_attention` — rows the operator can fix:
+        MISSING_ENV / DISABLED_BY_FLAG. NO_LIVE_IMPL is not in this
+        bucket (the operator can't write the live impl from the
+        dashboard).
+    """
+
+    rows: Tuple[ProviderAvailabilityRow, ...]
+
+    def by_state(self) -> Mapping[str, Tuple[ProviderAvailabilityRow, ...]]:
+        buckets: dict[str, list[ProviderAvailabilityRow]] = {}
+        for row in self.rows:
+            buckets.setdefault(row.availability, []).append(row)
+        return {
+            state: tuple(rows_in_state)
+            for state, rows_in_state in buckets.items()
+        }
+
+    def states_count(self) -> Mapping[str, int]:
+        counts: dict[str, int] = {}
+        for row in self.rows:
+            counts[row.availability] = counts.get(row.availability, 0) + 1
+        return counts
+
+    def needs_attention(self) -> Tuple[ProviderAvailabilityRow, ...]:
+        actionable = {
+            ProviderAvailability.MISSING_ENV.value,
+            ProviderAvailability.DISABLED_BY_FLAG.value,
+        }
+        return tuple(row for row in self.rows if row.availability in actionable)
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "rows": [row.to_payload() for row in self.rows],
+            "states_count": dict(self.states_count()),
+            "needs_attention": [
+                row.to_payload() for row in self.needs_attention()
+            ],
+        }
+
 
 # ---------------------------------------------------------------------------
 # Default registry seed
@@ -510,5 +652,7 @@ __all__ = [
     "LiveFetcherFactory",
     "ProviderAuthRequirement",
     "ProviderAvailability",
+    "ProviderAvailabilityRow",
+    "ProviderAvailabilitySummary",
     "default_registry",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from .models import SourceAxis, SourceEntry, SourceTier
+from .models import CollectionMode, SourceAxis, SourceEntry, SourceTier
 from .provider_registry import (
     KnowledgeProviderRegistration,
     KnowledgeProviderRegistry,
     ProviderAvailability,
+    ProviderAvailabilitySummary,
     default_registry,
 )
 from .providers import (
@@ -52,6 +53,12 @@ class RoutedRefreshCandidate:
     Plus the original :class:`RefreshPlanEntry` decision so the
     caller can still distinguish ``due`` vs ``skipped_*`` without
     re-running the planner.
+
+    ``transport_reason`` and ``availability_reason`` are short human
+    sentences explaining *why* this transport / availability was
+    picked. They land here so the operator dashboard + tick log can
+    answer "why did the runner pick rss-feed over manual?" without
+    re-deriving the heuristic.
     """
 
     source: SourceEntry
@@ -61,6 +68,8 @@ class RoutedRefreshCandidate:
     decision: str
     reason: str
     next_eligible_at: Optional[str] = None
+    transport_reason: str = ""
+    availability_reason: str = ""
 
     @property
     def axes(self) -> Tuple[SourceAxis, ...]:
@@ -69,6 +78,17 @@ class RoutedRefreshCandidate:
     @property
     def transport(self) -> ProviderTransport:
         return self.spec.transport
+
+    @property
+    def routing_reason(self) -> str:
+        """One-line ``transport=… availability=…`` explanation."""
+
+        parts: list[str] = []
+        if self.transport_reason:
+            parts.append(f"transport={self.transport_reason}")
+        if self.availability_reason:
+            parts.append(f"availability={self.availability_reason}")
+        return "; ".join(parts)
 
     def to_payload(self) -> Mapping[str, Any]:
         return {
@@ -81,7 +101,82 @@ class RoutedRefreshCandidate:
             "next_eligible_at": self.next_eligible_at,
             "axes": [axis.value for axis in self.axes],
             "auth": self.provider.auth.to_payload(),
+            "transport_reason": self.transport_reason,
+            "availability_reason": self.availability_reason,
+            "routing_reason": self.routing_reason,
         }
+
+
+# ---------------------------------------------------------------------------
+# Reasoning helpers — explain transport + availability choices
+# ---------------------------------------------------------------------------
+
+
+def _explain_transport_choice(source: SourceEntry) -> str:
+    """One-line "why this transport" for *source*.
+
+    Mirrors the dispatch order inside :func:`provider_spec_for` so
+    operators can map a routed candidate back to the heuristic that
+    picked it without re-reading the dispatcher source.
+    """
+
+    mode = source.collection_mode
+    url = source.base_url
+    if mode is CollectionMode.MANUAL:
+        return "manual (collection_mode=manual)"
+    if mode is CollectionMode.GITHUB_API:
+        return "github_api_repo_activity (collection_mode=github_api)"
+    if mode is CollectionMode.RSS:
+        if "github.com/" in url and "/releases" in url:
+            return "github_releases_atom (rss + github releases URL)"
+        if ".atom" in url or url.endswith("/atom"):
+            return "atom (rss + atom URL heuristic)"
+        return "rss (collection_mode=rss)"
+    if mode is CollectionMode.SITEMAP:
+        return "sitemap (collection_mode=sitemap)"
+    if mode is CollectionMode.HTML_LIST:
+        return "html_list (collection_mode=html_list)"
+    return "html_detail (fallback transport)"
+
+
+def _explain_availability(
+    registration: KnowledgeProviderRegistration,
+    *,
+    env: Mapping[str, str],
+    state: ProviderAvailability,
+) -> str:
+    """One-line "why this availability state" for *registration*.
+
+    The reason mentions the actionable thing first — missing env
+    keys or the disabled flag name — so an operator scanning the
+    dashboard can fix the right knob without opening the registry.
+    """
+
+    if state is ProviderAvailability.MANUAL_ONLY:
+        return "manual (operator enters items by hand)"
+    if state is ProviderAvailability.NO_LIVE_IMPL:
+        return "no live impl (fake fallback)"
+    if state is ProviderAvailability.MISSING_ENV:
+        missing = tuple(
+            key
+            for key in registration.auth.env_keys
+            if not (env.get(key) or "").strip()
+        )
+        keys_repr = ", ".join(missing) if missing else "(none)"
+        return f"missing env keys: {keys_repr}"
+    if state is ProviderAvailability.DISABLED_BY_FLAG:
+        flag = registration.auth.enable_flag or "(no flag)"
+        return f"flag {flag} not truthy"
+    if state is ProviderAvailability.AVAILABLE:
+        bits = []
+        if registration.auth.env_keys:
+            bits.append("env keys present")
+        if registration.auth.enable_flag:
+            bits.append(f"{registration.auth.enable_flag}=true")
+        if not bits:
+            bits.append("no auth contract")
+        return "live (" + ", ".join(bits) + ")"
+    return state.value  # pragma: no cover — defensive
 
 
 # ---------------------------------------------------------------------------
@@ -136,11 +231,90 @@ def route_refresh_plan(
             decision=entry.decision,
             reason=entry.reason,
             next_eligible_at=getattr(entry, "next_eligible_at", None),
+            transport_reason=_explain_transport_choice(source),
+            availability_reason=_explain_availability(
+                registration, env=env_map, state=availability
+            ),
         )
 
     due_routed = tuple(c for c in (_build(e) for e in plan.due) if c)
     skipped_routed = tuple(c for c in (_build(e) for e in plan.skipped) if c)
     return due_routed, skipped_routed
+
+
+# ---------------------------------------------------------------------------
+# refresh_plan_status — operator-friendly bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RefreshPlanStatus:
+    """One-shot bundle of "what's about to run + what's blocked" for a tick.
+
+    Threads three observables together:
+
+      * ``due`` / ``skipped`` — :class:`RoutedRefreshCandidate` lists
+        from :func:`route_refresh_plan`.
+      * ``availability`` — the registry's
+        :class:`ProviderAvailabilitySummary` so the dashboard can
+        show "5 transports live, 2 disabled by flag" alongside the
+        per-source decision.
+
+    The background refresh planner can dump this to JSON for the
+    operator log on every tick — one snapshot answers "will this
+    tick fetch anything? if not, what env is missing?".
+    """
+
+    role: str
+    now_iso: str
+    due: Tuple[RoutedRefreshCandidate, ...]
+    skipped: Tuple[RoutedRefreshCandidate, ...]
+    availability: ProviderAvailabilitySummary
+
+    @property
+    def transports_due(self) -> Tuple[str, ...]:
+        # Sorted unique transports the runner will actually call.
+        return tuple(
+            sorted({c.transport.value for c in self.due})
+        )
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "role": self.role,
+            "now": self.now_iso,
+            "transports_due": list(self.transports_due),
+            "due": [c.to_payload() for c in self.due],
+            "skipped": [c.to_payload() for c in self.skipped],
+            "availability": self.availability.to_payload(),
+        }
+
+
+def refresh_plan_status(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+) -> RefreshPlanStatus:
+    """Pure helper: route *plan* and bundle the registry availability.
+
+    Single call point for the background refresh planner — it gets
+    routed candidates *and* the registry summary in one go without
+    having to thread the registry/env through twice.
+    """
+
+    reg = registry if registry is not None else default_registry()
+    env_map: Mapping[str, str] = dict(env or {})
+    due, skipped = route_refresh_plan(
+        plan, role_id=role_id, registry=reg, env=env_map
+    )
+    return RefreshPlanStatus(
+        role=role_id,
+        now_iso=getattr(plan, "now_iso", ""),
+        due=due,
+        skipped=skipped,
+        availability=reg.availability_summary(env_map),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -250,8 +424,10 @@ def select_routed_due(
 
 
 __all__ = [
+    "RefreshPlanStatus",
     "RoutedRefreshCandidate",
     "axis_priority_order",
+    "refresh_plan_status",
     "route_refresh_plan",
     "select_routed_due",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
@@ -1,0 +1,257 @@
+"""Refresh-plan → provider routing.
+
+Given a :class:`RefreshPlan` from :mod:`.scheduler` and a
+:class:`KnowledgeProviderRegistry` from :mod:`.provider_registry`,
+this module annotates each entry with the transport, provider, and
+availability the orchestrator will dispatch to. It also offers a
+small re-ranker that prefers axes the role hasn't covered recently —
+so when a tick quota is tight, a chronically-unhealthy axis gets the
+slot instead of being starved by an axis that's already fresh.
+
+Strict offline. Pure functions. Tests pin behaviour deterministically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .models import SourceAxis, SourceEntry, SourceTier
+from .provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    ProviderAvailability,
+    default_registry,
+)
+from .providers import (
+    LiveProviderSpec,
+    ProviderTransport,
+    provider_spec_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Routed refresh candidate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutedRefreshCandidate:
+    """A due / skipped source enriched with provider routing.
+
+    Bundles four facts the tick runner needs for one source:
+
+      * ``source`` — the registry row (axes / role tags / content
+        policy travel with the candidate).
+      * ``spec`` — the :class:`LiveProviderSpec` (transport, endpoint,
+        parser, rate limit).
+      * ``provider`` — the registry row (auth contract, fetcher).
+      * ``availability`` — the resolved
+        :class:`ProviderAvailability` for the operator's env.
+
+    Plus the original :class:`RefreshPlanEntry` decision so the
+    caller can still distinguish ``due`` vs ``skipped_*`` without
+    re-running the planner.
+    """
+
+    source: SourceEntry
+    spec: LiveProviderSpec
+    provider: KnowledgeProviderRegistration
+    availability: ProviderAvailability
+    decision: str
+    reason: str
+    next_eligible_at: Optional[str] = None
+
+    @property
+    def axes(self) -> Tuple[SourceAxis, ...]:
+        return self.source.axes
+
+    @property
+    def transport(self) -> ProviderTransport:
+        return self.spec.transport
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source.source_id,
+            "transport": self.transport.value,
+            "provider_id": self.provider.provider_id,
+            "availability": self.availability.value,
+            "decision": self.decision,
+            "reason": self.reason,
+            "next_eligible_at": self.next_eligible_at,
+            "axes": [axis.value for axis in self.axes],
+            "auth": self.provider.auth.to_payload(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+def route_refresh_plan(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+) -> Tuple[
+    Tuple[RoutedRefreshCandidate, ...],
+    Tuple[RoutedRefreshCandidate, ...],
+]:
+    """Annotate every entry of *plan* with provider routing.
+
+    Returns ``(due_candidates, skipped_candidates)`` — both tuples of
+    :class:`RoutedRefreshCandidate`. Skipped entries also carry the
+    transport + availability so a "would have been due but provider
+    is blocked" combination is visible without recomputing.
+
+    *registry* defaults to :func:`default_registry` so the simplest
+    call site (``route_refresh_plan(plan, role_id=role)``) still
+    resolves to the seeded contract.
+
+    Pure function. The orchestrator threads a registry it constructed
+    once at startup plus the env mapping it already evaluated for
+    other components.
+    """
+
+    from .source_registry import role_sources  # local import keeps cycles out
+
+    reg = registry if registry is not None else default_registry()
+    sources_by_id = {s.source_id: s for s in role_sources(role_id)}
+    env_map: Mapping[str, str] = dict(env or {})
+
+    def _build(entry: Any) -> Optional[RoutedRefreshCandidate]:
+        source = sources_by_id.get(entry.source_id)
+        if source is None:
+            return None
+        spec = provider_spec_for(source)
+        registration = reg.get(spec.transport)
+        availability = registration.evaluate_availability(env_map)
+        return RoutedRefreshCandidate(
+            source=source,
+            spec=spec,
+            provider=registration,
+            availability=availability,
+            decision=entry.decision,
+            reason=entry.reason,
+            next_eligible_at=getattr(entry, "next_eligible_at", None),
+        )
+
+    due_routed = tuple(c for c in (_build(e) for e in plan.due) if c)
+    skipped_routed = tuple(c for c in (_build(e) for e in plan.skipped) if c)
+    return due_routed, skipped_routed
+
+
+# ---------------------------------------------------------------------------
+# axis_priority_order
+# ---------------------------------------------------------------------------
+
+
+_AVAILABILITY_RANK: Mapping[ProviderAvailability, int] = {
+    ProviderAvailability.AVAILABLE: 0,
+    ProviderAvailability.NO_LIVE_IMPL: 1,
+    ProviderAvailability.MANUAL_ONLY: 2,
+    ProviderAvailability.DISABLED_BY_FLAG: 3,
+    ProviderAvailability.MISSING_ENV: 4,
+}
+
+
+_TIER_RANK: Mapping[SourceTier, int] = {
+    SourceTier.TIER_1: 0,
+    SourceTier.TIER_2: 1,
+    SourceTier.TIER_3: 2,
+    SourceTier.TIER_4: 3,
+}
+
+
+def axis_priority_order(
+    candidates: Sequence[RoutedRefreshCandidate],
+    *,
+    overdue_axes: Sequence[str] = (),
+) -> Tuple[RoutedRefreshCandidate, ...]:
+    """Re-rank *candidates* so axes that are overdue come first.
+
+    Goal: when tick quota is tight, the slot goes to a source whose
+    axis hasn't been refreshed in the longest time. A chronically
+    broken axis surfaces fresh items first instead of being starved
+    by an already-healthy axis.
+
+    Tie-breakers (after axis health):
+      * provider availability — ``AVAILABLE`` first (keep live
+        bandwidth hot once it's actually live).
+      * source tier — Tier 1 first (officially-trusted wins ties).
+      * source_id alphabetical — for determinism in tests / replay.
+
+    Pass :func:`scheduler.overdue_axes_for_role` output directly as
+    *overdue_axes* — those are the axis values (string form) the
+    planner already considers stale.
+    """
+
+    overdue_set = set(overdue_axes)
+
+    def _hits_overdue_axis(c: RoutedRefreshCandidate) -> int:
+        # 0 = at least one axis is overdue (rank first), 1 otherwise.
+        for axis in c.axes:
+            if axis.value in overdue_set:
+                return 0
+        return 1
+
+    def _key(c: RoutedRefreshCandidate) -> Tuple[int, int, int, str]:
+        return (
+            _hits_overdue_axis(c),
+            _AVAILABILITY_RANK.get(c.availability, 99),
+            _TIER_RANK.get(c.source.tier, 99),
+            c.source.source_id,
+        )
+
+    return tuple(sorted(candidates, key=_key))
+
+
+# ---------------------------------------------------------------------------
+# Convenience: plan + route + axis priority + quota in one call
+# ---------------------------------------------------------------------------
+
+
+def select_routed_due(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+    overdue_axes: Sequence[str] = (),
+    tick_quota: Optional[int] = None,
+) -> Tuple[
+    Tuple[RoutedRefreshCandidate, ...],
+    Tuple[RoutedRefreshCandidate, ...],
+]:
+    """One-call helper: route *plan*, axis-prioritise, then truncate.
+
+    Returns ``(selected_due, deferred_due)`` — *selected_due* are the
+    candidates that fit under *tick_quota* after axis priority,
+    *deferred_due* are the rest (still due, but not picked this tick).
+
+    *tick_quota* is the cap applied *after* axis prioritisation. When
+    ``None`` no cap is applied (the planner already truncated). When
+    set, the operator can run ``compute_refresh_plan(..., tick_quota=-1)``
+    to disable the planner's cap and re-cap here using axis-aware
+    ordering. Skipped entries from the original plan are returned
+    separately via :func:`route_refresh_plan`; this helper focuses on
+    the "due" side only.
+    """
+
+    due, _ = route_refresh_plan(
+        plan, role_id=role_id, registry=registry, env=env
+    )
+    ordered = axis_priority_order(due, overdue_axes=overdue_axes)
+    if tick_quota is None or tick_quota < 0:
+        return ordered, ()
+    return ordered[:tick_quota], ordered[tick_quota:]
+
+
+__all__ = [
+    "RoutedRefreshCandidate",
+    "axis_priority_order",
+    "route_refresh_plan",
+    "select_routed_due",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/providers.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/providers.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Mapping, Optional, Protocol, Tuple
+from typing import Any, List, Mapping, Optional, Protocol, Sequence, Tuple
 
 from .models import (
     CollectionMode,
@@ -310,7 +310,57 @@ class StubLiveSourceFetcher:
         return ()
 
 
+# ---------------------------------------------------------------------------
+# Deterministic fixture-based fake — used by the provider registry seed
+# ---------------------------------------------------------------------------
+
+
+class FakeKnowledgeProvider:
+    """Fixture-based fake fetcher — returns items keyed on source_id.
+
+    Sits between :class:`StubLiveSourceFetcher` (records, returns empty)
+    and a real live provider (network). Tests / dev / cost-safe
+    operator runs use this so the registry resolves to a *fetcher
+    that produces predictable items* even when no live impl is
+    wired.
+
+    The contract intentionally matches :class:`LiveSourceFetcher`:
+    the orchestrator tick code calls one Protocol regardless of
+    whether bytes came from disk, fixture, or HTTP.
+    """
+
+    def __init__(
+        self,
+        payload: Optional[Mapping[str, Sequence[EngineeringKnowledgeItem]]] = None,
+    ) -> None:
+        self._payload: dict[str, Tuple[EngineeringKnowledgeItem, ...]] = {
+            source_id: tuple(items)
+            for source_id, items in (payload or {}).items()
+        }
+        self.calls: List[Tuple[str, ProviderTransport]] = []
+
+    def with_fixture(
+        self,
+        source_id: str,
+        items: Sequence[EngineeringKnowledgeItem],
+    ) -> "FakeKnowledgeProvider":
+        """Add / replace the fixture for *source_id*. Returns self."""
+
+        self._payload[source_id] = tuple(items)
+        return self
+
+    def __call__(
+        self,
+        spec: LiveProviderSpec,
+        *,
+        source: SourceEntry,
+    ) -> Tuple[EngineeringKnowledgeItem, ...]:
+        self.calls.append((source.source_id, spec.transport))
+        return self._payload.get(source.source_id, ())
+
+
 __all__ = [
+    "FakeKnowledgeProvider",
     "LiveProviderSpec",
     "LiveSourceFetcher",
     "ProviderTransport",

--- a/src/yule_orchestrator/agents/engineering_intelligence/providers.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/providers.py
@@ -1,0 +1,320 @@
+"""Live provider seam for the engineering_intelligence collector.
+
+The existing :class:`SourceCollectorAdapter` Protocol in :mod:`.collector`
+takes a :class:`SourceEntry` and returns items. That covers the
+"adapter" half — but production needs to know *how* to fetch each
+source: an RSS feed gets one URL, a sitemap gets a different parse,
+GitHub releases hit the API. This module owns the *transport spec*
+half so a future runtime can dispatch the right code path without
+re-deriving it from the registry every time.
+
+Design choices:
+
+  * The spec is pure data — no transport code lives here. The actual
+    HTTP/API client lives in a follow-up module (``providers_live.py``)
+    that downstream G6 wires up.
+  * Every spec carries its parser hint (``parser="rss"`` / ``"atom"``
+    / ``"sitemap"`` / ``"html_list"`` / ``"github_releases"``) so the
+    fetcher knows which decoder to invoke.
+  * :func:`provider_spec_for` is the single dispatch point. New
+    sources don't need bespoke wiring — they pick a transport at
+    registry time via ``collection_mode``.
+
+Strict offline. Absolutely no urllib / requests / socket import here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, List, Mapping, Optional, Protocol, Tuple
+
+from .models import (
+    CollectionMode,
+    EngineeringKnowledgeItem,
+    SourceEntry,
+    SourceKind,
+)
+
+
+# ---------------------------------------------------------------------------
+# Provider transport classification
+# ---------------------------------------------------------------------------
+
+
+class ProviderTransport(str, Enum):
+    """How a source's bytes arrive at the runtime.
+
+    Mapped 1:1 from :class:`CollectionMode` so the registry stays the
+    single source of truth — the transport is derivable from the mode
+    plus a couple of URL heuristics (atom vs rss; github releases
+    sitting under ``releases.atom``).
+    """
+
+    RSS = "rss"
+    ATOM = "atom"
+    SITEMAP = "sitemap"
+    HTML_LIST = "html_list"
+    HTML_DETAIL = "html_detail"
+    GITHUB_RELEASES_ATOM = "github_releases_atom"
+    GITHUB_API_REPO_ACTIVITY = "github_api_repo_activity"
+    MANUAL = "manual"
+
+
+# ---------------------------------------------------------------------------
+# Spec dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveProviderSpec:
+    """Recipe a future fetcher uses to pull from one source.
+
+    Carries no secrets — just the public URL + headers seed. The
+    fetcher layer is responsible for adding ``Authorization: Bearer …``
+    when the env supplies tokens. Per-source rate limits are stored
+    here so the operator can tune them without touching the registry.
+    """
+
+    source_id: str
+    transport: ProviderTransport
+    endpoint: str
+    parser: str
+    rate_limit_per_minute: int = 30
+    requested_user_agent: str = "yule-engineering-intelligence/0.1 (+contact: operator)"
+    request_headers_seed: Mapping[str, str] = field(default_factory=dict)
+    requires_auth_env: Tuple[str, ...] = ()
+    notes: str = ""
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "transport": self.transport.value,
+            "endpoint": self.endpoint,
+            "parser": self.parser,
+            "rate_limit_per_minute": int(self.rate_limit_per_minute),
+            "user_agent": self.requested_user_agent,
+            "request_headers_seed": dict(self.request_headers_seed),
+            "requires_auth_env": list(self.requires_auth_env),
+            "notes": self.notes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Live provider Protocol — what a future runtime impl must satisfy
+# ---------------------------------------------------------------------------
+
+
+class LiveSourceFetcher(Protocol):
+    """Protocol the future fetcher implementations satisfy.
+
+    Each impl reads ``LiveProviderSpec.endpoint`` over the right
+    transport, parses the bytes per ``parser``, and yields
+    :class:`EngineeringKnowledgeItem` candidates. Implementations
+    must:
+
+      * Block at most a few seconds per call (the orchestrator runs
+        adapters sequentially; long fetches stall the tick).
+      * Never raise on transport errors — return an empty tuple and
+        let the orchestrator's ``warn`` log it so the scheduler can
+        record the failure and back off.
+      * Never reproduce full source body — only summary + URL +
+        light snippets that fit the renderer's content policy.
+    """
+
+    def __call__(
+        self,
+        spec: LiveProviderSpec,
+        *,
+        source: SourceEntry,
+    ) -> Tuple[EngineeringKnowledgeItem, ...]:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_atom(url: str) -> bool:
+    return ".atom" in url or url.endswith("/atom")
+
+
+def _looks_like_github_releases(url: str) -> bool:
+    return "github.com/" in url and "/releases" in url
+
+
+def provider_spec_for(source: SourceEntry) -> LiveProviderSpec:
+    """Build the :class:`LiveProviderSpec` for *source*.
+
+    Heuristic but deterministic:
+
+      * ``MANUAL`` → manual transport (no fetch).
+      * ``GITHUB_API`` → repo activity (issues/releases) via REST API.
+      * ``RSS`` + ``.atom`` URL → ATOM (parser distinguishes, transport
+        is the same fetch).
+      * ``RSS`` + GitHub releases URL → GITHUB_RELEASES_ATOM bucket
+        so the fetcher can fast-path version cleanup.
+      * ``SITEMAP`` → SITEMAP transport with sitemap parser.
+      * ``HTML_LIST`` / ``HTML_DETAIL`` map to themselves.
+
+    Rate limits default conservatively — operators bump them up after
+    a manual probe.
+    """
+
+    base_seed: dict[str, str] = {}
+
+    mode = source.collection_mode
+    url = source.base_url
+
+    if mode is CollectionMode.MANUAL:
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=ProviderTransport.MANUAL,
+            endpoint=url,
+            parser="manual",
+            rate_limit_per_minute=0,
+            request_headers_seed=base_seed,
+            notes=(
+                "MANUAL — operator must register knowledge items by hand."
+            ),
+        )
+
+    if mode is CollectionMode.GITHUB_API:
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            endpoint=url,
+            parser="github_api",
+            rate_limit_per_minute=30,
+            request_headers_seed={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            requires_auth_env=("YULE_GITHUB_APP_ID",),
+            notes=(
+                "Backed by the existing GitHub App client; private repo "
+                "endpoints fail closed without the App env triple."
+            ),
+        )
+
+    if mode is CollectionMode.RSS and _looks_like_github_releases(url):
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=ProviderTransport.GITHUB_RELEASES_ATOM,
+            endpoint=url,
+            parser="atom",
+            rate_limit_per_minute=20,
+            request_headers_seed={"Accept": "application/atom+xml"},
+            notes=(
+                "GitHub releases atom feed — keep cadence ≤ 20/min to "
+                "stay well under the unauthenticated rate limit."
+            ),
+        )
+
+    if mode is CollectionMode.RSS:
+        transport = (
+            ProviderTransport.ATOM if _looks_like_atom(url) else ProviderTransport.RSS
+        )
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=transport,
+            endpoint=url,
+            parser=transport.value,
+            rate_limit_per_minute=30,
+            request_headers_seed={
+                "Accept": "application/rss+xml, application/atom+xml;q=0.9",
+            },
+        )
+
+    if mode is CollectionMode.SITEMAP:
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=ProviderTransport.SITEMAP,
+            endpoint=url,
+            parser="sitemap",
+            rate_limit_per_minute=10,
+            request_headers_seed={"Accept": "application/xml"},
+            notes=(
+                "Sitemap walks are heavier — keep cadence low, diff "
+                "against previous lastmod to skip unchanged sub-pages."
+            ),
+        )
+
+    if mode is CollectionMode.HTML_LIST:
+        return LiveProviderSpec(
+            source_id=source.source_id,
+            transport=ProviderTransport.HTML_LIST,
+            endpoint=url,
+            parser="html_list",
+            rate_limit_per_minute=15,
+            request_headers_seed={"Accept": "text/html"},
+            notes=(
+                "Index-page scrape. Parser must respect the source's "
+                "content_policy — link + summary only."
+            ),
+        )
+
+    # HTML_DETAIL fallback — used by ad-hoc crawl-once entries.
+    return LiveProviderSpec(
+        source_id=source.source_id,
+        transport=ProviderTransport.HTML_DETAIL,
+        endpoint=url,
+        parser="html_detail",
+        rate_limit_per_minute=5,
+        request_headers_seed={"Accept": "text/html"},
+        notes=(
+            "Detail-page fetch is the slowest path — call only when "
+            "list/sitemap mode missed the item."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: precompute specs for an entire role
+# ---------------------------------------------------------------------------
+
+
+def specs_for_role(role_id: str) -> Tuple[LiveProviderSpec, ...]:
+    """Bundle every source spec for *role_id* in registry order."""
+
+    from .source_registry import role_sources
+
+    return tuple(provider_spec_for(s) for s in role_sources(role_id))
+
+
+# ---------------------------------------------------------------------------
+# Dry-run "stub" fetcher — useful for CI smoke and developer sanity
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubLiveSourceFetcher:
+    """Records every spec it was called with, returns empty.
+
+    Mirrors :class:`FakeSourceCollectorAdapter` but at the spec level.
+    Useful when verifying that a future scheduler wiring picked the
+    expected transport per source without standing up a real HTTP
+    client.
+    """
+
+    seen: List[LiveProviderSpec] = field(default_factory=list)
+
+    def __call__(
+        self,
+        spec: LiveProviderSpec,
+        *,
+        source: SourceEntry,
+    ) -> Tuple[EngineeringKnowledgeItem, ...]:
+        self.seen.append(spec)
+        return ()
+
+
+__all__ = [
+    "LiveProviderSpec",
+    "LiveSourceFetcher",
+    "ProviderTransport",
+    "StubLiveSourceFetcher",
+    "provider_spec_for",
+    "specs_for_role",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/renderer.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/renderer.py
@@ -35,6 +35,7 @@ from typing import List, Optional, Sequence
 from .models import (
     ENGINEERING_KNOWLEDGE_CONTRACT,
     EngineeringKnowledgeItem,
+    KnowledgeShareScope,
 )
 
 
@@ -104,7 +105,14 @@ def _yaml_list(values: Sequence[str]) -> str:
 
 
 def render_frontmatter(item: EngineeringKnowledgeItem) -> str:
-    """Build the YAML frontmatter block (no leading/trailing markers)."""
+    """Build the YAML frontmatter block (no leading/trailing markers).
+
+    ``share_scope`` is stamped into the frontmatter so vault tooling
+    (memory indexer, archive sync, Discord digest) can decide whether
+    an item's body is safe to ship outside the vault. The body
+    renderer separately blanks restricted sections — frontmatter alone
+    is the discovery hint, never the enforcement.
+    """
 
     lines: List[str] = [
         f"title: {_quote(item.title)}",
@@ -122,6 +130,8 @@ def render_frontmatter(item: EngineeringKnowledgeItem) -> str:
         f"retrieval_queries: {_yaml_list(item.retrieval_queries)}",
         f"collected_at: {_quote(item.collected_at)}",
         f"review_after_days: {int(item.review_after_days)}",
+        f"share_scope: {_quote(item.share_scope.value)}",
+        f"share_scope_reason: {_quote(item.share_scope_reason)}",
         f"project: {_quote('yule-studio-agent')}",
         f"contract: {ENGINEERING_KNOWLEDGE_CONTRACT}",
         f"dedup_key: {_quote(item.dedup_key)}",
@@ -147,7 +157,31 @@ _REQUIRED_SECTIONS: tuple[str, ...] = (
     "10. 완료 기준",
     "11. 자주 하는 실수",
     "12. RAG/CAG 메타데이터",
-    "13. 참고 자료",
+    "13. 공유 가능 범위",
+    "14. 참고 자료",
+)
+
+
+# Sections we redact (replace body with a one-line placeholder) when
+# ``share_scope == RESTRICTED``. The L1 vault note still exists so the
+# operator can find it, but external surface payloads that copy any of
+# these sections by index won't accidentally leak content.
+_RESTRICTED_REDACTED_SECTION_INDEXES: tuple[int, ...] = (
+    1,   # 핵심 요약
+    2,   # 배경
+    3,   # 무엇이 바뀌었나
+    4,   # 왜 중요한가
+    5,   # 실무 영향
+    6,   # 권장 대응
+    7,   # 실습 주제
+    8,   # 실습 과정
+    9,   # 완료 기준
+    10,  # 자주 하는 실수
+)
+
+
+_RESTRICTED_PLACEHOLDER = (
+    "_공개 제한된 자료입니다 — 본문은 vault 내부 채널에서만 공유하세요._"
 )
 
 
@@ -341,8 +375,58 @@ def _render_rag_cag(item: EngineeringKnowledgeItem) -> str:
     return "\n".join(parts)
 
 
-def _render_references(item: EngineeringKnowledgeItem) -> str:
+_SHARE_SCOPE_LABELS: dict[KnowledgeShareScope, str] = {
+    KnowledgeShareScope.PUBLIC: (
+        "공개 가능 — 외부 surface(Discord 다이제스트, PR 본문, 합성 응답)에 "
+        "본문 요약과 함께 인용해도 된다"
+    ),
+    KnowledgeShareScope.TEAM_INTERNAL: (
+        "팀 내부 한정 — Obsidian vault 내에서만 본문 열람. 외부 채널에는 "
+        "제목 + 출처 링크 + share_scope 표시까지만 노출"
+    ),
+    KnowledgeShareScope.RESTRICTED: (
+        "공개 제한 — 본문 전체를 외부 surface 로 옮기지 않는다. "
+        "vault 안에서도 요약 1~2줄과 share_scope_reason 만 보존"
+    ),
+}
+
+
+_SHARE_SCOPE_EXTERNAL_RULES: dict[KnowledgeShareScope, tuple[str, ...]] = {
+    KnowledgeShareScope.PUBLIC: (
+        "Discord digest / 합성 응답에 제목·요약·source_url 인용 가능",
+        "PR 본문에 references 항목으로 그대로 추가 가능",
+    ),
+    KnowledgeShareScope.TEAM_INTERNAL: (
+        "외부 surface 에는 제목 + source_url + 'team-internal' 라벨만 노출",
+        "본문 요약은 합성 응답에 직접 인용하지 않는다 — vault link 로 우회",
+        "PR 본문 references 에 포함할 때 'internal-only' 노트와 함께",
+    ),
+    KnowledgeShareScope.RESTRICTED: (
+        "외부 surface 에는 '공개 제한된 자료 1건' 신호만 노출",
+        "본문/실습 단계 어떤 형태로도 chat·PR·로그에 인용 금지",
+        "공유가 필요하면 운영자가 별도 보안 채널에서 수동 전달",
+    ),
+}
+
+
+def _render_share_scope(item: EngineeringKnowledgeItem) -> str:
     parts: List[str] = [_section_header(_REQUIRED_SECTIONS[12])]
+    label = _SHARE_SCOPE_LABELS.get(
+        item.share_scope, item.share_scope.value
+    )
+    parts.append(f"- **share_scope**: `{item.share_scope.value}` — {label}")
+    if item.share_scope_reason:
+        parts.append(
+            f"- **share_scope_reason**: {_redact(item.share_scope_reason)}"
+        )
+    parts.append("- **외부 surface 노출 규칙**:")
+    for rule in _SHARE_SCOPE_EXTERNAL_RULES.get(item.share_scope, ()):
+        parts.append(f"  - {rule}")
+    return "\n".join(parts)
+
+
+def _render_references(item: EngineeringKnowledgeItem) -> str:
+    parts: List[str] = [_section_header(_REQUIRED_SECTIONS[13])]
     parts.append(f"- 출처: [{_redact(item.source_name)}]({_redact(item.source_url)})")
     for ref in item.references:
         if ref:
@@ -386,6 +470,13 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
 
     Raises :class:`RendererError` when the item violates one of the
     hard contracts (empty body, missing source, missing practice).
+
+    When ``item.share_scope == KnowledgeShareScope.RESTRICTED`` the
+    learning-body sections are replaced with a one-line placeholder so
+    the vault note still tracks the topic but no body content can be
+    copied to an external surface. The Overview / RAG-CAG metadata /
+    공유 가능 범위 / References sections still render — they are
+    structural pointers, not body content.
     """
 
     if not item.title.strip():
@@ -402,6 +493,30 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
         m.strip() for m in item.common_mistakes
     ):
         raise RendererError("common_mistakes must have at least 1 non-empty entry")
+    if (
+        item.share_scope == KnowledgeShareScope.RESTRICTED
+        and not item.share_scope_reason.strip()
+    ):
+        raise RendererError(
+            "share_scope=RESTRICTED requires share_scope_reason"
+        )
+
+    body_renderers = [
+        _render_overview,        # 0 — structural, keep
+        _render_summary,         # 1 — body
+        _render_background,      # 2 — body
+        _render_what_changed,    # 3 — body
+        _render_why_important,   # 4 — body
+        _render_practical_impact,# 5 — body
+        _render_recommended,     # 6 — body
+        _render_practice_topic,  # 7 — body
+        _render_practice_steps,  # 8 — body
+        _render_completion,      # 9 — body
+        _render_common_mistakes, # 10 — body
+        _render_rag_cag,         # 11 — metadata, keep
+        _render_share_scope,     # 12 — share-scope, keep
+        _render_references,      # 13 — references, keep
+    ]
 
     blocks: List[str] = []
     blocks.append("---")
@@ -412,32 +527,17 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
     blocks.append("")
     blocks.append(_toc())
     blocks.append("")
-    blocks.append(_render_overview(item))
-    blocks.append("")
-    blocks.append(_render_summary(item))
-    blocks.append("")
-    blocks.append(_render_background(item))
-    blocks.append("")
-    blocks.append(_render_what_changed(item))
-    blocks.append("")
-    blocks.append(_render_why_important(item))
-    blocks.append("")
-    blocks.append(_render_practical_impact(item))
-    blocks.append("")
-    blocks.append(_render_recommended(item))
-    blocks.append("")
-    blocks.append(_render_practice_topic(item))
-    blocks.append("")
-    blocks.append(_render_practice_steps(item))
-    blocks.append("")
-    blocks.append(_render_completion(item))
-    blocks.append("")
-    blocks.append(_render_common_mistakes(item))
-    blocks.append("")
-    blocks.append(_render_rag_cag(item))
-    blocks.append("")
-    blocks.append(_render_references(item))
-    blocks.append("")
+
+    restricted = item.share_scope == KnowledgeShareScope.RESTRICTED
+    for index, renderer in enumerate(body_renderers):
+        if restricted and index in _RESTRICTED_REDACTED_SECTION_INDEXES:
+            blocks.append(
+                f"{_section_header(_REQUIRED_SECTIONS[index])}\n"
+                f"{_RESTRICTED_PLACEHOLDER}"
+            )
+        else:
+            blocks.append(renderer(item))
+        blocks.append("")
     return "\n".join(blocks)
 
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
@@ -48,6 +48,7 @@ from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 from .models import (
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     SourceAxis,
 )
 from .source_registry import axis_hints_for_task_type
@@ -81,6 +82,8 @@ class KnowledgeRecord:
     note_path: Optional[str] = None
     project: Optional[str] = None
     secondary_roles: Tuple[str, ...] = ()
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC
+    share_scope_reason: str = ""
 
     @classmethod
     def from_item(
@@ -112,6 +115,8 @@ class KnowledgeRecord:
             collected_at=item.collected_at,
             note_path=note_path,
             secondary_roles=tuple(secondary_roles),
+            share_scope=item.share_scope,
+            share_scope_reason=item.share_scope_reason,
         )
 
     def to_payload(self) -> Mapping[str, Any]:
@@ -129,6 +134,8 @@ class KnowledgeRecord:
             "note_path": self.note_path,
             "project": self.project,
             "secondary_roles": list(self.secondary_roles),
+            "share_scope": self.share_scope.value,
+            "share_scope_reason": self.share_scope_reason,
         }
 
 
@@ -144,6 +151,52 @@ class KnowledgeMatch:
     record: KnowledgeRecord
     score: float
     signals: Tuple[str, ...]
+
+    def evidence_labels(self) -> Tuple[str, ...]:
+        """Return the score signals as human-readable Korean labels.
+
+        The raw signals are short tokens optimised for tests
+        (``role_primary_match``, ``axis_overlap:security,...``,
+        ``importance_critical``, ``fresh_7d``). For Obsidian /
+        Discord surfaces we want labels a human can read. This is a
+        deterministic projection — no I/O, no formatting beyond
+        ``label_for_signal``.
+        """
+
+        return tuple(label_for_signal(sig) for sig in self.signals if sig)
+
+
+def label_for_signal(signal: str) -> str:
+    """Map a retrieval signal token to a Korean label.
+
+    Unknown signals fall through with a leading "기타: " prefix so the
+    operator can still see the raw token without mistaking it for a
+    typo. Axis overlap signals carry a comma-separated list of axes;
+    we keep the axis names verbatim because they're structured tokens
+    the operator already understands.
+    """
+
+    if not signal:
+        return ""
+    if signal.startswith("axis_overlap:"):
+        axes = signal.split(":", 1)[1]
+        return f"task_type 축 일치 ({axes})"
+    if signal.startswith("topic_overlap:"):
+        count = signal.split(":", 1)[1]
+        return f"질문 토큰 겹침 (+{count})"
+    return _KNOWN_SIGNAL_LABELS.get(signal, f"기타: {signal}")
+
+
+_KNOWN_SIGNAL_LABELS: Mapping[str, str] = {
+    "role_primary_match": "요청 역할과 정확히 일치",
+    "role_secondary_match": "요청 역할이 보조 역할로 등록됨",
+    "importance_critical": "중요도 critical",
+    "importance_high": "중요도 high",
+    "importance_low": "중요도 low (감점)",
+    "fresh_7d": "최근 7일 이내 수집",
+    "fresh_30d": "최근 30일 이내 수집",
+    "empty_body_penalty": "본문/태그 비어 있음 (감점)",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -399,6 +452,11 @@ def _coerce_record(candidate: Any) -> Optional[KnowledgeRecord]:
             importance = Importance(importance_raw)
         except ValueError:
             importance = Importance.MEDIUM
+        share_raw = candidate.get("share_scope") or "public"
+        try:
+            share_scope = KnowledgeShareScope(share_raw)
+        except ValueError:
+            share_scope = KnowledgeShareScope.PUBLIC
         return KnowledgeRecord(
             topic_key=topic_key,
             title=title,
@@ -413,6 +471,8 @@ def _coerce_record(candidate: Any) -> Optional[KnowledgeRecord]:
             note_path=candidate.get("note_path"),
             project=candidate.get("project"),
             secondary_roles=tuple(candidate.get("secondary_roles") or ()),
+            share_scope=share_scope,
+            share_scope_reason=str(candidate.get("share_scope_reason") or ""),
         )
     return None
 
@@ -421,5 +481,6 @@ __all__ = [
     "KnowledgeMatch",
     "KnowledgeRecord",
     "KnowledgeRetriever",
+    "label_for_signal",
     "score_knowledge_record",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
@@ -1,0 +1,425 @@
+"""Request-time knowledge retrieval — pick top-k items for a request.
+
+Master plan §6.2 (request-time retrieval) needs the discussion layer
+to surface "what does the company already know about this topic /
+role / task_type?" without dumping every collected item into the
+prompt. This module owns that selection step.
+
+Two surfaces:
+
+  1. :class:`KnowledgeRecord` — lightweight projection of a stored
+     :class:`EngineeringKnowledgeItem`. Carries only what the
+     synthesizer needs (title / source url / role / axes / rag tags /
+     summary / freshness / importance / source name + topic key).
+     Built either from an :class:`EngineeringKnowledgeItem`
+     (``KnowledgeRecord.from_item``) or directly from a vault index
+     row.
+  2. :class:`KnowledgeRetriever` — callable that takes a candidate
+     iterable + (query / role / task_type / axis_hints) and returns
+     the top-k records by score. Score combines:
+
+       * role match (+3 if the record's role equals the requested
+         role, +1 if it's covered as a "secondary" role tag).
+       * axis hint match (+2 per axis the record covers from
+         ``axis_hints_for_task_type(task_type)``).
+       * topic / rag-tag overlap (+1 per overlap, capped at +3).
+       * importance bonus (critical=+2, high=+1).
+       * freshness bonus (collected within the last 7 days = +1,
+         within 30 days = +0.5).
+       * empty summary penalty (−1).
+
+The score numbers are deterministic and additive so tests can pin
+exact ordering. The synthesizer can use the same
+:class:`KnowledgeMatch` envelope to surface "why this knowledge item
+was selected" alongside the body.
+
+Strict no-I/O. Vault lookup is the caller's job — they hand in
+candidates via the ``knowledge_loader`` seam on
+:class:`ContextPackBuilder`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceAxis,
+)
+from .source_registry import axis_hints_for_task_type
+
+
+# ---------------------------------------------------------------------------
+# Lightweight projection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KnowledgeRecord:
+    """Per-item info the discussion layer cares about.
+
+    Designed to be cheap to construct from either an in-memory
+    :class:`EngineeringKnowledgeItem` or a vault index row. All fields
+    have defaults so partial rows still flow through scoring (they
+    just earn fewer points).
+    """
+
+    topic_key: str
+    title: str
+    role: str
+    source_url: str = ""
+    source_name: str = ""
+    summary: str = ""
+    axes: Tuple[SourceAxis, ...] = ()
+    rag_tags: Tuple[str, ...] = ()
+    importance: Importance = Importance.MEDIUM
+    collected_at: str = ""  # ISO-8601
+    note_path: Optional[str] = None
+    project: Optional[str] = None
+    secondary_roles: Tuple[str, ...] = ()
+
+    @classmethod
+    def from_item(
+        cls,
+        item: EngineeringKnowledgeItem,
+        *,
+        axes: Sequence[SourceAxis] = (),
+        secondary_roles: Sequence[str] = (),
+        note_path: Optional[str] = None,
+    ) -> "KnowledgeRecord":
+        """Build from a stored :class:`EngineeringKnowledgeItem`.
+
+        ``axes`` comes from the source registry — caller looks up the
+        item's source by name and copies its axis tuple in. We don't
+        store axes on the item itself because an item is bound to a
+        source's *knowledge*, not the source's transport metadata.
+        """
+
+        return cls(
+            topic_key=item.topic_key,
+            title=item.title,
+            role=item.role,
+            source_url=item.source_url,
+            source_name=item.source_name,
+            summary=item.summary,
+            axes=tuple(axes),
+            rag_tags=tuple(item.rag_tags),
+            importance=item.importance,
+            collected_at=item.collected_at,
+            note_path=note_path,
+            secondary_roles=tuple(secondary_roles),
+        )
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "topic_key": self.topic_key,
+            "title": self.title,
+            "role": self.role,
+            "source_url": self.source_url,
+            "source_name": self.source_name,
+            "summary": self.summary,
+            "axes": [axis.value for axis in self.axes],
+            "rag_tags": list(self.rag_tags),
+            "importance": self.importance.value,
+            "collected_at": self.collected_at,
+            "note_path": self.note_path,
+            "project": self.project,
+            "secondary_roles": list(self.secondary_roles),
+        }
+
+
+@dataclass(frozen=True)
+class KnowledgeMatch:
+    """Scored row — record + score + signals.
+
+    Used for tests and for surfacing "why this knowledge item was
+    picked" on the operator dashboard. The synthesizer can drop the
+    score / signals if it only needs the record.
+    """
+
+    record: KnowledgeRecord
+    score: float
+    signals: Tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_PATTERN = re.compile(r"[\w가-힣]+", re.UNICODE)
+
+
+def _tokens(text: Optional[str]) -> set[str]:
+    if not text:
+        return set()
+    return {tok.lower() for tok in _TOKEN_PATTERN.findall(text) if len(tok) >= 2}
+
+
+def _normalize_role(role: Optional[str]) -> str:
+    if not role:
+        return ""
+    return role.strip().lower().split("/")[-1]
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _freshness_bonus(
+    collected_at: Optional[str], *, now: Optional[datetime] = None
+) -> Tuple[float, str]:
+    parsed = _parse_iso(collected_at)
+    if parsed is None:
+        return (0.0, "")
+    anchor = now or datetime.now(tz=timezone.utc)
+    age = anchor - parsed
+    if age <= timedelta(days=7):
+        return (1.0, "fresh_7d")
+    if age <= timedelta(days=30):
+        return (0.5, "fresh_30d")
+    return (0.0, "")
+
+
+_IMPORTANCE_BONUS: Mapping[Importance, Tuple[float, str]] = {
+    Importance.CRITICAL: (2.0, "importance_critical"),
+    Importance.HIGH: (1.0, "importance_high"),
+    Importance.MEDIUM: (0.0, ""),
+    Importance.LOW: (-0.5, "importance_low"),
+}
+
+
+def score_knowledge_record(
+    record: KnowledgeRecord,
+    *,
+    query: Optional[str] = None,
+    role: Optional[str] = None,
+    task_type: Optional[str] = None,
+    axis_hints: Sequence[SourceAxis] = (),
+    now: Optional[datetime] = None,
+) -> KnowledgeMatch:
+    """Deterministic relevance score for a single record.
+
+    *axis_hints* overrides ``axis_hints_for_task_type(task_type)`` so
+    the caller can supply a custom hint set (useful when the request
+    explicitly mentions an axis like "security").
+    """
+
+    score = 0.0
+    signals: List[str] = []
+
+    # Role match
+    requested_role = _normalize_role(role)
+    record_role = _normalize_role(record.role)
+    if requested_role and record_role:
+        if requested_role == record_role:
+            score += 3.0
+            signals.append("role_primary_match")
+        elif requested_role in {_normalize_role(r) for r in record.secondary_roles}:
+            score += 1.0
+            signals.append("role_secondary_match")
+
+    # Axis hint match
+    if not axis_hints and task_type:
+        axis_hints = axis_hints_for_task_type(task_type)
+    if axis_hints:
+        record_axes = set(record.axes)
+        overlap = record_axes & set(axis_hints)
+        if overlap:
+            score += 2.0 * len(overlap)
+            signals.append(
+                "axis_overlap:" + ",".join(sorted(a.value for a in overlap))
+            )
+
+    # Topic / rag tag overlap
+    query_tokens = _tokens(query)
+    if query_tokens:
+        haystack_tokens = (
+            _tokens(record.title)
+            | _tokens(record.summary)
+            | _tokens(record.topic_key)
+            | {t.lower() for t in record.rag_tags if t}
+        )
+        overlap = query_tokens & haystack_tokens
+        if overlap:
+            bonus = min(len(overlap), 3)
+            score += float(bonus)
+            signals.append(f"topic_overlap:{bonus}")
+
+    # Importance bonus
+    importance_bonus, importance_signal = _IMPORTANCE_BONUS.get(
+        record.importance, (0.0, "")
+    )
+    if importance_bonus:
+        score += importance_bonus
+        if importance_signal:
+            signals.append(importance_signal)
+
+    # Freshness bonus
+    fresh_bonus, fresh_signal = _freshness_bonus(record.collected_at, now=now)
+    if fresh_bonus:
+        score += fresh_bonus
+        if fresh_signal:
+            signals.append(fresh_signal)
+
+    # Empty body penalty (signal-light record)
+    if not record.summary and not record.rag_tags:
+        score -= 1.0
+        signals.append("empty_body_penalty")
+
+    return KnowledgeMatch(record=record, score=score, signals=tuple(signals))
+
+
+# ---------------------------------------------------------------------------
+# Retriever
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KnowledgeRetriever:
+    """Score + truncate candidate :class:`KnowledgeRecord` rows.
+
+    Callable: ``retriever(candidates=..., query=..., role=...,
+    task_type=..., limit=5)``. Returns a tuple of
+    :class:`KnowledgeRecord` (the synthesizer rarely needs the score).
+    Use :meth:`with_signals` when the caller wants the score signal
+    payload.
+    """
+
+    min_score: float = 1.0
+    now: Optional[datetime] = None
+
+    def __call__(
+        self,
+        *,
+        candidates: Iterable[Any],
+        query: Optional[str] = None,
+        role: Optional[str] = None,
+        task_type: Optional[str] = None,
+        limit: int = 5,
+    ) -> Tuple[KnowledgeRecord, ...]:
+        matches = self.with_signals(
+            candidates=candidates,
+            query=query,
+            role=role,
+            task_type=task_type,
+            limit=limit,
+        )
+        return tuple(match.record for match in matches)
+
+    def with_signals(
+        self,
+        *,
+        candidates: Iterable[Any],
+        query: Optional[str] = None,
+        role: Optional[str] = None,
+        task_type: Optional[str] = None,
+        limit: int = 5,
+    ) -> Tuple[KnowledgeMatch, ...]:
+        scored: List[Tuple[float, int, KnowledgeMatch]] = []
+        for idx, candidate in enumerate(candidates):
+            record = _coerce_record(candidate)
+            if record is None:
+                continue
+            match = score_knowledge_record(
+                record,
+                query=query,
+                role=role,
+                task_type=task_type,
+                now=self.now,
+            )
+            if match.score < self.min_score:
+                continue
+            # Sort: score desc, freshness desc, idx asc.
+            freshness_key = _freshness_sort_key(record.collected_at)
+            scored.append((match.score, idx, match))
+            # ``freshness_key`` is folded into the secondary key by the
+            # final sort below to keep ties deterministic.
+        scored.sort(
+            key=lambda triplet: (
+                -triplet[0],
+                _freshness_sort_key(triplet[2].record.collected_at),
+                triplet[1],
+            )
+        )
+        return tuple(match for _, _, match in scored[: max(limit, 0)])
+
+
+def _freshness_sort_key(collected_at: str) -> str:
+    """Return an ASCII key that orders newer-first when ascending."""
+
+    if not collected_at:
+        return ""
+    return "".join(
+        chr(255 - ord(c)) if ord(c) < 255 else c for c in collected_at
+    )
+
+
+def _coerce_record(candidate: Any) -> Optional[KnowledgeRecord]:
+    """Accept :class:`KnowledgeRecord` / ``EngineeringKnowledgeItem`` /
+    plain Mapping; coerce or return None.
+
+    Mappings need at least ``topic_key``, ``title``, ``role`` to count.
+    """
+
+    if isinstance(candidate, KnowledgeRecord):
+        return candidate
+    if isinstance(candidate, EngineeringKnowledgeItem):
+        return KnowledgeRecord.from_item(candidate)
+    if isinstance(candidate, Mapping):
+        topic_key = str(candidate.get("topic_key") or "").strip()
+        title = str(candidate.get("title") or "").strip()
+        role = str(candidate.get("role") or "").strip()
+        if not (topic_key and title and role):
+            return None
+        axes_raw = candidate.get("axes") or ()
+        axes: List[SourceAxis] = []
+        for ax in axes_raw:
+            try:
+                axes.append(SourceAxis(ax))
+            except ValueError:
+                continue
+        importance_raw = candidate.get("importance") or "medium"
+        try:
+            importance = Importance(importance_raw)
+        except ValueError:
+            importance = Importance.MEDIUM
+        return KnowledgeRecord(
+            topic_key=topic_key,
+            title=title,
+            role=role,
+            source_url=str(candidate.get("source_url") or ""),
+            source_name=str(candidate.get("source_name") or ""),
+            summary=str(candidate.get("summary") or ""),
+            axes=tuple(axes),
+            rag_tags=tuple(candidate.get("rag_tags") or ()),
+            importance=importance,
+            collected_at=str(candidate.get("collected_at") or ""),
+            note_path=candidate.get("note_path"),
+            project=candidate.get("project"),
+            secondary_roles=tuple(candidate.get("secondary_roles") or ()),
+        )
+    return None
+
+
+__all__ = [
+    "KnowledgeMatch",
+    "KnowledgeRecord",
+    "KnowledgeRetriever",
+    "score_knowledge_record",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/scheduler.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/scheduler.py
@@ -1,0 +1,433 @@
+"""Background research refresh planner — pure decision layer.
+
+Master plan §6.1 (Background Knowledge Loop) says role-based sources must
+keep refreshing on their own cadence so that knowledge sits in the vault
+*before* a Discord request lands. This module owns the "which sources are
+due right now?" decision:
+
+  * :class:`SourceRefreshState` — what we know about a source's last
+    successful (or failed) refresh attempt.
+  * :class:`RefreshPlanEntry` — one decision row (``due`` / ``skipped`` /
+    ``backoff``) the orchestrator can act on.
+  * :class:`RefreshPlan` — the per-role bundle returned by the planner.
+  * :func:`compute_refresh_plan` — pure function: given the current time
+    + the per-source state map, return what the next ingestion tick
+    should attempt.
+  * :func:`record_refresh_outcome` — small immutable helper to update a
+    state row after the orchestrator actually called the adapter.
+
+Strict no-I/O. The actual scheduler loop (cron / Celery beat / runtime
+spawn) lives outside this package — this module just answers "what now?"
+deterministically so tests can pin the behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
+
+from .models import SourceEntry
+from .source_registry import role_sources
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    """ISO-8601 ('YYYY-MM-DDTHH:MM:SSZ' or with offset) → aware datetime."""
+
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# State row
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceRefreshState:
+    """Persisted state for one source between refresh ticks.
+
+    The orchestrator owns persistence (sqlite / vault sidecar / in-memory
+    map). This module never reads or writes — callers pass the map in
+    and apply the returned mutations.
+
+    ``last_status``:
+
+      * ``"never"`` — source has never been attempted (the default for a
+        freshly-seeded entry; planner treats it as immediately due).
+      * ``"success"`` — last attempt produced items (may be 0 — the
+        adapter just finished without raising).
+      * ``"failure"`` — last attempt raised. ``consecutive_failures`` is
+        incremented and the planner applies an exponential backoff
+        before next retry.
+    """
+
+    source_id: str
+    last_attempted_at: Optional[str] = None
+    last_succeeded_at: Optional[str] = None
+    last_status: str = "never"
+    consecutive_failures: int = 0
+    items_collected_last_run: int = 0
+    notes: str = ""
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "last_attempted_at": self.last_attempted_at,
+            "last_succeeded_at": self.last_succeeded_at,
+            "last_status": self.last_status,
+            "consecutive_failures": int(self.consecutive_failures),
+            "items_collected_last_run": int(self.items_collected_last_run),
+            "notes": self.notes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Plan entries
+# ---------------------------------------------------------------------------
+
+
+_DECISION_DUE = "due"
+_DECISION_SKIPPED_FRESH = "skipped_fresh"
+_DECISION_SKIPPED_BACKOFF = "skipped_backoff"
+_DECISION_SKIPPED_REVIEW_REQUIRED = "skipped_review_required"
+_DECISION_SKIPPED_AUTO_COLLECT_DISABLED = "skipped_auto_collect_disabled"
+
+
+@dataclass(frozen=True)
+class RefreshPlanEntry:
+    source_id: str
+    decision: str
+    reason: str
+    next_eligible_at: Optional[str] = None
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "decision": self.decision,
+            "reason": self.reason,
+            "next_eligible_at": self.next_eligible_at,
+        }
+
+
+@dataclass(frozen=True)
+class RefreshPlan:
+    role: str
+    now_iso: str
+    due: Tuple[RefreshPlanEntry, ...]
+    skipped: Tuple[RefreshPlanEntry, ...]
+    tick_quota: int
+
+    def due_source_ids(self) -> Tuple[str, ...]:
+        return tuple(entry.source_id for entry in self.due)
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "role": self.role,
+            "now": self.now_iso,
+            "tick_quota": int(self.tick_quota),
+            "due": [entry.to_payload() for entry in self.due],
+            "skipped": [entry.to_payload() for entry in self.skipped],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Backoff
+# ---------------------------------------------------------------------------
+
+
+# Exponential: 1× / 2× / 4× / 8× of the source interval, capped at 24h.
+_BACKOFF_MULTIPLIERS = (1, 2, 4, 8)
+_BACKOFF_CAP_MINUTES = 24 * 60
+
+
+def _backoff_delay_minutes(
+    interval_minutes: int, consecutive_failures: int
+) -> int:
+    """Increase wait between retries the more we've failed in a row.
+
+    0 failures returns the base interval; each subsequent failure
+    multiplies up the chain until the cap. Anchored to *interval* so
+    fast-cadence feeds (security advisories) recover quicker than slow
+    ones (docs sitemaps).
+    """
+
+    if consecutive_failures <= 0:
+        return interval_minutes
+    multiplier = _BACKOFF_MULTIPLIERS[
+        min(consecutive_failures - 1, len(_BACKOFF_MULTIPLIERS) - 1)
+    ]
+    return min(interval_minutes * multiplier, _BACKOFF_CAP_MINUTES)
+
+
+# ---------------------------------------------------------------------------
+# Planner
+# ---------------------------------------------------------------------------
+
+
+def compute_refresh_plan(
+    role_id: str,
+    *,
+    now: Optional[datetime] = None,
+    states: Mapping[str, SourceRefreshState] = (),  # type: ignore[assignment]
+    tick_quota: Optional[int] = None,
+    include_review_required: bool = False,
+    include_auto_collect_disabled: bool = False,
+) -> RefreshPlan:
+    """Decide which sources are due for *role_id* right now.
+
+    Behaviour:
+
+      1. Walk the role's full source list (per-role + common-core).
+      2. For each entry, look up its :class:`SourceRefreshState`. A
+         missing entry is treated as ``never`` — immediately due.
+      3. Compute ``next_eligible_at = last_attempted_at + interval``,
+         where ``interval`` includes exponential backoff for prior
+         failures.
+      4. ``review_required`` and ``auto_collect=False`` sources are
+         skipped by default (operator can opt in via the kwargs).
+      5. Apply *tick_quota* (default = role's daily limit) — once the
+         number of due sources exceeds the quota, the rest are
+         re-classified as ``skipped(reason=fresh-quota)`` so a single
+         tick never floods the adapter layer.
+
+    Pure function. Output is stable for fixed inputs — handy for tests.
+    """
+
+    now_dt = (now or datetime.now(tz=timezone.utc)).astimezone(timezone.utc)
+    now_iso = _format_iso(now_dt)
+
+    sources = role_sources(role_id)
+    state_map: Mapping[str, SourceRefreshState] = dict(states or {})
+
+    due: List[RefreshPlanEntry] = []
+    skipped: List[RefreshPlanEntry] = []
+
+    for source in sources:
+        if not source.auto_collect and not include_auto_collect_disabled:
+            skipped.append(
+                RefreshPlanEntry(
+                    source_id=source.source_id,
+                    decision=_DECISION_SKIPPED_AUTO_COLLECT_DISABLED,
+                    reason="auto_collect=False",
+                )
+            )
+            continue
+        if source.review_required and not include_review_required:
+            skipped.append(
+                RefreshPlanEntry(
+                    source_id=source.source_id,
+                    decision=_DECISION_SKIPPED_REVIEW_REQUIRED,
+                    reason="review_required=True",
+                )
+            )
+            continue
+
+        state = state_map.get(source.source_id) or SourceRefreshState(
+            source_id=source.source_id
+        )
+        interval_minutes = source.effective_refresh_interval_minutes()
+        delay_minutes = _backoff_delay_minutes(
+            interval_minutes, state.consecutive_failures
+        )
+
+        last_dt = _parse_iso(state.last_attempted_at)
+        if last_dt is None:
+            # Never attempted — immediately due.
+            due.append(
+                RefreshPlanEntry(
+                    source_id=source.source_id,
+                    decision=_DECISION_DUE,
+                    reason="never_attempted",
+                )
+            )
+            continue
+
+        next_eligible_at = last_dt + timedelta(minutes=delay_minutes)
+        if now_dt >= next_eligible_at:
+            reason = (
+                "due"
+                if state.last_status == "success"
+                else f"retry_after_{state.consecutive_failures}_failures"
+            )
+            due.append(
+                RefreshPlanEntry(
+                    source_id=source.source_id,
+                    decision=_DECISION_DUE,
+                    reason=reason,
+                    next_eligible_at=_format_iso(next_eligible_at),
+                )
+            )
+        else:
+            decision = (
+                _DECISION_SKIPPED_BACKOFF
+                if state.consecutive_failures > 0
+                else _DECISION_SKIPPED_FRESH
+            )
+            skipped.append(
+                RefreshPlanEntry(
+                    source_id=source.source_id,
+                    decision=decision,
+                    reason=(
+                        f"interval_{interval_minutes}m_backoff_x"
+                        f"{_BACKOFF_MULTIPLIERS[min(state.consecutive_failures - 1, len(_BACKOFF_MULTIPLIERS) - 1)] if state.consecutive_failures > 0 else 1}"
+                    ),
+                    next_eligible_at=_format_iso(next_eligible_at),
+                )
+            )
+
+    # Apply tick quota — protects the adapter layer from a thundering
+    # herd when many sources happen to be due in the same tick.
+    quota = tick_quota if tick_quota is not None else _default_tick_quota(role_id)
+    if quota >= 0 and len(due) > quota:
+        kept, overflow = due[:quota], due[quota:]
+        skipped.extend(
+            RefreshPlanEntry(
+                source_id=entry.source_id,
+                decision="skipped_quota",
+                reason=f"tick_quota_{quota}_exceeded",
+                next_eligible_at=entry.next_eligible_at,
+            )
+            for entry in overflow
+        )
+        due = kept
+
+    return RefreshPlan(
+        role=role_id,
+        now_iso=now_iso,
+        due=tuple(due),
+        skipped=tuple(skipped),
+        tick_quota=quota,
+    )
+
+
+def _default_tick_quota(role_id: str) -> int:
+    """Default sources per single tick = role daily limit (5).
+
+    Reusing the daily limit means at most ``daily_limit`` adapter calls
+    fire per tick per role even if every source happens to be due. The
+    operator can override via *tick_quota* on :func:`compute_refresh_plan`.
+    """
+
+    from .source_registry import daily_limit_for_role
+
+    return daily_limit_for_role(role_id)
+
+
+# ---------------------------------------------------------------------------
+# Outcome recording (immutable update)
+# ---------------------------------------------------------------------------
+
+
+def record_refresh_outcome(
+    state: SourceRefreshState,
+    *,
+    now: Optional[datetime] = None,
+    success: bool,
+    items_collected: int = 0,
+    notes: str = "",
+) -> SourceRefreshState:
+    """Return a new state row reflecting the outcome of this attempt.
+
+    Pure — never mutates *state*. The orchestrator should swap the row
+    in its persistence layer with the returned value.
+    """
+
+    attempted_iso = _format_iso(now or datetime.now(tz=timezone.utc))
+    if success:
+        return replace(
+            state,
+            last_attempted_at=attempted_iso,
+            last_succeeded_at=attempted_iso,
+            last_status="success",
+            consecutive_failures=0,
+            items_collected_last_run=int(items_collected),
+            notes=notes,
+        )
+    return replace(
+        state,
+        last_attempted_at=attempted_iso,
+        last_status="failure",
+        consecutive_failures=int(state.consecutive_failures) + 1,
+        items_collected_last_run=0,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-role multi-tick coverage check (operational guard)
+# ---------------------------------------------------------------------------
+
+
+def overdue_axes_for_role(
+    role_id: str,
+    *,
+    states: Mapping[str, SourceRefreshState],
+    now: Optional[datetime] = None,
+    grace_factor: float = 2.0,
+) -> Tuple[str, ...]:
+    """Axes whose every source is past ``interval × grace_factor`` overdue.
+
+    Used as a "we're failing this axis entirely" guard — the orchestrator
+    can surface this on the operator dashboard so a long-broken adapter
+    doesn't hide a missing knowledge axis. Returns axis values (string
+    form) sorted for determinism.
+    """
+
+    now_dt = (now or datetime.now(tz=timezone.utc)).astimezone(timezone.utc)
+    state_map = dict(states or {})
+
+    sources = role_sources(role_id)
+    axis_health: dict[str, bool] = {}
+    for source in sources:
+        if not source.axes:
+            continue
+        state = state_map.get(source.source_id)
+        last_succeeded = (
+            _parse_iso(state.last_succeeded_at) if state else None
+        )
+        threshold_minutes = (
+            source.effective_refresh_interval_minutes() * max(grace_factor, 1.0)
+        )
+        is_healthy = (
+            last_succeeded is not None
+            and now_dt - last_succeeded
+            <= timedelta(minutes=threshold_minutes)
+        )
+        for axis in source.axes:
+            key = axis.value
+            if axis_health.get(key) is True:
+                continue
+            axis_health[key] = is_healthy or axis_health.get(key, False)
+
+    overdue = [axis for axis, healthy in axis_health.items() if not healthy]
+    return tuple(sorted(overdue))
+
+
+__all__ = [
+    "RefreshPlan",
+    "RefreshPlanEntry",
+    "SourceRefreshState",
+    "compute_refresh_plan",
+    "overdue_axes_for_role",
+    "record_refresh_outcome",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/source_registry.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/source_registry.py
@@ -32,6 +32,7 @@ from typing import Mapping, Optional, Tuple
 
 from .models import (
     CollectionMode,
+    SourceAxis,
     SourceEntry,
     SourceKind,
     SourceTier,
@@ -65,6 +66,7 @@ COMMON_CORE_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.9,
         auto_collect=True,
         review_required=False,
+        axes=(SourceAxis.SECURITY,),
     ),
     SourceEntry(
         source_id="mdn-web-platform",
@@ -83,6 +85,7 @@ COMMON_CORE_SOURCES: Tuple[SourceEntry, ...] = (
         trust_weight=0.9,
         freshness_weight=0.85,
         auto_collect=True,
+        axes=(SourceAxis.WEB_PLATFORM_FRAMEWORK, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="github-engineering",
@@ -101,6 +104,10 @@ COMMON_CORE_SOURCES: Tuple[SourceEntry, ...] = (
         trust_weight=0.8,
         freshness_weight=0.8,
         auto_collect=True,
+        axes=(
+            SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+        ),
     ),
 )
 
@@ -129,6 +136,7 @@ _TECH_LEAD_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.3,
         auto_collect=False,
         review_required=True,
+        axes=(SourceAxis.ARCHITECTURE_ADR_TRADEOFF,),
     ),
     SourceEntry(
         source_id="adr-github",
@@ -143,6 +151,7 @@ _TECH_LEAD_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.5,
         auto_collect=False,
         review_required=True,
+        axes=(SourceAxis.ARCHITECTURE_ADR_TRADEOFF,),
     ),
     SourceEntry(
         source_id="cloudflare-engineering",
@@ -155,6 +164,10 @@ _TECH_LEAD_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+        ),
     ),
     SourceEntry(
         source_id="stripe-engineering",
@@ -167,6 +180,10 @@ _TECH_LEAD_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.8,
+        axes=(
+            SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+            SourceAxis.API_SCHEMA_AUTH,
+        ),
     ),
     SourceEntry(
         source_id="ietf-rfc-editor",
@@ -179,6 +196,10 @@ _TECH_LEAD_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.7,
+        axes=(
+            SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+            SourceAxis.OFFICIAL_DOCS,
+        ),
     ),
 )
 
@@ -195,6 +216,7 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.7,
+        axes=(SourceAxis.OFFICIAL_DOCS, SourceAxis.API_SCHEMA_AUTH),
     ),
     SourceEntry(
         source_id="spring-blog",
@@ -207,6 +229,7 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(SourceAxis.OFFICIAL_DOCS, SourceAxis.RELEASE_NOTES_CHANGELOG),
     ),
     SourceEntry(
         source_id="fastapi-changelog",
@@ -219,6 +242,10 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+            SourceAxis.API_SCHEMA_AUTH,
+        ),
     ),
     SourceEntry(
         source_id="postgresql-release-notes",
@@ -231,6 +258,10 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.8,
+        axes=(
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+            SourceAxis.API_SCHEMA_AUTH,
+        ),
     ),
     SourceEntry(
         source_id="redis-release-notes",
@@ -243,6 +274,7 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(SourceAxis.RELEASE_NOTES_CHANGELOG,),
     ),
     SourceEntry(
         source_id="owasp-top-10",
@@ -257,6 +289,7 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.4,
         auto_collect=False,
         review_required=True,
+        axes=(SourceAxis.SECURITY, SourceAxis.API_SCHEMA_AUTH),
     ),
     SourceEntry(
         source_id="nestjs-blog",
@@ -269,6 +302,7 @@ _BACKEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.8,
+        axes=(SourceAxis.OFFICIAL_DOCS, SourceAxis.API_SCHEMA_AUTH),
     ),
 )
 
@@ -285,6 +319,7 @@ _FRONTEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.85,
+        axes=(SourceAxis.OFFICIAL_DOCS, SourceAxis.WEB_PLATFORM_FRAMEWORK),
     ),
     SourceEntry(
         source_id="nextjs-changelog",
@@ -297,6 +332,10 @@ _FRONTEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.9,
+        axes=(
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+            SourceAxis.WEB_PLATFORM_FRAMEWORK,
+        ),
     ),
     SourceEntry(
         source_id="typescript-changelog",
@@ -309,6 +348,10 @@ _FRONTEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+            SourceAxis.WEB_PLATFORM_FRAMEWORK,
+        ),
     ),
     SourceEntry(
         source_id="web-dev-articles",
@@ -321,6 +364,7 @@ _FRONTEND_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.85,
+        axes=(SourceAxis.WEB_PLATFORM_FRAMEWORK, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="wcag-spec",
@@ -335,6 +379,7 @@ _FRONTEND_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.3,
         auto_collect=False,
         review_required=True,
+        axes=(SourceAxis.WEB_PLATFORM_FRAMEWORK, SourceAxis.OFFICIAL_DOCS),
     ),
 )
 
@@ -351,6 +396,10 @@ _DEVOPS_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="kubernetes-release-notes",
@@ -363,6 +412,10 @@ _DEVOPS_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.9,
+        axes=(
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="argo-cd-changelog",
@@ -375,6 +428,10 @@ _DEVOPS_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="github-actions-changelog",
@@ -387,6 +444,10 @@ _DEVOPS_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.9,
+        axes=(
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="terraform-changelog",
@@ -399,6 +460,10 @@ _DEVOPS_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
 )
 
@@ -415,6 +480,10 @@ _QA_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.9,
+        axes=(
+            SourceAxis.REGRESSION_TEST_PLAN,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="testing-library-blog",
@@ -427,6 +496,10 @@ _QA_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.8,
+        axes=(
+            SourceAxis.REGRESSION_TEST_PLAN,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="cypress-changelog",
@@ -439,6 +512,10 @@ _QA_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.REGRESSION_TEST_PLAN,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="iso-29119",
@@ -453,6 +530,7 @@ _QA_SOURCES: Tuple[SourceEntry, ...] = (
         freshness_weight=0.3,
         auto_collect=False,
         review_required=True,
+        axes=(SourceAxis.REGRESSION_TEST_PLAN, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="google-testing-blog",
@@ -465,6 +543,7 @@ _QA_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.7,
+        axes=(SourceAxis.REGRESSION_TEST_PLAN,),
     ),
 )
 
@@ -481,6 +560,7 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.95,
+        axes=(SourceAxis.AI_FRAMEWORK, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="anthropic-news",
@@ -493,6 +573,7 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.95,
+        axes=(SourceAxis.AI_FRAMEWORK, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="huggingface-blog",
@@ -505,6 +586,7 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.9,
+        axes=(SourceAxis.AI_FRAMEWORK,),
     ),
     SourceEntry(
         source_id="langchain-blog",
@@ -518,6 +600,7 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         trust_weight=0.7,
         freshness_weight=0.85,
         review_required=True,
+        axes=(SourceAxis.AI_FRAMEWORK,),
     ),
     SourceEntry(
         source_id="pgvector-releases",
@@ -530,6 +613,10 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.9,
         freshness_weight=0.85,
+        axes=(
+            SourceAxis.AI_FRAMEWORK,
+            SourceAxis.RELEASE_NOTES_CHANGELOG,
+        ),
     ),
     SourceEntry(
         source_id="ragas-eval-docs",
@@ -542,6 +629,10 @@ _AI_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.8,
         freshness_weight=0.8,
+        axes=(
+            SourceAxis.AI_FRAMEWORK,
+            SourceAxis.REGRESSION_TEST_PLAN,
+        ),
     ),
 )
 
@@ -558,6 +649,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.6,
+        axes=(SourceAxis.DESIGN_SYSTEM, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="material-design",
@@ -570,6 +662,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.6,
+        axes=(SourceAxis.DESIGN_SYSTEM, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="fluent-design",
@@ -582,6 +675,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.9,
         freshness_weight=0.6,
+        axes=(SourceAxis.DESIGN_SYSTEM, SourceAxis.OFFICIAL_DOCS),
     ),
     SourceEntry(
         source_id="atlassian-design",
@@ -594,6 +688,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.7,
+        axes=(SourceAxis.DESIGN_SYSTEM,),
     ),
     SourceEntry(
         source_id="carbon-design",
@@ -606,6 +701,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_2,
         trust_weight=0.85,
         freshness_weight=0.7,
+        axes=(SourceAxis.DESIGN_SYSTEM,),
     ),
     SourceEntry(
         source_id="govuk-design",
@@ -618,6 +714,7 @@ _PRODUCT_DESIGN_SOURCES: Tuple[SourceEntry, ...] = (
         tier=SourceTier.TIER_1,
         trust_weight=0.95,
         freshness_weight=0.7,
+        axes=(SourceAxis.DESIGN_SYSTEM, SourceAxis.OFFICIAL_DOCS),
     ),
 )
 
@@ -730,12 +827,154 @@ def daily_limit_for_role(role_id: str) -> int:
     return 5
 
 
+# ---------------------------------------------------------------------------
+# Axis-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def axes_for_role(role_id: str) -> Tuple[SourceAxis, ...]:
+    """Union of axes covered by *role_id*'s registry (sorted, deduped)."""
+
+    seen: set[SourceAxis] = set()
+    for entry in role_sources(role_id):
+        for axis in entry.axes:
+            seen.add(axis)
+    return tuple(sorted(seen, key=lambda a: a.value))
+
+
+def sources_for_axis(
+    role_id: str, axis: SourceAxis
+) -> Tuple[SourceEntry, ...]:
+    """Entries belonging to *role_id* that mention *axis*.
+
+    Used by retrieval-side filtering when the request hints a specific
+    axis (e.g. backend-feature task → API_SCHEMA_AUTH preference).
+    Returns the prioritised order so Tier 1 sits first.
+    """
+
+    matching = tuple(
+        entry for entry in role_sources(role_id) if axis in entry.axes
+    )
+    return prioritise_sources(matching)
+
+
+def role_axis_coverage_report(role_id: str) -> Mapping[SourceAxis, int]:
+    """Per-axis source count for *role_id* — used by audit + tests.
+
+    The map is total-coverage focused: it counts every entry whether
+    auto-collectable or review-required. Operators look at this to
+    spot a bare axis (count == 0) before adding new seeds.
+    """
+
+    counts: dict[SourceAxis, int] = {}
+    for entry in role_sources(role_id):
+        for axis in entry.axes:
+            counts[axis] = counts.get(axis, 0) + 1
+    return counts
+
+
+# Per-role minimum axes contract. A role must cover at least these axes
+# for the registry to be considered "operationally seeded". Tests pin
+# this so that adding a role without seeding the right kinds of sources
+# fails loudly instead of silently producing skinny digests.
+_ROLE_REQUIRED_AXES: Mapping[str, Tuple[SourceAxis, ...]] = {
+    "tech-lead": (
+        SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+        SourceAxis.OFFICIAL_DOCS,
+    ),
+    "backend-engineer": (
+        SourceAxis.OFFICIAL_DOCS,
+        SourceAxis.API_SCHEMA_AUTH,
+        SourceAxis.RELEASE_NOTES_CHANGELOG,
+        SourceAxis.SECURITY,
+    ),
+    "frontend-engineer": (
+        SourceAxis.WEB_PLATFORM_FRAMEWORK,
+        SourceAxis.OFFICIAL_DOCS,
+        SourceAxis.RELEASE_NOTES_CHANGELOG,
+    ),
+    "devops-engineer": (
+        SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+        SourceAxis.RELEASE_NOTES_CHANGELOG,
+        SourceAxis.SECURITY,
+    ),
+    "qa-engineer": (
+        SourceAxis.REGRESSION_TEST_PLAN,
+        SourceAxis.SECURITY,
+    ),
+    "ai-engineer": (SourceAxis.AI_FRAMEWORK,),
+    "product-designer": (SourceAxis.DESIGN_SYSTEM,),
+}
+
+
+def required_axes_for_role(role_id: str) -> Tuple[SourceAxis, ...]:
+    """Hard-coded "must-cover" axis list for *role_id*."""
+
+    if role_id not in _ROLE_REQUIRED_AXES:
+        raise KeyError(f"unknown role for required axes: {role_id!r}")
+    return _ROLE_REQUIRED_AXES[role_id]
+
+
+# ---------------------------------------------------------------------------
+# task_type → axis hint matrix (used by retrieval to weight)
+# ---------------------------------------------------------------------------
+
+
+_TASK_TYPE_AXIS_HINTS: Mapping[str, Tuple[SourceAxis, ...]] = {
+    "backend-feature": (
+        SourceAxis.API_SCHEMA_AUTH,
+        SourceAxis.OFFICIAL_DOCS,
+        SourceAxis.SECURITY,
+    ),
+    "frontend-feature": (
+        SourceAxis.WEB_PLATFORM_FRAMEWORK,
+        SourceAxis.OFFICIAL_DOCS,
+    ),
+    "landing-page": (
+        SourceAxis.DESIGN_SYSTEM,
+        SourceAxis.WEB_PLATFORM_FRAMEWORK,
+    ),
+    "onboarding-flow": (
+        SourceAxis.DESIGN_SYSTEM,
+        SourceAxis.WEB_PLATFORM_FRAMEWORK,
+    ),
+    "visual-polish": (SourceAxis.DESIGN_SYSTEM,),
+    "email-campaign": (SourceAxis.DESIGN_SYSTEM,),
+    "qa-test": (
+        SourceAxis.REGRESSION_TEST_PLAN,
+        SourceAxis.SECURITY,
+    ),
+    "platform-infra": (
+        SourceAxis.CI_CD_INFRA_OBSERVABILITY,
+        SourceAxis.ARCHITECTURE_ADR_TRADEOFF,
+    ),
+}
+
+
+def axis_hints_for_task_type(task_type: Optional[str]) -> Tuple[SourceAxis, ...]:
+    """Axes that retrieval should weight up for *task_type*.
+
+    Unknown / None task types return an empty tuple — retrieval falls
+    back to role + topic match alone. Kept tiny on purpose: the
+    weighting math should not branch on a long taxonomy.
+    """
+
+    if not task_type:
+        return ()
+    return _TASK_TYPE_AXIS_HINTS.get(str(task_type).strip().lower(), ())
+
+
 __all__ = [
     "COMMON_CORE_SOURCES",
     "SUPPORTED_ROLES",
     "auto_collectable_sources",
+    "axes_for_role",
+    "axis_hints_for_task_type",
     "daily_limit_for_role",
     "find_source",
     "prioritise_sources",
+    "required_axes_for_role",
+    "role_axis_coverage_report",
     "role_sources",
+    "sources_for_axis",
 ]

--- a/src/yule_orchestrator/agents/job_queue/__init__.py
+++ b/src/yule_orchestrator/agents/job_queue/__init__.py
@@ -44,6 +44,25 @@ from .approval_worker import (
     env_approval_channel_resolver,
     render_approval_request,
 )
+from .coding_execute_dispatcher import (
+    DispatchedCodingJob,
+    ENV_DEFAULT_BASE_BRANCH as ENV_CODING_EXECUTOR_DEFAULT_BASE_BRANCH,
+    ENV_DEFAULT_REPO as ENV_CODING_EXECUTOR_DEFAULT_REPO,
+    ENV_DRY_RUN as ENV_CODING_EXECUTOR_DRY_RUN,
+    ReadyCodingJob,
+    SESSION_EXTRA_DISPATCH_KEY as CODING_EXECUTOR_DISPATCH_EXTRA_KEY,
+    WorkflowSessionState,
+    build_coding_execute_request,
+    dispatch_ready_coding_jobs,
+    iter_ready_coding_jobs,
+)
+from .coding_executor_worker import (
+    CodingExecuteOutcome,
+    CodingExecuteRequest,
+    CodingExecutorWorker,
+    JOB_TYPE_CODING_EXECUTE,
+    SERVICE_ID_CODING_EXECUTOR,
+)
 from .github_work_order import (
     APPROVAL_KIND_GITHUB_WORK_ORDER,
     CodingIntent,
@@ -120,6 +139,21 @@ from .store import (
 
 __all__ = (
     "APPROVAL_KIND_ENGINEERING_WRITE",
+    "CODING_EXECUTOR_DISPATCH_EXTRA_KEY",
+    "CodingExecuteOutcome",
+    "CodingExecuteRequest",
+    "CodingExecutorWorker",
+    "DispatchedCodingJob",
+    "ENV_CODING_EXECUTOR_DEFAULT_BASE_BRANCH",
+    "ENV_CODING_EXECUTOR_DEFAULT_REPO",
+    "ENV_CODING_EXECUTOR_DRY_RUN",
+    "JOB_TYPE_CODING_EXECUTE",
+    "ReadyCodingJob",
+    "SERVICE_ID_CODING_EXECUTOR",
+    "WorkflowSessionState",
+    "build_coding_execute_request",
+    "dispatch_ready_coding_jobs",
+    "iter_ready_coding_jobs",
     "APPROVAL_KIND_GITHUB_WORK_ORDER",
     "APPROVAL_KIND_OBSIDIAN_WRITE",
     "APPROVAL_KIND_RESEARCH_PROMOTION",

--- a/src/yule_orchestrator/agents/job_queue/__init__.py
+++ b/src/yule_orchestrator/agents/job_queue/__init__.py
@@ -44,6 +44,13 @@ from .approval_worker import (
     env_approval_channel_resolver,
     render_approval_request,
 )
+from .ci_retry_orchestrator import (
+    CIRetryDecision,
+    CIStatusFetcher,
+    GithubAppCheckRunFetcher,
+    SESSION_EXTRA_PROGRESS_KEY as CODING_EXECUTOR_PROGRESS_EXTRA_KEY,
+    orchestrate_ci_retry,
+)
 from .coding_execute_dispatcher import (
     DispatchedCodingJob,
     ENV_DEFAULT_BASE_BRANCH as ENV_CODING_EXECUTOR_DEFAULT_BASE_BRANCH,
@@ -55,6 +62,14 @@ from .coding_execute_dispatcher import (
     build_coding_execute_request,
     dispatch_ready_coding_jobs,
     iter_ready_coding_jobs,
+)
+from .coding_execute_progress import (
+    ProgressEntry,
+    ProgressOutcome,
+    TASK_LOG_NOTE_KIND,
+    make_github_pr_comment_fn,
+    record_coding_execute_progress,
+    render_progress_markdown,
 )
 from .coding_executor_worker import (
     CodingExecuteOutcome,
@@ -139,7 +154,10 @@ from .store import (
 
 __all__ = (
     "APPROVAL_KIND_ENGINEERING_WRITE",
+    "CIRetryDecision",
+    "CIStatusFetcher",
     "CODING_EXECUTOR_DISPATCH_EXTRA_KEY",
+    "CODING_EXECUTOR_PROGRESS_EXTRA_KEY",
     "CodingExecuteOutcome",
     "CodingExecuteRequest",
     "CodingExecutorWorker",
@@ -147,13 +165,21 @@ __all__ = (
     "ENV_CODING_EXECUTOR_DEFAULT_BASE_BRANCH",
     "ENV_CODING_EXECUTOR_DEFAULT_REPO",
     "ENV_CODING_EXECUTOR_DRY_RUN",
+    "GithubAppCheckRunFetcher",
     "JOB_TYPE_CODING_EXECUTE",
+    "ProgressEntry",
+    "ProgressOutcome",
     "ReadyCodingJob",
     "SERVICE_ID_CODING_EXECUTOR",
+    "TASK_LOG_NOTE_KIND",
     "WorkflowSessionState",
     "build_coding_execute_request",
     "dispatch_ready_coding_jobs",
     "iter_ready_coding_jobs",
+    "make_github_pr_comment_fn",
+    "orchestrate_ci_retry",
+    "record_coding_execute_progress",
+    "render_progress_markdown",
     "APPROVAL_KIND_GITHUB_WORK_ORDER",
     "APPROVAL_KIND_OBSIDIAN_WRITE",
     "APPROVAL_KIND_RESEARCH_PROMOTION",

--- a/src/yule_orchestrator/agents/job_queue/ci_retry_orchestrator.py
+++ b/src/yule_orchestrator/agents/job_queue/ci_retry_orchestrator.py
@@ -1,0 +1,459 @@
+"""CI retry orchestrator — Round 3 of #73.
+
+The Round 2 ``ci_status`` module is *pure* — it only computes verdicts
+and partitions failed PRs. What was missing was the side-effect
+layer that:
+
+  * fetches the live CI status for a PR head_sha,
+  * appends a retry-attempt row to ``session.extra``,
+  * derives the standardised completion vocabulary
+    (``done`` / ``retry_ready`` / ``blocked``),
+  * for ``retry_ready``: requeues a fresh ``coding_execute`` row,
+  * for ``done`` / ``blocked``: funnels through
+    :func:`completion_hook.record_completion` so the next-task
+    selector + audit log see a consistent terminal event.
+
+Hard rails:
+
+  * Max-attempts cap honoured by delegating every retry decision to
+    :func:`ci_status.decide_retry`. Even if the orchestrator were
+    misconfigured, the pure decider refuses to recommend more than
+    ``policy.max_attempts`` retries.
+  * ``protected branch`` / ``force push`` rejection stays on the
+    worker side — the orchestrator's requeue path never sets either.
+  * Unknown CI conclusion (no checks configured / API unreachable)
+    escalates to ``blocked`` immediately so we don't spin while the
+    PR is in an indeterminate state.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+)
+
+from .ci_status import (
+    CIRetryPolicy,
+    CIStatus,
+    RetryAttemptLog,
+    decide_retry,
+    derive_completion_status_from_ci,
+    from_check_runs,
+    read_retry_log,
+    record_retry_attempt,
+)
+from .coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+    build_coding_execute_request,
+    iter_ready_coding_jobs,
+)
+from .coding_executor_worker import (
+    CodingExecuteRequest,
+    CodingExecutorWorker,
+)
+from .completion_hook import (
+    COMPLETION_BLOCKED,
+    COMPLETION_DONE,
+    COMPLETION_NEEDS_APPROVAL,
+    COMPLETION_RETRY_READY,
+    JobCompletionEvent,
+    record_completion,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+SESSION_EXTRA_PROGRESS_KEY: str = "coding_execute_progress"
+
+
+# ---------------------------------------------------------------------------
+# Live CI fetcher Protocol
+# ---------------------------------------------------------------------------
+
+
+class CIStatusFetcher(Protocol):
+    """Translate (repo, pr_number, head_sha) → :class:`CIStatus`."""
+
+    def fetch(
+        self, *, repo: str, pr_number: int, head_sha: str
+    ) -> CIStatus:  # pragma: no cover - Protocol
+        ...
+
+
+@dataclass(frozen=True)
+class GithubAppCheckRunFetcher:
+    """Default :class:`CIStatusFetcher` that wraps :class:`LiveGithubAppClient`.
+
+    Calls ``list_check_runs`` then projects via
+    :func:`ci_status.from_check_runs`. Failures bubble up as
+    :class:`CIStatus` with ``conclusion="unknown"`` so the
+    orchestrator can route them straight to the "blocked" branch
+    without re-implementing aggregation.
+    """
+
+    live_client: Any
+
+    def fetch(self, *, repo: str, pr_number: int, head_sha: str) -> CIStatus:
+        try:
+            runs = self.live_client.list_check_runs(repo=repo, head_sha=head_sha)
+        except Exception:  # noqa: BLE001 - GitHub API hiccup → unknown
+            logger.warning(
+                "GithubAppCheckRunFetcher: list_check_runs raised for %s@%s",
+                repo,
+                head_sha[:10],
+                exc_info=True,
+            )
+            return CIStatus(
+                pr_number=pr_number, head_sha=head_sha, conclusion="unknown"
+            )
+        return from_check_runs(
+            pr_number=pr_number, head_sha=head_sha, runs=tuple(runs or ())
+        )
+
+
+# ---------------------------------------------------------------------------
+# Result envelope
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CIRetryDecision:
+    """Outcome of one orchestrator pass for a single PR.
+
+    ``completion_status`` is the standard 4-state vocabulary the
+    next-task selector consumes. ``requeued_job_id`` is non-empty
+    when the orchestrator scheduled another ``coding_execute`` row.
+    """
+
+    pr_number: int
+    head_sha: str
+    completion_status: str
+    reason: str
+    attempt_count: int
+    max_attempts: int
+    wait_seconds: float = 0.0
+    requeued_job_id: Optional[str] = None
+    audit_entry_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Session helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso(now: Optional[datetime] = None) -> str:
+    return (now or datetime.now(tz=timezone.utc)).replace(microsecond=0).isoformat()
+
+
+def _persist_session_extra(
+    session: Any,
+    new_extra: Mapping[str, Any],
+    *,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+) -> None:
+    """Write *new_extra* back to *session* via the workflow store.
+
+    Failures log + return — the orchestrator's verdict is still
+    returned to the caller so a stale session doesn't block the
+    completion hook from firing.
+    """
+
+    if session is None:
+        return
+    try:
+        from dataclasses import replace as _replace
+        updated = _replace(session, extra=dict(new_extra))
+    except Exception:  # noqa: BLE001
+        return
+    persist = update_session_fn or _default_update_session
+    try:
+        persist(updated, now=(now or datetime.now(tz=timezone.utc)))
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ci_retry_orchestrator: persisting session.extra raised", exc_info=True
+        )
+
+
+def _default_update_session(session: Any, *, now: datetime) -> Any:
+    from ..workflow_state import update_session
+
+    return update_session(session, now=now)
+
+
+def _append_progress(
+    extra: Mapping[str, Any],
+    *,
+    pr_number: int,
+    head_sha: str,
+    completion_status: str,
+    reason: str,
+    attempt_count: int,
+    when_iso: str,
+) -> Mapping[str, Any]:
+    """Append a structured progress entry to ``coding_execute_progress``.
+
+    The list is bounded to 50 entries so a long-running session
+    doesn't grow ``session.extra`` unbounded. New entries land at
+    the end (chronological).
+    """
+
+    base: dict = dict(extra or {})
+    history_raw = base.get(SESSION_EXTRA_PROGRESS_KEY)
+    history: list = list(history_raw) if isinstance(history_raw, (list, tuple)) else []
+    history.append(
+        {
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "completion_status": completion_status,
+            "reason": reason,
+            "attempt_count": attempt_count,
+            "at": when_iso,
+        }
+    )
+    if len(history) > 50:
+        history = history[-50:]
+    base[SESSION_EXTRA_PROGRESS_KEY] = history
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Requeue helper
+# ---------------------------------------------------------------------------
+
+
+def _requeue_coding_execute(
+    *,
+    session: Any,
+    coding_job: Mapping[str, Any],
+    worker: CodingExecutorWorker,
+    env: Optional[Mapping[str, str]],
+    now: Optional[datetime],
+) -> Optional[str]:
+    """Schedule another ``coding_execute`` attempt for *session*.
+
+    Builds the request from the persisted coding_job (same path the
+    dispatcher uses) but bumps ``branch_hint`` with an ``-attemptN``
+    suffix so the worker doesn't dedup against the prior in-flight
+    branch. Returns the new ``job_id`` or None on failure.
+
+    The branch-suffix bump is the **only** mutation — write/forbidden
+    scope and safety rules carry through unchanged.
+    """
+
+    from .coding_execute_dispatcher import ReadyCodingJob
+
+    ready = ReadyCodingJob(
+        session=session,
+        coding_job=dict(coding_job),
+        session_id=str(coding_job.get("session_id") or getattr(session, "session_id", "")),
+    )
+    try:
+        request = build_coding_execute_request(ready, env=env)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ci_retry_orchestrator: build_coding_execute_request raised",
+            exc_info=True,
+        )
+        return None
+
+    bumped = _bump_branch_hint(request, session)
+    try:
+        job, _created = worker.enqueue(
+            bumped, now=(now.timestamp() if now else None)
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ci_retry_orchestrator: requeue worker.enqueue raised",
+            exc_info=True,
+        )
+        return None
+    return job.job_id
+
+
+def _bump_branch_hint(
+    request: CodingExecuteRequest, session: Any
+) -> CodingExecuteRequest:
+    """Append ``-attemptN`` to the branch hint so the worker dedup
+    treats it as a fresh attempt.
+
+    Counts the existing progress entries for the same PR + uses the
+    next index. Falls back to a UTC-second suffix when no progress
+    history is present (shouldn't happen in production, but keeps
+    the function pure).
+    """
+
+    extra = getattr(session, "extra", None) or {}
+    history = extra.get(SESSION_EXTRA_PROGRESS_KEY) if isinstance(extra, Mapping) else ()
+    attempts = 1
+    if isinstance(history, (list, tuple)):
+        attempts = max(1, len(history) + 1)
+    base = request.branch_hint or ""
+    if not base:
+        from dataclasses import replace as _replace
+        return _replace(request, branch_hint=f"agent/{request.executor_role}/retry-{attempts}")
+    # Strip prior ``-attemptN`` suffix so we don't get nested suffixes
+    # on the third / fourth retry.
+    if "-attempt" in base:
+        base = base.rsplit("-attempt", 1)[0]
+    new_hint = f"{base}-attempt{attempts}"
+    from dataclasses import replace as _replace
+    return _replace(request, branch_hint=new_hint)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def orchestrate_ci_retry(
+    *,
+    session: Any,
+    pr_number: int,
+    head_sha: str,
+    repo: str,
+    fetcher: CIStatusFetcher,
+    worker: CodingExecutorWorker,
+    policy: Optional[CIRetryPolicy] = None,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    progress_post_fn: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+) -> CIRetryDecision:
+    """Drive one CI poll → verdict → side-effect cycle.
+
+    Returns a :class:`CIRetryDecision` describing what was done.
+    Side effects:
+
+      * ``session.extra['ci_retry_logs'][pr_number]`` extended.
+      * ``session.extra['coding_execute_progress']`` appended.
+      * On ``retry_ready``: a new ``coding_execute`` row queued
+        (idempotent via the worker's ``find_active`` dedup).
+      * On any terminal status: :func:`completion_hook.record_completion`
+        invoked + audit entry stamped onto session.extra.
+      * Optional :func:`progress_post_fn` called so a Discord / PR
+        comment can be sent. The post is best-effort — failures
+        log but do not change the verdict.
+    """
+
+    pol = policy or CIRetryPolicy()
+    extra = dict(getattr(session, "extra", None) or {})
+    coding_job = extra.get("coding_job") if isinstance(extra, Mapping) else None
+    if not isinstance(coding_job, Mapping):
+        coding_job = {}
+
+    # 1. Fetch CI status.
+    status = fetcher.fetch(repo=repo, pr_number=pr_number, head_sha=head_sha)
+
+    # 2. Read prior retry log + record this attempt.
+    log = read_retry_log(extra, pr_number=pr_number)
+    extra = dict(record_retry_attempt(
+        extra,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        reason=("ci_failure" if status.is_failure() else status.conclusion),
+        when=_now_iso(now),
+    ))
+
+    # 3. Decide retry / done / blocked.
+    verdict = decide_retry(status=status, log=log, policy=pol)
+    completion_status = derive_completion_status_from_ci(
+        status=status, log=log, policy=pol
+    )
+
+    # 4. Stamp progress + maybe requeue.
+    when_iso = _now_iso(now)
+    extra = dict(_append_progress(
+        extra,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        completion_status=completion_status,
+        reason=verdict.reason,
+        attempt_count=log.attempts + 1,
+        when_iso=when_iso,
+    ))
+
+    requeued_job_id: Optional[str] = None
+    if verdict.should_retry:
+        requeued_job_id = _requeue_coding_execute(
+            session=session,
+            coding_job=coding_job,
+            worker=worker,
+            env=env,
+            now=now,
+        )
+        # On a successful requeue, drop the stale dispatch marker so
+        # the dispatcher / selector re-pick fresh on the next tick.
+        if requeued_job_id is not None:
+            extra.pop(SESSION_EXTRA_DISPATCH_KEY, None)
+
+    # 5. Funnel through the completion hook for terminal states.
+    audit_entry_id: Optional[str] = None
+    if completion_status in {COMPLETION_DONE, COMPLETION_BLOCKED, COMPLETION_NEEDS_APPROVAL}:
+        event = JobCompletionEvent(
+            job_id=str(coding_job.get("session_id") or getattr(session, "session_id", "")),
+            job_type="coding_execute",
+            session_id=str(getattr(session, "session_id", "") or coding_job.get("session_id") or ""),
+            status=completion_status,
+            reason=verdict.reason,
+            metadata={
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "attempts": log.attempts + 1,
+                "ci_conclusion": status.conclusion,
+            },
+            completed_at=when_iso,
+        )
+        new_extra, routing = record_completion(event=event, session_extra=extra)
+        extra = dict(new_extra)
+        audit_entry_id = routing.audit_entry_id
+
+    # 6. Persist + optional progress post.
+    _persist_session_extra(
+        session, extra, update_session_fn=update_session_fn, now=now
+    )
+
+    if progress_post_fn is not None:
+        try:
+            progress_post_fn(
+                pr_number=pr_number,
+                head_sha=head_sha,
+                completion_status=completion_status,
+                reason=verdict.reason,
+                attempt_count=log.attempts + 1,
+                requeued_job_id=requeued_job_id,
+            )
+        except Exception:  # noqa: BLE001 - post is best-effort
+            logger.warning(
+                "ci_retry_orchestrator: progress_post_fn raised", exc_info=True
+            )
+
+    return CIRetryDecision(
+        pr_number=pr_number,
+        head_sha=head_sha,
+        completion_status=completion_status,
+        reason=verdict.reason,
+        attempt_count=log.attempts + 1,
+        max_attempts=pol.max_attempts,
+        wait_seconds=verdict.wait_seconds,
+        requeued_job_id=requeued_job_id,
+        audit_entry_id=audit_entry_id,
+    )
+
+
+__all__ = (
+    "CIRetryDecision",
+    "CIStatusFetcher",
+    "GithubAppCheckRunFetcher",
+    "SESSION_EXTRA_PROGRESS_KEY",
+    "orchestrate_ci_retry",
+)

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
@@ -1,0 +1,587 @@
+"""Production wiring between approved coding_jobs and the executor worker.
+
+Round 3 of #73. Round 1 + 2 landed:
+
+  * the ``CodingExecutorWorker`` (Protocol seams + 7-step pipeline),
+  * ``coding_executor_live`` (live Protocol implementations under one
+    ``build_live_executor`` factory),
+  * the ``ci_status`` retry policy + selector guard.
+
+What was *missing* was the producer: when the engineering Discord
+gateway flips ``session.extra['coding_job']`` to ``status="ready"``,
+nothing actually enqueued a ``coding_execute`` row. Operators had to
+manually call the worker's ``enqueue`` or run a hand-crafted CLI.
+
+This module closes that gap:
+
+  * :func:`iter_ready_coding_jobs` scans
+    :func:`agents.workflow_state.list_sessions` for sessions whose
+    ``extra['coding_job']`` is ``status="ready"`` and which haven't
+    been dispatched yet (no ``extra['coding_execute_dispatch']`` or
+    a previous attempt that already terminal'd cleanly).
+  * :func:`build_coding_execute_request` lifts the persisted
+    coding_job dict into a :class:`CodingExecuteRequest` that the
+    worker accepts. Repo / base_branch / dry_run come from a
+    deterministic precedence: ``coding_job.metadata`` →
+    ``session.extra`` → injected env defaults.
+  * :func:`dispatch_ready_coding_jobs` runs the full producer cycle
+    once: load sessions, enqueue (idempotent via
+    ``CodingExecutorWorker.find_active``), stamp
+    ``extra['coding_execute_dispatch']`` so the next scan skips
+    the row.
+  * :class:`WorkflowSessionState` implements
+    :class:`SessionStateLike` from the next-task selector so the
+    same data also drives the runtime's "what next?" priority chain.
+
+Pure-side safety:
+
+  * The dispatcher *only* writes a single ``coding_execute_dispatch``
+    audit dict back onto the session — no other session fields move.
+  * Persistence is best-effort: a failed cache write logs a warning
+    and the session stays "ready" so the next tick re-tries.
+  * ``forbidden_scope`` from the persisted coding_job carries through
+    unchanged. Hard rails (``is_protected_branch``, force-push) live
+    on the worker; the dispatcher never relaxes them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from .coding_executor_worker import (
+    CodingExecuteRequest,
+    CodingExecutorWorker,
+    JOB_TYPE_CODING_EXECUTE,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants — env contract + session.extra keys
+# ---------------------------------------------------------------------------
+
+
+# session.extra key that the dispatcher writes after a successful enqueue.
+# Exposing it as a constant lets tests + downstream readers keep one
+# source of truth rather than re-typing the literal string.
+SESSION_EXTRA_DISPATCH_KEY: str = "coding_execute_dispatch"
+SESSION_EXTRA_CODING_JOB_KEY: str = "coding_job"
+
+# Env contract — operator-tunable defaults applied when the persisted
+# coding_job doesn't carry an explicit value.
+ENV_DEFAULT_REPO: str = "YULE_CODING_EXECUTOR_REPO"
+ENV_DEFAULT_BASE_BRANCH: str = "YULE_CODING_EXECUTOR_BASE_BRANCH"
+ENV_DRY_RUN: str = "YULE_CODING_EXECUTOR_DRY_RUN"
+
+DEFAULT_BASE_BRANCH: str = "main"
+
+
+# Ready coding_job statuses we'll dispatch on. Anything else (pending
+# approval, cancelled, in_progress already, completed, failed) is left
+# alone — dispatch is idempotent + only fires on the explicit ready
+# transition the gateway makes after the user types an approval phrase.
+READY_STATUSES: frozenset[str] = frozenset({"ready"})
+
+
+# ---------------------------------------------------------------------------
+# Session iteration helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReadyCodingJob:
+    """Snapshot of an approved-coding_job session ready for dispatch.
+
+    ``coding_job`` is the persisted ``session.extra['coding_job']``
+    dict (already serialised by :func:`agents.coding.job.CodingJob.to_dict`).
+    ``session`` carries the full WorkflowSession for callers that need
+    to write back (the dispatcher uses it to stamp dispatch metadata).
+    """
+
+    session: Any
+    coding_job: Mapping[str, Any]
+    session_id: str
+
+    def executor_role(self) -> str:
+        return str(self.coding_job.get("executor_role") or "").strip()
+
+    def has_been_dispatched(self) -> bool:
+        extra = getattr(self.session, "extra", None) or {}
+        marker = extra.get(SESSION_EXTRA_DISPATCH_KEY)
+        if not isinstance(marker, Mapping):
+            return False
+        return bool(marker.get("job_id"))
+
+
+def _read_coding_job(session: Any) -> Optional[Mapping[str, Any]]:
+    extra = getattr(session, "extra", None)
+    if not isinstance(extra, Mapping):
+        return None
+    payload = extra.get(SESSION_EXTRA_CODING_JOB_KEY)
+    if not isinstance(payload, Mapping):
+        return None
+    return payload
+
+
+def iter_ready_coding_jobs(
+    *,
+    session_loader: Optional[Callable[[], Iterable[Any]]] = None,
+    include_dispatched: bool = False,
+) -> Iterator[ReadyCodingJob]:
+    """Yield workflow sessions whose persisted coding_job is ``ready``.
+
+    *session_loader* defaults to :func:`agents.workflow_state.list_sessions`
+    with the standard limit. Tests inject a callable returning a fixed
+    sequence so the iteration logic can be exercised without SQLite.
+
+    Sessions that already have a dispatch marker are skipped unless
+    *include_dispatched* is True (selector-side queries set this so
+    the runtime's "what next?" surface still sees in-flight work).
+    """
+
+    loader = session_loader or _default_session_loader
+    try:
+        sessions = list(loader() or ())
+    except Exception:  # noqa: BLE001 - cache hiccup shouldn't crash dispatch
+        logger.warning("iter_ready_coding_jobs: session loader raised", exc_info=True)
+        return
+
+    for session in sessions:
+        coding_job = _read_coding_job(session)
+        if not coding_job:
+            continue
+        status = str(coding_job.get("status") or "").strip().lower()
+        if status not in READY_STATUSES:
+            continue
+        ready = ReadyCodingJob(
+            session=session,
+            coding_job=dict(coding_job),
+            session_id=str(coding_job.get("session_id") or getattr(session, "session_id", "")),
+        )
+        if not ready.session_id or not ready.executor_role():
+            continue
+        if not include_dispatched and ready.has_been_dispatched():
+            continue
+        yield ready
+
+
+def _default_session_loader() -> Sequence[Any]:
+    from ..workflow_state import list_sessions
+
+    return list_sessions(limit=200)
+
+
+# ---------------------------------------------------------------------------
+# CodingExecuteRequest builder
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_truthy_env(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_repo(coding_job: Mapping[str, Any], session: Any, env_repo: Optional[str]) -> str:
+    """Resolve repo_full_name with deterministic precedence.
+
+    Order: ``coding_job.metadata['repo_full_name']`` →
+    ``session.extra['coding_repo_full_name']`` → env default. Empty
+    string is acceptable — the worker only refuses to push when the
+    GithubAppPusher is invoked on an empty repo, which the dry-run
+    + RecordOnly editor short-circuits correctly.
+    """
+
+    metadata = coding_job.get("metadata") or {}
+    if isinstance(metadata, Mapping):
+        from_meta = str(metadata.get("repo_full_name") or "").strip()
+        if from_meta:
+            return from_meta
+    extra = getattr(session, "extra", None) or {}
+    if isinstance(extra, Mapping):
+        from_extra = str(extra.get("coding_repo_full_name") or "").strip()
+        if from_extra:
+            return from_extra
+    return (env_repo or "").strip()
+
+
+def _resolve_base_branch(coding_job: Mapping[str, Any], env_base: Optional[str]) -> str:
+    metadata = coding_job.get("metadata") or {}
+    if isinstance(metadata, Mapping):
+        candidate = str(metadata.get("base_branch") or "").strip()
+        if candidate:
+            return candidate
+    if env_base and env_base.strip():
+        return env_base.strip()
+    return DEFAULT_BASE_BRANCH
+
+
+def _resolve_dry_run(coding_job: Mapping[str, Any], env_dry_run: Optional[str]) -> bool:
+    """Default dry_run unless an explicit signal flips it false.
+
+    The worker's hard rail interprets ``dry_run=True`` as "exercise the
+    spec without invoking any Protocol". Production push is the
+    risky path so we keep dry_run=True unless either the persisted
+    coding_job or the env explicitly opts out. The env value wins
+    when both are set (operator override).
+    """
+
+    metadata = coding_job.get("metadata") or {}
+    metadata_dry: Optional[bool] = None
+    if isinstance(metadata, Mapping):
+        raw = metadata.get("dry_run")
+        if raw is not None:
+            metadata_dry = bool(raw)
+    if env_dry_run is not None and env_dry_run.strip():
+        flag = env_dry_run.strip().lower()
+        if flag in {"0", "false", "no", "off"}:
+            return False
+        if flag in {"1", "true", "yes", "on"}:
+            return True
+    if metadata_dry is not None:
+        return metadata_dry
+    return True
+
+
+def build_coding_execute_request(
+    ready: ReadyCodingJob,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> CodingExecuteRequest:
+    """Translate a :class:`ReadyCodingJob` into a worker request.
+
+    The returned request matches the worker's payload contract — the
+    caller can then ``worker.enqueue(request)`` directly. The function
+    is pure: no I/O, no mutation of *ready*.
+    """
+
+    env_map = env if env is not None else os.environ
+    coding_job = ready.coding_job
+
+    metadata_in = coding_job.get("metadata") or {}
+    proposal_metadata = (
+        metadata_in.get("proposal_metadata")
+        if isinstance(metadata_in, Mapping)
+        else {}
+    ) or {}
+
+    issue_number = _coerce_int(
+        (metadata_in.get("issue_number") if isinstance(metadata_in, Mapping) else None)
+        or (
+            proposal_metadata.get("issue_number")
+            if isinstance(proposal_metadata, Mapping)
+            else None
+        )
+    )
+
+    branch_hint = ""
+    if isinstance(metadata_in, Mapping):
+        branch_hint = str(metadata_in.get("branch_hint") or "").strip()
+    if not branch_hint and isinstance(proposal_metadata, Mapping):
+        branch_hint = str(proposal_metadata.get("branch_hint") or "").strip()
+
+    forwarded_metadata = {}
+    if isinstance(metadata_in, Mapping):
+        # Pass through known keys the executor or test runner consume.
+        for key in ("test_command", "executor_runner_id", "review_roles"):
+            if key in metadata_in:
+                forwarded_metadata[key] = metadata_in[key]
+    forwarded_metadata.setdefault(
+        "approved_at",
+        coding_job.get("approved_at"),
+    )
+    forwarded_metadata.setdefault(
+        "review_roles",
+        list(coding_job.get("review_roles") or ()),
+    )
+
+    return CodingExecuteRequest(
+        session_id=ready.session_id,
+        executor_role=ready.executor_role(),
+        user_request=str(coding_job.get("user_request") or ""),
+        generated_prompt=str(coding_job.get("generated_prompt") or ""),
+        write_scope=tuple(
+            str(s).strip() for s in (coding_job.get("write_scope") or ()) if str(s).strip()
+        ),
+        forbidden_scope=tuple(
+            str(s).strip() for s in (coding_job.get("forbidden_scope") or ()) if str(s).strip()
+        ),
+        safety_rules=tuple(
+            str(s).strip() for s in (coding_job.get("safety_rules") or ()) if str(s).strip()
+        ),
+        base_branch=_resolve_base_branch(
+            coding_job, env_map.get(ENV_DEFAULT_BASE_BRANCH)
+        ),
+        branch_hint=branch_hint,
+        repo_full_name=_resolve_repo(
+            coding_job, ready.session, env_map.get(ENV_DEFAULT_REPO)
+        ),
+        issue_number=issue_number,
+        dry_run=_resolve_dry_run(coding_job, env_map.get(ENV_DRY_RUN)),
+        metadata=forwarded_metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (producer)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DispatchedCodingJob:
+    """One row produced by :func:`dispatch_ready_coding_jobs`.
+
+    ``created`` is False when the worker dedup'd against an existing
+    in-flight job — the dispatcher still writes the dispatch marker
+    so subsequent scans skip without re-checking the queue.
+    ``error`` is non-empty when the enqueue raised; the marker is NOT
+    persisted in that case so a transient failure self-recovers on
+    the next tick.
+    """
+
+    session_id: str
+    executor_role: str
+    job_id: Optional[str]
+    created: bool
+    request: Optional[CodingExecuteRequest] = None
+    error: Optional[str] = None
+
+
+def _persist_dispatch_marker(
+    session: Any,
+    *,
+    job_id: str,
+    request: CodingExecuteRequest,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Write the ``coding_execute_dispatch`` audit dict to the session.
+
+    Returns True on persistence success. Failures log a warning and
+    return False — the dispatcher logs the partial success but
+    doesn't crash; the next tick will re-attempt and dedup against
+    the worker queue's in-flight row.
+    """
+
+    if session is None:
+        return False
+
+    try:
+        from dataclasses import replace as _replace
+    except Exception:  # noqa: BLE001 - stdlib import shouldn't fail
+        return False
+
+    extra = dict(getattr(session, "extra", None) or {})
+    when = (now or datetime.now(tz=timezone.utc)).replace(microsecond=0).isoformat()
+    extra[SESSION_EXTRA_DISPATCH_KEY] = {
+        "job_id": job_id,
+        "executor_role": request.executor_role,
+        "branch_hint": request.branch_hint,
+        "dispatched_at": when,
+        "dry_run": bool(request.dry_run),
+        "repo_full_name": request.repo_full_name,
+        "base_branch": request.base_branch,
+    }
+    try:
+        updated = _replace(session, extra=extra)
+    except TypeError:
+        return False
+
+    persist = update_session_fn or _default_update_session
+    try:
+        persist(updated, now=(now or datetime.now(tz=timezone.utc)))
+    except Exception:  # noqa: BLE001 - persistence is observability
+        logger.warning(
+            "coding_execute dispatcher: persisting dispatch marker raised",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def _default_update_session(session: Any, *, now: datetime) -> Any:
+    from ..workflow_state import update_session
+
+    return update_session(session, now=now)
+
+
+def dispatch_ready_coding_jobs(
+    *,
+    worker: CodingExecutorWorker,
+    session_loader: Optional[Callable[[], Iterable[Any]]] = None,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    now: Optional[datetime] = None,
+) -> Tuple[DispatchedCodingJob, ...]:
+    """Run one producer cycle.
+
+    Pulls every ``coding_job=ready`` session, builds the executor
+    request, calls ``worker.enqueue`` (idempotent via the worker's own
+    ``find_active`` dedup), then stamps the dispatch marker so the
+    next call skips. Safe to invoke from a periodic scheduler tick or
+    directly after the user's "수정 승인" message.
+    """
+
+    out: list[DispatchedCodingJob] = []
+    for ready in iter_ready_coding_jobs(session_loader=session_loader):
+        try:
+            request = build_coding_execute_request(ready, env=env)
+        except Exception as exc:  # noqa: BLE001 - bad payload shouldn't kill loop
+            logger.warning(
+                "coding_execute dispatcher: build_request raised for session=%s",
+                ready.session_id,
+                exc_info=True,
+            )
+            out.append(
+                DispatchedCodingJob(
+                    session_id=ready.session_id,
+                    executor_role=ready.executor_role(),
+                    job_id=None,
+                    created=False,
+                    error=f"build_request failed: {exc}",
+                )
+            )
+            continue
+
+        try:
+            job, created = worker.enqueue(request, now=(now.timestamp() if now else None))
+        except Exception as exc:  # noqa: BLE001 - queue write may fail transiently
+            logger.warning(
+                "coding_execute dispatcher: worker.enqueue raised for session=%s",
+                ready.session_id,
+                exc_info=True,
+            )
+            out.append(
+                DispatchedCodingJob(
+                    session_id=ready.session_id,
+                    executor_role=request.executor_role,
+                    job_id=None,
+                    created=False,
+                    request=request,
+                    error=f"enqueue failed: {exc}",
+                )
+            )
+            continue
+
+        _persist_dispatch_marker(
+            ready.session,
+            job_id=job.job_id,
+            request=request,
+            update_session_fn=update_session_fn,
+            now=now,
+        )
+        out.append(
+            DispatchedCodingJob(
+                session_id=ready.session_id,
+                executor_role=request.executor_role,
+                job_id=job.job_id,
+                created=created,
+                request=request,
+            )
+        )
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Selector adapter — feeds next_task_selector.SessionStateLike
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkflowSessionState:
+    """Production :class:`SessionStateLike` implementation.
+
+    Rounded out so the next-task selector can fire against real
+    workflow_state without a custom shim. Keeps the implementation
+    simple — we delegate the iteration to :func:`iter_ready_coding_jobs`
+    and surface the per-row dict shape the selector documents.
+
+    ``include_dispatched`` controls whether sessions whose jobs are
+    already in-flight count as "approved coding job ready". Default
+    is False so the selector doesn't re-pick a row the dispatcher
+    already pushed onto the worker queue.
+    """
+
+    session_loader: Optional[Callable[[], Iterable[Any]]] = None
+    include_dispatched: bool = False
+    discussion_loader: Optional[Callable[[], Iterable[Mapping[str, Any]]]] = None
+
+    def list_approved_coding_jobs(self) -> Sequence[Mapping[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for ready in iter_ready_coding_jobs(
+            session_loader=self.session_loader,
+            include_dispatched=self.include_dispatched,
+        ):
+            row = {
+                "session_id": ready.session_id,
+                "executor_role": ready.executor_role(),
+                "coding_job": dict(ready.coding_job),
+                "thread_id": getattr(ready.session, "thread_id", None),
+                "channel_id": getattr(ready.session, "channel_id", None),
+            }
+            extra = getattr(ready.session, "extra", None) or {}
+            if isinstance(extra, Mapping):
+                marker = extra.get(SESSION_EXTRA_DISPATCH_KEY)
+                if isinstance(marker, Mapping):
+                    row["dispatch"] = dict(marker)
+            rows.append(row)
+        return rows
+
+    def list_unresolved_discussion_threads(self) -> Sequence[Mapping[str, Any]]:
+        if self.discussion_loader is None:
+            return ()
+        try:
+            rows = list(self.discussion_loader() or ())
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "WorkflowSessionState: discussion_loader raised",
+                exc_info=True,
+            )
+            return ()
+        normalized: list[dict[str, Any]] = []
+        for row in rows:
+            if isinstance(row, Mapping):
+                normalized.append(dict(row))
+        return normalized
+
+
+__all__ = (
+    "DEFAULT_BASE_BRANCH",
+    "DispatchedCodingJob",
+    "ENV_DEFAULT_BASE_BRANCH",
+    "ENV_DEFAULT_REPO",
+    "ENV_DRY_RUN",
+    "JOB_TYPE_CODING_EXECUTE",
+    "READY_STATUSES",
+    "ReadyCodingJob",
+    "SESSION_EXTRA_CODING_JOB_KEY",
+    "SESSION_EXTRA_DISPATCH_KEY",
+    "WorkflowSessionState",
+    "build_coding_execute_request",
+    "dispatch_ready_coding_jobs",
+    "iter_ready_coding_jobs",
+)

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_progress.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_progress.py
@@ -1,0 +1,433 @@
+"""Progress surface for coding_execute outcomes — Round 3 of #73.
+
+After a ``coding_execute`` job lands (success / fail / blocked) the
+runtime needs to leave a trail in two places operators / users
+already watch:
+
+  * Obsidian — a ``task-log`` note appended via the existing
+    ``obsidian_write`` queue. Same format as discussion / research
+    progress notes so the operator's vault stays consistent.
+  * GitHub — a PR comment on the draft PR the executor opened.
+
+This module is the **producer** for both. It does not perform either
+write directly; instead it:
+
+  * normalises a :class:`CodingExecuteOutcome` into a small
+    :class:`ProgressEntry` payload,
+  * enqueues an ``obsidian_write`` job (tagged
+    ``note_kind="task-log"`` — does NOT require approval),
+  * (optionally) calls a GitHub PR comment poster the caller
+    injects (typically wired around
+    :meth:`LiveGithubAppClient.create_issue_comment`),
+  * appends the entry to ``session.extra['coding_execute_progress']``
+    so the next task selector / status diagnostic can see "what
+    just happened" without scraping the queue.
+
+Hard rails:
+
+  * Obsidian write is enqueued, never written inline — the writer
+    worker still owns vault permissions / approval guards.
+  * GitHub poster is fail-safe: a 4xx from GitHub logs + returns,
+    the rest of the pipeline still records the entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    Optional,
+    Tuple,
+)
+
+from .coding_execute_dispatcher import SESSION_EXTRA_DISPATCH_KEY
+from .coding_executor_worker import (
+    CodingExecuteOutcome,
+    CodingExecuteRequest,
+)
+from .obsidian_writer_worker import (
+    NOTE_KIND_RESEARCH_LOG,
+    ObsidianWriteRequest,
+    ObsidianWriterWorker,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+SESSION_EXTRA_PROGRESS_KEY: str = "coding_execute_progress"
+TASK_LOG_NOTE_KIND: str = "task-log"
+
+
+GithubPRCommentFn = Callable[..., Any]
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProgressEntry:
+    """Structured snapshot of what an outcome should record.
+
+    Designed so :func:`render_progress_markdown` produces a stable
+    Discord / PR comment / Obsidian body without the caller having
+    to hand-render every field.
+    """
+
+    session_id: str
+    executor_role: str
+    branch: str
+    completion_status: str
+    reason: str
+    pr_number: Optional[int] = None
+    pr_url: Optional[str] = None
+    commit_sha: Optional[str] = None
+    test_summary: Mapping[str, Any] = field(default_factory=dict)
+    at: str = ""
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "executor_role": self.executor_role,
+            "branch": self.branch,
+            "completion_status": self.completion_status,
+            "reason": self.reason,
+            "pr_number": self.pr_number,
+            "pr_url": self.pr_url,
+            "commit_sha": self.commit_sha,
+            "test_summary": dict(self.test_summary),
+            "at": self.at,
+        }
+
+
+@dataclass(frozen=True)
+class ProgressOutcome:
+    """Returned from :func:`record_coding_execute_progress`.
+
+    Captures whether each side-effect succeeded so the caller can
+    log / surface degraded states. Persistence failures are
+    represented as ``False`` flags rather than exceptions — the
+    progress entry is still recorded onto the in-memory session
+    extras so callers keep observability even when the writers
+    are misconfigured.
+    """
+
+    entry: ProgressEntry
+    obsidian_job_id: Optional[str] = None
+    obsidian_skipped_reason: Optional[str] = None
+    github_comment_posted: bool = False
+    github_comment_error: Optional[str] = None
+    session_persisted: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def status_from_outcome(outcome: CodingExecuteOutcome) -> str:
+    """Map an executor outcome's terminal state to the standard vocab."""
+
+    state = (outcome.terminal_state or "").lower()
+    if state == "saved":
+        return "done"
+    if state == "failed_retryable":
+        return "retry_ready"
+    if state == "failed_terminal":
+        return "blocked"
+    return "blocked"
+
+
+def build_progress_entry(
+    outcome: CodingExecuteOutcome,
+    *,
+    request: Optional[CodingExecuteRequest] = None,
+    completion_status: Optional[str] = None,
+    when: Optional[datetime] = None,
+) -> ProgressEntry:
+    """Lift a worker outcome (+ originating request) into a ProgressEntry."""
+
+    job = outcome.job
+    payload: Mapping[str, Any] = (job.payload if job is not None else {}) or {}
+
+    session_id = ""
+    executor_role = ""
+    if request is not None:
+        session_id = request.session_id
+        executor_role = request.executor_role
+    if not session_id:
+        session_id = str(payload.get("session_id") or "")
+    if not executor_role:
+        executor_role = str(payload.get("executor_role") or "")
+
+    when_iso = (when or datetime.now(tz=timezone.utc)).replace(microsecond=0).isoformat()
+    return ProgressEntry(
+        session_id=session_id,
+        executor_role=executor_role,
+        branch=outcome.branch or "",
+        completion_status=completion_status or status_from_outcome(outcome),
+        reason=outcome.failure_reason or "",
+        pr_number=outcome.pr_number,
+        pr_url=outcome.pr_url,
+        commit_sha=outcome.commit_sha,
+        test_summary=dict(outcome.test_summary or {}),
+        at=when_iso,
+    )
+
+
+def render_progress_markdown(entry: ProgressEntry) -> str:
+    """Render *entry* as the body shared between PR comment + task-log.
+
+    Keeps the structure deterministic so the Obsidian writer and the
+    GitHub PR comment surface the same content, and the operator
+    can grep across both worlds for a single ``session_id``.
+    """
+
+    lines: list[str] = []
+    lines.append(
+        f"## 🤖 coding-executor — {entry.completion_status} (executor=`{entry.executor_role}`)"
+    )
+    lines.append("")
+    if entry.session_id:
+        lines.append(f"- session: `{entry.session_id}`")
+    if entry.branch:
+        lines.append(f"- branch: `{entry.branch}`")
+    if entry.commit_sha:
+        lines.append(f"- commit: `{entry.commit_sha[:10]}`")
+    if entry.pr_number is not None:
+        url = entry.pr_url or ""
+        if url:
+            lines.append(f"- PR: [#{entry.pr_number}]({url})")
+        else:
+            lines.append(f"- PR: #{entry.pr_number}")
+    if entry.reason:
+        lines.append(f"- 사유: {entry.reason}")
+    if entry.test_summary:
+        lines.append("- tests:")
+        for key in ("status", "command", "exit_code", "dry_run", "stderr_tail"):
+            if key in entry.test_summary:
+                value = entry.test_summary[key]
+                lines.append(f"  - {key}: `{value}`")
+    lines.append("")
+    lines.append(f"_{entry.at}_")
+    return "\n".join(lines)
+
+
+def append_progress_history(
+    extra: Mapping[str, Any], entry: ProgressEntry
+) -> Mapping[str, Any]:
+    """Append *entry* to ``coding_execute_progress`` (bounded list).
+
+    Pure transform — returns a new mapping the caller persists.
+    History capped at 50 entries so a long-running session doesn't
+    grow ``session.extra`` unbounded.
+    """
+
+    base: dict = dict(extra or {})
+    history_raw = base.get(SESSION_EXTRA_PROGRESS_KEY)
+    history: list = list(history_raw) if isinstance(history_raw, (list, tuple)) else []
+    history.append(dict(entry.to_payload()))
+    if len(history) > 50:
+        history = history[-50:]
+    base[SESSION_EXTRA_PROGRESS_KEY] = history
+    return base
+
+
+def record_coding_execute_progress(
+    *,
+    session: Any,
+    outcome: CodingExecuteOutcome,
+    request: Optional[CodingExecuteRequest] = None,
+    completion_status: Optional[str] = None,
+    obsidian_writer: Optional[ObsidianWriterWorker] = None,
+    github_comment_fn: Optional[GithubPRCommentFn] = None,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    repo_full_name: Optional[str] = None,
+    when: Optional[datetime] = None,
+) -> ProgressOutcome:
+    """End-to-end progress recorder.
+
+    Wraps the four side-effects (entry build, history append,
+    obsidian enqueue, GitHub PR comment) under one call. Each
+    side-effect is tolerant of the other being absent — a session
+    with no GitHub comment fn still gets the Obsidian write +
+    history; a session with no Obsidian writer still posts the
+    PR comment.
+    """
+
+    entry = build_progress_entry(
+        outcome,
+        request=request,
+        completion_status=completion_status,
+        when=when,
+    )
+
+    new_extra = append_progress_history(getattr(session, "extra", None) or {}, entry)
+    persisted = _persist_session_extra(
+        session,
+        new_extra,
+        update_session_fn=update_session_fn,
+        when=when,
+    )
+
+    obsidian_job_id, obsidian_skipped_reason = _maybe_enqueue_obsidian(
+        writer=obsidian_writer, entry=entry
+    )
+    posted, comment_error = _maybe_post_github_comment(
+        post_fn=github_comment_fn,
+        entry=entry,
+        repo_full_name=repo_full_name,
+    )
+    return ProgressOutcome(
+        entry=entry,
+        obsidian_job_id=obsidian_job_id,
+        obsidian_skipped_reason=obsidian_skipped_reason,
+        github_comment_posted=posted,
+        github_comment_error=comment_error,
+        session_persisted=persisted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _persist_session_extra(
+    session: Any,
+    new_extra: Mapping[str, Any],
+    *,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    when: Optional[datetime] = None,
+) -> bool:
+    if session is None:
+        return False
+    try:
+        from dataclasses import replace as _replace
+        updated = _replace(session, extra=dict(new_extra))
+    except Exception:  # noqa: BLE001
+        return False
+    persist = update_session_fn or _default_update_session
+    try:
+        persist(updated, now=(when or datetime.now(tz=timezone.utc)))
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "coding_execute_progress: persisting session.extra raised",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def _default_update_session(session: Any, *, now: datetime) -> Any:
+    from ..workflow_state import update_session
+
+    return update_session(session, now=now)
+
+
+def _maybe_enqueue_obsidian(
+    *,
+    writer: Optional[ObsidianWriterWorker],
+    entry: ProgressEntry,
+) -> Tuple[Optional[str], Optional[str]]:
+    if writer is None:
+        return None, "no_obsidian_writer"
+    if not entry.session_id:
+        return None, "missing_session_id"
+    try:
+        request = ObsidianWriteRequest(
+            session_id=entry.session_id,
+            note_kind=TASK_LOG_NOTE_KIND,
+            title=f"coding-executor — {entry.completion_status} ({entry.executor_role})",
+            metadata={
+                "kind": "coding_execute_progress",
+                "branch": entry.branch,
+                "commit_sha": entry.commit_sha,
+                "pr_number": entry.pr_number,
+                "pr_url": entry.pr_url,
+                "completion_status": entry.completion_status,
+                "executor_role": entry.executor_role,
+                "reason": entry.reason,
+                "rendered_markdown": render_progress_markdown(entry),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "coding_execute_progress: ObsidianWriteRequest construction raised",
+            exc_info=True,
+        )
+        return None, "request_build_failed"
+
+    try:
+        job, _ = writer.enqueue(request)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "coding_execute_progress: writer.enqueue raised", exc_info=True
+        )
+        return None, "enqueue_failed"
+    return job.job_id, None
+
+
+def _maybe_post_github_comment(
+    *,
+    post_fn: Optional[GithubPRCommentFn],
+    entry: ProgressEntry,
+    repo_full_name: Optional[str],
+) -> Tuple[bool, Optional[str]]:
+    if post_fn is None:
+        return False, None
+    if entry.pr_number is None:
+        # No PR yet — happens for dry-run / failed-before-push outcomes.
+        return False, "no_pr"
+    body = render_progress_markdown(entry)
+    try:
+        post_fn(
+            repo=repo_full_name or "",
+            pr_number=int(entry.pr_number),
+            body=body,
+        )
+    except Exception as exc:  # noqa: BLE001 - never crash on GitHub blip
+        logger.warning(
+            "coding_execute_progress: github_comment_fn raised", exc_info=True
+        )
+        return False, str(exc)[:200]
+    return True, None
+
+
+def make_github_pr_comment_fn(
+    live_client: Any,
+) -> GithubPRCommentFn:
+    """Wrap a :class:`LiveGithubAppClient` into a poster callable.
+
+    The wrapper hides the LiveGithubAppClient method shape from the
+    progress recorder so a future CLI / Discord poster can swap in
+    a different surface without touching the recorder.
+    """
+
+    def _post(*, repo: str, pr_number: int, body: str) -> Any:
+        return live_client.create_issue_comment(
+            repo=repo, issue_number=int(pr_number), body=body
+        )
+
+    return _post
+
+
+__all__ = (
+    "GithubPRCommentFn",
+    "ProgressEntry",
+    "ProgressOutcome",
+    "SESSION_EXTRA_PROGRESS_KEY",
+    "TASK_LOG_NOTE_KIND",
+    "append_progress_history",
+    "build_progress_entry",
+    "make_github_pr_comment_fn",
+    "record_coding_execute_progress",
+    "render_progress_markdown",
+    "status_from_outcome",
+)

--- a/src/yule_orchestrator/discord/engineering_discussion_turn.py
+++ b/src/yule_orchestrator/discord/engineering_discussion_turn.py
@@ -1,0 +1,142 @@
+"""tech-lead discussion turn — gateway가 호출하는 단일 진입점.
+
+``engineering_conversation.py``는 fast-path / split / intake 분류를 담당
+하는 외부 surface 모듈이다. 본 모듈은 그 위에 ``discussion_mode``를
+얹어, **gateway가 토의로 받기로 결정한 메시지**를 처리한다.
+
+흐름:
+
+1. caller(보통 channel router)가 메시지가 토의로 받아져야 한다고 판단.
+   (예: status diagnostic / confirm 등 fast-path가 아니고, 자유 발화일 때.)
+2. 본 모듈의 :func:`build_discussion_turn_response`를 호출.
+3. 함수는 ``ContextPackBuilder``로 pack을 만들고, ``classify_discussion_mode``
+   로 모드를 결정하고, ``synthesize_discussion``으로 응답을 합성한다.
+4. 결정된 mode가 ``IMPLEMENTATION_CANDIDATE``면 ``build_implementation_handoff``
+   까지 한 번에 부르고, ``CodingAuthorizationProposal``을 follow-up text와
+   함께 응답에 끼워 넣는다.
+
+본 모듈은 외부 IO를 하지 않는다. ContextPackBuilder의 seam(thread / issue
+/ PR / note / code) 콜러블은 모두 caller가 주입한다 — 본 모듈은 builder를
+얇게 wrapping해서 동일 입력에서 같은 출력을 내도록 보장한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from ..agents.coding.authorization import (
+    CodingAuthorizationProposal,
+    format_authorization_message,
+)
+from ..agents.discussion import (
+    ContextPack,
+    ContextPackBuilder,
+    DiscussionHandoff,
+    DiscussionMode,
+    DiscussionModeMatch,
+    DiscussionSynthesis,
+    build_implementation_handoff,
+    classify_discussion_mode,
+    synthesize_discussion,
+)
+
+
+@dataclass(frozen=True)
+class DiscussionTurnResponse:
+    """tech-lead가 한 turn에 만들어 내는 모든 산출물.
+
+    Discord 게이트웨이는 ``rendered_text``를 그대로 채널에 게시하면
+    되고, ``handoff.proposal``이 채워져 있으면 그 다음 메시지로
+    권한 제안 카드를 함께 게시한다. ``synthesis``와 ``classification``,
+    ``context_pack``은 status diagnostic / 디버그 / Obsidian
+    handoff에서 그대로 재사용 가능하도록 노출한다.
+    """
+
+    rendered_text: str
+    classification: DiscussionModeMatch
+    synthesis: DiscussionSynthesis
+    context_pack: ContextPack
+    handoff: Optional[DiscussionHandoff] = None
+    blockers: Sequence[str] = field(default_factory=tuple)
+
+
+def build_discussion_turn_response(
+    *,
+    message_text: str,
+    session: Optional[Any] = None,
+    suggested_task_type: Optional[str] = None,
+    role_for_research: str = "engineering-agent/tech-lead",
+    retrieval_query: Optional[str] = None,
+    builder: Optional[ContextPackBuilder] = None,
+    llm_classifier: Optional[Any] = None,
+    llm_synthesizer: Optional[Any] = None,
+    department_dir: Optional[Path] = None,
+    role_profile_loader: Optional[Mapping[str, Mapping[str, object]]] = None,
+) -> DiscussionTurnResponse:
+    """One-shot tech-lead discussion turn.
+
+    *builder*가 None이면 빈 :class:`ContextPackBuilder`를 사용한다 — 그
+    경우 pack은 message + session에서 끌어낸 정보만 담고, issue/PR/note
+    seam은 비어 있는 상태로 전달된다. caller가 풍부한 pack을 원하면
+    seam이 채워진 builder를 주입한다.
+    """
+
+    if builder is None:
+        builder = ContextPackBuilder()
+    pack = builder.build(
+        message_text=message_text,
+        session=session,
+        suggested_task_type=suggested_task_type,
+        role_for_research=role_for_research,
+        retrieval_query=retrieval_query,
+    )
+
+    classification = classify_discussion_mode(
+        message_text,
+        context_pack=pack.as_dict(),
+        llm_classifier=llm_classifier,
+    )
+
+    synthesis = synthesize_discussion(
+        pack=pack,
+        classification=classification,
+        llm_synthesizer=llm_synthesizer,
+    )
+
+    handoff: Optional[DiscussionHandoff] = None
+    rendered_parts: list[str] = [synthesis.response_text]
+    if synthesis.mode == DiscussionMode.IMPLEMENTATION_CANDIDATE and synthesis.implementation_ready:
+        handoff = build_implementation_handoff(
+            synthesis=synthesis,
+            pack=pack,
+            department_dir=department_dir,
+            role_profile_loader=role_profile_loader,
+        )
+        rendered_parts.append(handoff.follow_up_text)
+        if handoff.proposal is not None:
+            rendered_parts.append("")
+            rendered_parts.append(format_authorization_message(handoff.proposal))
+
+    blockers = list(pack.blockers) + list(synthesis.blockers)
+    if handoff is not None and handoff.blocker is not None:
+        blocker_text = handoff.blocker.reason
+        if handoff.blocker.detail:
+            blocker_text += f" ({handoff.blocker.detail})"
+        blockers.append(blocker_text)
+
+    return DiscussionTurnResponse(
+        rendered_text="\n\n".join(part for part in rendered_parts if part),
+        classification=classification,
+        synthesis=synthesis,
+        context_pack=pack,
+        handoff=handoff,
+        blockers=tuple(dict.fromkeys(blockers)),  # dedup, stable order
+    )
+
+
+__all__ = (
+    "DiscussionTurnResponse",
+    "build_discussion_turn_response",
+)

--- a/src/yule_orchestrator/github_app/live_client.py
+++ b/src/yule_orchestrator/github_app/live_client.py
@@ -300,6 +300,50 @@ class LiveGithubAppClient:
             body["base_tree"] = str(base_tree)
         return self._post(f"{self._api_base}/repos/{repo}/git/trees", body=body)
 
+    def list_check_runs(
+        self, *, repo: str, head_sha: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """List GitHub Check Runs for a commit SHA.
+
+        Used by the CI retry orchestrator to decide whether the latest
+        executor commit passed / failed / is still pending. The endpoint
+        already returns the per-run conclusion the
+        :func:`agents.job_queue.ci_status.from_check_runs` aggregator
+        consumes; we only need to project to a list of ``{name, status,
+        conclusion}`` dicts so the caller doesn't ship a GitHub-API
+        coupling beyond the adapter boundary.
+        """
+
+        if not head_sha:
+            return ()
+        url = f"{self._api_base}/repos/{repo}/commits/{head_sha}/check-runs"
+        payload = self._get(url)
+        runs = payload.get("check_runs") if isinstance(payload, Mapping) else None
+        if not runs:
+            return ()
+        out: list[dict[str, Any]] = []
+        for run in runs:
+            if not isinstance(run, Mapping):
+                continue
+            out.append(
+                {
+                    "name": str(run.get("name") or ""),
+                    "status": str(run.get("status") or ""),
+                    "conclusion": str(run.get("conclusion") or ""),
+                    "html_url": str(run.get("html_url") or ""),
+                }
+            )
+        return tuple(out)
+
+    def get_pull_request(
+        self, *, repo: str, pr_number: int
+    ) -> Mapping[str, Any]:
+        """Fetch a PR by number — head SHA + state used by the orchestrator."""
+
+        return self._get(
+            f"{self._api_base}/repos/{repo}/pulls/{int(pr_number)}"
+        )
+
     # ------------------------------------------------------------------
     # HTTP helpers — every call funnels through a single token-headers
     # path so the Authorization redaction stays in one place.

--- a/src/yule_orchestrator/runtime/run_service.py
+++ b/src/yule_orchestrator/runtime/run_service.py
@@ -41,9 +41,17 @@ from ..agents.job_queue.approval_discord_poster import (
     build_approval_channel_resolver,
     build_production_post_fn,
 )
+from ..agents.job_queue.coding_execute_progress import (
+    make_github_pr_comment_fn,
+    record_coding_execute_progress,
+)
 from ..agents.job_queue.coding_executor_live import (
     build_live_executor,
     detect_live_executor_availability,
+)
+from ..agents.job_queue.coding_executor_worker import (
+    CodingExecuteOutcome,
+    CodingExecuteRequest,
 )
 from ..agents.job_queue.standalone_runners import (
     build_research_runner,
@@ -350,6 +358,15 @@ def _build_process_job(spec: ServiceSpec, *, queue, heartbeats):
             heartbeats=heartbeats,
             **bundle,
         )
+        obsidian_progress_writer = ObsidianWriterWorker(
+            queue=queue,
+            heartbeats=heartbeats,
+            render_fn=default_render_fn,
+            write_fn=default_write_fn,
+            vault_root_resolver=default_vault_root_resolver,
+        )
+        progress_post_fn = _build_coding_progress_post_fn()
+
         # Producer side runs once per consumer tick — picks up any
         # ``coding_job=ready`` session the gateway approved between
         # iterations and stamps the dispatch marker on the session.
@@ -363,7 +380,12 @@ def _build_process_job(spec: ServiceSpec, *, queue, heartbeats):
                 logger.warning(
                     "coding_execute dispatcher tick raised", exc_info=True
                 )
-            worker.process_job(job)
+            outcome = worker.process_job(job)
+            _record_coding_progress_after_outcome(
+                outcome=outcome,
+                obsidian_writer=obsidian_progress_writer,
+                progress_post_fn=progress_post_fn,
+            )
 
         return _process
 
@@ -443,6 +465,75 @@ def build_coding_executor_bundle(
         availability.code_editor,
     )
     return bundle
+
+
+def _build_coding_progress_post_fn() -> Optional[Any]:
+    """Construct the GitHub PR comment poster wired around the live client.
+
+    Returns None when the GitHub App env is absent so the runtime
+    happily writes only the Obsidian task-log + in-memory progress
+    history. The poster is shared across all coding_execute outcomes
+    in this process — tokens are minted lazily inside the live client.
+    """
+
+    import os as _os
+
+    live_client = _maybe_build_live_github_client(env=_os.environ)
+    if live_client is None:
+        return None
+    return make_github_pr_comment_fn(live_client)
+
+
+def _record_coding_progress_after_outcome(
+    *,
+    outcome: CodingExecuteOutcome,
+    obsidian_writer: Any,
+    progress_post_fn: Optional[Any],
+) -> None:
+    """Wrap :func:`record_coding_execute_progress` for the run-service path.
+
+    Loads the originating session via the workflow store (best effort —
+    when the cache row is gone the recorder still creates the in-memory
+    entry but the persisted history isn't updated). All exceptions are
+    swallowed so a progress recorder bug never derails the consumer.
+    """
+
+    if outcome is None or outcome.job is None:
+        return
+    payload = outcome.job.payload or {}
+    session_id = str(payload.get("session_id") or outcome.job.session_id or "")
+    if not session_id:
+        return
+
+    try:
+        from ..agents.workflow_state import load_session
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        session = load_session(session_id)
+    except Exception:  # noqa: BLE001
+        session = None
+    if session is None:
+        return
+
+    try:
+        request = CodingExecuteRequest.from_payload(payload)
+    except Exception:  # noqa: BLE001
+        request = None
+
+    try:
+        record_coding_execute_progress(
+            session=session,
+            outcome=outcome,
+            request=request,
+            obsidian_writer=obsidian_writer,
+            github_comment_fn=progress_post_fn,
+            repo_full_name=request.repo_full_name if request else None,
+        )
+    except Exception:  # noqa: BLE001 - never crash consumer on progress bug
+        logger.warning(
+            "coding_execute progress recorder raised", exc_info=True
+        )
 
 
 def _maybe_build_live_github_client(*, env: Mapping[str, str]) -> Optional[Any]:

--- a/src/yule_orchestrator/runtime/run_service.py
+++ b/src/yule_orchestrator/runtime/run_service.py
@@ -22,10 +22,11 @@ import logging
 import signal
 import sys
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from ..agents.job_queue import (
     ApprovalWorker,
+    CodingExecutorWorker,
     HeartbeatStore,
     JobQueue,
     ObsidianWriterWorker,
@@ -34,10 +35,15 @@ from ..agents.job_queue import (
     default_render_fn,
     default_vault_root_resolver,
     default_write_fn,
+    dispatch_ready_coding_jobs,
 )
 from ..agents.job_queue.approval_discord_poster import (
     build_approval_channel_resolver,
     build_production_post_fn,
+)
+from ..agents.job_queue.coding_executor_live import (
+    build_live_executor,
+    detect_live_executor_availability,
 )
 from ..agents.job_queue.standalone_runners import (
     build_research_runner,
@@ -337,7 +343,135 @@ def _build_process_job(spec: ServiceSpec, *, queue, heartbeats):
 
         return _process
 
+    if spec.kind == ServiceKind.CODING_EXECUTOR:
+        bundle = build_coding_executor_bundle()
+        worker = CodingExecutorWorker(
+            queue=queue,
+            heartbeats=heartbeats,
+            **bundle,
+        )
+        # Producer side runs once per consumer tick — picks up any
+        # ``coding_job=ready`` session the gateway approved between
+        # iterations and stamps the dispatch marker on the session.
+        # Failures inside the dispatcher are swallowed (see the
+        # dispatcher's per-row try/except) so a bad session can never
+        # crash the consumer loop.
+        async def _process(job):
+            try:
+                dispatch_ready_coding_jobs(worker=worker)
+            except Exception:  # noqa: BLE001 - producer must not break consumer
+                logger.warning(
+                    "coding_execute dispatcher tick raised", exc_info=True
+                )
+            worker.process_job(job)
+
+        return _process
+
     raise ValueError(f"no worker builder for kind={spec.kind!r}")
+
+
+# ---------------------------------------------------------------------------
+# Coding executor bundle — Round 3 wiring
+# ---------------------------------------------------------------------------
+#
+# Resolves the live executor Protocol implementations once at service
+# startup. The bundle composition is *layered* so an operator can opt in
+# to live push without first wiring the LLM editor (which the project
+# treats as a separate authorization gate):
+#
+#   * worktree provisioner / record-only editor / subprocess test runner /
+#     local git committer — always wired (no external creds).
+#   * pusher + draft PR creator — wired ONLY when GitHub App env is set
+#     (``YULE_GITHUB_APP_ID`` + installation id + private key path).
+#     Otherwise the worker keeps the ``_NotImplementedStep`` defaults
+#     and a live ``dry_run=False`` job lands as
+#     ``REASON_NOT_IMPLEMENTED`` rather than half-running.
+#
+# An operator who explicitly forces the dry-run env wins over both
+# (we never push when the operator says "just verify the plumbing").
+ENV_CODING_EXECUTOR_REPO_ROOT: str = "YULE_CODING_EXECUTOR_REPO_ROOT"
+ENV_CODING_EXECUTOR_WORKTREE_ROOT: str = "YULE_CODING_EXECUTOR_WORKTREE_ROOT"
+
+
+def build_coding_executor_bundle(
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    live_client_factory: Optional[Any] = None,
+) -> Mapping[str, Any]:
+    """Return the kwargs for :class:`CodingExecutorWorker` construction.
+
+    *env* defaults to ``os.environ``; tests pass a controlled mapping
+    to drive the matrix without polluting the live process. The
+    *live_client_factory* injection point lets tests stub the live
+    GitHub App client without exercising the real JWT path.
+    """
+
+    import os as _os
+
+    source: Mapping[str, str] = env if env is not None else _os.environ
+    repo_root = (source.get(ENV_CODING_EXECUTOR_REPO_ROOT) or "").strip()
+    if not repo_root:
+        repo_root = (source.get("YULE_REPO_ROOT") or _os.getcwd()).strip() or _os.getcwd()
+    worktree_root = (source.get(ENV_CODING_EXECUTOR_WORKTREE_ROOT) or "").strip() or None
+
+    live_client = None
+    if live_client_factory is not None:
+        try:
+            live_client = live_client_factory()
+        except Exception:  # noqa: BLE001 - never crash service startup
+            logger.warning(
+                "coding executor: live_client_factory raised; "
+                "pusher / draft PR will fall back to dry-run blocker",
+                exc_info=True,
+            )
+            live_client = None
+    else:
+        live_client = _maybe_build_live_github_client(env=source)
+
+    bundle = build_live_executor(
+        repo_root=repo_root,
+        live_client=live_client,
+        worktree_root=worktree_root,
+    )
+    availability = detect_live_executor_availability(
+        repo_root=repo_root, live_client=live_client
+    )
+    logger.info(
+        "coding executor wiring: pusher=%s draft_pr=%s editor=%s",
+        availability.pusher,
+        availability.draft_pr_creator,
+        availability.code_editor,
+    )
+    return bundle
+
+
+def _maybe_build_live_github_client(*, env: Mapping[str, str]) -> Optional[Any]:
+    """Return a live GitHub App client if env is set, else None.
+
+    The factory only fires when *all three* env keys are present —
+    we don't want a partial config (e.g. app id but no key path) to
+    silently force a stub through. Errors at construction are
+    swallowed so the consumer falls back to dry-run-only.
+    """
+
+    needed = (
+        "YULE_GITHUB_APP_ID",
+        "YULE_GITHUB_APP_INSTALLATION_ID",
+        "YULE_GITHUB_APP_PRIVATE_KEY_PATH",
+    )
+    if not all((env.get(name) or "").strip() for name in needed):
+        return None
+    try:
+        from ..github_app.live_client import build_live_client_from_env
+
+        return build_live_client_from_env(env)
+    except Exception:  # noqa: BLE001 - log and continue dry-run
+        logger.warning(
+            "coding executor: build_live_client_from_env raised; falling "
+            "back to push-blocked bundle",
+            exc_info=True,
+        )
+        return None
 
 
 def _pick_filters_for(spec: ServiceSpec):
@@ -351,6 +485,8 @@ def _pick_filters_for(spec: ServiceSpec):
         return (("approval_post",), ())
     if spec.kind == ServiceKind.OBSIDIAN_WRITER:
         return (("obsidian_write",), ())
+    if spec.kind == ServiceKind.CODING_EXECUTOR:
+        return (("coding_execute",), ())
     return ((), ())
 
 
@@ -484,9 +620,12 @@ def parse_args_and_run(argv: Optional[Iterable[str]] = None) -> int:
 
 
 __all__ = (
+    "ENV_CODING_EXECUTOR_REPO_ROOT",
+    "ENV_CODING_EXECUTOR_WORKTREE_ROOT",
     "EXIT_INTERNAL_ERROR",
     "EXIT_OK",
     "EXIT_UNKNOWN_SERVICE",
+    "build_coding_executor_bundle",
     "parse_args_and_run",
     "run_service_main",
 )

--- a/tests/discord/test_engineering_discussion_turn.py
+++ b/tests/discord/test_engineering_discussion_turn.py
@@ -1,0 +1,129 @@
+"""Integration tests for ``discord/engineering_discussion_turn.py``.
+
+분류 → context pack → synthesis → (필요 시) handoff까지 한 번에 호출하는
+gateway 진입점이 4가지 모드 모두에서 일관된 envelope를 만들어내는지 검증.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    ContextPackBuilder,
+    DiscussionMode,
+    GithubIssueRef,
+    ObsidianNoteRef,
+    RelevantMemorySelector,
+    ThreadMessage,
+)
+from yule_orchestrator.discord.engineering_discussion_turn import (
+    build_discussion_turn_response,
+)
+
+
+class BuildDiscussionTurnResponseTestCase(unittest.TestCase):
+    def test_discussion_path_renders_role_perspectives(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="이 구조 맞아? devops 관점에서 어떻게 풀지",
+        )
+        self.assertEqual(result.classification.mode, DiscussionMode.DISCUSSION)
+        self.assertIn("devops", result.rendered_text.lower())
+        self.assertIn("권한 제안", result.rendered_text)
+        self.assertIsNone(result.handoff)
+
+    def test_research_path_lists_followups(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="일단 조사만 해줘 — auth 흐름 정리",
+        )
+        self.assertEqual(result.classification.mode, DiscussionMode.RESEARCH_ONLY)
+        self.assertTrue(any("research profile" in f for f in result.synthesis.research_followups))
+        self.assertIsNone(result.handoff)
+
+    def test_implementation_path_includes_proposal_block(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="Spring Security 인증 마이그 패치 작성, API 흐름도 조정해줘 / PR 올려",
+        )
+        self.assertEqual(
+            result.classification.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE
+        )
+        self.assertIsNotNone(result.handoff)
+        self.assertIsNotNone(result.handoff.proposal)
+        self.assertIn("코딩 권한 제안", result.rendered_text)
+        self.assertIn("backend-engineer", result.rendered_text)
+
+    def test_clarification_path_asks_questions(self) -> None:
+        result = build_discussion_turn_response(message_text="ㅎ")
+        self.assertEqual(
+            result.classification.mode, DiscussionMode.CLARIFICATION_NEEDED
+        )
+        self.assertGreater(len(result.synthesis.open_questions), 0)
+        self.assertIsNone(result.handoff)
+
+    def test_pack_seams_propagate_into_synthesis(self) -> None:
+        builder = ContextPackBuilder(
+            thread_loader=lambda sid: [
+                ThreadMessage(role="user", content="이전에 같은 화면 hero 정리하던 흐름"),
+                ThreadMessage(role="tech-lead", content="hero 정리 PR #99 닫혔음"),
+            ],
+            issue_loader=lambda q: [
+                GithubIssueRef(number=42, title="hero hero", state="open"),
+            ],
+            note_loader=lambda q: [
+                ObsidianNoteRef(
+                    title="hero 회의록",
+                    path="notes/hero.md",
+                    summary="hero 의사결정",
+                    tags=("frontend-engineer",),
+                ),
+            ],
+            memory_selector=RelevantMemorySelector(min_score=0.0),
+        )
+        result = build_discussion_turn_response(
+            message_text="이 hero 구조 맞아?",
+            session=SimpleNamespace(
+                session_id="abc12345",
+                task_type="frontend-feature",
+                write_requested=False,
+                write_blocked_reason=None,
+                extra={"research_pack": {"x": 1}},
+            ),
+            builder=builder,
+        )
+        self.assertEqual(result.classification.mode, DiscussionMode.DISCUSSION)
+        self.assertIn("issue #42", result.rendered_text)
+        self.assertIn("hero 회의록", result.rendered_text)
+
+    def test_seam_failure_surfaces_blocker_but_does_not_crash(self) -> None:
+        def crash(_):
+            raise RuntimeError("offline")
+
+        builder = ContextPackBuilder(
+            issue_loader=crash,
+            pr_loader=crash,
+        )
+        result = build_discussion_turn_response(
+            message_text="이 구조 맞아?",
+            builder=builder,
+        )
+        self.assertEqual(result.classification.mode, DiscussionMode.DISCUSSION)
+        self.assertTrue(any("issue_loader" in b for b in result.blockers))
+        self.assertTrue(any("pr_loader" in b for b in result.blockers))
+
+    def test_llm_seam_takes_over_on_ambiguous_text(self) -> None:
+        # deterministic 신호가 약한 메시지 — LLM seam이 분류를 먹는다.
+        result = build_discussion_turn_response(
+            message_text="users 흐름 관련해서 한 번 봐줄래",
+            llm_classifier=lambda **_: DiscussionMode.RESEARCH_ONLY,
+        )
+        self.assertEqual(result.classification.mode, DiscussionMode.RESEARCH_ONLY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -1,0 +1,177 @@
+"""Tests for ``yule_orchestrator.agents.discussion.context_pack``."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    CodeHint,
+    ContextPack,
+    ContextPackBuilder,
+    GithubIssueRef,
+    GithubPRRef,
+    ObsidianNoteRef,
+    RelevantMemorySelector,
+    ThreadMessage,
+)
+
+
+class ContextPackBuilderTestCase(unittest.TestCase):
+    def _session(self, **kwargs):
+        defaults = dict(
+            session_id="abc12345",
+            task_type="backend-feature",
+            write_requested=False,
+            write_blocked_reason=None,
+            extra={"research_pack": {"x": 1}},
+        )
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_empty_builder_returns_pack_with_only_message(self) -> None:
+        builder = ContextPackBuilder()
+        pack = builder.build(message_text="hello world")
+        self.assertEqual(pack.current_message, "hello world")
+        self.assertIsNone(pack.session_id)
+        self.assertEqual(pack.recent_thread, ())
+        self.assertEqual(pack.related_issues, ())
+        self.assertEqual(pack.relevant_notes, ())
+        self.assertEqual(pack.blockers, ())
+
+    def test_thread_loader_truncates_long_messages(self) -> None:
+        long_msg = "ㄱ" * 500
+        builder = ContextPackBuilder(
+            thread_loader=lambda sid: [
+                ThreadMessage(role="user", content=long_msg, posted_at="2026-05-09T10:00"),
+                ThreadMessage(role="tech-lead", content="짧은 답변"),
+            ],
+            max_thread_message_chars=100,
+        )
+        pack = builder.build(
+            message_text="후속 질문",
+            session=self._session(),
+        )
+        self.assertEqual(len(pack.recent_thread), 2)
+        self.assertLessEqual(len(pack.recent_thread[0].content), 100)
+        self.assertTrue(pack.recent_thread[0].content.endswith("…"))
+        self.assertIn("최근 thread 발화", pack.thread_summary or "")
+
+    def test_thread_loader_accepts_mappings(self) -> None:
+        builder = ContextPackBuilder(
+            thread_loader=lambda sid: [
+                {"role": "user", "content": "안녕"},
+                {"role": "tech-lead", "content": "응 들어왔다"},
+            ]
+        )
+        pack = builder.build(
+            message_text="x",
+            session=self._session(),
+        )
+        self.assertEqual(len(pack.recent_thread), 2)
+        self.assertEqual(pack.recent_thread[0].role, "user")
+
+    def test_seam_failure_is_captured_as_blocker(self) -> None:
+        def crashing(query: str):
+            raise RuntimeError("github offline")
+
+        builder = ContextPackBuilder(
+            issue_loader=crashing,
+            pr_loader=crashing,
+            note_loader=crashing,
+            code_hint_loader=crashing,
+        )
+        pack = builder.build(message_text="hi")
+        self.assertEqual(pack.related_issues, ())
+        self.assertEqual(pack.related_prs, ())
+        self.assertEqual(pack.relevant_notes, ())
+        self.assertEqual(pack.code_hints, ())
+        for needle in ("issue_loader", "pr_loader", "note_loader", "code_hint_loader"):
+            self.assertTrue(
+                any(needle in b for b in pack.blockers),
+                f"missing blocker for {needle}: {pack.blockers}",
+            )
+
+    def test_memory_selector_filters_notes(self) -> None:
+        notes = [
+            ObsidianNoteRef(
+                title="auth migration retro",
+                summary="auth migration #42 had a token leak",
+                tags=("backend-feature", "auth", "backend-engineer"),
+                kind="retrospective",
+            ),
+            ObsidianNoteRef(
+                title="diary",
+                summary="lunch was good",
+                tags=("personal",),
+                kind="reference",
+            ),
+        ]
+        builder = ContextPackBuilder(
+            note_loader=lambda q: notes,
+            memory_selector=RelevantMemorySelector(),
+        )
+        pack = builder.build(
+            message_text="auth migration 어떻게 정리했지",
+            session=self._session(task_type="backend-feature"),
+            role_for_research="engineering-agent/backend-engineer",
+        )
+        self.assertEqual(len(pack.relevant_notes), 1)
+        self.assertEqual(pack.relevant_notes[0].title, "auth migration retro")
+
+    def test_role_profile_loader_summary_used(self) -> None:
+        builder = ContextPackBuilder(
+            role_profile_loader=lambda role: f"profile for {role}",
+            role_research_profile_loader=lambda role: f"research for {role}",
+        )
+        pack = builder.build(
+            message_text="hi",
+            role_for_research="engineering-agent/qa-engineer",
+        )
+        self.assertEqual(pack.role_profile_summary, "profile for engineering-agent/qa-engineer")
+        self.assertEqual(
+            pack.role_research_profile_summary,
+            "research for engineering-agent/qa-engineer",
+        )
+
+    def test_session_extra_summary_lists_known_keys(self) -> None:
+        builder = ContextPackBuilder()
+        pack = builder.build(
+            message_text="hi",
+            session=self._session(extra={
+                "research_pack": {"x": 1},
+                "coding_proposal": {"y": 2},
+                "secret_token": "should-not-appear",
+            }),
+        )
+        self.assertIsNotNone(pack.session_extra_summary)
+        self.assertIn("research_pack", pack.session_extra_summary or "")
+        self.assertIn("coding_proposal", pack.session_extra_summary or "")
+        self.assertNotIn("secret_token", pack.session_extra_summary or "")
+        self.assertNotIn("should-not-appear", pack.session_extra_summary or "")
+
+    def test_as_dict_round_trip_keys(self) -> None:
+        pack = ContextPack(
+            current_message="hi",
+            session_id="sid",
+            related_issues=(GithubIssueRef(number=1, title="x"),),
+            related_prs=(GithubPRRef(number=2, title="y"),),
+            relevant_notes=(ObsidianNoteRef(title="n"),),
+            code_hints=(CodeHint(path="src/a.py"),),
+        )
+        payload = pack.as_dict()
+        self.assertEqual(payload["session_id"], "sid")
+        self.assertEqual(payload["related_issues"][0]["number"], 1)
+        self.assertEqual(payload["related_prs"][0]["number"], 2)
+        self.assertEqual(payload["relevant_notes"][0]["title"], "n")
+        self.assertEqual(payload["code_hints"][0]["path"], "src/a.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -317,5 +317,146 @@ class ContextPackKnowledgeIntegrationTestCase(unittest.TestCase):
         )
 
 
+class ContextPackEvidenceSurfaceTestCase(unittest.TestCase):
+    """``relevant_knowledge`` → 사람이 읽을 수 있는 evidence 블록."""
+
+    def _public_ref(self, **overrides) -> EngineeringKnowledgeRef:
+        base = dict(
+            title="Spring Security 인증 흐름",
+            role="backend-engineer",
+            topic_key="spring-auth",
+            source_url="https://example.com/spring-auth",
+            source_name="Spring Docs",
+            summary="OAuth2 + Filter chain 정리",
+            score=8.0,
+            signals=("role_primary_match", "axis_overlap:api_schema_auth"),
+            evidence_labels=(
+                "요청 역할과 정확히 일치",
+                "task_type 축 일치 (api_schema_auth)",
+            ),
+            share_scope="public",
+        )
+        base.update(overrides)
+        return EngineeringKnowledgeRef(**base)
+
+    def test_empty_relevant_knowledge_returns_empty_string(self) -> None:
+        pack = ContextPack(current_message="hi")
+        self.assertEqual(pack.format_knowledge_evidence_block(), "")
+
+    def test_public_evidence_includes_summary_and_signals(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(self._public_ref(),),
+        )
+        block = pack.format_knowledge_evidence_block()
+        self.assertIn("근거 자료", block)
+        self.assertIn("Spring Security 인증 흐름", block)
+        self.assertIn("OAuth2 + Filter chain 정리", block)
+        # 사람이 읽는 evidence 라벨이 그대로 노출된다.
+        self.assertIn("요청 역할과 정확히 일치", block)
+        self.assertIn("task_type 축 일치", block)
+        self.assertIn("score=8.0", block)
+
+    def test_team_internal_evidence_drops_summary(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                self._public_ref(
+                    share_scope="team_internal",
+                    summary="이 요약은 외부 surface 에 노출되면 안 된다",
+                ),
+            ),
+        )
+        block = pack.format_knowledge_evidence_block()
+        self.assertIn("Spring Security 인증 흐름", block)
+        self.assertIn("team-internal", block)
+        self.assertNotIn("외부 surface 에 노출되면 안 된다", block)
+
+    def test_restricted_evidence_redacts_title_and_url(self) -> None:
+        pack = ContextPack(
+            current_message="incident",
+            relevant_knowledge=(
+                self._public_ref(
+                    share_scope="restricted",
+                    share_scope_reason="customer PII",
+                    title="2026-04-29 customer data leak",
+                    source_url="https://internal.example.com/incidents/2026-04-29",
+                    summary="민감 본문",
+                ),
+            ),
+        )
+        block = pack.format_knowledge_evidence_block()
+        # 제목/URL/요약 어떤 것도 외부에 옮겨지지 않는다.
+        self.assertNotIn("customer data leak", block)
+        self.assertNotIn("internal.example.com/incidents", block)
+        self.assertNotIn("민감 본문", block)
+        self.assertIn("공개 제한된 자료", block)
+        self.assertIn("customer PII", block)
+
+    def test_max_items_caps_block_length(self) -> None:
+        refs = tuple(
+            self._public_ref(topic_key=f"k{i}", title=f"item {i}")
+            for i in range(8)
+        )
+        pack = ContextPack(current_message="x", relevant_knowledge=refs)
+        block = pack.format_knowledge_evidence_block(max_items=3)
+        for visible in ("item 0", "item 1", "item 2"):
+            self.assertIn(visible, block)
+        self.assertNotIn("item 5", block)
+
+    def test_as_dict_carries_share_scope_and_evidence_labels(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(self._public_ref(share_scope="team_internal"),),
+        )
+        payload = pack.as_dict()
+        knowledge = payload["relevant_knowledge"][0]
+        self.assertEqual(knowledge["share_scope"], "team_internal")
+        self.assertEqual(knowledge["score"], 8.0)
+        self.assertIn("요청 역할과 정확히 일치", knowledge["evidence_labels"])
+
+
+class ContextPackKnowledgeMatchUnwrapTestCase(unittest.TestCase):
+    """``KnowledgeRetriever.with_signals`` 가 ContextPack 까지 흘러들어와야 한다."""
+
+    def test_with_signals_path_carries_score_and_labels(self) -> None:
+        candidates = [
+            KnowledgeRecord(
+                topic_key="spring-auth",
+                title="Spring 인증",
+                role="backend-engineer",
+                source_url="https://example.com/spring-auth",
+                source_name="Spring Docs",
+                summary="OAuth2 흐름",
+                axes=(SourceAxis.API_SCHEMA_AUTH,),
+                rag_tags=("auth",),
+                collected_at="2026-05-08T00:00:00Z",
+            ),
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            knowledge_retriever=KnowledgeRetriever(min_score=0.0),
+        )
+        pack = builder.build(
+            message_text="spring auth 흐름이 어떻게 되지",
+            session=SimpleNamespace(
+                session_id="abc",
+                task_type="backend-feature",
+                write_requested=False,
+                write_blocked_reason=None,
+                extra={},
+            ),
+            role_for_research="engineering-agent/backend-engineer",
+        )
+        self.assertEqual(len(pack.relevant_knowledge), 1)
+        ref = pack.relevant_knowledge[0]
+        # score 와 signals 가 ContextPack 으로 전달되어 surface 가 가능
+        self.assertIsNotNone(ref.score)
+        self.assertGreater(ref.score, 0.0)
+        self.assertTrue(ref.signals, msg="signals were not propagated")
+        # evidence_labels 도 ContextPack 까지 살아 들어온다 (한국어 라벨).
+        self.assertTrue(ref.evidence_labels)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -416,6 +416,71 @@ class ContextPackEvidenceSurfaceTestCase(unittest.TestCase):
         self.assertIn("요청 역할과 정확히 일치", knowledge["evidence_labels"])
 
 
+class ContextPackShortSummaryTestCase(unittest.TestCase):
+    """`knowledge_short_summary` + `share_boundary_breakdown` 회귀 가드."""
+
+    def _ref(self, **overrides) -> EngineeringKnowledgeRef:
+        base = dict(
+            title="Spring Security 인증 흐름",
+            role="backend-engineer",
+            topic_key="spring-auth",
+            source_url="https://example.com/spring-auth",
+            source_name="Spring Docs",
+            summary="OAuth2 정리",
+            share_scope="public",
+        )
+        base.update(overrides)
+        return EngineeringKnowledgeRef(**base)
+
+    def test_empty_pack_returns_empty_summary_and_zero_breakdown(self) -> None:
+        pack = ContextPack(current_message="hi")
+        self.assertEqual(pack.knowledge_short_summary(), "")
+        breakdown = pack.share_boundary_breakdown()
+        self.assertEqual(breakdown["public"], 0)
+        self.assertEqual(breakdown["team_internal"], 0)
+        self.assertEqual(breakdown["restricted"], 0)
+        self.assertEqual(breakdown["total"], 0)
+
+    def test_summary_lists_top_titles_and_scope_counts(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                self._ref(),
+                self._ref(
+                    title="사내 OAuth playbook",
+                    topic_key="company-oauth",
+                    share_scope="team_internal",
+                ),
+                self._ref(
+                    title="incident-2026-04-29",
+                    topic_key="incident-2026-04-29",
+                    share_scope="restricted",
+                    share_scope_reason="PII",
+                ),
+            ),
+        )
+        summary = pack.knowledge_short_summary()
+        self.assertIn("근거 자료 3건", summary)
+        self.assertIn("public 1", summary)
+        self.assertIn("team_internal 1", summary)
+        self.assertIn("restricted 1", summary)
+        # 상위 2 건의 제목이 들어가지만 restricted 의 제목/url 은 절대 새지 않는다.
+        self.assertIn("Spring Security 인증 흐름", summary)
+        self.assertIn("사내 OAuth playbook", summary)
+        self.assertIn("team-internal", summary)
+        self.assertNotIn("incident-2026-04-29", summary)
+
+    def test_summary_max_topics_caps_preview(self) -> None:
+        refs = tuple(
+            self._ref(topic_key=f"k{i}", title=f"item {i}") for i in range(4)
+        )
+        pack = ContextPack(current_message="x", relevant_knowledge=refs)
+        summary = pack.knowledge_short_summary(max_topics=1)
+        self.assertIn("외 3건", summary)
+        self.assertIn("item 0", summary)
+        self.assertNotIn("item 1", summary)
+
+
 class ContextPackKnowledgeMatchUnwrapTestCase(unittest.TestCase):
     """``KnowledgeRetriever.with_signals`` 가 ContextPack 까지 흘러들어와야 한다."""
 

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -15,11 +15,17 @@ from yule_orchestrator.agents.discussion import (
     CodeHint,
     ContextPack,
     ContextPackBuilder,
+    EngineeringKnowledgeRef,
     GithubIssueRef,
     GithubPRRef,
     ObsidianNoteRef,
     RelevantMemorySelector,
     ThreadMessage,
+)
+from yule_orchestrator.agents.engineering_intelligence import (
+    KnowledgeRecord,
+    KnowledgeRetriever,
+    SourceAxis,
 )
 
 
@@ -163,6 +169,15 @@ class ContextPackBuilderTestCase(unittest.TestCase):
             related_issues=(GithubIssueRef(number=1, title="x"),),
             related_prs=(GithubPRRef(number=2, title="y"),),
             relevant_notes=(ObsidianNoteRef(title="n"),),
+            relevant_knowledge=(
+                EngineeringKnowledgeRef(
+                    title="Spring auth",
+                    role="backend-engineer",
+                    topic_key="spring-auth",
+                    axes=("api_schema_auth",),
+                    rag_tags=("auth",),
+                ),
+            ),
             code_hints=(CodeHint(path="src/a.py"),),
         )
         payload = pack.as_dict()
@@ -171,6 +186,135 @@ class ContextPackBuilderTestCase(unittest.TestCase):
         self.assertEqual(payload["related_prs"][0]["number"], 2)
         self.assertEqual(payload["relevant_notes"][0]["title"], "n")
         self.assertEqual(payload["code_hints"][0]["path"], "src/a.py")
+        self.assertEqual(payload["relevant_knowledge"][0]["topic_key"], "spring-auth")
+        self.assertEqual(payload["relevant_knowledge"][0]["axes"], ["api_schema_auth"])
+
+
+class ContextPackKnowledgeIntegrationTestCase(unittest.TestCase):
+    """`engineering_intelligence` retrieval ↔ ContextPackBuilder wiring."""
+
+    def _record(
+        self,
+        topic_key: str,
+        title: str,
+        role: str = "backend-engineer",
+        axes: tuple = (SourceAxis.API_SCHEMA_AUTH,),
+    ) -> KnowledgeRecord:
+        return KnowledgeRecord(
+            topic_key=topic_key,
+            title=title,
+            role=role,
+            source_url=f"https://example.com/{topic_key}",
+            source_name="Spring Docs",
+            summary=f"summary for {topic_key}",
+            axes=axes,
+            rag_tags=("spring", "auth"),
+            collected_at="2026-05-08T00:00:00Z",
+        )
+
+    def test_knowledge_loader_results_appear_in_pack(self) -> None:
+        candidates = [
+            self._record("spring-auth", "Spring 인증"),
+            self._record(
+                "qa-cypress",
+                "Cypress 회귀",
+                role="qa-engineer",
+                axes=(SourceAxis.REGRESSION_TEST_PLAN,),
+            ),
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            knowledge_retriever=KnowledgeRetriever(min_score=0.5),
+            max_knowledge=5,
+        )
+        pack = builder.build(
+            message_text="spring auth 흐름이 어떻게 되지",
+            session=SimpleNamespace(
+                session_id="abc",
+                task_type="backend-feature",
+                write_requested=False,
+                write_blocked_reason=None,
+                extra={},
+            ),
+            role_for_research="engineering-agent/backend-engineer",
+        )
+        self.assertGreater(len(pack.relevant_knowledge), 0)
+        # Backend-feature task + backend-engineer role → spring-auth
+        # should outscore the qa-engineer record.
+        self.assertEqual(pack.relevant_knowledge[0].topic_key, "spring-auth")
+
+    def test_knowledge_retriever_omitted_uses_role_first_fallback(self) -> None:
+        candidates = [
+            self._record("qa-cypress", "Cypress", role="qa-engineer"),
+            self._record("spring-auth", "Spring 인증"),
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            max_knowledge=5,
+        )
+        pack = builder.build(
+            message_text="auth",
+            role_for_research="backend-engineer",
+        )
+        # Same-role record (spring-auth) should land before the
+        # qa-engineer one even without a retriever.
+        self.assertEqual(pack.relevant_knowledge[0].topic_key, "spring-auth")
+        self.assertEqual(pack.relevant_knowledge[1].topic_key, "qa-cypress")
+
+    def test_knowledge_loader_failure_records_blocker(self) -> None:
+        def boom(query: str):
+            raise RuntimeError("vault offline")
+
+        builder = ContextPackBuilder(knowledge_loader=boom)
+        pack = builder.build(message_text="hi")
+        self.assertEqual(pack.relevant_knowledge, ())
+        self.assertTrue(
+            any("knowledge_loader" in b for b in pack.blockers),
+            f"expected knowledge_loader blocker; got {pack.blockers}",
+        )
+
+    def test_knowledge_loader_capped_by_max_knowledge(self) -> None:
+        candidates = [
+            self._record(f"k{i}", f"item {i}") for i in range(10)
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            knowledge_retriever=KnowledgeRetriever(min_score=0.0),
+            max_knowledge=3,
+        )
+        pack = builder.build(
+            message_text="hi",
+            role_for_research="backend-engineer",
+        )
+        self.assertEqual(len(pack.relevant_knowledge), 3)
+
+    def test_dict_candidates_coerce(self) -> None:
+        candidates = [
+            {
+                "topic_key": "spring-auth",
+                "title": "Spring 인증",
+                "role": "backend-engineer",
+                "summary": "OAuth2 정리",
+                "axes": ["api_schema_auth"],
+                "rag_tags": ["auth"],
+                "collected_at": "2026-05-08T00:00:00Z",
+                "importance": "high",
+            }
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            knowledge_retriever=KnowledgeRetriever(min_score=0.0),
+        )
+        pack = builder.build(
+            message_text="spring",
+            role_for_research="backend-engineer",
+        )
+        self.assertEqual(len(pack.relevant_knowledge), 1)
+        self.assertEqual(pack.relevant_knowledge[0].topic_key, "spring-auth")
+        self.assertEqual(
+            pack.relevant_knowledge[0].axes,
+            ("api_schema_auth",),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/engineering/test_discussion_handoff.py
+++ b/tests/engineering/test_discussion_handoff.py
@@ -1,0 +1,100 @@
+"""Tests for ``yule_orchestrator.agents.discussion.handoff``."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    ContextPack,
+    DiscussionMode,
+    DiscussionSynthesis,
+    build_implementation_handoff,
+)
+
+
+def _impl_synth(*, ready: bool = True) -> DiscussionSynthesis:
+    return DiscussionSynthesis(
+        mode=DiscussionMode.IMPLEMENTATION_CANDIDATE,
+        rationale="impl",
+        response_text="hello",
+        implementation_ready=ready,
+    )
+
+
+def _other_synth(mode: DiscussionMode) -> DiscussionSynthesis:
+    return DiscussionSynthesis(
+        mode=mode,
+        rationale="x",
+        response_text="x",
+    )
+
+
+class BuildImplementationHandoffTestCase(unittest.TestCase):
+    def test_proposal_for_clear_implementation(self) -> None:
+        pack = ContextPack(
+            current_message="Spring Security 인증 마이그 패치 작성, API 흐름도 조정해줘",
+            session_id="abc12345",
+        )
+        handoff = build_implementation_handoff(synthesis=_impl_synth(), pack=pack)
+        self.assertIsNotNone(handoff.proposal)
+        self.assertEqual(handoff.proposal.executor_role, "backend-engineer")
+        self.assertIn("권한 제안을 만들었습니다", handoff.follow_up_text)
+        self.assertIsNone(handoff.blocker)
+
+    def test_skips_when_not_implementation_mode(self) -> None:
+        for mode in (
+            DiscussionMode.DISCUSSION,
+            DiscussionMode.RESEARCH_ONLY,
+            DiscussionMode.CLARIFICATION_NEEDED,
+        ):
+            with self.subTest(mode=mode):
+                handoff = build_implementation_handoff(
+                    synthesis=_other_synth(mode),
+                    pack=ContextPack(current_message="x"),
+                )
+                self.assertIsNone(handoff.proposal)
+                self.assertIsNotNone(handoff.blocker)
+
+    def test_skips_when_implementation_ready_false(self) -> None:
+        handoff = build_implementation_handoff(
+            synthesis=_impl_synth(ready=False),
+            pack=ContextPack(current_message="x"),
+        )
+        self.assertIsNone(handoff.proposal)
+        self.assertIsNotNone(handoff.blocker)
+
+    def test_blocks_when_user_request_empty(self) -> None:
+        pack = ContextPack(current_message="   ")
+        handoff = build_implementation_handoff(synthesis=_impl_synth(), pack=pack)
+        self.assertIsNone(handoff.proposal)
+        assert handoff.blocker is not None
+        self.assertEqual(handoff.blocker.reason, "user_request가 비어 있음")
+
+    def test_falls_back_to_thread_summary(self) -> None:
+        pack = ContextPack(
+            current_message="",
+            thread_summary="auth 마이그 PR 만들어 달라는 누적 thread",
+        )
+        handoff = build_implementation_handoff(synthesis=_impl_synth(), pack=pack)
+        # auth/마이그 키워드 → backend-engineer
+        self.assertIsNotNone(handoff.proposal)
+
+    def test_research_only_recommendation_becomes_blocker(self) -> None:
+        # 본문이 "조사만" 신호를 강하게 가지면 recommend_authorization은
+        # research-only로 떨어진다. 토의 분류가 implementation이라고 봤어
+        # 도, handoff는 충돌 신호로 처리해 사용자에게 다시 묻게 한다.
+        pack = ContextPack(current_message="조사만 해줘 — auth 흐름 정리")
+        handoff = build_implementation_handoff(synthesis=_impl_synth(), pack=pack)
+        self.assertIsNone(handoff.proposal)
+        assert handoff.blocker is not None
+        self.assertIn("research-only", handoff.blocker.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_memory_selector.py
+++ b/tests/engineering/test_discussion_memory_selector.py
@@ -1,0 +1,155 @@
+"""Tests for ``yule_orchestrator.agents.discussion.memory_selector``."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    ObsidianNoteRef,
+    RelevantMemorySelector,
+    score_memory_candidate,
+)
+
+
+def _note(**kwargs) -> ObsidianNoteRef:
+    defaults = dict(
+        title="t",
+        path="p",
+        summary="s",
+        tags=(),
+        kind=None,
+        project=None,
+        updated_at=None,
+    )
+    defaults.update(kwargs)
+    return ObsidianNoteRef(**defaults)
+
+
+class ScoreMemoryCandidateTestCase(unittest.TestCase):
+    def test_topic_overlap_increases_score(self) -> None:
+        cand = score_memory_candidate(
+            _note(
+                title="Spring Security 인증 마이그레이션",
+                summary="기존 인증 흐름을 정리하면서 발견한 케이스",
+                tags=("auth", "backend-engineer"),
+            ),
+            query="Spring Security 인증 마이그레이션 정리",
+            task_type=None,
+            role=None,
+        )
+        self.assertGreater(cand.score, 2.5)
+        self.assertIn("topic_overlap", "/".join(cand.signals))
+
+    def test_role_match_adds_two(self) -> None:
+        cand = score_memory_candidate(
+            _note(
+                title="bg",
+                summary="없음",
+                tags=("backend-engineer",),
+            ),
+            query="x",
+            task_type=None,
+            role="engineering-agent/backend-engineer",
+        )
+        self.assertIn("role_match", cand.signals)
+
+    def test_kind_retrospective_adds_one(self) -> None:
+        cand = score_memory_candidate(
+            _note(
+                title="auth post-mortem",
+                summary="post-mortem details",
+                kind="retrospective",
+            ),
+            query="auth",
+            task_type=None,
+            role=None,
+        )
+        self.assertIn("retrospective_or_decision", cand.signals)
+
+    def test_pr_reference_adds_signal(self) -> None:
+        cand = score_memory_candidate(
+            _note(
+                title="auth",
+                summary="see PR #42 for prior fix",
+            ),
+            query="auth",
+            task_type=None,
+            role=None,
+        )
+        self.assertIn("references_pr_or_issue", cand.signals)
+
+    def test_empty_body_penalised(self) -> None:
+        cand = score_memory_candidate(
+            _note(title="empty", summary=None, tags=()),
+            query="anything",
+            task_type=None,
+            role=None,
+        )
+        self.assertLess(cand.score, 0)
+        self.assertIn("body_empty", cand.signals)
+
+
+class RelevantMemorySelectorTestCase(unittest.TestCase):
+    def test_filters_below_min_score(self) -> None:
+        selector = RelevantMemorySelector(min_score=1.0)
+        notes = [
+            _note(title="auth migration", summary="auth", tags=("backend-engineer",)),
+            _note(title="random", summary="lunch was ok"),
+        ]
+        picked = selector(
+            candidates=notes,
+            query="auth migration",
+            role="backend-engineer",
+        )
+        # 첫 노트는 topic + role이 모두 매치되어 통과,
+        # 두 번째는 0점이라 제외.
+        self.assertEqual([n.title for n in picked], ["auth migration"])
+
+    def test_orders_by_score_desc_then_recent(self) -> None:
+        selector = RelevantMemorySelector(min_score=0.0)
+        notes = [
+            _note(
+                title="older",
+                summary="auth migration old",
+                tags=(),
+                updated_at="2026-04-01T00:00:00",
+            ),
+            _note(
+                title="newer",
+                summary="auth migration new",
+                tags=(),
+                updated_at="2026-05-01T00:00:00",
+            ),
+        ]
+        picked = selector(
+            candidates=notes,
+            query="auth migration",
+            role=None,
+            limit=2,
+        )
+        # 두 노트 점수가 같으면 updated_at desc → newer가 앞으로.
+        self.assertEqual([n.title for n in picked], ["newer", "older"])
+
+    def test_limit_caps_results(self) -> None:
+        selector = RelevantMemorySelector(min_score=0.0)
+        notes = [
+            _note(title=f"n{i}", summary="auth migration", tags=())
+            for i in range(8)
+        ]
+        picked = selector(
+            candidates=notes,
+            query="auth migration",
+            role=None,
+            limit=3,
+        )
+        self.assertEqual(len(picked), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_mode.py
+++ b/tests/engineering/test_discussion_mode.py
@@ -1,0 +1,140 @@
+"""Tests for ``yule_orchestrator.agents.discussion.mode``."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    DiscussionMode,
+    classify_discussion_mode,
+)
+
+
+class ClassifyDiscussionModeTestCase(unittest.TestCase):
+    def test_explicit_research_only(self) -> None:
+        for text in (
+            "일단 조사만 해줘",
+            "조사부터 해보자",
+            "코드 수정 없이 자료만 모아줘",
+            "리서치만 정리해줘",
+            "정리까지만 해주면 돼",
+            "research only please",
+        ):
+            with self.subTest(text=text):
+                match = classify_discussion_mode(text)
+                self.assertEqual(match.mode, DiscussionMode.RESEARCH_ONLY)
+                self.assertEqual(match.source, "deterministic")
+
+    def test_clarification_for_too_vague(self) -> None:
+        for text in ("도와줘", "ㅎ", "ㅁㄴㅇ", "  ", "헤이"):
+            with self.subTest(text=text):
+                match = classify_discussion_mode(text)
+                self.assertEqual(match.mode, DiscussionMode.CLARIFICATION_NEEDED)
+
+    def test_discussion_for_design_questions(self) -> None:
+        for text in (
+            "이 구조 맞아?",
+            "이건 devops 관점에서 어떻게 풀지?",
+            "이 접근이 맞을까 — 토의 좀",
+            "어떻게 생각해?",
+            "리스크부터 정리하자",
+            "어느 쪽이 좋을까",
+        ):
+            with self.subTest(text=text):
+                match = classify_discussion_mode(text)
+                self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+
+    def test_implementation_for_explicit_write(self) -> None:
+        for text in (
+            "PR 올려줘",
+            "구현 진행해주세요",
+            "이 버그 고쳐줘",
+            "Spring Security 컨피그 패치 작성",
+            "기능 구현 부탁",
+        ):
+            with self.subTest(text=text):
+                match = classify_discussion_mode(text)
+                self.assertEqual(
+                    match.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE,
+                    f"text={text}, signals={match.signals}",
+                )
+
+    def test_review_signal_blocks_implementation(self) -> None:
+        # 검토 신호 + 구현 동사가 같이 오면 implementation으로 가지 않고
+        # discussion으로 받아야 한다.
+        match = classify_discussion_mode(
+            "이 구조 맞아? 그리고 PR 만들어 볼까?"
+        )
+        self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+
+    def test_ambiguous_falls_back_to_discussion(self) -> None:
+        # deterministic 신호가 없으면 LLM 부재 시 discussion fallback.
+        match = classify_discussion_mode(
+            "users 테이블에 email_verified 칼럼 관련해서 한번 봐주세요"
+        )
+        self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+        self.assertEqual(match.source, "fallback")
+
+    def test_llm_classifier_used_only_when_deterministic_undecided(self) -> None:
+        called: list[str] = []
+
+        def fake_llm(*, message_text, normalized, context_pack):
+            called.append(message_text)
+            return DiscussionMode.RESEARCH_ONLY
+
+        # 명확한 implementation은 deterministic이라 LLM 호출 없음.
+        match = classify_discussion_mode("PR 올려줘", llm_classifier=fake_llm)
+        self.assertEqual(match.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE)
+        self.assertEqual(called, [])
+
+        # 모호한 요청만 LLM seam을 친다.
+        match = classify_discussion_mode(
+            "users 테이블에 email_verified 추가에 대해서",
+            llm_classifier=fake_llm,
+        )
+        self.assertEqual(match.mode, DiscussionMode.RESEARCH_ONLY)
+        self.assertEqual(match.source, "llm")
+        self.assertEqual(len(called), 1)
+
+    def test_llm_classifier_failure_falls_back(self) -> None:
+        def crashing_llm(**_kwargs):
+            raise RuntimeError("offline")
+
+        match = classify_discussion_mode(
+            "users 테이블 마이그 관련 어떻게 처리할지",
+            llm_classifier=crashing_llm,
+        )
+        self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+        self.assertEqual(match.source, "fallback")
+
+    def test_llm_classifier_invalid_value_falls_back(self) -> None:
+        match = classify_discussion_mode(
+            "users 마이그 관련 묻고 싶음",
+            llm_classifier=lambda **_: "garbage",
+        )
+        self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+        self.assertEqual(match.source, "fallback")
+
+    def test_llm_classifier_dict_with_rationale(self) -> None:
+        match = classify_discussion_mode(
+            "users 변경 검토해줄래",
+            llm_classifier=lambda **_: {
+                "mode": "implementation_candidate",
+                "rationale": "explicit verb 발견 (LLM)",
+                "signals": ["llm_keyword:변경"],
+            },
+        )
+        self.assertEqual(match.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE)
+        self.assertEqual(match.source, "llm")
+        self.assertEqual(match.rationale, "explicit verb 발견 (LLM)")
+        self.assertEqual(match.signals, ("llm_keyword:변경",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_pipeline.py
+++ b/tests/engineering/test_discussion_pipeline.py
@@ -1,0 +1,143 @@
+"""End-to-end integration: classify → context_pack → synthesize → handoff.
+
+마스터 플랜 §13 Phase 1 완료 기준은 "Discord에서 기술 토의 가능 + context
+pack 구성 + implementation 여부 판단". 본 테스트는 4가지 사용자 시나리오를
+실제 호출 체인으로 돌려서 합성 결과 + handoff payload가 일관되게 나오는지
+잠근다. 외부 I/O (Discord/GitHub/Obsidian)는 stub seam으로 대체한다.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.coding.authorization import reset_role_profile_cache
+from yule_orchestrator.agents.discussion import (
+    ContextPackBuilder,
+    DiscussionMode,
+    GithubIssueRef,
+    GithubPRRef,
+    ObsidianNoteRef,
+    RelevantMemorySelector,
+    ThreadMessage,
+    build_implementation_handoff,
+    classify_discussion_mode,
+    synthesize_discussion,
+)
+
+
+def _session(extra=None):
+    return SimpleNamespace(
+        session_id="sess-xyz",
+        task_type="backend-feature",
+        write_requested=False,
+        write_blocked_reason=None,
+        extra=extra or {},
+    )
+
+
+def _builder() -> ContextPackBuilder:
+    """Live retrieval seam을 모두 stub로 채운 builder."""
+
+    return ContextPackBuilder(
+        thread_loader=lambda sid: [
+            ThreadMessage(role="user", content="이전에 hero 영역 정리 얘기 있었음"),
+        ],
+        issue_loader=lambda q: [
+            GithubIssueRef(number=42, title=f"{q[:20]} 회귀", state="open"),
+        ],
+        pr_loader=lambda q: [
+            GithubPRRef(number=99, title=f"{q[:20]} 시도 1", state="closed"),
+        ],
+        note_loader=lambda q: [
+            ObsidianNoteRef(
+                title="auth migration 회고",
+                summary=f"이전 {q[:30]} 정리 메모 — PR #42 참고",
+                tags=("auth", "backend-engineer"),
+                kind="retrospective",
+                updated_at="2026-04-01T00:00:00",
+            ),
+            ObsidianNoteRef(
+                title="다른 프로젝트",
+                summary="lunch was good",
+                tags=("personal",),
+            ),
+        ],
+        memory_selector=RelevantMemorySelector(min_score=0.5),
+        code_hint_loader=lambda q: [],
+        role_profile_loader=lambda role: f"profile for {role}",
+        role_research_profile_loader=lambda role: f"research for {role}",
+    )
+
+
+class DiscussionPipelineTests(unittest.TestCase):
+    def setUp(self) -> None:  # noqa: D401 - test setup
+        reset_role_profile_cache()
+
+    def _run(self, message: str, *, role: str = "engineering-agent/tech-lead"):
+        builder = _builder()
+        pack = builder.build(
+            message_text=message,
+            session=_session(),
+            role_for_research=role,
+        )
+        match = classify_discussion_mode(message, context_pack=pack.as_dict())
+        synthesis = synthesize_discussion(pack=pack, classification=match)
+        handoff = build_implementation_handoff(synthesis=synthesis, pack=pack)
+        return pack, match, synthesis, handoff
+
+    def test_design_question_routes_to_discussion_no_handoff(self) -> None:
+        pack, match, synth, handoff = self._run(
+            "이 구조 맞아? backend 관점에서 어떻게 풀지 같이 보자"
+        )
+        self.assertEqual(match.mode, DiscussionMode.DISCUSSION)
+        self.assertFalse(synth.implementation_ready)
+        self.assertIn("backend-engineer", synth.role_perspectives)
+        # handoff는 not-impl mode → blocker.
+        self.assertIsNone(handoff.proposal)
+        # context pack 자체에는 thread/issue/pr/note가 모두 채워졌다.
+        self.assertGreater(len(pack.recent_thread), 0)
+        self.assertGreater(len(pack.related_issues), 0)
+        self.assertGreater(len(pack.related_prs), 0)
+        # auth migration 회고 note만 통과 (relevant memory selector)
+        self.assertEqual(len(pack.relevant_notes), 1)
+        self.assertEqual(pack.relevant_notes[0].title, "auth migration 회고")
+
+    def test_research_request_routes_to_research_only(self) -> None:
+        pack, match, synth, handoff = self._run("일단 조사만 할까")
+        self.assertEqual(match.mode, DiscussionMode.RESEARCH_ONLY)
+        self.assertFalse(synth.implementation_ready)
+        self.assertIn("운영-리서치", synth.response_text)
+        self.assertIsNone(handoff.proposal)
+
+    def test_implementation_request_routes_and_creates_proposal(self) -> None:
+        pack, match, synth, handoff = self._run(
+            "Spring Security 기반 API auth 흐름 구현 진행해줘"
+        )
+        self.assertEqual(match.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE)
+        self.assertTrue(synth.implementation_ready)
+        # handoff는 정상적으로 proposal 생성
+        self.assertIsNotNone(handoff.proposal)
+        self.assertEqual(handoff.proposal.executor_role, "backend-engineer")
+        self.assertEqual(handoff.proposal.session_id, "sess-xyz")
+        self.assertTrue(handoff.proposal.approval_required)
+        # response_text에 "권한 제안" 안내가 포함됨
+        self.assertIn("권한 제안", synth.response_text)
+
+    def test_too_short_message_routes_to_clarification(self) -> None:
+        pack, match, synth, handoff = self._run("?")
+        self.assertEqual(match.mode, DiscussionMode.CLARIFICATION_NEEDED)
+        self.assertGreater(len(synth.open_questions), 0)
+        self.assertIsNone(handoff.proposal)
+        # handoff blocker는 not-impl mode
+        self.assertIsNotNone(handoff.blocker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_discussion_synthesizer.py
+++ b/tests/engineering/test_discussion_synthesizer.py
@@ -15,6 +15,7 @@ from yule_orchestrator.agents.discussion import (
     DiscussionMode,
     DiscussionModeMatch,
     DiscussionSynthesis,
+    EngineeringKnowledgeRef,
     GithubIssueRef,
     GithubPRRef,
     ObsidianNoteRef,
@@ -149,6 +150,146 @@ class SynthesizeDiscussionTestCase(unittest.TestCase):
         self.assertEqual(payload["mode"], "implementation_candidate")
         self.assertTrue(payload["implementation_ready"])
         self.assertIn("response_text", payload)
+        # share_boundary 는 항상 dict — 빈 pack 이어도 4 키 carries.
+        self.assertEqual(payload["share_boundary"]["total"], 0)
+        self.assertEqual(payload["share_boundary"]["public"], 0)
+        self.assertEqual(payload["knowledge_evidence_block"], "")
+        self.assertEqual(payload["knowledge_short_summary"], "")
+
+
+def _public_ref(**overrides) -> EngineeringKnowledgeRef:
+    base = dict(
+        title="Spring Security 인증 흐름",
+        role="backend-engineer",
+        topic_key="spring-auth",
+        source_url="https://example.com/spring-auth",
+        source_name="Spring Docs",
+        summary="OAuth2 + Filter chain 정리",
+        score=8.0,
+        signals=("role_primary_match",),
+        evidence_labels=("요청 역할과 정확히 일치",),
+        share_scope="public",
+    )
+    base.update(overrides)
+    return EngineeringKnowledgeRef(**base)
+
+
+class SynthesizeKnowledgeEvidenceTestCase(unittest.TestCase):
+    """``relevant_knowledge`` 가 응답 surface 에 그대로 흘러야 한다."""
+
+    def test_discussion_appends_evidence_block_and_summary(self) -> None:
+        pack = ContextPack(
+            current_message="auth 흐름 정리하자",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="사내 OAuth playbook",
+                    topic_key="company-oauth",
+                    share_scope="team_internal",
+                    summary="외부 surface 에는 노출 금지",
+                ),
+            ),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+        )
+        # Response 본문에 evidence 블록 + 짧은 요약 한 줄이 모두 들어간다.
+        self.assertIn("근거 자료", synth.response_text)
+        self.assertIn("Spring Security 인증 흐름", synth.response_text)
+        self.assertIn("team-internal", synth.response_text)
+        # 짧은 요약 라인 — 운영자가 본문 펼치기 전에 한 눈에 본다.
+        self.assertIn("근거 자료 2건", synth.response_text)
+        # 별도 surface field 도 채워져 있다.
+        self.assertIn("Spring Security", synth.knowledge_evidence_block)
+        self.assertIn("근거 자료 2건", synth.knowledge_short_summary)
+        self.assertEqual(synth.share_boundary["public"], 1)
+        self.assertEqual(synth.share_boundary["team_internal"], 1)
+        self.assertEqual(synth.share_boundary["total"], 2)
+        # team_internal 자료의 본문 요약은 응답에 새지 않는다.
+        self.assertNotIn(
+            "외부 surface 에는 노출 금지", synth.response_text
+        )
+
+    def test_research_response_carries_existing_evidence_when_available(self) -> None:
+        pack = ContextPack(
+            current_message="auth 자료 모아 보자",
+            relevant_knowledge=(_public_ref(),),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.RESEARCH_ONLY),
+        )
+        self.assertIn("이미 모인 자료", synth.response_text)
+        self.assertIn("이미 vault 에 있는 근거 자료", synth.response_text)
+        self.assertIn("Spring Security 인증 흐름", synth.response_text)
+        self.assertEqual(synth.share_boundary["total"], 1)
+
+    def test_implementation_includes_decision_evidence_summary(self) -> None:
+        pack = ContextPack(
+            current_message="API auth 흐름 패치 작성, schema 마이그도 같이",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="incident-2026-04-29",
+                    topic_key="incident-2026-04-29",
+                    share_scope="restricted",
+                    share_scope_reason="customer PII",
+                ),
+            ),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.IMPLEMENTATION_CANDIDATE),
+        )
+        self.assertIn("결정 근거 요약", synth.response_text)
+        self.assertIn("이번 결정 근거 자료", synth.response_text)
+        # restricted 자료는 제목 / URL 이 모두 마스킹되고 reason 만 노출.
+        self.assertNotIn("internal.example", synth.response_text)
+        self.assertIn("공개 제한된 자료", synth.response_text)
+        self.assertIn("customer PII", synth.response_text)
+        # share_boundary 는 restricted/public 둘 다 카운트.
+        self.assertEqual(synth.share_boundary["restricted"], 1)
+        self.assertEqual(synth.share_boundary["public"], 1)
+
+    def test_short_summary_orders_scope_breakdown(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="internal-doc",
+                    topic_key="internal-1",
+                    share_scope="team_internal",
+                ),
+                _public_ref(
+                    title="restricted-doc",
+                    topic_key="restricted-1",
+                    share_scope="restricted",
+                    share_scope_reason="PII",
+                ),
+            ),
+        )
+        summary = pack.knowledge_short_summary()
+        self.assertIn("근거 자료 3건", summary)
+        # public → team_internal → restricted 순으로 축약 카운트가 들어간다.
+        self.assertLess(summary.index("public"), summary.index("team_internal"))
+        self.assertLess(
+            summary.index("team_internal"), summary.index("restricted")
+        )
+
+    def test_share_boundary_breakdown_handles_unknown_scope(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                _public_ref(share_scope="weird-value"),
+            ),
+        )
+        breakdown = pack.share_boundary_breakdown()
+        # Unknown scopes fall back into the public bucket so the
+        # boundary surface never silently drops items.
+        self.assertEqual(breakdown["public"], 1)
+        self.assertEqual(breakdown["total"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/engineering/test_discussion_synthesizer.py
+++ b/tests/engineering/test_discussion_synthesizer.py
@@ -1,0 +1,155 @@
+"""Tests for ``yule_orchestrator.agents.discussion.synthesizer``."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.discussion import (
+    ContextPack,
+    DiscussionMode,
+    DiscussionModeMatch,
+    DiscussionSynthesis,
+    GithubIssueRef,
+    GithubPRRef,
+    ObsidianNoteRef,
+    synthesize_discussion,
+)
+
+
+def _classification(mode: DiscussionMode, *, signals=()) -> DiscussionModeMatch:
+    return DiscussionModeMatch(
+        mode=mode,
+        rationale="test classification",
+        signals=tuple(signals),
+        source="deterministic",
+    )
+
+
+class SynthesizeDiscussionTestCase(unittest.TestCase):
+    def test_clarification_lists_questions(self) -> None:
+        pack = ContextPack(current_message="ㅎ")
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.CLARIFICATION_NEEDED),
+        )
+        self.assertEqual(synth.mode, DiscussionMode.CLARIFICATION_NEEDED)
+        self.assertGreaterEqual(len(synth.open_questions), 2)
+        self.assertIn("어디부터 봐야", synth.response_text)
+
+    def test_research_lists_followups(self) -> None:
+        pack = ContextPack(
+            current_message="auth 마이그레이션 자료 정리",
+            suggested_task_type="backend-feature",
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.RESEARCH_ONLY),
+        )
+        self.assertEqual(synth.mode, DiscussionMode.RESEARCH_ONLY)
+        self.assertTrue(any("research profile" in f for f in synth.research_followups))
+        self.assertIn("운영-리서치", synth.response_text)
+        # research profile 미주입 시 blocker 라인 추가.
+        self.assertTrue(
+            any("research profile 미주입" in b for b in synth.blockers),
+            f"blockers={synth.blockers}",
+        )
+
+    def test_discussion_lists_role_perspectives(self) -> None:
+        pack = ContextPack(
+            current_message="이 구조 맞아? devops 관점에서 어떻게 풀지",
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+        )
+        self.assertEqual(synth.mode, DiscussionMode.DISCUSSION)
+        self.assertIn("devops-engineer", synth.role_perspectives)
+        self.assertIn("**devops-engineer**", synth.response_text)
+        self.assertIn("권한 제안", synth.response_text)
+
+    def test_discussion_includes_related_links(self) -> None:
+        pack = ContextPack(
+            current_message="hero 섹션 재작업",
+            related_issues=(
+                GithubIssueRef(number=42, title="hero hero", state="open"),
+            ),
+            related_prs=(
+                GithubPRRef(number=99, title="hero attempt 1", state="closed"),
+            ),
+            relevant_notes=(
+                ObsidianNoteRef(title="hero 회의록", path="notes/hero.md"),
+            ),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+        )
+        self.assertIn("issue #42", synth.response_text)
+        self.assertIn("PR #99", synth.response_text)
+        self.assertIn("hero 회의록", synth.response_text)
+
+    def test_implementation_marks_ready_and_includes_executor_hint(self) -> None:
+        pack = ContextPack(
+            current_message="API auth 흐름 패치 작성, schema 마이그도 같이",
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.IMPLEMENTATION_CANDIDATE),
+        )
+        self.assertEqual(synth.mode, DiscussionMode.IMPLEMENTATION_CANDIDATE)
+        self.assertTrue(synth.implementation_ready)
+        self.assertEqual(synth.suggested_handoff_role, "backend-engineer")
+        self.assertIn("권한 제안", synth.response_text)
+
+    def test_llm_synthesizer_failure_falls_back(self) -> None:
+        pack = ContextPack(current_message="x")
+
+        def crash(**_):
+            raise RuntimeError("offline")
+
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+            llm_synthesizer=crash,
+        )
+        self.assertEqual(synth.mode, DiscussionMode.DISCUSSION)
+
+    def test_llm_synthesizer_can_replace_response(self) -> None:
+        pack = ContextPack(current_message="x")
+
+        def replacement(synthesis, pack):
+            return DiscussionSynthesis(
+                mode=synthesis.mode,
+                rationale="LLM 재합성",
+                response_text="LLM 본문",
+                next_actions=("LLM 다음 행동",),
+            )
+
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+            llm_synthesizer=replacement,
+        )
+        self.assertEqual(synth.response_text, "LLM 본문")
+        self.assertEqual(synth.next_actions, ("LLM 다음 행동",))
+
+    def test_to_dict_serialises_all_fields(self) -> None:
+        pack = ContextPack(current_message="API patch")
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.IMPLEMENTATION_CANDIDATE),
+        )
+        payload = synth.to_dict()
+        self.assertEqual(payload["mode"], "implementation_candidate")
+        self.assertTrue(payload["implementation_ready"])
+        self.assertIn("response_text", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_discord_summary.py
+++ b/tests/engineering_intelligence/test_discord_summary.py
@@ -12,10 +12,12 @@ except ModuleNotFoundError:
 from yule_orchestrator.agents.engineering_intelligence.discord_summary import (
     render_daily_role_summary,
     render_multi_role_summary,
+    share_boundary_breakdown,
 )
 from yule_orchestrator.agents.engineering_intelligence.models import (
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     SourceKind,
 )
 
@@ -26,6 +28,8 @@ def _it(
     importance: Importance = Importance.MEDIUM,
     source_name: str = "Spring Engineering Blog",
     source_url: str = "https://spring.io/blog/x",
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC,
+    share_scope_reason: str = "",
 ) -> EngineeringKnowledgeItem:
     return EngineeringKnowledgeItem(
         item_id=title,
@@ -38,6 +42,8 @@ def _it(
         source_kind=SourceKind.ENGINEERING_BLOG,
         collected_at="2026-05-08T00:00:00Z",
         importance=importance,
+        share_scope=share_scope,
+        share_scope_reason=share_scope_reason,
     )
 
 
@@ -77,6 +83,65 @@ class DailyRoleSummaryTests(unittest.TestCase):
         )
         self.assertIn("Obsidian", text)
         self.assertIn("engineering-knowledge", text)
+
+
+class ShareBoundaryFooterTests(unittest.TestCase):
+    """Daily digest footer 가 share_scope 분포를 정확히 노출한다."""
+
+    def test_all_public_skips_footer(self) -> None:
+        items = [_it("public-only")]
+        text = render_daily_role_summary("backend-engineer", items)
+        # 정상 footer (Obsidian pointer) 는 그대로 — share boundary
+        # 안내는 일부러 추가하지 않는다.
+        self.assertNotIn("share boundary", text)
+        self.assertIn("Obsidian", text)
+
+    def test_team_internal_item_triggers_footer(self) -> None:
+        items = [
+            _it("public-doc"),
+            _it(
+                "internal-doc",
+                share_scope=KnowledgeShareScope.TEAM_INTERNAL,
+            ),
+        ]
+        text = render_daily_role_summary("backend-engineer", items)
+        self.assertIn("share boundary", text)
+        self.assertIn("public 1건", text)
+        self.assertIn("team-internal 1건", text)
+        self.assertIn("vault link", text)
+
+    def test_restricted_item_marked_in_footer_and_body(self) -> None:
+        items = [
+            _it(
+                "incident",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            ),
+        ]
+        text = render_daily_role_summary("backend-engineer", items)
+        # body 에는 제목/URL 모두 마스킹.
+        self.assertNotIn("https://spring.io/blog/x", text)
+        self.assertIn("🔒 공개 제한된 자료", text)
+        # footer 에 restricted 카운트가 잡힌다.
+        self.assertIn("share boundary", text)
+        self.assertIn("공개 제한 1건", text)
+
+    def test_breakdown_helper_classifies_each_scope(self) -> None:
+        items = [
+            _it("a"),
+            _it("b", share_scope=KnowledgeShareScope.TEAM_INTERNAL),
+            _it(
+                "c",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="needed",
+            ),
+            _it("d"),
+        ]
+        breakdown = share_boundary_breakdown(items)
+        self.assertEqual(breakdown["public"], 2)
+        self.assertEqual(breakdown["team_internal"], 1)
+        self.assertEqual(breakdown["restricted"], 1)
+        self.assertEqual(breakdown["total"], 4)
 
 
 class MultiRoleSummaryTests(unittest.TestCase):

--- a/tests/engineering_intelligence/test_feed_parser.py
+++ b/tests/engineering_intelligence/test_feed_parser.py
@@ -1,0 +1,387 @@
+"""Feed parser: deterministic Atom / RSS / GitHub releases atom decode."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.feed_parser import (
+    BytesFetcher,
+    FeedParserError,
+    make_feed_live_factory,
+    parse_atom_bytes,
+    parse_feed_bytes,
+    parse_rss_bytes,
+    register_safe_feed_providers,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    find_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample payloads — small enough to read inline
+# ---------------------------------------------------------------------------
+
+
+_ATOM_FIXTURE = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Engineering Blog</title>
+  <updated>2026-05-09T10:00:00Z</updated>
+  <entry>
+    <title>Latency-aware retries</title>
+    <link rel="alternate" href="https://example.com/posts/latency-aware-retries"/>
+    <id>tag:example.com,2026:post-1</id>
+    <updated>2026-05-09T09:30:00Z</updated>
+    <summary>How retry budgets interact with p99 latency.</summary>
+  </entry>
+  <entry>
+    <title>Schema migration tactics</title>
+    <link href="https://example.com/posts/schema-migration"/>
+    <id>tag:example.com,2026:post-2</id>
+    <published>2026-05-08T08:00:00Z</published>
+    <content>Three patterns for online schema migration.</content>
+  </entry>
+</feed>
+"""
+
+
+_RSS_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Releases</title>
+    <link>https://example.com/releases</link>
+    <description>Release notes</description>
+    <item>
+      <title>v1.2.0</title>
+      <link>https://example.com/releases/v1.2.0</link>
+      <description>Adds OAuth refresh handling.</description>
+      <pubDate>Mon, 09 May 2026 12:00:00 GMT</pubDate>
+      <guid>https://example.com/releases/v1.2.0</guid>
+    </item>
+    <item>
+      <title>v1.1.5</title>
+      <link>https://example.com/releases/v1.1.5</link>
+      <description>Security patch for CVE-2026-0001.</description>
+      <pubDate>Fri, 02 May 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+_GITHUB_RELEASES_ATOM_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>tag:github.com,2008:https://github.com/example/proj/releases</id>
+  <title>Release notes from proj</title>
+  <updated>2026-05-09T10:00:00Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Repository/123/v2.0.0</id>
+    <updated>2026-05-09T09:00:00Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/example/proj/releases/tag/v2.0.0"/>
+    <title>v2.0.0</title>
+    <content type="html">&lt;p&gt;Major release.&lt;/p&gt;</content>
+  </entry>
+</feed>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Atom parser
+# ---------------------------------------------------------------------------
+
+
+class AtomParserTests(unittest.TestCase):
+    def setUp(self) -> None:
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        self.source = spring
+
+    def test_parses_two_entries_with_titles_and_links(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        self.assertEqual(len(items), 2)
+        titles = [i.title for i in items]
+        self.assertIn("Latency-aware retries", titles)
+        self.assertIn("Schema migration tactics", titles)
+        urls = {i.source_url for i in items}
+        self.assertIn(
+            "https://example.com/posts/latency-aware-retries", urls
+        )
+        self.assertIn("https://example.com/posts/schema-migration", urls)
+
+    def test_prefers_alternate_link_over_first_link(self) -> None:
+        # The Atom fixture has rel="alternate" on entry 1; entry 2 only
+        # has a bare <link href>. Both should be picked up.
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        latency = next(i for i in items if i.title == "Latency-aware retries")
+        self.assertEqual(
+            latency.source_url,
+            "https://example.com/posts/latency-aware-retries",
+        )
+
+    def test_falls_back_to_published_when_updated_missing(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        migration = next(
+            i for i in items if i.title == "Schema migration tactics"
+        )
+        self.assertEqual(migration.published_at, "2026-05-08T08:00:00Z")
+
+    def test_falls_back_to_content_when_summary_missing(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        migration = next(
+            i for i in items if i.title == "Schema migration tactics"
+        )
+        self.assertIn("schema migration", migration.summary.lower())
+
+    def test_inherits_source_metadata(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        for item in items:
+            self.assertEqual(item.source_name, self.source.name)
+            self.assertEqual(item.source_kind, self.source.source_kind)
+            self.assertEqual(item.role, self.source.role_tags[0])
+            self.assertEqual(tuple(item.stack_tags), self.source.stack_tags)
+
+    def test_malformed_xml_raises_feed_parser_error(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_atom_bytes(b"<feed><entry></feed>", source=self.source)
+
+    def test_empty_feed_returns_empty_tuple(self) -> None:
+        empty = b'<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"/>'
+        self.assertEqual(parse_atom_bytes(empty, source=self.source), ())
+
+
+# ---------------------------------------------------------------------------
+# RSS parser
+# ---------------------------------------------------------------------------
+
+
+class RssParserTests(unittest.TestCase):
+    def setUp(self) -> None:
+        nvd = find_source("backend-engineer", "cve-nvd")
+        assert nvd is not None
+        self.source = nvd
+
+    def test_parses_two_items_with_titles_and_links(self) -> None:
+        items = parse_rss_bytes(_RSS_FIXTURE, source=self.source)
+        self.assertEqual(len(items), 2)
+        titles = [i.title for i in items]
+        self.assertIn("v1.2.0", titles)
+        self.assertIn("v1.1.5", titles)
+
+    def test_pubdate_normalised_to_iso_z(self) -> None:
+        items = parse_rss_bytes(_RSS_FIXTURE, source=self.source)
+        v120 = next(i for i in items if i.title == "v1.2.0")
+        self.assertEqual(v120.published_at, "2026-05-09T12:00:00Z")
+
+    def test_summary_truncated_to_safe_quotation(self) -> None:
+        long_desc = "A" * 800
+        rss = (
+            b'<?xml version="1.0"?>'
+            b"<rss version=\"2.0\"><channel>"
+            b"<title>x</title><link>https://x</link>"
+            b"<description>x</description>"
+            b"<item><title>t</title><link>https://x/1</link>"
+            b"<description>" + long_desc.encode() + b"</description>"
+            b"</item></channel></rss>"
+        )
+        items = parse_rss_bytes(rss, source=self.source)
+        self.assertEqual(len(items), 1)
+        self.assertLessEqual(len(items[0].summary), 500)
+        self.assertTrue(items[0].summary.endswith("…"))
+
+    def test_malformed_rss_raises_feed_parser_error(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_rss_bytes(b"<rss><channel><item>", source=self.source)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class ParseFeedDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.atom_source = find_source("backend-engineer", "spring-blog")
+        self.rss_source = find_source("backend-engineer", "cve-nvd")
+        assert self.atom_source is not None
+        assert self.rss_source is not None
+
+    def test_atom_transport_uses_atom_parser(self) -> None:
+        items = parse_feed_bytes(
+            _ATOM_FIXTURE,
+            source=self.atom_source,
+            transport=ProviderTransport.ATOM,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_github_releases_atom_uses_atom_parser(self) -> None:
+        items = parse_feed_bytes(
+            _GITHUB_RELEASES_ATOM_FIXTURE,
+            source=self.atom_source,
+            transport=ProviderTransport.GITHUB_RELEASES_ATOM,
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].title, "v2.0.0")
+        self.assertEqual(
+            items[0].source_url,
+            "https://github.com/example/proj/releases/tag/v2.0.0",
+        )
+
+    def test_rss_transport_with_atom_payload_sniffs_and_dispatches(self) -> None:
+        # Edge case: an "rss-mode" source endpoint actually serves Atom.
+        # The sniff routes the bytes to the atom parser instead of failing.
+        items = parse_feed_bytes(
+            _ATOM_FIXTURE,
+            source=self.rss_source,
+            transport=ProviderTransport.RSS,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_rss_transport_with_rss_payload_uses_rss_parser(self) -> None:
+        items = parse_feed_bytes(
+            _RSS_FIXTURE,
+            source=self.rss_source,
+            transport=ProviderTransport.RSS,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_unsupported_transport_raises(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_feed_bytes(
+                b"",
+                source=self.rss_source,
+                transport=ProviderTransport.MANUAL,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Live factory glue
+# ---------------------------------------------------------------------------
+
+
+class LiveFactoryGlueTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source = find_source("backend-engineer", "spring-blog")
+        assert self.source is not None
+        self.spec = provider_spec_for(self.source)
+
+    def test_factory_calls_parser_through_bytes_fetcher(self) -> None:
+        seen_specs: list = []
+
+        def factory(env: Mapping[str, str]) -> BytesFetcher:
+            def fetcher(spec):
+                seen_specs.append(spec.transport)
+                return _ATOM_FIXTURE
+            return fetcher
+
+        live_factory = make_feed_live_factory(factory)
+        fetcher = live_factory({})
+        items = fetcher(self.spec, source=self.source)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(seen_specs, [ProviderTransport.ATOM])
+
+    def test_factory_swallows_transport_errors(self) -> None:
+        def factory(env: Mapping[str, str]) -> BytesFetcher:
+            def fetcher(spec):
+                raise ConnectionError("simulated")
+            return fetcher
+
+        live_factory = make_feed_live_factory(factory)
+        items = live_factory({})(self.spec, source=self.source)
+        self.assertEqual(items, ())
+
+    def test_factory_swallows_parser_errors(self) -> None:
+        def factory(env):
+            return lambda spec: b"<not really xml"
+
+        live_factory = make_feed_live_factory(factory)
+        items = live_factory({})(self.spec, source=self.source)
+        self.assertEqual(items, ())
+
+    def test_factory_returns_empty_for_empty_payload(self) -> None:
+        def factory(env):
+            return lambda spec: b""
+
+        items = make_feed_live_factory(factory)({})(
+            self.spec, source=self.source
+        )
+        self.assertEqual(items, ())
+
+
+# ---------------------------------------------------------------------------
+# register_safe_feed_providers
+# ---------------------------------------------------------------------------
+
+
+class RegisterSafeFeedProvidersTests(unittest.TestCase):
+    def test_registers_three_default_transports(self) -> None:
+        registry = default_registry()
+
+        def factory(env):
+            return lambda spec: _ATOM_FIXTURE
+
+        registered = register_safe_feed_providers(
+            registry, bytes_fetcher_factory=factory
+        )
+        self.assertEqual(
+            set(registered),
+            {
+                ProviderTransport.RSS,
+                ProviderTransport.ATOM,
+                ProviderTransport.GITHUB_RELEASES_ATOM,
+            },
+        )
+        # All three now resolve to AVAILABLE when their flag is set.
+        env = {
+            "YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true",
+            "YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true",
+            "YULE_KNOWLEDGE_GITHUB_RELEASES_ATOM_LIVE_ENABLED": "true",
+        }
+        for transport in registered:
+            with self.subTest(transport=transport):
+                self.assertEqual(
+                    registry.evaluate(transport, env=env),
+                    ProviderAvailability.AVAILABLE,
+                )
+        # And other transports stay unaffected.
+        self.assertEqual(
+            registry.evaluate(ProviderTransport.SITEMAP, env=env),
+            ProviderAvailability.NO_LIVE_IMPL,
+        )
+
+    def test_skips_transports_not_in_registry(self) -> None:
+        from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+            KnowledgeProviderRegistry,
+        )
+
+        empty = KnowledgeProviderRegistry()
+
+        def factory(env):
+            return lambda spec: b""
+
+        # Empty registry — nothing is registered, so the helper returns ().
+        # No KeyError leaks out.
+        self.assertEqual(
+            register_safe_feed_providers(empty, bytes_fetcher_factory=factory),
+            (),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_obsidian.py
+++ b/tests/engineering_intelligence/test_obsidian.py
@@ -14,6 +14,7 @@ from yule_orchestrator.agents.engineering_intelligence.models import (
     CagContext,
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     LearningLevel,
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
     PracticeVerification,
@@ -23,6 +24,7 @@ from yule_orchestrator.agents.engineering_intelligence.obsidian import (
     build_engineering_knowledge_write_request,
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
+    summarize_share_boundary,
 )
 
 
@@ -180,6 +182,50 @@ class GateFailTests(unittest.TestCase):
         item = _good_item(review_after_days=0)
         gate = evaluate_quality_gate(item)
         self.assertIn("missing:review_after_days", gate.reasons)
+
+
+class SummarizeShareBoundaryTests(unittest.TestCase):
+    """`summarize_share_boundary` 가 운영자 한 줄 요약을 만든다."""
+
+    def test_empty_input_returns_zero_summary(self) -> None:
+        payload = summarize_share_boundary(())
+        self.assertEqual(payload["counts"]["total"], 0)
+        self.assertEqual(payload["summary"], "")
+
+    def test_public_only_summary_has_no_warning(self) -> None:
+        items = (_good_item(),)
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["public"], 1)
+        self.assertIn("public 1건", payload["summary"])
+        self.assertNotIn("vault link", payload["summary"])
+        self.assertNotIn("외부 채널", payload["summary"])
+
+    def test_team_internal_summary_warns(self) -> None:
+        items = (
+            _good_item(),
+            _good_item(
+                topic_key="company-oauth",
+                share_scope=KnowledgeShareScope.TEAM_INTERNAL,
+                share_scope_reason="사내 ADR",
+            ),
+        )
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["team_internal"], 1)
+        self.assertIn("team_internal 1건", payload["summary"])
+        self.assertIn("vault link", payload["summary"])
+
+    def test_restricted_summary_blocks_external_quotation(self) -> None:
+        items = (
+            _good_item(
+                topic_key="incident-2026-04-29",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            ),
+        )
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["restricted"], 1)
+        self.assertIn("restricted 1건", payload["summary"])
+        self.assertIn("외부 채널 인용 금지", payload["summary"])
 
 
 class RejectionAuditTests(unittest.TestCase):

--- a/tests/engineering_intelligence/test_provider_availability_summary.py
+++ b/tests/engineering_intelligence/test_provider_availability_summary.py
@@ -1,0 +1,394 @@
+"""Provider availability summary + routing reason + status bundle."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    ProviderAvailabilityRow,
+    ProviderAvailabilitySummary,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_routing import (
+    RefreshPlanStatus,
+    RoutedRefreshCandidate,
+    refresh_plan_status,
+    route_refresh_plan,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+)
+from yule_orchestrator.agents.engineering_intelligence.scheduler import (
+    compute_refresh_plan,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# ProviderAvailabilitySummary
+# ---------------------------------------------------------------------------
+
+
+class AvailabilitySummaryTests(unittest.TestCase):
+    def test_summary_has_one_row_per_transport(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        transports = {row.transport for row in summary.rows}
+        for t in ProviderTransport:
+            self.assertIn(t.value, transports)
+
+    def test_default_env_is_no_live_impl_or_manual_only(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        for row in summary.rows:
+            self.assertIn(
+                row.availability,
+                {
+                    ProviderAvailability.NO_LIVE_IMPL.value,
+                    ProviderAvailability.MANUAL_ONLY.value,
+                },
+                f"unexpected availability for {row.transport}",
+            )
+
+    def test_missing_env_keys_listed_for_github_api(self) -> None:
+        registry = default_registry()
+        # Plug a live factory for github_api so availability is gated
+        # on the env triple rather than NO_LIVE_IMPL.
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        summary = registry.availability_summary(env={})
+        github = next(
+            row
+            for row in summary.rows
+            if row.transport
+            == ProviderTransport.GITHUB_API_REPO_ACTIVITY.value
+        )
+        self.assertEqual(
+            github.availability, ProviderAvailability.MISSING_ENV.value
+        )
+        self.assertIn("YULE_GITHUB_APP_ID", github.missing_env_keys)
+
+    def test_disabled_by_flag_when_keys_present_but_flag_off(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {
+            "YULE_GITHUB_APP_ID": "1",
+            "YULE_GITHUB_APP_INSTALLATION_ID": "2",
+            "YULE_GITHUB_APP_PRIVATE_KEY_PATH": "/tmp/k.pem",
+        }
+        summary = registry.availability_summary(env=env)
+        github = next(
+            row
+            for row in summary.rows
+            if row.transport
+            == ProviderTransport.GITHUB_API_REPO_ACTIVITY.value
+        )
+        self.assertEqual(
+            github.availability,
+            ProviderAvailability.DISABLED_BY_FLAG.value,
+        )
+        self.assertEqual(github.missing_env_keys, ())
+        self.assertFalse(github.enable_flag_set)
+
+    def test_available_when_env_and_flag_set(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.RSS,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        summary = registry.availability_summary(env=env)
+        rss = next(
+            row
+            for row in summary.rows
+            if row.transport == ProviderTransport.RSS.value
+        )
+        self.assertEqual(
+            rss.availability, ProviderAvailability.AVAILABLE.value
+        )
+        self.assertTrue(rss.enable_flag_set)
+        self.assertTrue(rss.has_live_impl)
+
+    def test_by_state_groups_rows_into_buckets(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        buckets = summary.by_state()
+        # MANUAL_ONLY must contain exactly one row (the manual transport).
+        manual_bucket = buckets.get(ProviderAvailability.MANUAL_ONLY.value, ())
+        self.assertEqual(
+            [row.transport for row in manual_bucket],
+            [ProviderTransport.MANUAL.value],
+        )
+        # All non-manual transports land under NO_LIVE_IMPL by default.
+        no_live_bucket = buckets.get(
+            ProviderAvailability.NO_LIVE_IMPL.value, ()
+        )
+        self.assertEqual(
+            len(no_live_bucket), len(ProviderTransport) - 1
+        )
+
+    def test_states_count_totals_match_row_count(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        counts = summary.states_count()
+        self.assertEqual(sum(counts.values()), len(summary.rows))
+
+    def test_needs_attention_excludes_no_live_impl_and_manual(self) -> None:
+        registry = default_registry()
+        # Plug live impl for github_api, leave env empty → MISSING_ENV
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        summary = registry.availability_summary(env={})
+        attention = summary.needs_attention()
+        # Only github_api appears (MISSING_ENV); RSS/ATOM/etc still
+        # NO_LIVE_IMPL and excluded.
+        self.assertEqual(
+            [row.transport for row in attention],
+            [ProviderTransport.GITHUB_API_REPO_ACTIVITY.value],
+        )
+
+    def test_payload_round_trip_has_states_count_and_needs_attention(
+        self,
+    ) -> None:
+        registry = default_registry()
+        payload = registry.availability_summary(env={}).to_payload()
+        self.assertIn("rows", payload)
+        self.assertIn("states_count", payload)
+        self.assertIn("needs_attention", payload)
+        self.assertEqual(
+            len(payload["rows"]), len(ProviderTransport)
+        )
+
+    def test_row_from_registration_carries_description_and_notes(self) -> None:
+        registry = default_registry()
+        rss = registry.get(ProviderTransport.RSS)
+        row = ProviderAvailabilityRow.from_registration(rss, env={})
+        self.assertEqual(row.provider_id, "rss-feed")
+        self.assertTrue(row.description)
+        self.assertIn("RSS", row.description.upper())
+
+
+# ---------------------------------------------------------------------------
+# Routing reasoning
+# ---------------------------------------------------------------------------
+
+
+class RoutingReasonTests(unittest.TestCase):
+    def test_every_routed_candidate_has_transport_and_availability_reasons(
+        self,
+    ) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, skipped = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        for cand in due + skipped:
+            self.assertTrue(
+                cand.transport_reason,
+                f"{cand.source.source_id} missing transport_reason",
+            )
+            self.assertTrue(
+                cand.availability_reason,
+                f"{cand.source.source_id} missing availability_reason",
+            )
+
+    def test_atom_url_heuristic_explained_in_transport_reason(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        # Spring blog is registered as RSS-mode but uses an .atom URL —
+        # the transport reason must call that out.
+        spring = next(
+            (c for c in due if c.source.source_id == "spring-blog"), None
+        )
+        self.assertIsNotNone(spring)
+        self.assertIn("atom", spring.transport_reason)
+
+    def test_no_live_impl_explained_in_availability_reason(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        rss_or_atom = next(
+            (
+                c
+                for c in due
+                if c.transport
+                in (ProviderTransport.RSS, ProviderTransport.ATOM)
+            ),
+            None,
+        )
+        self.assertIsNotNone(rss_or_atom)
+        self.assertIn("no live impl", rss_or_atom.availability_reason)
+        self.assertIn("transport=", rss_or_atom.routing_reason)
+        self.assertIn("availability=", rss_or_atom.routing_reason)
+
+    def test_missing_env_reason_lists_missing_keys(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        # tech-lead has the adr-github source (collection_mode=github_api,
+        # auto_collect=False, review_required=True) — include both gates
+        # so the planner surfaces it.
+        plan = compute_refresh_plan(
+            "tech-lead",
+            now=_now(),
+            states={},
+            tick_quota=99,
+            include_review_required=True,
+            include_auto_collect_disabled=True,
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="tech-lead", registry=registry, env={}
+        )
+        github = next(
+            (
+                c
+                for c in due
+                if c.transport
+                is ProviderTransport.GITHUB_API_REPO_ACTIVITY
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            github, "expected at least one github_api source on tech-lead"
+        )
+        self.assertIn(
+            "missing env keys", github.availability_reason
+        )
+        self.assertIn(
+            "YULE_GITHUB_APP_ID", github.availability_reason
+        )
+
+    def test_available_reason_mentions_flag_truthy(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        atom = next(
+            (c for c in due if c.transport is ProviderTransport.ATOM),
+            None,
+        )
+        self.assertIsNotNone(atom)
+        self.assertIn("live", atom.availability_reason)
+        self.assertIn(
+            "YULE_KNOWLEDGE_ATOM_LIVE_ENABLED", atom.availability_reason
+        )
+
+    def test_routing_reason_payload_round_trips(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        sample = due[0].to_payload()
+        self.assertIn("transport_reason", sample)
+        self.assertIn("availability_reason", sample)
+        self.assertIn("routing_reason", sample)
+
+
+# ---------------------------------------------------------------------------
+# RefreshPlanStatus bundle
+# ---------------------------------------------------------------------------
+
+
+class RefreshPlanStatusTests(unittest.TestCase):
+    def test_status_bundles_routed_candidates_with_summary(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan, role_id="backend-engineer", env={}
+        )
+        self.assertIsInstance(status, RefreshPlanStatus)
+        self.assertGreater(len(status.due), 0)
+        self.assertEqual(status.role, "backend-engineer")
+        self.assertIsInstance(
+            status.availability, ProviderAvailabilitySummary
+        )
+        # transports_due is sorted unique.
+        self.assertEqual(
+            list(status.transports_due),
+            sorted(set(status.transports_due)),
+        )
+
+    def test_status_payload_has_full_round_trip(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan, role_id="backend-engineer", env={}
+        )
+        payload = status.to_payload()
+        self.assertIn("transports_due", payload)
+        self.assertIn("availability", payload)
+        self.assertIn("rows", payload["availability"])
+        self.assertIn("states_count", payload["availability"])
+
+    def test_status_uses_passed_registry_when_provided(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.RSS,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        rss_rows = [
+            row
+            for row in status.availability.rows
+            if row.transport == ProviderTransport.RSS.value
+        ]
+        self.assertEqual(len(rss_rows), 1)
+        self.assertEqual(
+            rss_rows[0].availability,
+            ProviderAvailability.AVAILABLE.value,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_provider_registry.py
+++ b/tests/engineering_intelligence/test_provider_registry.py
@@ -1,0 +1,350 @@
+"""Provider registry: auth contract, availability, fake fixture."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    FakeKnowledgeProvider,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    ProviderAuthRequirement,
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    find_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _knowledge_item(source_id: str) -> EngineeringKnowledgeItem:
+    return EngineeringKnowledgeItem(
+        item_id=f"{source_id}-1",
+        topic_key=f"{source_id}-topic",
+        title=f"item from {source_id}",
+        role="backend-engineer",
+        stack_tags=("test",),
+        source_name=source_id,
+        source_url=f"https://example.com/{source_id}",
+        source_kind=SourceKind.RELEASE_NOTES,
+        collected_at="2026-05-09T12:00:00Z",
+        importance=Importance.MEDIUM,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ProviderAuthRequirement
+# ---------------------------------------------------------------------------
+
+
+class AuthRequirementTests(unittest.TestCase):
+    def test_no_keys_no_flag_is_always_satisfied(self) -> None:
+        req = ProviderAuthRequirement()
+        self.assertTrue(req.env_keys_present({}))
+        self.assertTrue(req.enable_flag_set({}))
+
+    def test_blank_value_counts_as_missing(self) -> None:
+        req = ProviderAuthRequirement(env_keys=("FOO",))
+        self.assertFalse(req.env_keys_present({}))
+        self.assertFalse(req.env_keys_present({"FOO": ""}))
+        self.assertFalse(req.env_keys_present({"FOO": "   "}))
+        self.assertTrue(req.env_keys_present({"FOO": "x"}))
+
+    def test_enable_flag_recognises_truthy_strings(self) -> None:
+        req = ProviderAuthRequirement(enable_flag="GO")
+        self.assertFalse(req.enable_flag_set({}))
+        self.assertFalse(req.enable_flag_set({"GO": "false"}))
+        self.assertFalse(req.enable_flag_set({"GO": "0"}))
+        self.assertFalse(req.enable_flag_set({"GO": "no"}))
+        for truthy in ("1", "true", "True", "TRUE", "yes", "on"):
+            with self.subTest(value=truthy):
+                self.assertTrue(req.enable_flag_set({"GO": truthy}))
+
+
+# ---------------------------------------------------------------------------
+# Registration availability resolution
+# ---------------------------------------------------------------------------
+
+
+class AvailabilityResolutionTests(unittest.TestCase):
+    def test_manual_collapses_to_manual_only(self) -> None:
+        reg = KnowledgeProviderRegistration(
+            provider_id="manual",
+            transport=ProviderTransport.MANUAL,
+            auth=ProviderAuthRequirement(),
+            fake_fetcher=StubLiveSourceFetcher(),
+            manual=True,
+        )
+        # Even with a perfectly-set env, manual stays manual.
+        self.assertEqual(
+            reg.evaluate_availability({"YULE_GO": "true"}),
+            ProviderAvailability.MANUAL_ONLY,
+        )
+
+    def test_no_live_impl_short_circuits_before_env(self) -> None:
+        # Auth is fully satisfied; missing live factory still wins.
+        reg = KnowledgeProviderRegistration(
+            provider_id="rss-feed",
+            transport=ProviderTransport.RSS,
+            auth=ProviderAuthRequirement(
+                env_keys=("FOO",), enable_flag="GO"
+            ),
+            fake_fetcher=StubLiveSourceFetcher(),
+            live_factory=None,
+        )
+        env = {"FOO": "x", "GO": "true"}
+        self.assertEqual(
+            reg.evaluate_availability(env),
+            ProviderAvailability.NO_LIVE_IMPL,
+        )
+
+    def test_missing_env_before_disabled_flag(self) -> None:
+        # When both env and flag are off, the env reason is more
+        # actionable for the operator (you must fill the secret first
+        # before flipping the flag is even meaningful).
+        live_calls: list = []
+
+        def factory(env):
+            return lambda spec, *, source: live_calls.append(spec)
+
+        reg = KnowledgeProviderRegistration(
+            provider_id="github-api",
+            transport=ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            auth=ProviderAuthRequirement(
+                env_keys=("APP_ID",), enable_flag="GO"
+            ),
+            fake_fetcher=StubLiveSourceFetcher(),
+            live_factory=factory,
+        )
+        self.assertEqual(
+            reg.evaluate_availability({}),
+            ProviderAvailability.MISSING_ENV,
+        )
+        self.assertEqual(
+            reg.evaluate_availability({"APP_ID": "x"}),
+            ProviderAvailability.DISABLED_BY_FLAG,
+        )
+        self.assertEqual(
+            reg.evaluate_availability(
+                {"APP_ID": "x", "GO": "true"}
+            ),
+            ProviderAvailability.AVAILABLE,
+        )
+
+    def test_select_fetcher_respects_availability(self) -> None:
+        live_seen: list = []
+
+        def factory(env):
+            def fetch(spec, *, source):
+                live_seen.append((source.source_id, env.get("FLAG")))
+                return ()
+
+            return fetch
+
+        fake = StubLiveSourceFetcher()
+        reg = KnowledgeProviderRegistration(
+            provider_id="rss",
+            transport=ProviderTransport.RSS,
+            auth=ProviderAuthRequirement(enable_flag="FLAG"),
+            fake_fetcher=fake,
+            live_factory=factory,
+        )
+
+        # Disabled → fake.
+        f1 = reg.select_fetcher({})
+        self.assertIs(f1, fake)
+        # Enabled → live.
+        f2 = reg.select_fetcher({"FLAG": "true"})
+        self.assertIsNot(f2, fake)
+
+
+# ---------------------------------------------------------------------------
+# default_registry seed
+# ---------------------------------------------------------------------------
+
+
+class DefaultRegistrySeedTests(unittest.TestCase):
+    def test_every_transport_has_a_registration(self) -> None:
+        reg = default_registry()
+        registered = {r.transport for r in reg.iter_registrations()}
+        for transport in ProviderTransport:
+            self.assertIn(
+                transport, registered, f"missing registration: {transport}"
+            )
+
+    def test_default_registry_is_no_live_impl_everywhere(self) -> None:
+        reg = default_registry()
+        report = dict(reg.availability_report({}))
+        # Manual is manual_only by design; everything else is no_live_impl
+        # until the live PR plugs a factory in.
+        self.assertEqual(report[ProviderTransport.MANUAL.value], "manual_only")
+        for transport in ProviderTransport:
+            if transport is ProviderTransport.MANUAL:
+                continue
+            with self.subTest(transport=transport):
+                self.assertEqual(
+                    report[transport.value], "no_live_impl"
+                )
+
+    def test_github_api_requires_app_env_triple(self) -> None:
+        reg = default_registry()
+        github = reg.get(ProviderTransport.GITHUB_API_REPO_ACTIVITY)
+        self.assertIn("YULE_GITHUB_APP_ID", github.auth.env_keys)
+        self.assertIn(
+            "YULE_GITHUB_APP_INSTALLATION_ID", github.auth.env_keys
+        )
+        self.assertIn(
+            "YULE_GITHUB_APP_PRIVATE_KEY_PATH", github.auth.env_keys
+        )
+
+    def test_public_feeds_have_only_enable_flag_no_env_keys(self) -> None:
+        reg = default_registry()
+        for transport in (
+            ProviderTransport.RSS,
+            ProviderTransport.ATOM,
+            ProviderTransport.GITHUB_RELEASES_ATOM,
+            ProviderTransport.SITEMAP,
+            ProviderTransport.HTML_LIST,
+            ProviderTransport.HTML_DETAIL,
+        ):
+            with self.subTest(transport=transport):
+                row = reg.get(transport)
+                self.assertEqual(row.auth.env_keys, ())
+                self.assertTrue(row.auth.enable_flag)
+                self.assertTrue(
+                    row.auth.enable_flag.startswith("YULE_KNOWLEDGE_")
+                )
+
+    def test_manual_registration_has_no_enable_flag(self) -> None:
+        reg = default_registry()
+        manual = reg.get(ProviderTransport.MANUAL)
+        self.assertTrue(manual.manual)
+        self.assertIsNone(manual.auth.enable_flag)
+        self.assertFalse(manual.has_live_impl())
+
+    def test_register_live_attaches_factory(self) -> None:
+        reg = default_registry()
+
+        seen: list = []
+
+        def factory(env):
+            return lambda spec, *, source: (seen.append(spec.transport) or ())
+
+        reg.register_live(
+            ProviderTransport.RSS,
+            live_factory=factory,
+        )
+        # With env / flag set, RSS becomes available.
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        self.assertEqual(
+            reg.evaluate(ProviderTransport.RSS, env=env),
+            ProviderAvailability.AVAILABLE,
+        )
+        # Without the flag, falls back to fake.
+        self.assertEqual(
+            reg.evaluate(ProviderTransport.RSS, env={}),
+            ProviderAvailability.DISABLED_BY_FLAG,
+        )
+
+    def test_register_live_refuses_manual_transport(self) -> None:
+        reg = default_registry()
+        with self.assertRaises(ValueError):
+            reg.register_live(
+                ProviderTransport.MANUAL,
+                live_factory=lambda env: (lambda spec, *, source: ()),
+            )
+
+    def test_register_live_unknown_transport_raises_keyerror(self) -> None:
+        reg = KnowledgeProviderRegistry()  # empty registry
+        with self.assertRaises(KeyError):
+            reg.register_live(
+                ProviderTransport.RSS,
+                live_factory=lambda env: (lambda spec, *, source: ()),
+            )
+
+
+# ---------------------------------------------------------------------------
+# FakeKnowledgeProvider
+# ---------------------------------------------------------------------------
+
+
+class FakeKnowledgeProviderTests(unittest.TestCase):
+    def test_returns_fixture_items_keyed_on_source_id(self) -> None:
+        items = (_knowledge_item("foo"), _knowledge_item("foo"))
+        fake = FakeKnowledgeProvider({"foo": items})
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        # Source id "spring-blog" has no fixture → empty.
+        self.assertEqual(fake(provider_spec_for(spring), source=spring), ())
+        # Source whose source_id matches the fixture key → returns items.
+        # We synthesise one by editing source_id via a copy.
+        from dataclasses import replace as _replace
+        fake_source = _replace(spring, source_id="foo")
+        produced = fake(provider_spec_for(fake_source), source=fake_source)
+        self.assertEqual(produced, items)
+
+    def test_records_calls_with_transport(self) -> None:
+        fake = FakeKnowledgeProvider()
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        fake(provider_spec_for(spring), source=spring)
+        self.assertEqual(
+            fake.calls,
+            [("spring-blog", ProviderTransport.ATOM)],
+        )
+
+    def test_with_fixture_can_be_chained_after_construction(self) -> None:
+        fake = FakeKnowledgeProvider().with_fixture(
+            "x", (_knowledge_item("x"),)
+        )
+        self.assertEqual(len(fake._payload["x"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# select_fetcher_for + route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+class SelectFetcherForSourceTests(unittest.TestCase):
+    def test_returns_spec_fetcher_and_availability_in_one_call(self) -> None:
+        reg = default_registry()
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        spec, fetcher, availability = reg.select_fetcher_for(spring, env={})
+        self.assertEqual(spec.transport, ProviderTransport.ATOM)
+        self.assertEqual(availability, ProviderAvailability.NO_LIVE_IMPL)
+        # fetcher fall-back is the registry's fake.
+        self.assertIs(
+            fetcher, reg.get(ProviderTransport.ATOM).fake_fetcher
+        )
+
+    def test_routes_owasp_to_manual_only(self) -> None:
+        reg = default_registry()
+        owasp = find_source("backend-engineer", "owasp-top-10")
+        assert owasp is not None
+        _, _, availability = reg.select_fetcher_for(owasp, env={})
+        self.assertEqual(availability, ProviderAvailability.MANUAL_ONLY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_provider_routing.py
+++ b/tests/engineering_intelligence/test_provider_routing.py
@@ -1,0 +1,319 @@
+"""Refresh-plan → provider routing + axis priority + tick selection."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    SourceAxis,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_routing import (
+    RoutedRefreshCandidate,
+    axis_priority_order,
+    route_refresh_plan,
+    select_routed_due,
+)
+from yule_orchestrator.agents.engineering_intelligence.scheduler import (
+    compute_refresh_plan,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    SUPPORTED_ROLES,
+    role_sources,
+)
+
+
+def _now() -> datetime:
+    # Pinned anchor — keeps "never_attempted" classification stable.
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+class RouteRefreshPlanTests(unittest.TestCase):
+    def test_due_candidates_carry_transport_axes_and_availability(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=99,  # don't truncate — we want every source
+        )
+        due, skipped = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        self.assertGreater(len(due), 0)
+        for cand in due:
+            self.assertIsInstance(cand, RoutedRefreshCandidate)
+            self.assertEqual(cand.decision, "due")
+            self.assertTrue(cand.axes)
+            self.assertEqual(
+                cand.transport, provider_spec_for(cand.source).transport
+            )
+            # No live impl wired → fakes everywhere.
+            self.assertIn(
+                cand.availability,
+                {
+                    ProviderAvailability.NO_LIVE_IMPL,
+                    ProviderAvailability.MANUAL_ONLY,
+                },
+            )
+        # Skipped entries (auto_collect=False / review_required) annotated too.
+        skipped_ids = {c.source.source_id for c in skipped}
+        # OWASP Top 10 is auto_collect=False on backend → ends up in skipped.
+        self.assertIn("owasp-top-10", skipped_ids)
+
+    def test_skipped_candidate_carries_manual_only_availability(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=99,
+            include_auto_collect_disabled=True,
+            include_review_required=True,
+        )
+        # When both gates opted-in, OWASP appears in due and routing
+        # surfaces its MANUAL transport + MANUAL_ONLY availability so
+        # the runner knows there is no live call to make.
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        owasp = next(
+            (c for c in due if c.source.source_id == "owasp-top-10"),
+            None,
+        )
+        self.assertIsNotNone(owasp)
+        self.assertEqual(owasp.transport, ProviderTransport.MANUAL)
+        self.assertEqual(
+            owasp.availability, ProviderAvailability.MANUAL_ONLY
+        )
+
+    def test_routing_with_partial_live_factory_marks_available(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        atom_candidates = [
+            c for c in due if c.transport is ProviderTransport.ATOM
+        ]
+        self.assertTrue(atom_candidates, "expected at least one atom source")
+        for c in atom_candidates:
+            self.assertEqual(c.availability, ProviderAvailability.AVAILABLE)
+        # Non-atom sources still no_live_impl (env flag only enables atom).
+        non_atom = [
+            c for c in due if c.transport is not ProviderTransport.ATOM
+        ]
+        for c in non_atom:
+            self.assertNotEqual(c.availability, ProviderAvailability.AVAILABLE)
+
+    def test_payload_round_trip_contains_axes_and_auth_keys(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        sample = due[0].to_payload()
+        self.assertIn("transport", sample)
+        self.assertIn("provider_id", sample)
+        self.assertIn("availability", sample)
+        self.assertIn("axes", sample)
+        self.assertIn("auth", sample)
+        self.assertIn("env_keys", sample["auth"])
+        self.assertIn("enable_flag", sample["auth"])
+
+
+# ---------------------------------------------------------------------------
+# axis_priority_order
+# ---------------------------------------------------------------------------
+
+
+class AxisPriorityOrderTests(unittest.TestCase):
+    def test_overdue_axis_candidates_rank_first(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        ordered = axis_priority_order(
+            due, overdue_axes=(SourceAxis.SECURITY.value,)
+        )
+        # Every leading candidate (until the first non-security one) must
+        # carry SECURITY in its axes.
+        leading_security = []
+        for c in ordered:
+            if SourceAxis.SECURITY in c.axes:
+                leading_security.append(c)
+            else:
+                break
+        self.assertTrue(leading_security)
+        self.assertIn(SourceAxis.SECURITY, leading_security[0].axes)
+
+    def test_available_provider_beats_fake_within_same_axis_bucket(self) -> None:
+        registry = default_registry()
+        # Make ATOM live; RSS stays no-live-impl.
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        ordered = axis_priority_order(due, overdue_axes=())
+        # The leading candidates should include AVAILABLE atom sources.
+        leading_avail = {
+            ordered[i].availability for i in range(min(2, len(ordered)))
+        }
+        self.assertIn(ProviderAvailability.AVAILABLE, leading_avail)
+
+    def test_tier_breaks_ties_when_no_overdue_and_same_availability(self) -> None:
+        # All due candidates here have NO_LIVE_IMPL availability, so the
+        # tier_rank tie-breaker decides ordering. Tier 1 sources should
+        # precede Tier 2 / 3.
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        ordered = axis_priority_order(due, overdue_axes=())
+        # Within the same availability bucket the order must be tier-monotonic.
+        same_bucket = [
+            c for c in ordered
+            if c.availability == ProviderAvailability.NO_LIVE_IMPL
+        ]
+        tiers = [c.source.tier.value for c in same_bucket]
+        # tier_1 < tier_2 < tier_3 alphabetically (the enum values are
+        # "tier_1_official_docs", "tier_2_official_release", ...) so a
+        # non-decreasing sequence verifies Tier 1 wins ties.
+        self.assertEqual(sorted(tiers), tiers)
+
+    def test_deterministic_for_fixed_inputs(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        a = axis_priority_order(due, overdue_axes=(SourceAxis.SECURITY.value,))
+        b = axis_priority_order(due, overdue_axes=(SourceAxis.SECURITY.value,))
+        self.assertEqual(
+            [c.source.source_id for c in a],
+            [c.source.source_id for c in b],
+        )
+
+
+# ---------------------------------------------------------------------------
+# select_routed_due — plan + route + axis priority + tick quota in one
+# ---------------------------------------------------------------------------
+
+
+class SelectRoutedDueTests(unittest.TestCase):
+    def test_quota_truncates_to_axis_priority_head(self) -> None:
+        # Disable planner cap (tick_quota=-1) so axis priority decides
+        # the head; then take just 1 candidate. Backend-engineer only
+        # carries one SECURITY-tagged auto-collectable source (the
+        # cve-nvd common-core feed), so quota=1 verifies the overdue
+        # axis bucket fills the slot.
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=-1,
+        )
+        selected, deferred = select_routed_due(
+            plan,
+            role_id="backend-engineer",
+            env={},
+            overdue_axes=(SourceAxis.SECURITY.value,),
+            tick_quota=1,
+        )
+        self.assertEqual(len(selected), 1)
+        self.assertIn(SourceAxis.SECURITY, selected[0].axes)
+        # The rest are deferred — none lost.
+        self.assertEqual(
+            len(selected) + len(deferred),
+            len(plan.due),
+        )
+
+    def test_no_quota_keeps_full_ordered_list(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        selected, deferred = select_routed_due(
+            plan, role_id="backend-engineer", env={}, tick_quota=None
+        )
+        self.assertEqual(deferred, ())
+        self.assertEqual(len(selected), len(plan.due))
+
+
+# ---------------------------------------------------------------------------
+# Cross-role: every role's plan resolves to routed candidates without raising
+# ---------------------------------------------------------------------------
+
+
+class CrossRoleRoutingTests(unittest.TestCase):
+    def test_every_role_has_routable_candidates(self) -> None:
+        for role in SUPPORTED_ROLES:
+            with self.subTest(role=role):
+                plan = compute_refresh_plan(
+                    role,
+                    now=_now(),
+                    states={},
+                    tick_quota=99,
+                    include_review_required=True,
+                    include_auto_collect_disabled=True,
+                )
+                due, skipped = route_refresh_plan(
+                    plan, role_id=role, env={}
+                )
+                # Total candidates equal the role's full source list.
+                expected = len(role_sources(role))
+                self.assertEqual(len(due) + len(skipped), expected)
+                for cand in due + skipped:
+                    self.assertTrue(cand.spec.endpoint)
+                    self.assertTrue(cand.provider.provider_id)
+                    self.assertIn(
+                        cand.availability,
+                        set(ProviderAvailability),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_providers.py
+++ b/tests/engineering_intelligence/test_providers.py
@@ -1,0 +1,187 @@
+"""Live provider spec dispatch — every CollectionMode resolves cleanly."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    CollectionMode,
+    SourceEntry,
+    SourceKind,
+    SourceTier,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    LiveProviderSpec,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+    specs_for_role,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    SUPPORTED_ROLES,
+    find_source,
+)
+
+
+def _entry(
+    *,
+    source_id: str,
+    base_url: str,
+    collection_mode: CollectionMode,
+    source_kind: SourceKind = SourceKind.DOCS,
+    role_tags: tuple = ("backend-engineer",),
+) -> SourceEntry:
+    return SourceEntry(
+        source_id=source_id,
+        name=source_id,
+        base_url=base_url,
+        role_tags=role_tags,
+        stack_tags=("test",),
+        source_kind=source_kind,
+        collection_mode=collection_mode,
+        tier=SourceTier.TIER_2,
+    )
+
+
+class DispatchTests(unittest.TestCase):
+    def test_manual_collection_mode_yields_manual_transport(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="m",
+                base_url="https://example.com",
+                collection_mode=CollectionMode.MANUAL,
+            )
+        )
+        self.assertEqual(spec.transport, ProviderTransport.MANUAL)
+        self.assertEqual(spec.parser, "manual")
+        self.assertEqual(spec.rate_limit_per_minute, 0)
+
+    def test_github_api_collection_mode_yields_repo_activity(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="g",
+                base_url="https://github.com/foo/bar",
+                collection_mode=CollectionMode.GITHUB_API,
+                source_kind=SourceKind.REPO,
+            )
+        )
+        self.assertEqual(
+            spec.transport, ProviderTransport.GITHUB_API_REPO_ACTIVITY
+        )
+        self.assertIn("YULE_GITHUB_APP_ID", spec.requires_auth_env)
+        self.assertEqual(
+            spec.request_headers_seed["Accept"],
+            "application/vnd.github+json",
+        )
+
+    def test_rss_with_github_releases_url_uses_github_releases_transport(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="g-r",
+                base_url="https://github.com/foo/bar/releases.atom",
+                collection_mode=CollectionMode.RSS,
+                source_kind=SourceKind.RELEASE_NOTES,
+            )
+        )
+        self.assertEqual(
+            spec.transport, ProviderTransport.GITHUB_RELEASES_ATOM
+        )
+        self.assertEqual(spec.parser, "atom")
+
+    def test_rss_with_atom_url_uses_atom_transport(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="atom",
+                base_url="https://spring.io/blog.atom",
+                collection_mode=CollectionMode.RSS,
+                source_kind=SourceKind.ENGINEERING_BLOG,
+            )
+        )
+        self.assertEqual(spec.transport, ProviderTransport.ATOM)
+
+    def test_rss_with_xml_url_uses_rss_transport(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="rss",
+                base_url="https://web.dev/feed.xml",
+                collection_mode=CollectionMode.RSS,
+                source_kind=SourceKind.DOCS,
+            )
+        )
+        self.assertEqual(spec.transport, ProviderTransport.RSS)
+
+    def test_sitemap_yields_sitemap_transport(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="map",
+                base_url="https://docs.spring.io/spring-framework/reference/index.html",
+                collection_mode=CollectionMode.SITEMAP,
+                source_kind=SourceKind.DOCS,
+            )
+        )
+        self.assertEqual(spec.transport, ProviderTransport.SITEMAP)
+        self.assertEqual(spec.parser, "sitemap")
+
+    def test_html_list_yields_html_list(self) -> None:
+        spec = provider_spec_for(
+            _entry(
+                source_id="html",
+                base_url="https://www.postgresql.org/docs/release/",
+                collection_mode=CollectionMode.HTML_LIST,
+                source_kind=SourceKind.RELEASE_NOTES,
+            )
+        )
+        self.assertEqual(spec.transport, ProviderTransport.HTML_LIST)
+
+
+class RegistryDispatchTests(unittest.TestCase):
+    def test_specs_for_every_role_resolve_without_raising(self) -> None:
+        for role in SUPPORTED_ROLES:
+            specs = specs_for_role(role)
+            self.assertGreater(len(specs), 0)
+            for spec in specs:
+                self.assertIsInstance(spec, LiveProviderSpec)
+                # endpoint should be a non-empty URL even for MANUAL.
+                self.assertTrue(spec.endpoint)
+                # parser is one of the known strings.
+                self.assertIn(
+                    spec.parser,
+                    {
+                        "rss",
+                        "atom",
+                        "sitemap",
+                        "html_list",
+                        "html_detail",
+                        "github_api",
+                        "manual",
+                    },
+                )
+
+    def test_owasp_review_required_still_gets_a_manual_spec(self) -> None:
+        # Provider dispatch ignores review_required — that's a planner
+        # concern. The spec still resolves so the operator can click
+        # through to the URL on the dashboard.
+        owasp = find_source("backend-engineer", "owasp-top-10")
+        assert owasp is not None
+        spec = provider_spec_for(owasp)
+        self.assertEqual(spec.transport, ProviderTransport.MANUAL)
+
+
+class StubFetcherTests(unittest.TestCase):
+    def test_stub_records_specs_returns_empty(self) -> None:
+        owasp = find_source("backend-engineer", "owasp-top-10")
+        assert owasp is not None
+        spec = provider_spec_for(owasp)
+        fetcher = StubLiveSourceFetcher()
+        items = fetcher(spec, source=owasp)
+        self.assertEqual(items, ())
+        self.assertEqual(fetcher.seen, [spec])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_renderer.py
+++ b/tests/engineering_intelligence/test_renderer.py
@@ -134,16 +134,18 @@ class FrontmatterTests(unittest.TestCase):
 
 
 class SectionPresenceTests(unittest.TestCase):
-    def test_all_thirteen_sections_rendered(self) -> None:
+    def test_all_required_sections_rendered(self) -> None:
         body = render_engineering_knowledge_note(_full_item())
         for title in required_sections():
             self.assertIn(f"## {title}", body, msg=f"missing section: {title}")
 
-    def test_toc_lists_thirteen_sections(self) -> None:
+    def test_toc_lists_all_required_sections(self) -> None:
         body = render_engineering_knowledge_note(_full_item())
         self.assertIn("## 목차", body)
-        # The TOC line numbers 1..13 each appear on their own line.
-        for index in range(1, 14):
+        # TOC line numbers 1..N each appear on their own line, where N
+        # is the current required-section count (14 — share_scope was
+        # added between RAG/CAG and References).
+        for index in range(1, len(required_sections()) + 1):
             self.assertRegex(body, rf"\n{index}\. ")
 
     def test_practice_section_includes_steps_checklist_verification(self) -> None:

--- a/tests/engineering_intelligence/test_retrieval.py
+++ b/tests/engineering_intelligence/test_retrieval.py
@@ -1,0 +1,282 @@
+"""KnowledgeRetriever — role / axis / topic / freshness scoring."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceAxis,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.retrieval import (
+    KnowledgeRecord,
+    KnowledgeRetriever,
+    score_knowledge_record,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _record(
+    *,
+    topic_key: str = "spring-auth",
+    title: str = "Spring Security 인증 흐름",
+    role: str = "backend-engineer",
+    summary: str = "OAuth2 + Filter chain 정리",
+    axes: tuple = (SourceAxis.API_SCHEMA_AUTH, SourceAxis.OFFICIAL_DOCS),
+    rag_tags: tuple = ("spring", "auth", "oauth2"),
+    importance: Importance = Importance.HIGH,
+    collected_at: str = "2026-05-08T00:00:00Z",
+    secondary_roles: tuple = (),
+) -> KnowledgeRecord:
+    return KnowledgeRecord(
+        topic_key=topic_key,
+        title=title,
+        role=role,
+        source_url=f"https://example.com/{topic_key}",
+        source_name="Spring Docs",
+        summary=summary,
+        axes=axes,
+        rag_tags=rag_tags,
+        importance=importance,
+        collected_at=collected_at,
+        secondary_roles=secondary_roles,
+    )
+
+
+class ScoreKnowledgeRecordTests(unittest.TestCase):
+    def test_role_primary_match_adds_three(self) -> None:
+        match = score_knowledge_record(
+            _record(),
+            query="auth",
+            role="engineering-agent/backend-engineer",
+            now=_now(),
+        )
+        self.assertIn("role_primary_match", match.signals)
+        # role match (3) + topic overlap on "auth" (1) + axis hint via
+        # task_type=None (0) + importance HIGH (1) + freshness 1 day
+        # ago (1) = 6.
+        self.assertGreaterEqual(match.score, 6.0)
+
+    def test_axis_hint_from_task_type_adds_two_per_overlap(self) -> None:
+        match = score_knowledge_record(
+            _record(),
+            query=None,
+            role="backend-engineer",
+            task_type="backend-feature",
+            now=_now(),
+        )
+        # axis_hints_for_task_type("backend-feature") returns
+        # API_SCHEMA_AUTH, OFFICIAL_DOCS, SECURITY. Record covers
+        # API_SCHEMA_AUTH and OFFICIAL_DOCS = 2 overlap × 2 = +4.
+        signals_str = ",".join(match.signals)
+        self.assertIn("axis_overlap:", signals_str)
+        # Score components: role (3) + axis (4) + importance HIGH (1)
+        # + freshness 7d (1) = 9. Verify score reflects axis bonus.
+        self.assertGreaterEqual(match.score, 9.0)
+
+    def test_topic_overlap_capped_at_three(self) -> None:
+        # Stuff the query with many overlapping tokens — score must cap
+        # the topic bonus at +3. Tokens must be ≥ 2 chars to count.
+        match = score_knowledge_record(
+            _record(rag_tags=("aa", "bb", "cc", "dd", "ee", "ff")),
+            query="aa bb cc dd ee ff",
+            role=None,
+            task_type=None,
+            now=_now(),
+        )
+        self.assertIn("topic_overlap:3", match.signals)
+
+    def test_freshness_bonus_decays(self) -> None:
+        recent = score_knowledge_record(
+            _record(collected_at="2026-05-08T00:00:00Z"),
+            query=None,
+            role=None,
+            task_type=None,
+            now=_now(),
+        )
+        old = score_knowledge_record(
+            _record(collected_at="2026-01-01T00:00:00Z"),
+            query=None,
+            role=None,
+            task_type=None,
+            now=_now(),
+        )
+        # Recent record should outscore the old one purely on freshness
+        # since every other dimension matches.
+        self.assertGreater(recent.score, old.score)
+        self.assertIn("fresh_7d", recent.signals)
+        self.assertNotIn("fresh_7d", old.signals)
+        self.assertNotIn("fresh_30d", old.signals)
+
+    def test_low_importance_penalised(self) -> None:
+        match = score_knowledge_record(
+            _record(importance=Importance.LOW),
+            query=None,
+            role=None,
+            task_type=None,
+            now=_now(),
+        )
+        self.assertIn("importance_low", match.signals)
+
+    def test_empty_body_penalised(self) -> None:
+        match = score_knowledge_record(
+            _record(summary="", rag_tags=()),
+            query=None,
+            role=None,
+            task_type=None,
+            now=_now(),
+        )
+        self.assertIn("empty_body_penalty", match.signals)
+
+    def test_secondary_role_counts(self) -> None:
+        match = score_knowledge_record(
+            _record(role="ai-engineer", secondary_roles=("backend-engineer",)),
+            query=None,
+            role="backend-engineer",
+            task_type=None,
+            now=_now(),
+        )
+        self.assertIn("role_secondary_match", match.signals)
+
+
+class KnowledgeRetrieverTests(unittest.TestCase):
+    def test_filters_below_min_score(self) -> None:
+        retriever = KnowledgeRetriever(min_score=2.0, now=_now())
+        candidates = [
+            _record(role="backend-engineer", title="Spring auth"),  # score>>2
+            _record(
+                role="qa-engineer",
+                title="random test note",
+                axes=(),
+                rag_tags=(),
+                summary="",
+                importance=Importance.LOW,
+                collected_at="2026-01-01T00:00:00Z",
+            ),
+        ]
+        picked = retriever(
+            candidates=candidates,
+            query="spring auth",
+            role="backend-engineer",
+            task_type="backend-feature",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(picked[0].topic_key, "spring-auth")
+
+    def test_orders_by_score_desc_then_freshness(self) -> None:
+        # Two records both passing min_score; the one with bigger axis
+        # overlap should land first.
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        big_axis = _record(
+            topic_key="big-axis",
+            axes=(SourceAxis.API_SCHEMA_AUTH, SourceAxis.OFFICIAL_DOCS),
+        )
+        small_axis = _record(
+            topic_key="small-axis",
+            axes=(SourceAxis.OFFICIAL_DOCS,),
+        )
+        picked = retriever(
+            candidates=[small_axis, big_axis],
+            query=None,
+            role="backend-engineer",
+            task_type="backend-feature",
+        )
+        self.assertEqual(picked[0].topic_key, "big-axis")
+
+    def test_limit_caps_results(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        candidates = [
+            _record(topic_key=f"t{i}", title=f"item {i}") for i in range(8)
+        ]
+        picked = retriever(
+            candidates=candidates,
+            query=None,
+            role="backend-engineer",
+            limit=3,
+        )
+        self.assertEqual(len(picked), 3)
+
+    def test_with_signals_returns_scored_envelopes(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        matches = retriever.with_signals(
+            candidates=[_record()],
+            query="auth",
+            role="backend-engineer",
+            task_type="backend-feature",
+        )
+        self.assertEqual(len(matches), 1)
+        self.assertGreater(matches[0].score, 0)
+        self.assertTrue(matches[0].signals)
+
+
+class CoercionTests(unittest.TestCase):
+    def test_engineering_knowledge_item_coerces_to_record(self) -> None:
+        item = EngineeringKnowledgeItem(
+            item_id="x",
+            topic_key="spring-auth",
+            title="Spring Auth",
+            role="backend-engineer",
+            stack_tags=("spring",),
+            source_name="Spring Docs",
+            source_url="https://example.com/spring-auth",
+            source_kind=SourceKind.DOCS,
+            collected_at="2026-05-08T00:00:00Z",
+            importance=Importance.HIGH,
+            summary="OAuth2 정리",
+            rag_tags=("spring", "auth"),
+        )
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[item],
+            query="spring",
+            role="backend-engineer",
+            task_type="backend-feature",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(picked[0].topic_key, "spring-auth")
+
+    def test_mapping_candidate_with_required_fields_coerces(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[
+                {
+                    "topic_key": "k",
+                    "title": "T",
+                    "role": "backend-engineer",
+                    "axes": ["api_schema_auth"],
+                    "importance": "high",
+                    "summary": "x",
+                    "rag_tags": ["auth"],
+                    "collected_at": "2026-05-08T00:00:00Z",
+                }
+            ],
+            query="auth",
+            role="backend-engineer",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(picked[0].title, "T")
+        self.assertEqual(picked[0].importance, Importance.HIGH)
+
+    def test_mapping_missing_required_field_dropped(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[{"title": "no role"}],
+            query=None,
+            role=None,
+        )
+        self.assertEqual(picked, ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_retrieval.py
+++ b/tests/engineering_intelligence/test_retrieval.py
@@ -19,7 +19,11 @@ from yule_orchestrator.agents.engineering_intelligence.models import (
 from yule_orchestrator.agents.engineering_intelligence.retrieval import (
     KnowledgeRecord,
     KnowledgeRetriever,
+    label_for_signal,
     score_knowledge_record,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    KnowledgeShareScope,
 )
 
 
@@ -276,6 +280,92 @@ class CoercionTests(unittest.TestCase):
             role=None,
         )
         self.assertEqual(picked, ())
+
+
+class EvidenceLabelTests(unittest.TestCase):
+    def test_known_signals_have_korean_labels(self) -> None:
+        self.assertEqual(
+            label_for_signal("role_primary_match"), "요청 역할과 정확히 일치"
+        )
+        self.assertEqual(
+            label_for_signal("importance_critical"), "중요도 critical"
+        )
+        self.assertEqual(label_for_signal("fresh_7d"), "최근 7일 이내 수집")
+
+    def test_axis_overlap_keeps_axis_names(self) -> None:
+        label = label_for_signal("axis_overlap:api_schema_auth,official_docs")
+        self.assertEqual(
+            label, "task_type 축 일치 (api_schema_auth,official_docs)"
+        )
+
+    def test_topic_overlap_extracts_count(self) -> None:
+        self.assertEqual(label_for_signal("topic_overlap:2"), "질문 토큰 겹침 (+2)")
+
+    def test_unknown_signal_falls_through(self) -> None:
+        label = label_for_signal("future_signal_xyz")
+        self.assertTrue(label.startswith("기타: "))
+
+    def test_match_evidence_labels_uses_known_labels(self) -> None:
+        match = score_knowledge_record(
+            _record(),
+            query="auth",
+            role="backend-engineer",
+            task_type="backend-feature",
+            now=_now(),
+        )
+        labels = match.evidence_labels()
+        self.assertIn("요청 역할과 정확히 일치", labels)
+        # axis 매칭이 발생했으면 사람이 읽을 수 있는 라벨로 풀어진다.
+        self.assertTrue(
+            any("task_type 축 일치" in lbl for lbl in labels),
+            f"axis label missing in {labels}",
+        )
+
+
+class ShareScopePropagationTests(unittest.TestCase):
+    def test_share_scope_default_public(self) -> None:
+        rec = _record()
+        self.assertEqual(rec.share_scope, KnowledgeShareScope.PUBLIC)
+        payload = rec.to_payload()
+        self.assertEqual(payload["share_scope"], "public")
+
+    def test_mapping_share_scope_team_internal_coerces(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[
+                {
+                    "topic_key": "k",
+                    "title": "T",
+                    "role": "backend-engineer",
+                    "share_scope": "team_internal",
+                    "share_scope_reason": "private repo",
+                }
+            ],
+            query=None,
+            role="backend-engineer",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(
+            picked[0].share_scope, KnowledgeShareScope.TEAM_INTERNAL
+        )
+        self.assertEqual(picked[0].share_scope_reason, "private repo")
+
+    def test_mapping_unknown_share_scope_falls_back_to_public(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[
+                {
+                    "topic_key": "k",
+                    "title": "T",
+                    "role": "backend-engineer",
+                    "share_scope": "future_unknown_value",
+                }
+            ],
+            query=None,
+            role="backend-engineer",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(picked[0].share_scope, KnowledgeShareScope.PUBLIC)
 
 
 if __name__ == "__main__":

--- a/tests/engineering_intelligence/test_scheduler.py
+++ b/tests/engineering_intelligence/test_scheduler.py
@@ -1,0 +1,302 @@
+"""Refresh planner — due / skipped / backoff / quota / overdue axes."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.collector import (
+    FakeSourceCollectorAdapter,
+    collect_for_role_with_schedule,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceAxis,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.scheduler import (
+    SourceRefreshState,
+    compute_refresh_plan,
+    overdue_axes_for_role,
+    record_refresh_outcome,
+)
+
+
+def _now() -> datetime:
+    # Pinned anchor so backoff math is reproducible.
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class ComputeRefreshPlanBasicsTests(unittest.TestCase):
+    def test_never_attempted_sources_are_immediately_due(self) -> None:
+        plan = compute_refresh_plan("backend-engineer", now=_now(), states={})
+        # Every auto-collectable source is due in the empty-state case
+        # (capped by tick quota).
+        self.assertEqual(plan.role, "backend-engineer")
+        self.assertGreater(len(plan.due), 0)
+        for entry in plan.due:
+            self.assertEqual(entry.decision, "due")
+            self.assertEqual(entry.reason, "never_attempted")
+
+    def test_review_required_sources_are_skipped_by_default(self) -> None:
+        # ai-engineer carries langchain-blog: review_required=True but
+        # auto_collect=True (the only seed where review_required gates
+        # without auto_collect=False also gating). That's the entry the
+        # planner classifies as "skipped_review_required".
+        plan = compute_refresh_plan("ai-engineer", now=_now(), states={})
+        skipped_review = [
+            e for e in plan.skipped if e.decision == "skipped_review_required"
+        ]
+        self.assertTrue(skipped_review)
+        self.assertIn(
+            "langchain-blog", {e.source_id for e in skipped_review}
+        )
+
+    def test_review_required_can_be_opted_in(self) -> None:
+        plan = compute_refresh_plan(
+            "ai-engineer",
+            now=_now(),
+            states={},
+            include_review_required=True,
+            include_auto_collect_disabled=True,
+            tick_quota=99,
+        )
+        # langchain-blog appears in due now.
+        self.assertIn(
+            "langchain-blog",
+            {e.source_id for e in plan.due},
+        )
+
+    def test_auto_collect_disabled_sources_are_skipped_by_default(self) -> None:
+        plan = compute_refresh_plan("backend-engineer", now=_now(), states={})
+        skipped_disabled = [
+            e
+            for e in plan.skipped
+            if e.decision == "skipped_auto_collect_disabled"
+        ]
+        # OWASP Top 10 is auto_collect=False on the backend registry.
+        self.assertIn(
+            "owasp-top-10", {e.source_id for e in skipped_disabled}
+        )
+
+    def test_tick_quota_caps_due(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=2,
+        )
+        self.assertEqual(len(plan.due), 2)
+        # Overflow re-classified as skipped_quota.
+        quota_skipped = [
+            e for e in plan.skipped if e.decision == "skipped_quota"
+        ]
+        self.assertTrue(quota_skipped)
+
+
+class FreshnessAndBackoffTests(unittest.TestCase):
+    def test_fresh_success_within_interval_is_skipped(self) -> None:
+        # spring-blog uses ENGINEERING_BLOG → 360 minute (6h) cadence.
+        # Mark it as just-attempted; should land in skipped_fresh.
+        last_iso = (_now() - timedelta(minutes=5)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        states = {
+            "spring-blog": SourceRefreshState(
+                source_id="spring-blog",
+                last_attempted_at=last_iso,
+                last_succeeded_at=last_iso,
+                last_status="success",
+            )
+        }
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states=states, tick_quota=99
+        )
+        skipped_ids = {
+            e.source_id for e in plan.skipped if e.decision == "skipped_fresh"
+        }
+        self.assertIn("spring-blog", skipped_ids)
+        self.assertNotIn(
+            "spring-blog", {e.source_id for e in plan.due}
+        )
+
+    def test_failure_applies_exponential_backoff(self) -> None:
+        # Same fresh anchor (5 min ago) on an RSS source whose interval
+        # is 360m. With 1 prior failure, backoff = 360 × 1 = 360m → still
+        # in backoff. With 0 failures (fresh success), only 5/360 has
+        # passed so it's also fresh-skipped — testing the *backoff* tag.
+        last_iso = (_now() - timedelta(minutes=5)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        states = {
+            "spring-blog": SourceRefreshState(
+                source_id="spring-blog",
+                last_attempted_at=last_iso,
+                last_status="failure",
+                consecutive_failures=2,  # backoff multiplier 4
+            )
+        }
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states=states, tick_quota=99
+        )
+        backoff_skipped = {
+            e.source_id
+            for e in plan.skipped
+            if e.decision == "skipped_backoff"
+        }
+        self.assertIn("spring-blog", backoff_skipped)
+
+    def test_overdue_failure_eventually_retried(self) -> None:
+        # Push last_attempted way back so even ×8 backoff has elapsed.
+        # 360m × 8 = 2880m = 2 days.
+        last_iso = (_now() - timedelta(days=10)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        states = {
+            "spring-blog": SourceRefreshState(
+                source_id="spring-blog",
+                last_attempted_at=last_iso,
+                last_status="failure",
+                consecutive_failures=4,
+            )
+        }
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states=states, tick_quota=99
+        )
+        due_ids = {e.source_id for e in plan.due}
+        self.assertIn("spring-blog", due_ids)
+        # Due reason mentions retry.
+        for entry in plan.due:
+            if entry.source_id == "spring-blog":
+                self.assertTrue(entry.reason.startswith("retry_after_"))
+
+
+class RecordOutcomeTests(unittest.TestCase):
+    def test_success_resets_failure_counter(self) -> None:
+        prior = SourceRefreshState(
+            source_id="x",
+            last_attempted_at="2026-05-09T11:00:00Z",
+            last_status="failure",
+            consecutive_failures=3,
+        )
+        updated = record_refresh_outcome(
+            prior, now=_now(), success=True, items_collected=2
+        )
+        self.assertEqual(updated.last_status, "success")
+        self.assertEqual(updated.consecutive_failures, 0)
+        self.assertEqual(updated.items_collected_last_run, 2)
+        self.assertEqual(updated.last_succeeded_at, "2026-05-09T12:00:00Z")
+        # Original is unchanged (frozen dataclass).
+        self.assertEqual(prior.consecutive_failures, 3)
+
+    def test_failure_increments_counter(self) -> None:
+        prior = SourceRefreshState(
+            source_id="x", consecutive_failures=1, last_status="failure"
+        )
+        updated = record_refresh_outcome(
+            prior, now=_now(), success=False, notes="HTTPError"
+        )
+        self.assertEqual(updated.consecutive_failures, 2)
+        self.assertEqual(updated.last_status, "failure")
+        self.assertEqual(updated.notes, "HTTPError")
+        self.assertIsNone(updated.last_succeeded_at)
+
+
+class OverdueAxesTests(unittest.TestCase):
+    def test_axis_with_recent_success_is_healthy(self) -> None:
+        # Mark every backend axis source as successfully refreshed
+        # within its interval — overdue list should be empty.
+        from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+            role_sources,
+        )
+
+        recent_iso = (_now() - timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        states = {
+            s.source_id: SourceRefreshState(
+                source_id=s.source_id,
+                last_attempted_at=recent_iso,
+                last_succeeded_at=recent_iso,
+                last_status="success",
+            )
+            for s in role_sources("backend-engineer")
+        }
+        overdue = overdue_axes_for_role(
+            "backend-engineer", states=states, now=_now()
+        )
+        self.assertEqual(overdue, ())
+
+    def test_axis_with_no_recent_success_is_overdue(self) -> None:
+        # Empty state map → never refreshed → every axis is overdue.
+        overdue = overdue_axes_for_role(
+            "backend-engineer", states={}, now=_now()
+        )
+        # API_SCHEMA_AUTH should appear (Spring/PostgreSQL/etc seed it).
+        self.assertIn(SourceAxis.API_SCHEMA_AUTH.value, overdue)
+
+
+class CollectorWithScheduleTests(unittest.TestCase):
+    def test_only_due_sources_get_called(self) -> None:
+        # Block spring-blog with a fresh state so the adapter shouldn't
+        # see it.
+        last_iso = (_now() - timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        states = {
+            "spring-blog": SourceRefreshState(
+                source_id="spring-blog",
+                last_attempted_at=last_iso,
+                last_succeeded_at=last_iso,
+                last_status="success",
+            )
+        }
+
+        def _item(source_id: str) -> EngineeringKnowledgeItem:
+            return EngineeringKnowledgeItem(
+                item_id=f"{source_id}-1",
+                topic_key=f"{source_id}-topic",
+                title=f"item from {source_id}",
+                role="backend-engineer",
+                stack_tags=("test",),
+                source_name=source_id,
+                source_url=f"https://example.com/{source_id}",
+                source_kind=SourceKind.RELEASE_NOTES,
+                collected_at="2026-05-09T12:00:00Z",
+                importance=Importance.MEDIUM,
+            )
+
+        adapter = FakeSourceCollectorAdapter(
+            {
+                "spring-blog": [_item("spring-blog")],
+                "fastapi-changelog": [_item("fastapi-changelog")],
+                "postgresql-release-notes": [_item("postgresql-release-notes")],
+            }
+        )
+        result, new_states = collect_for_role_with_schedule(
+            "backend-engineer",
+            adapter=adapter,
+            states=states,
+            now=_now(),
+            tick_quota=99,
+        )
+        self.assertNotIn("spring-blog", adapter.calls)
+        self.assertIn("fastapi-changelog", adapter.calls)
+        # New state row created for the visited source, with success.
+        self.assertEqual(
+            new_states["fastapi-changelog"].last_status, "success"
+        )
+        self.assertEqual(new_states["fastapi-changelog"].items_collected_last_run, 1)
+        # Skipped sources surface in result.rejected.
+        skipped_reasons = {r["reason"] for r in result.rejected if "source_id" in r}
+        self.assertIn("skipped_fresh", skipped_reasons)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_share_scope.py
+++ b/tests/engineering_intelligence/test_share_scope.py
@@ -1,0 +1,265 @@
+"""Share boundary — renderer / obsidian / discord_summary contract.
+
+새 ``KnowledgeShareScope`` 가 note/report formatting 전반에 어떻게
+반영되는지 한 번에 본다. 한 자료 항목이 share_scope 만 다르게 들어
+왔을 때 surface 별로 어떻게 다르게 노출되는지가 핵심 회귀 보호.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.discord_summary import (
+    render_daily_role_summary,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    Audience,
+    CagContext,
+    EngineeringKnowledgeItem,
+    Importance,
+    KnowledgeShareScope,
+    LearningLevel,
+    PracticeVerification,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.obsidian import (
+    build_engineering_knowledge_write_request,
+    evaluate_quality_gate,
+    shareable_external_payload,
+    vault_only_metadata,
+)
+from yule_orchestrator.agents.engineering_intelligence.renderer import (
+    RendererError,
+    render_engineering_knowledge_note,
+    required_sections,
+)
+
+
+def _item(**overrides) -> EngineeringKnowledgeItem:
+    base = dict(
+        item_id="incident-2026-04-29-customer-data-leak",
+        topic_key="customer-data-leak-2026-04-29",
+        title="2026-04-29 고객 데이터 노출 사고 — 내부 분석",
+        role="backend-engineer",
+        stack_tags=("incident",),
+        source_name="Internal Postmortem",
+        source_url="https://internal.example.com/incidents/2026-04-29",
+        source_kind=SourceKind.SECURITY_ADVISORY,
+        collected_at="2026-04-30T01:00:00Z",
+        importance=Importance.CRITICAL,
+        audience=Audience.SENIOR,
+        summary="customer 데이터 1.2k 건이 일시적으로 외부에 노출됨.",
+        why_it_matters="동일 패턴 반복 시 사용자 신뢰 손상 + 규제 노출.",
+        what_changed="audit log 보존 정책 변경 + access guard 강화.",
+        practical_impact="향후 고객 데이터 접근 endpoint 변경 시 추가 검증 필요.",
+        recommended_action="incident-2026-04-29 의 root cause 5가지 점검 항목 확인.",
+        practice_topic="incident replay (내부 한정)",
+        practice_goal="audit log + access guard 수정 흐름을 한 번 따라가 본다",
+        practice_steps=(
+            "audit log 변경 PR 다시 본다",
+            "access guard 새 case 의 unit test 를 본다",
+        ),
+        practice_checklist=("내부 채널에서 incident 카드 닫음",),
+        expected_output="incident retrospective 한 줄 요약",
+        common_mistakes=("동일 패턴 후속 endpoint 에 guard 안 거는 케이스",),
+        practice_verification=PracticeVerification(
+            expected_result="postmortem 마지막 액션 아이템이 close 됨",
+            command_to_run=None,
+        ),
+        rag_tags=("incident", "security"),
+        cag_context_key="incident-2026-04-29-when-similar-spike",
+        cag_context=CagContext(
+            when_to_use="고객 데이터 path 변경 / access guard 회귀 의심 시",
+        ),
+        retrieval_queries=(
+            "incident 2026-04-29 어떤 audit guard 가 새로 들어갔지?",
+            "고객 데이터 노출 회귀 어디서 잡지?",
+        ),
+        retrieval_summary="audit/access guard 회귀 의심 시 incident postmortem 다시 본다",
+        learning_level=LearningLevel.ADVANCED,
+        prerequisites=("audit log 정책",),
+        next_topics=("access-guard-v2",),
+        estimated_practice_time="30분",
+        review_after_days=30,
+        references=(
+            "https://internal.example.com/incidents/2026-04-29",
+        ),
+        confidence=0.9,
+        dedup_key="eng-knowledge:backend-engineer:incident-2026-04-29",
+    )
+    base.update(overrides)
+    return EngineeringKnowledgeItem(**base)
+
+
+class FrontmatterAndSectionTests(unittest.TestCase):
+    def test_share_scope_section_listed_in_required_sections(self) -> None:
+        sections = required_sections()
+        self.assertEqual(len(sections), 14)
+        self.assertIn("13. 공유 가능 범위", sections)
+        self.assertIn("14. 참고 자료", sections)
+
+    def test_frontmatter_carries_share_scope_default_public(self) -> None:
+        body = render_engineering_knowledge_note(_item())
+        self.assertIn('share_scope: "public"', body)
+
+    def test_frontmatter_share_scope_team_internal(self) -> None:
+        body = render_engineering_knowledge_note(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertIn('share_scope: "team_internal"', body)
+        # 본문(요약/실무 영향)은 정상 렌더되지만 share-scope 섹션이 추가
+        # 외부 surface 규칙을 안내한다.
+        self.assertIn("팀 내부 한정", body)
+        self.assertIn("외부 surface 노출 규칙", body)
+
+
+class RestrictedScopeBodyTests(unittest.TestCase):
+    def test_restricted_requires_share_scope_reason(self) -> None:
+        with self.assertRaises(RendererError):
+            render_engineering_knowledge_note(
+                _item(share_scope=KnowledgeShareScope.RESTRICTED)
+            )
+
+    def test_restricted_body_redacts_learning_sections(self) -> None:
+        body = render_engineering_knowledge_note(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII 가 포함된 incident",
+            )
+        )
+        # 핵심 요약 / 권장 대응 / 실습 단계 본문은 placeholder 로 대체된다.
+        self.assertIn("공개 제한된 자료", body)
+        self.assertNotIn("customer 데이터 1.2k 건", body)
+        self.assertNotIn("audit log 변경 PR 다시 본다", body)
+        self.assertNotIn("동일 패턴 반복 시", body)
+        # 그래도 share_scope 섹션 / 참고자료 / RAG/CAG 메타는 살아있다.
+        self.assertIn("share_scope_reason", body)
+        self.assertIn("customer PII 가 포함된 incident", body)
+        self.assertIn("https://internal.example.com/incidents/2026-04-29", body)
+        self.assertIn("rag_tags", body)
+
+
+class QualityGateShareScopeTests(unittest.TestCase):
+    def test_default_public_passes_gate(self) -> None:
+        gate = evaluate_quality_gate(_item())
+        self.assertTrue(gate.passed, msg=f"reasons={gate.reasons}")
+
+    def test_restricted_without_reason_blocks(self) -> None:
+        gate = evaluate_quality_gate(
+            _item(share_scope=KnowledgeShareScope.RESTRICTED)
+        )
+        self.assertFalse(gate.passed)
+        self.assertIn(
+            "missing:share_scope_reason_for_restricted", gate.reasons
+        )
+
+    def test_restricted_with_reason_passes(self) -> None:
+        gate = evaluate_quality_gate(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII 가 포함된 incident",
+            )
+        )
+        self.assertTrue(gate.passed, msg=f"reasons={gate.reasons}")
+
+    def test_write_request_metadata_carries_share_scope(self) -> None:
+        request = build_engineering_knowledge_write_request(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        assert request is not None
+        ei = request.metadata["engineering_intelligence"]
+        self.assertEqual(ei["share_scope"], "team_internal")
+        external = request.metadata["shareable_external_payload"]
+        self.assertEqual(external["share_scope"], "team_internal")
+        # team-internal: title + source 노출, summary 는 surface 차단.
+        self.assertIn("title", external)
+        self.assertIn("source_url", external)
+        self.assertNotIn("summary", external)
+
+
+class ShareablePayloadTests(unittest.TestCase):
+    def test_public_payload_includes_summary(self) -> None:
+        payload = shareable_external_payload(_item())
+        self.assertEqual(payload["share_scope"], "public")
+        self.assertIn("summary", payload)
+        self.assertIn("title", payload)
+
+    def test_team_internal_payload_drops_summary(self) -> None:
+        payload = shareable_external_payload(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertEqual(payload["share_scope"], "team_internal")
+        self.assertNotIn("summary", payload)
+        self.assertTrue(payload.get("internal_only"))
+
+    def test_restricted_payload_only_marker(self) -> None:
+        payload = shareable_external_payload(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            )
+        )
+        self.assertEqual(payload["share_scope"], "restricted")
+        # 외부 surface 가 우연히라도 본문/제목/링크를 가져가지 않게 차단.
+        self.assertNotIn("title", payload)
+        self.assertNotIn("source_url", payload)
+        self.assertNotIn("summary", payload)
+        self.assertEqual(payload["restricted_marker"], "🔒 공개 제한된 자료")
+        self.assertEqual(payload["share_scope_reason"], "customer PII")
+
+
+class VaultOnlyMetadataTests(unittest.TestCase):
+    def test_vault_only_carries_practice_body(self) -> None:
+        meta = vault_only_metadata(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertEqual(meta["share_scope"], "team_internal")
+        self.assertIn("practice_steps", meta)
+        self.assertIn("common_mistakes", meta)
+        self.assertIn("recommended_action", meta)
+
+
+class DiscordSummaryShareScopeTests(unittest.TestCase):
+    def test_public_line_unchanged(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [_item()],
+            today="2026-04-30",
+        )
+        self.assertIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertNotIn("team-internal", text)
+
+    def test_team_internal_keeps_title_with_tag(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [_item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)],
+            today="2026-04-30",
+        )
+        self.assertIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertIn("team-internal", text)
+
+    def test_restricted_line_hides_title_and_url(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [
+                _item(
+                    share_scope=KnowledgeShareScope.RESTRICTED,
+                    share_scope_reason="customer PII",
+                )
+            ],
+            today="2026-04-30",
+        )
+        # 제목과 URL 은 제거되고 공개 제한 마커 + topic_key 만 남는다.
+        self.assertNotIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertNotIn("https://internal.example.com/", text)
+        self.assertIn("공개 제한된 자료", text)
+        self.assertIn("customer-data-leak-2026-04-29", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_source_registry.py
+++ b/tests/engineering_intelligence/test_source_registry.py
@@ -10,17 +10,24 @@ except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
 from yule_orchestrator.agents.engineering_intelligence.models import (
+    SourceAxis,
     SourceKind,
     SourceTier,
+    default_refresh_interval_for_kind,
 )
 from yule_orchestrator.agents.engineering_intelligence.source_registry import (
     COMMON_CORE_SOURCES,
     SUPPORTED_ROLES,
     auto_collectable_sources,
+    axes_for_role,
+    axis_hints_for_task_type,
     daily_limit_for_role,
     find_source,
     prioritise_sources,
+    required_axes_for_role,
+    role_axis_coverage_report,
     role_sources,
+    sources_for_axis,
 )
 
 
@@ -140,6 +147,127 @@ class DailyLimitTests(unittest.TestCase):
     def test_daily_limit_unknown_role_raises(self) -> None:
         with self.assertRaises(KeyError):
             daily_limit_for_role("not-a-role")
+
+
+class AxisCoverageTests(unittest.TestCase):
+    """Each role must cover the axes named by master plan §9.1."""
+
+    def test_every_role_meets_required_axes(self) -> None:
+        for role in SUPPORTED_ROLES:
+            covered = set(axes_for_role(role))
+            for axis in required_axes_for_role(role):
+                self.assertIn(
+                    axis,
+                    covered,
+                    msg=f"role={role} missing required axis={axis.value}",
+                )
+
+    def test_axis_coverage_report_counts_match(self) -> None:
+        # Report must list every axis a role's entries mention, with at
+        # least 1 source per axis (we only seed used axes).
+        for role in SUPPORTED_ROLES:
+            report = role_axis_coverage_report(role)
+            for axis, count in report.items():
+                self.assertGreater(count, 0, msg=f"role={role} axis={axis} count")
+            self.assertEqual(set(report.keys()), set(axes_for_role(role)))
+
+    def test_required_axes_unknown_role_raises(self) -> None:
+        with self.assertRaises(KeyError):
+            required_axes_for_role("data-engineer")
+
+    def test_security_axis_present_via_common_core(self) -> None:
+        # NIST CVE seed (security_advisory) tags SECURITY axis and
+        # merges into every role — every role must therefore cover
+        # SECURITY through that route.
+        for role in SUPPORTED_ROLES:
+            self.assertIn(
+                SourceAxis.SECURITY,
+                axes_for_role(role),
+                msg=f"role={role} missing SECURITY axis",
+            )
+
+    def test_design_system_axis_for_designer_only_among_design_seeds(self) -> None:
+        # Sanity: ai-engineer / qa-engineer should NOT have DESIGN_SYSTEM
+        # in their axis surface (no seeded design source).
+        self.assertNotIn(SourceAxis.DESIGN_SYSTEM, axes_for_role("ai-engineer"))
+        self.assertNotIn(SourceAxis.DESIGN_SYSTEM, axes_for_role("qa-engineer"))
+        self.assertIn(SourceAxis.DESIGN_SYSTEM, axes_for_role("product-designer"))
+
+    def test_sources_for_axis_returns_only_matching(self) -> None:
+        for source in sources_for_axis(
+            "backend-engineer", SourceAxis.API_SCHEMA_AUTH
+        ):
+            self.assertIn(SourceAxis.API_SCHEMA_AUTH, source.axes)
+        # Empty list when role registry has no source for the axis.
+        self.assertEqual(
+            sources_for_axis("ai-engineer", SourceAxis.DESIGN_SYSTEM),
+            (),
+        )
+
+
+class RefreshIntervalTests(unittest.TestCase):
+    def test_default_intervals_per_source_kind(self) -> None:
+        # Spot-check: security advisories are most aggressive; standards
+        # the slowest. These are operational defaults — if you change
+        # them, update the policy doc too.
+        self.assertEqual(
+            default_refresh_interval_for_kind(SourceKind.SECURITY_ADVISORY),
+            30,
+        )
+        self.assertEqual(
+            default_refresh_interval_for_kind(SourceKind.RELEASE_NOTES),
+            60,
+        )
+        self.assertEqual(
+            default_refresh_interval_for_kind(SourceKind.DOCS),
+            1440,
+        )
+        self.assertEqual(
+            default_refresh_interval_for_kind(SourceKind.STANDARD),
+            10080,
+        )
+
+    def test_effective_interval_uses_entry_override_when_set(self) -> None:
+        # Pick any seeded source — it currently has interval=0 so we
+        # exercise the kind fallback.
+        s = find_source("backend-engineer", "spring-blog")
+        assert s is not None
+        # default — interval not overridden, falls back to kind default
+        self.assertEqual(
+            s.effective_refresh_interval_minutes(),
+            default_refresh_interval_for_kind(s.source_kind),
+        )
+
+    def test_to_payload_includes_axes_and_interval(self) -> None:
+        s = find_source("backend-engineer", "spring-blog")
+        assert s is not None
+        payload = s.to_payload()
+        self.assertIn("axes", payload)
+        self.assertIn("refresh_interval_minutes", payload)
+        # Override-less entry surfaces the resolved (effective) interval.
+        self.assertEqual(
+            payload["refresh_interval_minutes"],
+            s.effective_refresh_interval_minutes(),
+        )
+
+
+class TaskTypeAxisHintsTests(unittest.TestCase):
+    def test_backend_feature_hints_api_schema_axis(self) -> None:
+        hints = axis_hints_for_task_type("backend-feature")
+        self.assertIn(SourceAxis.API_SCHEMA_AUTH, hints)
+        self.assertIn(SourceAxis.OFFICIAL_DOCS, hints)
+
+    def test_qa_test_hints_regression_axis(self) -> None:
+        hints = axis_hints_for_task_type("qa-test")
+        self.assertIn(SourceAxis.REGRESSION_TEST_PLAN, hints)
+
+    def test_unknown_task_type_returns_empty_tuple(self) -> None:
+        self.assertEqual(axis_hints_for_task_type("mystery"), ())
+        self.assertEqual(axis_hints_for_task_type(None), ())
+
+    def test_landing_page_hints_design_axis(self) -> None:
+        hints = axis_hints_for_task_type("landing-page")
+        self.assertIn(SourceAxis.DESIGN_SYSTEM, hints)
 
 
 if __name__ == "__main__":

--- a/tests/github_app/test_live_client_check_runs.py
+++ b/tests/github_app/test_live_client_check_runs.py
@@ -1,0 +1,148 @@
+"""LiveGithubAppClient.list_check_runs / get_pull_request — Round 3 of #73.
+
+Pin the new GET endpoints the CI retry orchestrator depends on:
+
+  * /repos/{repo}/commits/{sha}/check-runs returns the per-run array
+    we project to ``{name, status, conclusion, html_url}`` dicts.
+  * /repos/{repo}/pulls/{number} round-trips so the orchestrator can
+    read head_sha + state.
+  * Auth header is *not* observable on the response (regression
+    guard — the token must stay inside the adapter).
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.github_app.client import HTTPResponse
+from yule_orchestrator.github_app.config import GitHubAppConfig
+from yule_orchestrator.github_app.live_client import LiveGithubAppClient
+
+
+# A 32-byte fake PEM-shaped key satisfies GitHubAppConfig's path
+# validation when we redirect the path to a temp file. We keep the
+# key bytes in-process so the live client can mint a fake token.
+_FAKE_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIBOgIBAAJBAJtest+placeholder=\n"
+    "-----END RSA PRIVATE KEY-----\n"
+).encode("utf-8")
+
+
+@dataclass
+class _FakeHTTP:
+    """Minimal HTTPClient stub recording calls + returning canned responses."""
+
+    get_responses: List[Mapping[str, Any]] = field(default_factory=list)
+    posted: List[Mapping[str, Any]] = field(default_factory=list)
+    gotten: List[Mapping[str, Any]] = field(default_factory=list)
+
+    def post(self, url, *, headers, body):
+        self.posted.append({"url": url, "headers": dict(headers), "body": dict(body)})
+        # Token mint endpoint — return a fake installation token.
+        return HTTPResponse(status=201, body={"token": "tok", "expires_at": "2030-01-01T00:00:00Z"})
+
+    def get(self, url, *, headers):
+        idx = len(self.gotten)
+        self.gotten.append({"url": url, "headers": dict(headers)})
+        body = self.get_responses[idx] if idx < len(self.get_responses) else {}
+        return HTTPResponse(status=200, body=dict(body))
+
+
+def _build_client(http: _FakeHTTP) -> LiveGithubAppClient:
+    cfg = GitHubAppConfig(
+        app_id="123456",
+        installation_id="999999",
+        private_key_path="/dev/null",  # bypassed via private_key_bytes
+        owner="owner",
+        repo="name",
+    )
+    # Inject a no-op signer so token minting bypasses crypto.
+    class _NullSigner:
+        def sign(self, message: bytes, private_key: bytes) -> bytes:  # noqa: ARG002
+            return b"signed"
+
+    return LiveGithubAppClient(
+        config=cfg,
+        http=http,
+        signer=_NullSigner(),
+        private_key_bytes=_FAKE_PEM,
+    )
+
+
+class ListCheckRunsTests(unittest.TestCase):
+    def test_returns_projected_runs(self) -> None:
+        http = _FakeHTTP(
+            get_responses=[
+                {
+                    "check_runs": [
+                        {
+                            "name": "lint",
+                            "status": "completed",
+                            "conclusion": "success",
+                            "html_url": "https://x/y/runs/1",
+                        },
+                        {
+                            "name": "test",
+                            "status": "completed",
+                            "conclusion": "failure",
+                            "html_url": "https://x/y/runs/2",
+                        },
+                    ]
+                }
+            ]
+        )
+        client = _build_client(http)
+        runs = client.list_check_runs(repo="owner/name", head_sha="abc123")
+        self.assertEqual(len(runs), 2)
+        self.assertEqual(runs[0]["name"], "lint")
+        self.assertEqual(runs[1]["conclusion"], "failure")
+        # Auth header must NOT appear in the projected payload — it
+        # only flows on the wire request.
+        self.assertNotIn("Authorization", runs[0])
+
+    def test_empty_head_sha_short_circuits(self) -> None:
+        http = _FakeHTTP()
+        client = _build_client(http)
+        runs = client.list_check_runs(repo="owner/name", head_sha="")
+        self.assertEqual(runs, ())
+        # No HTTP call fired.
+        self.assertEqual(http.gotten, [])
+
+    def test_missing_check_runs_key_returns_empty(self) -> None:
+        http = _FakeHTTP(get_responses=[{}])
+        client = _build_client(http)
+        runs = client.list_check_runs(repo="owner/name", head_sha="abc")
+        self.assertEqual(runs, ())
+
+    def test_filters_non_mapping_run_entries(self) -> None:
+        http = _FakeHTTP(
+            get_responses=[
+                {"check_runs": [{"name": "ok", "status": "completed", "conclusion": "success"}, "junk"]}
+            ]
+        )
+        client = _build_client(http)
+        runs = client.list_check_runs(repo="owner/name", head_sha="abc")
+        self.assertEqual(len(runs), 1)
+
+
+class GetPullRequestTests(unittest.TestCase):
+    def test_round_trips_payload(self) -> None:
+        http = _FakeHTTP(
+            get_responses=[{"number": 99, "head": {"sha": "deadbeef"}, "state": "open"}]
+        )
+        client = _build_client(http)
+        pr = client.get_pull_request(repo="owner/name", pr_number=99)
+        self.assertEqual(pr["number"], 99)
+        self.assertEqual(pr["head"]["sha"], "deadbeef")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_ci_retry_orchestrator.py
+++ b/tests/job_queue/test_ci_retry_orchestrator.py
@@ -1,0 +1,380 @@
+"""ci_retry_orchestrator — Round 3 of #73.
+
+Pin the side-effect layer that turns CI status + retry log into a
+``done`` / ``retry_ready`` / ``blocked`` decision and (for retry)
+schedules the next coding_execute attempt.
+
+Coverage:
+  * success → done + completion hook fires (no requeue).
+  * failure under budget → retry_ready + new coding_execute row.
+  * failure over budget → blocked + completion hook fires (no requeue).
+  * unknown CI → blocked.
+  * pending → keep alive (no completion event).
+  * GithubAppCheckRunFetcher swallows GitHub failures into
+    ``conclusion=unknown`` (so the orchestrator escalates safely).
+  * progress_post_fn failure does NOT corrupt the verdict.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, List, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.ci_retry_orchestrator import (
+    CIRetryDecision,
+    GithubAppCheckRunFetcher,
+    SESSION_EXTRA_PROGRESS_KEY,
+    orchestrate_ci_retry,
+)
+from yule_orchestrator.agents.job_queue.ci_status import (
+    CI_FAILURE,
+    CI_PENDING,
+    CI_SUCCESS,
+    CI_UNKNOWN,
+    CIRetryPolicy,
+    CIStatus,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecutorWorker,
+    JOB_TYPE_CODING_EXECUTE,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    session_id: str
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _coding_job(*, session_id: str = "sess-A") -> Mapping[str, Any]:
+    return {
+        "session_id": session_id,
+        "user_request": "fix login",
+        "executor_role": "backend-engineer",
+        "review_roles": ["tech-lead"],
+        "participant_roles": ["backend-engineer", "tech-lead"],
+        "write_scope": ["services/auth/**"],
+        "forbidden_scope": [".github/workflows/**"],
+        "safety_rules": ["no force push"],
+        "reason": "test",
+        "status": "ready",
+        "generated_prompt": "(prompt)",
+        "created_at": "2026-05-08T00:00:00+00:00",
+        "approved_at": "2026-05-08T01:00:00+00:00",
+        "metadata": {
+            "repo_full_name": "yule-studio/yule-studio-agent",
+            "base_branch": "main",
+            "issue_number": 99,
+            "branch_hint": "agent/backend-engineer/issue-99-fix",
+        },
+    }
+
+
+@dataclass
+class _StaticFetcher:
+    """Returns a canned :class:`CIStatus` regardless of arguments."""
+
+    status: CIStatus
+
+    def fetch(self, *, repo, pr_number, head_sha):
+        return self.status
+
+
+# Tracks `update_session` writes against an in-memory store keyed by
+# session_id so the orchestrator's session.extra mutations are
+# observable from the test.
+class _SessionStore:
+    def __init__(self) -> None:
+        self.sessions: dict = {}
+
+    def update(self, session, *, now):
+        self.sessions[session.session_id] = session
+        return session
+
+    def get(self, sid):
+        return self.sessions.get(sid)
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=db)
+        self.heartbeats = HeartbeatStore(db_path=db)
+        self.worker = CodingExecutorWorker(queue=self.queue, heartbeats=self.heartbeats)
+        self.store = _SessionStore()
+
+
+# ---------------------------------------------------------------------------
+# Verdict matrix
+# ---------------------------------------------------------------------------
+
+
+class SuccessPathTests(_Fixture):
+    def test_ci_success_marks_done_and_does_not_requeue(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(pr_number=999, head_sha="aaa", conclusion=CI_SUCCESS)
+            ),
+            worker=self.worker,
+            update_session_fn=self.store.update,
+            env={},
+        )
+        self.assertEqual(decision.completion_status, "done")
+        self.assertIsNone(decision.requeued_job_id)
+        # Audit entry created via completion_hook.
+        self.assertIsNotNone(decision.audit_entry_id)
+        # No new coding_execute row queued.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-A")
+            if r.job_type == JOB_TYPE_CODING_EXECUTE
+        ]
+        self.assertEqual(rows, [])
+
+
+class FailureUnderBudgetTests(_Fixture):
+    def test_first_failure_requeues_new_coding_execute(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(
+                    pr_number=999,
+                    head_sha="aaa",
+                    conclusion=CI_FAILURE,
+                    failing_runs=("test",),
+                )
+            ),
+            worker=self.worker,
+            policy=CIRetryPolicy(max_attempts=3),
+            update_session_fn=self.store.update,
+            env={},
+        )
+        self.assertEqual(decision.completion_status, "retry_ready")
+        self.assertIsNotNone(decision.requeued_job_id)
+        # New coding_execute row exists.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-A")
+            if r.job_type == JOB_TYPE_CODING_EXECUTE
+        ]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].state, JobState.QUEUED)
+        # branch_hint bumped with -attemptN suffix.
+        self.assertIn("-attempt", rows[0].payload["branch_hint"])
+
+    def test_progress_history_appended(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+        orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(pr_number=999, head_sha="aaa", conclusion=CI_FAILURE)
+            ),
+            worker=self.worker,
+            update_session_fn=self.store.update,
+            env={},
+        )
+        persisted = self.store.get("sess-A")
+        self.assertIsNotNone(persisted)
+        history = persisted.extra.get(SESSION_EXTRA_PROGRESS_KEY)
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]["completion_status"], "retry_ready")
+        self.assertEqual(history[0]["pr_number"], 999)
+
+
+class FailureOverBudgetTests(_Fixture):
+    def test_max_attempts_hit_blocks_and_does_not_requeue(self) -> None:
+        # Pre-stamp a retry log at attempts=3 to simulate prior fails.
+        prior = {
+            "ci_retry_logs": {
+                "999": {
+                    "pr_number": 999,
+                    "attempts": 3,
+                    "last_attempt_at": "t",
+                    "last_failure_reason": "test failed",
+                    "head_sha_history": ["a1", "a2", "a3"],
+                }
+            }
+        }
+        session = _FakeSession(
+            session_id="sess-A",
+            extra={"coding_job": _coding_job(session_id="sess-A"), **prior},
+        )
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="bbb",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(pr_number=999, head_sha="bbb", conclusion=CI_FAILURE)
+            ),
+            worker=self.worker,
+            policy=CIRetryPolicy(max_attempts=3),
+            update_session_fn=self.store.update,
+            env={},
+        )
+        self.assertEqual(decision.completion_status, "blocked")
+        self.assertIsNone(decision.requeued_job_id)
+        # No new coding_execute row queued.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-A")
+            if r.job_type == JOB_TYPE_CODING_EXECUTE
+        ]
+        self.assertEqual(rows, [])
+        # Completion hook fired — audit entry id present.
+        self.assertIsNotNone(decision.audit_entry_id)
+
+
+class UnknownAndPendingTests(_Fixture):
+    def test_unknown_ci_blocks(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(pr_number=999, head_sha="aaa", conclusion=CI_UNKNOWN)
+            ),
+            worker=self.worker,
+            update_session_fn=self.store.update,
+            env={},
+        )
+        self.assertEqual(decision.completion_status, "blocked")
+
+    def test_pending_keeps_alive_no_completion_hook(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(
+                    pr_number=999, head_sha="aaa", conclusion=CI_PENDING, pending_runs=("test",)
+                )
+            ),
+            worker=self.worker,
+            update_session_fn=self.store.update,
+            env={},
+        )
+        # Pending → derive_completion_status maps to retry_ready, but
+        # decide_retry's verdict.should_retry stays False — no requeue.
+        self.assertEqual(decision.completion_status, "retry_ready")
+        self.assertIsNone(decision.requeued_job_id)
+        # No completion hook for non-terminal pending.
+        self.assertIsNone(decision.audit_entry_id)
+
+
+# ---------------------------------------------------------------------------
+# GithubAppCheckRunFetcher
+# ---------------------------------------------------------------------------
+
+
+class _FakeLive:
+    def __init__(self, runs=None, raises: bool = False) -> None:
+        self.runs = runs or []
+        self.raises = raises
+        self.calls: list = []
+
+    def list_check_runs(self, *, repo, head_sha):
+        self.calls.append((repo, head_sha))
+        if self.raises:
+            raise RuntimeError("github 502")
+        return list(self.runs)
+
+
+class GithubAppCheckRunFetcherTests(unittest.TestCase):
+    def test_aggregates_into_ci_status(self) -> None:
+        client = _FakeLive(
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success"},
+                {"name": "test", "status": "completed", "conclusion": "failure"},
+            ]
+        )
+        fetcher = GithubAppCheckRunFetcher(live_client=client)
+        status = fetcher.fetch(repo="o/r", pr_number=1, head_sha="abc")
+        self.assertEqual(status.conclusion, CI_FAILURE)
+
+    def test_github_failure_becomes_unknown(self) -> None:
+        client = _FakeLive(raises=True)
+        fetcher = GithubAppCheckRunFetcher(live_client=client)
+        status = fetcher.fetch(repo="o/r", pr_number=1, head_sha="abc")
+        self.assertEqual(status.conclusion, CI_UNKNOWN)
+
+
+# ---------------------------------------------------------------------------
+# progress_post_fn fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class ProgressPosterFaultToleranceTests(_Fixture):
+    def test_progress_post_failure_does_not_change_decision(self) -> None:
+        session = _FakeSession(
+            session_id="sess-A", extra={"coding_job": _coding_job(session_id="sess-A")}
+        )
+
+        def boom(**_kwargs):
+            raise RuntimeError("discord 503")
+
+        decision = orchestrate_ci_retry(
+            session=session,
+            pr_number=999,
+            head_sha="aaa",
+            repo="yule-studio/yule-studio-agent",
+            fetcher=_StaticFetcher(
+                CIStatus(pr_number=999, head_sha="aaa", conclusion=CI_SUCCESS)
+            ),
+            worker=self.worker,
+            update_session_fn=self.store.update,
+            env={},
+            progress_post_fn=boom,
+        )
+        self.assertEqual(decision.completion_status, "done")
+        # History still recorded.
+        history = self.store.get("sess-A").extra.get(SESSION_EXTRA_PROGRESS_KEY)
+        self.assertEqual(len(history), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_coding_execute_dispatcher.py
+++ b/tests/job_queue/test_coding_execute_dispatcher.py
@@ -1,0 +1,541 @@
+"""coding_execute_dispatcher — Round 3 of #73.
+
+Pin the production producer that turns ``session.extra['coding_job']``
+``status="ready"`` into a queued ``coding_execute`` row:
+
+  * iter_ready_coding_jobs filters statuses + already-dispatched rows.
+  * build_coding_execute_request maps the persisted dict cleanly.
+  * dispatch_ready_coding_jobs is idempotent against the worker's
+    own dedup AND against repeated session scans (writes a marker
+    so the next iteration skips).
+  * WorkflowSessionState surfaces the same data to the next-task
+    selector.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+    WorkflowSessionState,
+    build_coding_execute_request,
+    dispatch_ready_coding_jobs,
+    iter_ready_coding_jobs,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecutorWorker,
+    JOB_TYPE_CODING_EXECUTE,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# Fakes — minimal session shape the dispatcher reads
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    """Minimal mutable stand-in for WorkflowSession.
+
+    The dispatcher reads ``extra`` and writes back via ``replace``;
+    ``thread_id`` / ``channel_id`` are surfaced by
+    :class:`WorkflowSessionState` for the selector.
+    """
+
+    session_id: str
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    thread_id: int = 0
+    channel_id: int = 0
+
+
+def _coding_job(
+    *,
+    session_id: str = "sess-A",
+    executor_role: str = "backend-engineer",
+    status: str = "ready",
+    issue_number: int = 99,
+    repo_full_name: str = "yule-studio/yule-studio-agent",
+    base_branch: str = "main",
+    branch_hint: str = "agent/backend-engineer/issue-99-fix",
+    user_request: str = "users 401 회복",
+    write_scope=("services/auth/**",),
+    forbidden_scope=(".github/workflows/**",),
+    safety_rules=("no force push",),
+    generated_prompt: str = "(prompt)",
+    extra_metadata: Mapping[str, Any] = None,
+) -> Mapping[str, Any]:
+    """Build a persisted coding_job dict the way the gateway writes it."""
+
+    metadata = {
+        "repo_full_name": repo_full_name,
+        "base_branch": base_branch,
+        "issue_number": issue_number,
+        "branch_hint": branch_hint,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    return {
+        "session_id": session_id,
+        "user_request": user_request,
+        "executor_role": executor_role,
+        "review_roles": ["tech-lead", "qa-engineer"],
+        "participant_roles": [executor_role, "tech-lead", "qa-engineer"],
+        "write_scope": list(write_scope),
+        "forbidden_scope": list(forbidden_scope),
+        "safety_rules": list(safety_rules),
+        "reason": "deterministic test fixture",
+        "status": status,
+        "generated_prompt": generated_prompt,
+        "created_at": "2026-05-08T00:00:00+00:00",
+        "approved_at": "2026-05-08T01:00:00+00:00" if status == "ready" else None,
+        "metadata": metadata,
+    }
+
+
+# ---------------------------------------------------------------------------
+# iter_ready_coding_jobs
+# ---------------------------------------------------------------------------
+
+
+class IterReadyCodingJobsTests(unittest.TestCase):
+    def test_yields_only_ready_status(self) -> None:
+        ready = _FakeSession(
+            session_id="ready-1",
+            extra={"coding_job": _coding_job(session_id="ready-1")},
+        )
+        pending = _FakeSession(
+            session_id="pending-1",
+            extra={
+                "coding_job": _coding_job(session_id="pending-1", status="pending_approval")
+            },
+        )
+        completed = _FakeSession(
+            session_id="completed-1",
+            extra={
+                "coding_job": _coding_job(session_id="completed-1", status="completed")
+            },
+        )
+        out = list(iter_ready_coding_jobs(session_loader=lambda: [ready, pending, completed]))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].session_id, "ready-1")
+
+    def test_skips_already_dispatched(self) -> None:
+        already = _FakeSession(
+            session_id="already-1",
+            extra={
+                "coding_job": _coding_job(session_id="already-1"),
+                SESSION_EXTRA_DISPATCH_KEY: {
+                    "job_id": "queued-job-xyz",
+                    "executor_role": "backend-engineer",
+                    "dispatched_at": "2026-05-08T01:00:00+00:00",
+                },
+            },
+        )
+        out = list(iter_ready_coding_jobs(session_loader=lambda: [already]))
+        self.assertEqual(out, [])
+
+    def test_includes_dispatched_when_flag_set(self) -> None:
+        already = _FakeSession(
+            session_id="already-1",
+            extra={
+                "coding_job": _coding_job(session_id="already-1"),
+                SESSION_EXTRA_DISPATCH_KEY: {"job_id": "queued"},
+            },
+        )
+        out = list(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [already], include_dispatched=True
+            )
+        )
+        self.assertEqual(len(out), 1)
+
+    def test_skips_session_without_executor_role(self) -> None:
+        bad = _FakeSession(
+            session_id="bad",
+            extra={"coding_job": _coding_job(session_id="bad", executor_role="")},
+        )
+        out = list(iter_ready_coding_jobs(session_loader=lambda: [bad]))
+        self.assertEqual(out, [])
+
+    def test_loader_failure_is_swallowed(self) -> None:
+        def loader():
+            raise RuntimeError("cache exploded")
+        # Must not raise.
+        out = list(iter_ready_coding_jobs(session_loader=loader))
+        self.assertEqual(out, [])
+
+    def test_missing_coding_job_extra_is_skipped(self) -> None:
+        s = _FakeSession(session_id="x", extra={"unrelated": "value"})
+        out = list(iter_ready_coding_jobs(session_loader=lambda: [s]))
+        self.assertEqual(out, [])
+
+
+# ---------------------------------------------------------------------------
+# build_coding_execute_request
+# ---------------------------------------------------------------------------
+
+
+class BuildRequestTests(unittest.TestCase):
+    def test_metadata_repo_wins_over_env(self) -> None:
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(
+                        session_id="A",
+                        extra={"coding_job": _coding_job(session_id="A", repo_full_name="meta/repo")},
+                    )
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={"YULE_CODING_EXECUTOR_REPO": "env/repo"})
+        self.assertEqual(req.repo_full_name, "meta/repo")
+
+    def test_falls_back_to_env_repo(self) -> None:
+        job = _coding_job(session_id="A", repo_full_name="")
+        # remove repo from metadata
+        job["metadata"].pop("repo_full_name", None)
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(session_id="A", extra={"coding_job": job})
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={"YULE_CODING_EXECUTOR_REPO": "env/repo"})
+        self.assertEqual(req.repo_full_name, "env/repo")
+
+    def test_dry_run_defaults_true(self) -> None:
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(
+                        session_id="A",
+                        extra={"coding_job": _coding_job(session_id="A")},
+                    )
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={})
+        self.assertTrue(req.dry_run)
+
+    def test_env_can_force_live(self) -> None:
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(
+                        session_id="A",
+                        extra={"coding_job": _coding_job(session_id="A")},
+                    )
+                ]
+            )
+        )
+        req = build_coding_execute_request(
+            ready, env={"YULE_CODING_EXECUTOR_DRY_RUN": "false"}
+        )
+        self.assertFalse(req.dry_run)
+
+    def test_metadata_can_opt_out_of_dry_run(self) -> None:
+        job = _coding_job(session_id="A", extra_metadata={"dry_run": False})
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(session_id="A", extra={"coding_job": job})
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={})
+        self.assertFalse(req.dry_run)
+
+    def test_env_forces_dry_run_back_on(self) -> None:
+        # Operator emergency switch: even if metadata says go live, an
+        # env-set dry_run still flips it back.
+        job = _coding_job(session_id="A", extra_metadata={"dry_run": False})
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(session_id="A", extra={"coding_job": job})
+                ]
+            )
+        )
+        req = build_coding_execute_request(
+            ready, env={"YULE_CODING_EXECUTOR_DRY_RUN": "1"}
+        )
+        self.assertTrue(req.dry_run)
+
+    def test_carries_write_and_forbidden_scope_intact(self) -> None:
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(
+                        session_id="A",
+                        extra={"coding_job": _coding_job(session_id="A")},
+                    )
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={})
+        self.assertIn("services/auth/**", req.write_scope)
+        self.assertIn(".github/workflows/**", req.forbidden_scope)
+        # Hard rail: forbidden_scope must NOT silently drop entries the
+        # gateway approved.
+        self.assertEqual(req.safety_rules, ("no force push",))
+
+    def test_branch_hint_carries_through(self) -> None:
+        ready = next(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [
+                    _FakeSession(
+                        session_id="A",
+                        extra={
+                            "coding_job": _coding_job(
+                                session_id="A",
+                                branch_hint="agent/backend-engineer/issue-99-fix",
+                            )
+                        },
+                    )
+                ]
+            )
+        )
+        req = build_coding_execute_request(ready, env={})
+        self.assertEqual(req.branch_hint, "agent/backend-engineer/issue-99-fix")
+
+
+# ---------------------------------------------------------------------------
+# dispatch_ready_coding_jobs — full producer cycle against a real queue
+# ---------------------------------------------------------------------------
+
+
+class DispatchProducerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db_path = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=db_path)
+        self.heartbeats = HeartbeatStore(db_path=db_path)
+        self.worker = CodingExecutorWorker(
+            queue=self.queue, heartbeats=self.heartbeats
+        )
+        # In-memory session "store" — dispatcher's update_session_fn
+        # writes back here so test assertions can read the marker.
+        self.sessions: list[_FakeSession] = []
+
+        def _loader() -> Sequence[Any]:
+            return list(self.sessions)
+
+        def _update_session(session: Any, *, now: datetime) -> Any:
+            for idx, existing in enumerate(self.sessions):
+                if existing.session_id == session.session_id:
+                    self.sessions[idx] = session
+                    return session
+            self.sessions.append(session)
+            return session
+
+        self.loader = _loader
+        self.update_session_fn = _update_session
+
+    def test_single_session_produces_one_queue_row(self) -> None:
+        self.sessions.append(
+            _FakeSession(
+                session_id="A",
+                extra={"coding_job": _coding_job(session_id="A")},
+            )
+        )
+        out = dispatch_ready_coding_jobs(
+            worker=self.worker,
+            session_loader=self.loader,
+            update_session_fn=self.update_session_fn,
+            env={},
+        )
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].created)
+        self.assertIsNotNone(out[0].job_id)
+        # Worker queue row exists.
+        rows = self.queue.list_for_session("A")
+        coding = [r for r in rows if r.job_type == JOB_TYPE_CODING_EXECUTE]
+        self.assertEqual(len(coding), 1)
+        self.assertEqual(coding[0].state, JobState.QUEUED)
+        # Marker stamped.
+        marker = self.sessions[0].extra.get(SESSION_EXTRA_DISPATCH_KEY)
+        self.assertIsNotNone(marker)
+        self.assertEqual(marker["job_id"], out[0].job_id)
+
+    def test_second_dispatch_is_idempotent(self) -> None:
+        self.sessions.append(
+            _FakeSession(
+                session_id="A",
+                extra={"coding_job": _coding_job(session_id="A")},
+            )
+        )
+        first = dispatch_ready_coding_jobs(
+            worker=self.worker,
+            session_loader=self.loader,
+            update_session_fn=self.update_session_fn,
+            env={},
+        )
+        self.assertEqual(len(first), 1)
+        # Second pass — marker present, dispatcher skips entirely.
+        second = dispatch_ready_coding_jobs(
+            worker=self.worker,
+            session_loader=self.loader,
+            update_session_fn=self.update_session_fn,
+            env={},
+        )
+        self.assertEqual(second, ())
+        # Queue stays at 1 row.
+        rows = [r for r in self.queue.list_for_session("A") if r.job_type == JOB_TYPE_CODING_EXECUTE]
+        self.assertEqual(len(rows), 1)
+
+    def test_multiple_sessions_each_produce_one_row(self) -> None:
+        for sid in ("A", "B", "C"):
+            self.sessions.append(
+                _FakeSession(
+                    session_id=sid,
+                    extra={"coding_job": _coding_job(session_id=sid)},
+                )
+            )
+        out = dispatch_ready_coding_jobs(
+            worker=self.worker,
+            session_loader=self.loader,
+            update_session_fn=self.update_session_fn,
+            env={},
+        )
+        self.assertEqual(len(out), 3)
+        self.assertEqual({d.session_id for d in out}, {"A", "B", "C"})
+
+    def test_pending_approval_session_ignored(self) -> None:
+        self.sessions.append(
+            _FakeSession(
+                session_id="A",
+                extra={
+                    "coding_job": _coding_job(
+                        session_id="A", status="pending_approval"
+                    )
+                },
+            )
+        )
+        out = dispatch_ready_coding_jobs(
+            worker=self.worker,
+            session_loader=self.loader,
+            update_session_fn=self.update_session_fn,
+            env={},
+        )
+        self.assertEqual(out, ())
+
+    def test_enqueue_failure_does_not_persist_marker(self) -> None:
+        self.sessions.append(
+            _FakeSession(
+                session_id="A",
+                extra={"coding_job": _coding_job(session_id="A")},
+            )
+        )
+
+        def _bad_enqueue(*args, **kwargs):
+            raise RuntimeError("queue write failed")
+
+        # Surgical patch: monkey-patch worker.enqueue for this test only.
+        original = self.worker.enqueue
+        self.worker.enqueue = _bad_enqueue  # type: ignore[assignment]
+        try:
+            out = dispatch_ready_coding_jobs(
+                worker=self.worker,
+                session_loader=self.loader,
+                update_session_fn=self.update_session_fn,
+                env={},
+            )
+        finally:
+            self.worker.enqueue = original  # type: ignore[assignment]
+
+        self.assertEqual(len(out), 1)
+        self.assertIsNone(out[0].job_id)
+        self.assertIn("enqueue failed", out[0].error or "")
+        # Marker NOT persisted — next tick will retry.
+        self.assertNotIn(
+            SESSION_EXTRA_DISPATCH_KEY, self.sessions[0].extra
+        )
+
+
+# ---------------------------------------------------------------------------
+# WorkflowSessionState — selector adapter
+# ---------------------------------------------------------------------------
+
+
+class WorkflowSessionStateTests(unittest.TestCase):
+    def test_lists_only_undispatched_by_default(self) -> None:
+        sessions = [
+            _FakeSession(
+                session_id="ready-1",
+                extra={"coding_job": _coding_job(session_id="ready-1")},
+            ),
+            _FakeSession(
+                session_id="ready-2",
+                extra={
+                    "coding_job": _coding_job(session_id="ready-2"),
+                    SESSION_EXTRA_DISPATCH_KEY: {"job_id": "in-flight"},
+                },
+            ),
+            _FakeSession(
+                session_id="pending",
+                extra={"coding_job": _coding_job(session_id="pending", status="pending_approval")},
+            ),
+        ]
+        state = WorkflowSessionState(session_loader=lambda: sessions)
+        rows = list(state.list_approved_coding_jobs())
+        self.assertEqual([r["session_id"] for r in rows], ["ready-1"])
+        self.assertEqual(rows[0]["executor_role"], "backend-engineer")
+
+    def test_includes_dispatched_when_opt_in(self) -> None:
+        sessions = [
+            _FakeSession(
+                session_id="ready-1",
+                extra={"coding_job": _coding_job(session_id="ready-1")},
+            ),
+            _FakeSession(
+                session_id="ready-2",
+                extra={
+                    "coding_job": _coding_job(session_id="ready-2"),
+                    SESSION_EXTRA_DISPATCH_KEY: {"job_id": "in-flight"},
+                },
+            ),
+        ]
+        state = WorkflowSessionState(
+            session_loader=lambda: sessions, include_dispatched=True
+        )
+        rows = list(state.list_approved_coding_jobs())
+        self.assertEqual(len(rows), 2)
+        # In-flight row carries the dispatch marker so the operator
+        # surface can show it.
+        in_flight = next(r for r in rows if r["session_id"] == "ready-2")
+        self.assertEqual(in_flight["dispatch"]["job_id"], "in-flight")
+
+    def test_no_discussion_loader_returns_empty_tuple(self) -> None:
+        state = WorkflowSessionState()
+        self.assertEqual(state.list_unresolved_discussion_threads(), ())
+
+    def test_discussion_loader_filters_non_mappings(self) -> None:
+        state = WorkflowSessionState(
+            discussion_loader=lambda: [
+                {"session_id": "A", "thread_id": 11},
+                "junk",
+                {"session_id": "B"},
+            ]
+        )
+        rows = list(state.list_unresolved_discussion_threads())
+        self.assertEqual([r["session_id"] for r in rows], ["A", "B"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_coding_execute_progress.py
+++ b/tests/job_queue/test_coding_execute_progress.py
@@ -1,0 +1,344 @@
+"""coding_execute_progress — Round 3 of #73.
+
+Pin the surface that records a coding-executor outcome to:
+
+  * ``session.extra['coding_execute_progress']`` history list (capped),
+  * an ``obsidian_write`` queue row (kind=task-log → no approval gate),
+  * an injected GitHub PR comment poster (best-effort, swallowed on
+    failure so a GitHub blip never crashes the runtime).
+
+The recorder must not perform any of those side-effects when the
+collaborators are absent — a session with no obsidian writer + no
+GitHub poster still gets the in-memory progress entry.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_execute_progress import (
+    SESSION_EXTRA_PROGRESS_KEY,
+    TASK_LOG_NOTE_KIND,
+    ProgressEntry,
+    append_progress_history,
+    build_progress_entry,
+    make_github_pr_comment_fn,
+    record_coding_execute_progress,
+    render_progress_markdown,
+    status_from_outcome,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteOutcome,
+    CodingExecuteRequest,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.obsidian_writer_worker import (
+    JOB_TYPE_OBSIDIAN_WRITE,
+    ObsidianWriterWorker,
+)
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import Job, JobQueue
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    session_id: str
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _request(**overrides) -> CodingExecuteRequest:
+    base = dict(
+        session_id="sess-X",
+        executor_role="backend-engineer",
+        user_request="fix login",
+        generated_prompt="(prompt)",
+        write_scope=("services/auth/**",),
+        forbidden_scope=(".github/workflows/**",),
+        safety_rules=("no force push",),
+        base_branch="main",
+        branch_hint="agent/backend-engineer/issue-99-fix",
+        repo_full_name="yule-studio/yule-studio-agent",
+        issue_number=99,
+        dry_run=True,
+        metadata={},
+    )
+    base.update(overrides)
+    return CodingExecuteRequest(**base)
+
+
+def _outcome(
+    *,
+    terminal_state: str = JobState.SAVED.value,
+    pr_number: int = 999,
+    pr_url: str = "https://github.com/x/y/pull/999",
+    commit_sha: str = "abc123def",
+    branch: str = "agent/backend-engineer/issue-99-fix",
+    test_summary=None,
+    failure_reason=None,
+) -> CodingExecuteOutcome:
+    job = Job(
+        job_id="job-1",
+        session_id="sess-X",
+        job_type="coding_execute",
+        state=JobState.IN_PROGRESS,
+        payload={
+            "session_id": "sess-X",
+            "executor_role": "backend-engineer",
+        },
+    )
+    return CodingExecuteOutcome(
+        job=job,
+        terminal_state=terminal_state,
+        branch=branch,
+        commit_sha=commit_sha,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        test_summary=test_summary or {"status": "ok"},
+        failure_reason=failure_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# status_from_outcome
+# ---------------------------------------------------------------------------
+
+
+class StatusFromOutcomeTests(unittest.TestCase):
+    def test_saved_to_done(self) -> None:
+        self.assertEqual(status_from_outcome(_outcome()), "done")
+
+    def test_failed_retryable_to_retry_ready(self) -> None:
+        self.assertEqual(
+            status_from_outcome(
+                _outcome(
+                    terminal_state=JobState.FAILED_RETRYABLE.value,
+                    failure_reason="test_failed",
+                )
+            ),
+            "retry_ready",
+        )
+
+    def test_failed_terminal_to_blocked(self) -> None:
+        self.assertEqual(
+            status_from_outcome(
+                _outcome(
+                    terminal_state=JobState.FAILED_TERMINAL.value,
+                    failure_reason="protected_branch_blocked",
+                )
+            ),
+            "blocked",
+        )
+
+
+# ---------------------------------------------------------------------------
+# render_progress_markdown
+# ---------------------------------------------------------------------------
+
+
+class RenderMarkdownTests(unittest.TestCase):
+    def test_includes_pr_link_when_url_present(self) -> None:
+        entry = build_progress_entry(_outcome(), request=_request())
+        body = render_progress_markdown(entry)
+        self.assertIn("PR: [#999](https://github.com/x/y/pull/999)", body)
+        self.assertIn("backend-engineer", body)
+        self.assertIn("agent/backend-engineer/issue-99-fix", body)
+
+    def test_omits_pr_link_when_dry_run(self) -> None:
+        entry = build_progress_entry(
+            _outcome(pr_number=None, pr_url="", commit_sha=""),
+            request=_request(dry_run=True),
+        )
+        body = render_progress_markdown(entry)
+        self.assertNotIn("PR:", body)
+
+
+# ---------------------------------------------------------------------------
+# append_progress_history bounds
+# ---------------------------------------------------------------------------
+
+
+class AppendHistoryTests(unittest.TestCase):
+    def test_bounds_at_50_entries(self) -> None:
+        existing = [
+            {"session_id": "sess", "completion_status": "done", "at": str(i)}
+            for i in range(60)
+        ]
+        extra = {SESSION_EXTRA_PROGRESS_KEY: existing}
+        entry = build_progress_entry(_outcome(), request=_request())
+        new_extra = append_progress_history(extra, entry)
+        history = new_extra[SESSION_EXTRA_PROGRESS_KEY]
+        self.assertEqual(len(history), 50)
+        # Newest entry is the one we appended.
+        self.assertEqual(history[-1]["session_id"], "sess-X")
+
+
+# ---------------------------------------------------------------------------
+# record_coding_execute_progress — full integration with a real
+# ObsidianWriterWorker + fake comment poster
+# ---------------------------------------------------------------------------
+
+
+class _SessionStore:
+    def __init__(self) -> None:
+        self.sessions: dict = {}
+
+    def update(self, session, *, now):
+        self.sessions[session.session_id] = session
+        return session
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=db)
+        self.heartbeats = HeartbeatStore(db_path=db)
+        # ObsidianWriterWorker needs render/write fns even when only
+        # used as an enqueue surface — pass no-op stubs.
+        self.writer = ObsidianWriterWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            render_fn=lambda req: type("Note", (), {"frontmatter": {}, "body": ""})(),
+            write_fn=lambda note, path, req: None,
+            vault_root_resolver=lambda req: None,
+        )
+        self.store = _SessionStore()
+
+
+class RecordIntegrationTests(_Fixture):
+    def test_full_pipeline_enqueues_obsidian_and_posts_pr_comment(self) -> None:
+        comments: list = []
+
+        def post_fn(*, repo, pr_number, body):
+            comments.append({"repo": repo, "pr_number": pr_number, "body": body})
+
+        session = _FakeSession(session_id="sess-X")
+        result = record_coding_execute_progress(
+            session=session,
+            outcome=_outcome(),
+            request=_request(),
+            obsidian_writer=self.writer,
+            github_comment_fn=post_fn,
+            update_session_fn=self.store.update,
+            repo_full_name="yule-studio/yule-studio-agent",
+        )
+        self.assertEqual(result.entry.completion_status, "done")
+        self.assertIsNotNone(result.obsidian_job_id)
+        self.assertTrue(result.github_comment_posted)
+        # Obsidian queue row exists, kind=task-log.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-X")
+            if r.job_type == JOB_TYPE_OBSIDIAN_WRITE
+        ]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].payload["note_kind"], TASK_LOG_NOTE_KIND)
+        # task-log does NOT need approval — payload approval_id is empty.
+        self.assertEqual(rows[0].payload.get("approval_id"), None)
+        # PR comment fired with rendered markdown.
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["pr_number"], 999)
+        self.assertIn("coding-executor", comments[0]["body"])
+        # Session persisted with progress entry.
+        self.assertTrue(result.session_persisted)
+        history = self.store.sessions["sess-X"].extra[SESSION_EXTRA_PROGRESS_KEY]
+        self.assertEqual(len(history), 1)
+
+    def test_no_collaborators_still_records_history(self) -> None:
+        session = _FakeSession(session_id="sess-X")
+        result = record_coding_execute_progress(
+            session=session,
+            outcome=_outcome(),
+            request=_request(),
+            obsidian_writer=None,
+            github_comment_fn=None,
+            update_session_fn=self.store.update,
+        )
+        self.assertEqual(result.obsidian_skipped_reason, "no_obsidian_writer")
+        self.assertFalse(result.github_comment_posted)
+        # Progress entry STILL ends up on the session.
+        self.assertTrue(result.session_persisted)
+
+    def test_github_failure_is_swallowed(self) -> None:
+        def boom(**_kwargs):
+            raise RuntimeError("github 502")
+
+        session = _FakeSession(session_id="sess-X")
+        result = record_coding_execute_progress(
+            session=session,
+            outcome=_outcome(),
+            request=_request(),
+            obsidian_writer=self.writer,
+            github_comment_fn=boom,
+            update_session_fn=self.store.update,
+        )
+        self.assertFalse(result.github_comment_posted)
+        self.assertIn("502", result.github_comment_error or "")
+        # Obsidian write still happened.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-X")
+            if r.job_type == JOB_TYPE_OBSIDIAN_WRITE
+        ]
+        self.assertEqual(len(rows), 1)
+
+    def test_dry_run_skips_pr_comment(self) -> None:
+        comments: list = []
+
+        def post_fn(*, repo, pr_number, body):
+            comments.append((repo, pr_number, body))
+
+        session = _FakeSession(session_id="sess-X")
+        # dry-run outcome — no PR was opened.
+        outcome = _outcome(
+            pr_number=None, pr_url="", commit_sha="", test_summary={"dry_run": True}
+        )
+        result = record_coding_execute_progress(
+            session=session,
+            outcome=outcome,
+            request=_request(dry_run=True),
+            obsidian_writer=self.writer,
+            github_comment_fn=post_fn,
+            update_session_fn=self.store.update,
+        )
+        self.assertFalse(result.github_comment_posted)
+        self.assertEqual(result.github_comment_error, "no_pr")
+        self.assertEqual(comments, [])
+
+
+# ---------------------------------------------------------------------------
+# make_github_pr_comment_fn
+# ---------------------------------------------------------------------------
+
+
+class MakeGithubCommentFnTests(unittest.TestCase):
+    def test_routes_to_create_issue_comment(self) -> None:
+        calls: list = []
+
+        class _FakeLive:
+            def create_issue_comment(self, *, repo, issue_number, body):
+                calls.append({"repo": repo, "issue_number": issue_number, "body": body})
+                return {"id": 1}
+
+        post_fn = make_github_pr_comment_fn(_FakeLive())
+        post_fn(repo="o/r", pr_number=42, body="hello")
+        self.assertEqual(calls, [{"repo": "o/r", "issue_number": 42, "body": "hello"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_run_service_coding_executor.py
+++ b/tests/runtime/test_run_service_coding_executor.py
@@ -1,0 +1,238 @@
+"""run_service ``CODING_EXECUTOR`` builder — Round 3 wiring tests.
+
+Pin that:
+
+  * ``_build_process_job`` returns a closure for the
+    ``eng-coding-executor`` service that wraps a real
+    :class:`CodingExecutorWorker`.
+  * ``_pick_filters_for`` returns the ``coding_execute`` job-type
+    filter so ``run_worker_loop`` only picks coding rows.
+  * ``build_coding_executor_bundle`` falls back to the dry-run /
+    push-blocked bundle when GitHub App env is absent.
+  * The bundle wires the live pusher + draft PR creator when a
+    fake live client factory is injected.
+  * The closure invokes :func:`dispatch_ready_coding_jobs` before
+    each consumer tick — producer / consumer share the same worker.
+"""
+
+from __future__ import annotations
+
+import inspect
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue import (
+    CodingExecutorWorker,
+    HeartbeatStore,
+    JobQueue,
+)
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    JOB_TYPE_CODING_EXECUTE,
+)
+from yule_orchestrator.runtime.run_service import (
+    _build_process_job,
+    _pick_filters_for,
+    build_coding_executor_bundle,
+)
+from yule_orchestrator.runtime.services import resolve_service
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    session_id: str
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    thread_id: int = 0
+    channel_id: int = 0
+
+
+def _ready_coding_job_payload(*, session_id: str = "sess-X") -> Mapping[str, Any]:
+    return {
+        "session_id": session_id,
+        "user_request": "fix login",
+        "executor_role": "backend-engineer",
+        "review_roles": ["tech-lead"],
+        "participant_roles": ["backend-engineer", "tech-lead"],
+        "write_scope": ["services/auth/**"],
+        "forbidden_scope": [".github/workflows/**"],
+        "safety_rules": ["no force push"],
+        "reason": "test fixture",
+        "status": "ready",
+        "generated_prompt": "(prompt)",
+        "created_at": "2026-05-08T00:00:00+00:00",
+        "approved_at": "2026-05-08T01:00:00+00:00",
+        "metadata": {
+            "repo_full_name": "yule-studio/yule-studio-agent",
+            "base_branch": "main",
+            "issue_number": 99,
+            "branch_hint": "agent/backend-engineer/issue-99-fix",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filter / spec wiring
+# ---------------------------------------------------------------------------
+
+
+class CodingExecutorFiltersTests(unittest.TestCase):
+    def test_pick_filters_returns_coding_execute_only(self) -> None:
+        spec = resolve_service("eng-coding-executor")
+        self.assertIsNotNone(spec)
+        types, roles = _pick_filters_for(spec)
+        self.assertEqual(types, ("coding_execute",))
+        self.assertEqual(roles, ())
+
+    def test_spec_resolves_under_engineering_profile(self) -> None:
+        spec = resolve_service("eng-coding-executor")
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.kind.value, "coding_executor")
+
+
+# ---------------------------------------------------------------------------
+# build_coding_executor_bundle — env matrix
+# ---------------------------------------------------------------------------
+
+
+class BuildBundleEnvMatrixTests(unittest.TestCase):
+    def test_no_github_env_returns_dry_only_bundle(self) -> None:
+        bundle = build_coding_executor_bundle(env={})
+        # Live pusher / draft_pr only land when a live client appears.
+        self.assertNotIn("pusher", bundle)
+        self.assertNotIn("draft_pr_creator", bundle)
+        # Always-on protocols.
+        self.assertIn("worktree_provisioner", bundle)
+        self.assertIn("code_editor", bundle)
+        self.assertIn("test_runner", bundle)
+        self.assertIn("committer", bundle)
+
+    def test_factory_injection_wires_pusher_and_pr(self) -> None:
+        class _Stub:
+            pass
+
+        bundle = build_coding_executor_bundle(
+            env={}, live_client_factory=lambda: _Stub()
+        )
+        self.assertIn("pusher", bundle)
+        self.assertIn("draft_pr_creator", bundle)
+
+    def test_factory_failure_falls_back_to_dry_only(self) -> None:
+        def boom():
+            raise RuntimeError("creds missing")
+
+        # Must not raise — startup degrades to dry-run rather than
+        # failing the supervisor entirely.
+        bundle = build_coding_executor_bundle(env={}, live_client_factory=boom)
+        self.assertNotIn("pusher", bundle)
+
+    def test_partial_github_env_does_not_attempt_live_client(self) -> None:
+        # Missing private key path → factory must not fire.
+        env = {
+            "YULE_GITHUB_APP_ID": "1",
+            "YULE_GITHUB_APP_INSTALLATION_ID": "2",
+            # YULE_GITHUB_APP_PRIVATE_KEY_PATH absent on purpose.
+        }
+        bundle = build_coding_executor_bundle(env=env)
+        self.assertNotIn("pusher", bundle)
+
+
+# ---------------------------------------------------------------------------
+# _build_process_job — closure shape + producer tick
+# ---------------------------------------------------------------------------
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._db = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=self._db)
+        self.heartbeats = HeartbeatStore(db_path=self._db)
+
+
+class CodingExecutorBuilderTests(_Fixture):
+    def test_builder_returns_async_closure_with_worker_capture(self) -> None:
+        spec = resolve_service("eng-coding-executor")
+        process_fn = _build_process_job(
+            spec, queue=self.queue, heartbeats=self.heartbeats
+        )
+        # The closure captures the worker instance; the captured
+        # worker must be a real CodingExecutorWorker, not a stub.
+        free = inspect.getclosurevars(process_fn).nonlocals
+        worker = free.get("worker")
+        self.assertIsInstance(worker, CodingExecutorWorker)
+        # Builder is async to match the run_worker_loop contract.
+        self.assertTrue(inspect.iscoroutinefunction(process_fn))
+
+    def test_dispatcher_runs_before_consumer_processes_job(self) -> None:
+        # Drop a "ready" coding_job session into a fake loader so the
+        # producer side enqueues a coding_execute row, then the
+        # consumer (process_job) runs that row through dry-run.
+        spec = resolve_service("eng-coding-executor")
+        process_fn = _build_process_job(
+            spec, queue=self.queue, heartbeats=self.heartbeats
+        )
+
+        # Ride the closure's captured worker to enqueue manually so we
+        # don't have to monkey-patch the dispatcher's session loader at
+        # the supervisor level — but also assert that the closure body
+        # tolerates the dispatcher call (no raise) while the consumer
+        # processes the job.
+        free = inspect.getclosurevars(process_fn).nonlocals
+        worker = free.get("worker")
+        from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+            CodingExecuteRequest,
+        )
+        request = CodingExecuteRequest(
+            session_id="sess-X",
+            executor_role="backend-engineer",
+            user_request="fix login",
+            generated_prompt="(prompt)",
+            write_scope=("services/auth/**",),
+            forbidden_scope=(".github/workflows/**",),
+            safety_rules=("no force push",),
+            base_branch="main",
+            branch_hint="agent/backend-engineer/issue-99-fix",
+            repo_full_name="yule-studio/yule-studio-agent",
+            issue_number=99,
+            dry_run=True,
+        )
+        job, _ = worker.enqueue(request)
+        # Pick the row so the closure's worker.process_job receives an
+        # already-leased Job (mirrors the run_worker_loop contract).
+        leased = self.queue.pick(
+            worker_id="test", job_types=[JOB_TYPE_CODING_EXECUTE]
+        )
+        self.assertIsNotNone(leased)
+
+        import asyncio
+        asyncio.run(process_fn(leased))
+
+        # Job landed in SAVED via the dry-run path.
+        rows = [
+            r
+            for r in self.queue.list_for_session("sess-X")
+            if r.job_type == JOB_TYPE_CODING_EXECUTE
+        ]
+        self.assertEqual(len(rows), 1)
+        from yule_orchestrator.agents.job_queue.state_machine import JobState
+        self.assertEqual(rows[0].state, JobState.SAVED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- derived from #73

## ✨ 과제 내용
- 역할별 source axes + refresh interval 모델 추가
- background refresh planner + live provider seam 추가
- request-time knowledge retrieval + ContextPackBuilder 통합
- structured knowledge loop를 discussion context에 연결

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs/engineering-company-runtime-master-plan.md
- policies/runtime/agents/engineering-agent/research-collector.md
- policies/runtime/agents/engineering-agent/research-profiles.md
- 요청 전 background ingestion, 요청 시 selective retrieval 구조를 코드로 land 함