### PR TITLE
✨ #75 knowledge provider registry and routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,10 +252,19 @@ DISCORD_GUILD_ID=
 # manual transport 는 ProviderAvailability.MANUAL_ONLY 슬롯이며 운영자가
 # 직접 vault 에 등록하는 경로다 — 라이브 호출이 존재하지 않는다.
 #
-# 현재 코드베이스 상태: 모든 transport 가 NO_LIVE_IMPL 상태다. 별도 PR
-# (live fetcher) 에서 implementation 이 등록될 때까지 fake 가 항상 사용된다.
+# 현재 코드베이스 상태:
+#   - rss / atom / github_releases_atom: parser 가 결정적으로 land 됨
+#     (feed_parser.parse_feed_bytes). 라이브 전환은 urllib 기반
+#     BytesFetcher 한 조각만 별도 PR 에서 등록하면 된다 — 그 PR 이
+#     register_safe_feed_providers() 한 번 호출하면 세 transport 가
+#     동시에 AVAILABLE 로 전환된다.
+#   - sitemap / html_list / html_detail / github_api_repo_activity:
+#     아직 NO_LIVE_IMPL. 별도 PR 에서 register_live(transport=...) 로
+#     채운다.
+#   - manual: ProviderAvailability.MANUAL_ONLY (라이브 호출 없음).
 # 아래 플래그는 운영자가 cost-budget / rate-limit 검토를 마친 뒤 켜는
-# "준비 완료 시 활성화" 스위치 역할이다.
+# "준비 완료 시 활성화" 스위치 역할이다. 셋업 상태는
+# KnowledgeProviderRegistry.availability_summary(env) 로 한눈에 본다.
 
 # 모든 transport 가 공유하는 user-agent (provider_spec_for 의 기본값과 동일)
 # YULE_KNOWLEDGE_USER_AGENT=yule-engineering-intelligence/0.1 (+contact: operator)

--- a/.env.example
+++ b/.env.example
@@ -236,3 +236,42 @@ DISCORD_GUILD_ID=
 # YULE_DECISION_OLLAMA_TIMEOUT=20
 # YULE_DECISION_ANTHROPIC_ENABLED=false
 # YULE_DECISION_OPENAI_ENABLED=false
+
+# =====================================================================
+# #73 — Engineering knowledge provider env (background ingestion 루프)
+#
+# `engineering_intelligence` 패키지는 역할별 source 를 background 로 수집한다.
+# 각 transport(rss / atom / sitemap / html_list / html_detail /
+# github_releases_atom / github_api_repo_activity / manual)에는 provider 가
+# 하나씩 등록되어 있고, decision classifier 와 동일한 dual-gate 정책을 따른다:
+#   1. transport 가 요구하는 env 키가 모두 채워져 있음.
+#   2. transport 의 ``YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED`` 플래그가
+#      true 로 셋업되어 있음.
+# 둘 중 하나라도 빠지면 결정적 FakeKnowledgeProvider 가 사용된다.
+#
+# manual transport 는 ProviderAvailability.MANUAL_ONLY 슬롯이며 운영자가
+# 직접 vault 에 등록하는 경로다 — 라이브 호출이 존재하지 않는다.
+#
+# 현재 코드베이스 상태: 모든 transport 가 NO_LIVE_IMPL 상태다. 별도 PR
+# (live fetcher) 에서 implementation 이 등록될 때까지 fake 가 항상 사용된다.
+# 아래 플래그는 운영자가 cost-budget / rate-limit 검토를 마친 뒤 켜는
+# "준비 완료 시 활성화" 스위치 역할이다.
+
+# 모든 transport 가 공유하는 user-agent (provider_spec_for 의 기본값과 동일)
+# YULE_KNOWLEDGE_USER_AGENT=yule-engineering-intelligence/0.1 (+contact: operator)
+
+# 인증 불필요 (public feed) — 활성화 = enable flag 만 true.
+# YULE_KNOWLEDGE_RSS_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_ATOM_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_GITHUB_RELEASES_ATOM_LIVE_ENABLED=false
+
+# Sitemap / HTML — public 이지만 cadence/parse 부담이 있다. 운영자가 명시
+# 활성화. Tier 1 docs 사이트맵은 24h cadence 가 표준이다.
+# YULE_KNOWLEDGE_SITEMAP_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_HTML_LIST_LIVE_ENABLED=false
+# YULE_KNOWLEDGE_HTML_DETAIL_LIVE_ENABLED=false
+
+# GitHub API repo activity — 기존 GitHub App env 3종(YULE_GITHUB_APP_*) 를
+# 그대로 재사용한다. 셋이 모두 채워지지 않으면 ProviderAvailability.MISSING_ENV
+# 로 떨어져 fake 로 폴백한다.
+# YULE_KNOWLEDGE_GITHUB_API_REPO_ACTIVITY_LIVE_ENABLED=false

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -290,10 +290,17 @@ Round 4-bis 에서 추가된 구현 (provider 측 강화):
 - [provider_routing.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `route_refresh_plan(plan, *, role_id, registry, env)` 가 `RefreshPlan` 의 due/skipped 각 entry 에 transport / provider_id / availability / axes 를 붙여 `RoutedRefreshCandidate` 로 변환. `axis_priority_order(...)` 가 `overdue_axes_for_role` 결과를 받아 SECURITY 같이 비어 있는 axis 를 가진 candidate 를 우선 큐 앞으로 보낸다 (tier / availability / source_id 가 tie-breaker). `select_routed_due(...)` 한 번 호출로 plan→route→axis priority→tick quota 까지 처리.
 - [.env.example #73 — Engineering knowledge provider env](../.env.example) — `YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED` 8개와 `YULE_GITHUB_APP_*` 재사용 정책 명시. 모든 플래그 기본값은 false (cost-budget 검토 후 운영자가 켠다).
 
+Round 4-ter 에서 추가된 구현 (live-ready parser + 운영 가시성):
+
+- [feed_parser.py](../src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py) — `parse_atom_bytes` / `parse_rss_bytes` / `parse_feed_bytes` 결정적 parser (xml.etree + email.utils 만 사용, urllib 무관). RSS-mode 소스가 실제로 Atom 페이로드를 내려주는 edge case 까지 sniff 로 dispatch. summary 는 `_SUMMARY_LIMIT=500` 자로 자동 truncate 되어 content_policy ("link + 짧은 인용") 자동 준수. `BytesFetcher` Protocol + `make_feed_live_factory` glue 가 별도 PR 에서 작성할 urllib 한 조각을 그대로 받아 `LiveFetcherFactory` 로 변환. `register_safe_feed_providers(registry, bytes_fetcher_factory=...)` 한 번 호출로 RSS / ATOM / GITHUB_RELEASES_ATOM 세 transport 가 동시에 라이브 전환된다.
+- [provider_registry.py — availability_summary](../src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py) — `ProviderAvailabilityRow` (transport / provider_id / availability / has_live_impl / manual / env_keys / enable_flag / missing_env_keys / enable_flag_set / description / notes) + `ProviderAvailabilitySummary` (`by_state` / `states_count` / `needs_attention` / `to_payload`). 운영자 대시보드는 `registry.availability_summary(env).to_payload()` 한 번 호출로 "5 transports live, 2 missing_env, 1 disabled_by_flag" 를 그대로 그릴 수 있다.
+- [provider_routing.py — reasoning trail](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `RoutedRefreshCandidate` 가 `transport_reason` (왜 이 transport 가 선택됐는지: `rss + atom URL heuristic`, `manual (collection_mode=manual)` 등) 와 `availability_reason` (왜 이 availability state 가 됐는지: `missing env keys: YULE_GITHUB_APP_ID, ...`, `flag YULE_KNOWLEDGE_RSS_LIVE_ENABLED not truthy` 등) 두 필드를 추가로 가진다. `routing_reason` property 로 한 줄 요약 (`transport=…; availability=…`) 도 노출. `RefreshPlanStatus` 와 `refresh_plan_status(plan, *, role_id, registry, env)` 헬퍼는 routed candidates + registry availability_summary 를 한 번에 묶어서 background refresh planner 가 tick 마다 JSON 한 덩어리로 dump 할 수 있게 만든다.
+
 남은 일 (별도 worktree / PR):
 
-- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API). `KnowledgeProviderRegistry.register_live(transport, live_factory=...)` 한 번 호출로 활성화된다.
-- runtime service spawn (`eng-research-collector`) — scheduler tick → `select_routed_due` → registry fetcher → adapter → vault writer.
+- urllib 기반 `BytesFetcher` 한 조각 (timeout / user-agent / 30x 처리). `register_safe_feed_providers(registry, bytes_fetcher_factory=...)` 한 번 호출로 RSS / Atom / GitHub releases atom 이 동시에 live 전환된다.
+- sitemap / html_list / html_detail / github_api_repo_activity 의 live fetcher (parser 까지 미구현; 본 PR 시점에서 NO_LIVE_IMPL).
+- runtime service spawn (`eng-research-collector`) — scheduler tick → `refresh_plan_status` 로 가시성 dump → `select_routed_due` → registry fetcher → adapter → vault writer.
 - `SourceRefreshState` persistence (sqlite or vault sidecar).
 - discussion synthesizer 가 `relevant_knowledge` slot 을 prompt 에 어떻게 짜 넣을지.
 

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -283,10 +283,17 @@ Round 4 에서 추가된 구현:
 - [retrieval.py](../src/yule_orchestrator/agents/engineering_intelligence/retrieval.py) — `KnowledgeRecord` (lightweight projection), `score_knowledge_record` (role × axis × topic × importance × freshness), `KnowledgeRetriever` (`with_signals` 로 score 노출).
 - [discussion/context_pack.py](../src/yule_orchestrator/agents/discussion/context_pack.py) — `EngineeringKnowledgeRef` slot + `knowledge_loader` / `knowledge_retriever` seam 추가. ContextPack.relevant_knowledge 가 자동으로 채워진다.
 
+Round 4-bis 에서 추가된 구현 (provider 측 강화):
+
+- [provider_registry.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py) — 8 transport (rss / atom / sitemap / html_list / html_detail / github_releases_atom / github_api_repo_activity / manual) 각각에 한 줄씩 등록되는 `KnowledgeProviderRegistration` (provider_id / auth / fake_fetcher / live_factory / manual flag). `ProviderAuthRequirement` 가 decision classifier 와 동일한 dual gate (env_keys + enable_flag) 를 쓴다. `ProviderAvailability` 5 상태 (available / disabled_by_flag / missing_env / no_live_impl / manual_only) 가 운영자 대시보드에 그대로 노출. `default_registry()` 가 시드한 8 row 의 .env contract 가 `.env.example` 에 명시되어 있다.
+- [providers.py — FakeKnowledgeProvider](../src/yule_orchestrator/agents/engineering_intelligence/providers.py) — `StubLiveSourceFetcher` (records, returns empty) 와 별도로 `source_id → items` fixture 기반의 결정적 fake. 라이브 PR 이 들어오기 전까지 모든 transport 의 fallback fetcher 로 사용된다.
+- [provider_routing.py](../src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py) — `route_refresh_plan(plan, *, role_id, registry, env)` 가 `RefreshPlan` 의 due/skipped 각 entry 에 transport / provider_id / availability / axes 를 붙여 `RoutedRefreshCandidate` 로 변환. `axis_priority_order(...)` 가 `overdue_axes_for_role` 결과를 받아 SECURITY 같이 비어 있는 axis 를 가진 candidate 를 우선 큐 앞으로 보낸다 (tier / availability / source_id 가 tie-breaker). `select_routed_due(...)` 한 번 호출로 plan→route→axis priority→tick quota 까지 처리.
+- [.env.example #73 — Engineering knowledge provider env](../.env.example) — `YULE_KNOWLEDGE_<TRANSPORT>_LIVE_ENABLED` 8개와 `YULE_GITHUB_APP_*` 재사용 정책 명시. 모든 플래그 기본값은 false (cost-budget 검토 후 운영자가 켠다).
+
 남은 일 (별도 worktree / PR):
 
-- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
-- runtime service spawn (`eng-research-collector`) — scheduler tick → fetcher → adapter → vault writer.
+- live source fetcher 구현 (urllib 기반 RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API). `KnowledgeProviderRegistry.register_live(transport, live_factory=...)` 한 번 호출로 활성화된다.
+- runtime service spawn (`eng-research-collector`) — scheduler tick → `select_routed_due` → registry fetcher → adapter → vault writer.
 - `SourceRefreshState` persistence (sqlite or vault sidecar).
 - discussion synthesizer 가 `relevant_knowledge` slot 을 prompt 에 어떻게 짜 넣을지.
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -67,11 +67,15 @@ from .provider_registry import (
     LiveFetcherFactory,
     ProviderAuthRequirement,
     ProviderAvailability,
+    ProviderAvailabilityRow,
+    ProviderAvailabilitySummary,
     default_registry,
 )
 from .provider_routing import (
+    RefreshPlanStatus,
     RoutedRefreshCandidate,
     axis_priority_order,
+    refresh_plan_status,
     route_refresh_plan,
     select_routed_due,
 )
@@ -182,10 +186,14 @@ __all__ = [
     "LiveFetcherFactory",
     "ProviderAuthRequirement",
     "ProviderAvailability",
+    "ProviderAvailabilityRow",
+    "ProviderAvailabilitySummary",
     "default_registry",
     # provider routing (refresh-plan → registry → fetch decision)
+    "RefreshPlanStatus",
     "RoutedRefreshCandidate",
     "axis_priority_order",
+    "refresh_plan_status",
     "route_refresh_plan",
     "select_routed_due",
     # retrieval

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -59,6 +59,12 @@ from .provider_registry import (
     ProviderAvailability,
     default_registry,
 )
+from .provider_routing import (
+    RoutedRefreshCandidate,
+    axis_priority_order,
+    route_refresh_plan,
+    select_routed_due,
+)
 from .retrieval import (
     KnowledgeMatch,
     KnowledgeRecord,
@@ -158,6 +164,11 @@ __all__ = [
     "ProviderAuthRequirement",
     "ProviderAvailability",
     "default_registry",
+    # provider routing (refresh-plan → registry → fetch decision)
+    "RoutedRefreshCandidate",
+    "axis_priority_order",
+    "route_refresh_plan",
+    "select_routed_due",
     # retrieval
     "KnowledgeMatch",
     "KnowledgeRecord",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -51,6 +51,16 @@ from .providers import (
     provider_spec_for,
     specs_for_role,
 )
+from .feed_parser import (
+    BytesFetcher,
+    FeedFetchOutcome,
+    FeedParserError,
+    make_feed_live_factory,
+    parse_atom_bytes,
+    parse_feed_bytes,
+    parse_rss_bytes,
+    register_safe_feed_providers,
+)
 from .provider_registry import (
     KnowledgeProviderRegistration,
     KnowledgeProviderRegistry,
@@ -157,6 +167,15 @@ __all__ = [
     "StubLiveSourceFetcher",
     "provider_spec_for",
     "specs_for_role",
+    # feed parser (live-ready RSS / Atom / GitHub releases atom)
+    "BytesFetcher",
+    "FeedFetchOutcome",
+    "FeedParserError",
+    "make_feed_live_factory",
+    "parse_atom_bytes",
+    "parse_feed_bytes",
+    "parse_rss_bytes",
+    "register_safe_feed_providers",
     # provider registry / auth contract
     "KnowledgeProviderRegistration",
     "KnowledgeProviderRegistry",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -43,12 +43,21 @@ from .collector import (
     utc_now_iso,
 )
 from .providers import (
+    FakeKnowledgeProvider,
     LiveProviderSpec,
     LiveSourceFetcher,
     ProviderTransport,
     StubLiveSourceFetcher,
     provider_spec_for,
     specs_for_role,
+)
+from .provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    LiveFetcherFactory,
+    ProviderAuthRequirement,
+    ProviderAvailability,
+    default_registry,
 )
 from .retrieval import (
     KnowledgeMatch,
@@ -135,12 +144,20 @@ __all__ = [
     "collect_for_role_with_schedule",
     "utc_now_iso",
     # providers
+    "FakeKnowledgeProvider",
     "LiveProviderSpec",
     "LiveSourceFetcher",
     "ProviderTransport",
     "StubLiveSourceFetcher",
     "provider_spec_for",
     "specs_for_role",
+    # provider registry / auth contract
+    "KnowledgeProviderRegistration",
+    "KnowledgeProviderRegistry",
+    "LiveFetcherFactory",
+    "ProviderAuthRequirement",
+    "ProviderAvailability",
+    "default_registry",
     # retrieval
     "KnowledgeMatch",
     "KnowledgeRecord",

--- a/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
@@ -1,0 +1,429 @@
+"""Deterministic feed parser — bytes → :class:`EngineeringKnowledgeItem`.
+
+Round 4-ter brings the safest provider class (public RSS / Atom /
+GitHub releases atom) one step closer to live without taking the
+network dependency yet. The transport seam (.providers.LiveSourceFetcher)
+still has no urllib import and no live impl in the registry — but the
+*parser half* lands here so a follow-up PR can ship a thin urllib
+``BytesFetcher`` and call ``register_safe_feed_providers`` instead of
+writing a full transport+parser.
+
+What ships now:
+
+  * :func:`parse_atom_bytes` / :func:`parse_rss_bytes` /
+    :func:`parse_feed_bytes` — pure functions over an XML byte
+    payload. Fill the required :class:`EngineeringKnowledgeItem`
+    fields from the source's metadata and the entry's title / link /
+    summary / published timestamp.
+  * :class:`BytesFetcher` — Protocol the live half satisfies once
+    the urllib client lands. Tests pass a closure returning canned
+    XML; production passes a small urllib wrapper.
+  * :func:`make_feed_live_factory` — glues a BytesFetcher to the
+    parser and returns a ``LiveFetcherFactory`` shaped exactly like
+    ``KnowledgeProviderRegistry.register_live`` expects.
+  * :func:`register_safe_feed_providers` — convenience: registers
+    RSS / ATOM / GITHUB_RELEASES_ATOM in one call so the operator
+    flips three transports at once when the urllib bytes_fetcher is
+    ready.
+
+Strict offline. Only stdlib ``xml.etree.ElementTree`` /
+``email.utils.parsedate_to_datetime`` are imported. No urllib /
+requests / socket. Tests pin the parser end-to-end against canned
+XML so the contract can't silently regress when the live PR plugs
+the BytesFetcher in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Callable, Mapping, Optional, Protocol, Tuple
+from xml.etree import ElementTree as ET
+
+from .models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceEntry,
+)
+from .providers import LiveProviderSpec, ProviderTransport
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+_SUMMARY_LIMIT = 500
+
+
+class FeedParserError(Exception):
+    """Raised when bytes are not a valid feed.
+
+    Distinct from a transport error: malformed XML usually means the
+    operator wired a wrong endpoint, not a transient blip. The live
+    factory swallows transport errors but logs / surfaces parse
+    failures so the dashboard can flag the bad source.
+    """
+
+
+class BytesFetcher(Protocol):
+    """The live half of a feed fetch — bytes only, no parsing."""
+
+    def __call__(self, spec: LiveProviderSpec) -> bytes:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _hash_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha1(
+        "|".join(parts).encode("utf-8", errors="replace")
+    ).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+def _coerce_iso(text: str) -> Optional[str]:
+    """ISO-8601 (atom) or RFC-822 (rss) → ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    Best-effort: parse with :func:`datetime.fromisoformat` first and
+    fall back to :func:`email.utils.parsedate_to_datetime` for the
+    RSS-2.0 ``Mon, 01 Jan 2026 00:00:00 GMT`` shape. Anything else
+    returns ``None`` — the item still flows through with no
+    ``published_at``; freshness scoring will rank it lower but the
+    pipeline doesn't drop it.
+    """
+
+    text = (text or "").strip()
+    if not text:
+        return None
+    iso_candidate = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(iso_candidate)
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(text)
+        except (TypeError, ValueError):
+            return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _text(elem: Optional[ET.Element]) -> str:
+    if elem is None or elem.text is None:
+        return ""
+    return elem.text.strip()
+
+
+def _trim(value: str, *, limit: int = _SUMMARY_LIMIT) -> str:
+    """Cap summary length per content_policy ("light quotation only")."""
+
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _build_item(
+    source: SourceEntry,
+    *,
+    title: str,
+    url: str,
+    summary: str,
+    published: Optional[str],
+) -> EngineeringKnowledgeItem:
+    """Compose one :class:`EngineeringKnowledgeItem` from parsed feed bits.
+
+    The collector / dedup layer takes over from here — it sets the
+    final ``dedup_key`` and may merge with prior items. We just have
+    to fill enough fields that those layers don't drop the row.
+    """
+
+    role = source.role_tags[0] if source.role_tags else "tech-lead"
+    final_title = title or url or source.name
+    final_url = url or source.base_url
+    item_id = _hash_id(source.source_id, final_title, final_url)
+    topic_key = _hash_id("topic", source.source_id, final_title.lower())
+    return EngineeringKnowledgeItem(
+        item_id=item_id,
+        topic_key=topic_key,
+        title=final_title,
+        role=role,
+        stack_tags=tuple(source.stack_tags),
+        source_name=source.name,
+        source_url=final_url,
+        source_kind=source.source_kind,
+        collected_at=_now_iso(),
+        published_at=published,
+        importance=Importance.MEDIUM,
+        summary=_trim(summary),
+        rag_tags=tuple(source.stack_tags),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atom 1.0 parser
+# ---------------------------------------------------------------------------
+
+
+def parse_atom_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Parse an Atom 1.0 feed into items for *source*.
+
+    Recognises the standard ``<feed><entry>...`` shape plus
+    ``<link rel="alternate" href="...">`` (preferred) with a
+    fallback to the first ``<link>``. ``updated`` is the canonical
+    timestamp; ``published`` is the fallback when ``updated`` is
+    absent.
+    """
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise FeedParserError(f"atom parse failed: {exc}") from exc
+
+    items: list[EngineeringKnowledgeItem] = []
+    for entry in root.findall(f"{_ATOM_NS}entry"):
+        title = _text(entry.find(f"{_ATOM_NS}title"))
+
+        link_elem = entry.find(f"{_ATOM_NS}link[@rel='alternate']")
+        if link_elem is None:
+            link_elem = entry.find(f"{_ATOM_NS}link")
+        url = (link_elem.get("href") if link_elem is not None else "") or ""
+
+        summary = _text(entry.find(f"{_ATOM_NS}summary"))
+        if not summary:
+            summary = _text(entry.find(f"{_ATOM_NS}content"))
+
+        published = _coerce_iso(_text(entry.find(f"{_ATOM_NS}updated")))
+        if not published:
+            published = _coerce_iso(_text(entry.find(f"{_ATOM_NS}published")))
+
+        items.append(
+            _build_item(
+                source,
+                title=title,
+                url=url,
+                summary=summary,
+                published=published,
+            )
+        )
+    return tuple(items)
+
+
+# ---------------------------------------------------------------------------
+# RSS 2.0 parser
+# ---------------------------------------------------------------------------
+
+
+def parse_rss_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Parse an RSS 2.0 (or RDF) feed into items for *source*.
+
+    Handles the ``<rss><channel><item>...`` shape. RDF (``<rdf:RDF>``)
+    falls back to scanning the root for ``<item>`` directly so older
+    feeds still parse without a namespace dance.
+    """
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise FeedParserError(f"rss parse failed: {exc}") from exc
+
+    channel = root.find("channel")
+    item_elements = (
+        channel.findall("item") if channel is not None else root.findall("item")
+    )
+
+    items: list[EngineeringKnowledgeItem] = []
+    for item in item_elements:
+        title = _text(item.find("title"))
+        url = _text(item.find("link"))
+        summary = _text(item.find("description"))
+        published = _coerce_iso(_text(item.find("pubDate")))
+        items.append(
+            _build_item(
+                source,
+                title=title,
+                url=url,
+                summary=summary,
+                published=published,
+            )
+        )
+    return tuple(items)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_atom_payload(payload: bytes) -> bool:
+    head = payload[:200].lower()
+    return b"<feed" in head and b"atom" in head
+
+
+def parse_feed_bytes(
+    payload: bytes,
+    *,
+    source: SourceEntry,
+    transport: ProviderTransport,
+) -> Tuple[EngineeringKnowledgeItem, ...]:
+    """Pick the right parser for *transport* and apply it to *payload*.
+
+    GitHub releases atom uses the same Atom 1.0 shape as a regular
+    atom feed, so they share a parser. RSS-mode sources sometimes
+    expose an Atom payload (we already do this URL heuristic at
+    spec-build time, but a misregistered source can leak through);
+    we sniff the head and dispatch to the atom parser when the bytes
+    say "feed/atom".
+    """
+
+    if transport in (
+        ProviderTransport.ATOM,
+        ProviderTransport.GITHUB_RELEASES_ATOM,
+    ):
+        return parse_atom_bytes(payload, source=source)
+    if transport is ProviderTransport.RSS:
+        if _looks_like_atom_payload(payload):
+            return parse_atom_bytes(payload, source=source)
+        return parse_rss_bytes(payload, source=source)
+    raise FeedParserError(
+        f"unsupported transport for feed parser: {transport.value}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live factory glue
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeedFetchOutcome:
+    """Diagnostic record the live factory can hand back per call.
+
+    Currently unused by the registry's :class:`LiveSourceFetcher`
+    callable contract (which returns items only) — kept around as a
+    lightweight pure-data shape so the future operator dashboard can
+    surface "fetch ok / parse failed / transport error" without
+    re-running the call.
+    """
+
+    source_id: str
+    transport: str
+    item_count: int
+    fetched_bytes: int
+    parse_ok: bool
+    note: str = ""
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "transport": self.transport,
+            "item_count": int(self.item_count),
+            "fetched_bytes": int(self.fetched_bytes),
+            "parse_ok": bool(self.parse_ok),
+            "note": self.note,
+        }
+
+
+def make_feed_live_factory(
+    bytes_fetcher_factory: Callable[[Mapping[str, str]], BytesFetcher],
+    *,
+    parser: Callable[
+        ..., Tuple[EngineeringKnowledgeItem, ...]
+    ] = parse_feed_bytes,
+) -> Callable[[Mapping[str, str]], Any]:
+    """Wrap *bytes_fetcher_factory* into a registry-shaped live factory.
+
+    The registered live factory must take ``env`` and return a
+    :class:`LiveSourceFetcher`. The bytes-fetcher factory takes the
+    same env and returns a :class:`BytesFetcher`. We glue them with
+    the parser and obey the LiveSourceFetcher Protocol contract:
+
+      * Never raise on transport errors — return ``()`` so the
+        scheduler can record the failure and back off.
+      * Empty payload → empty tuple. The collector treats this the
+        same as "feed has no new items".
+      * Parser failures are swallowed at this layer too (the live
+        factory's job is to be safe by default); callers that want
+        the explicit error observe it via :class:`FeedFetchOutcome`
+        once the dashboard lands.
+    """
+
+    def factory(env: Mapping[str, str]) -> Callable[..., Any]:
+        fetcher = bytes_fetcher_factory(env)
+
+        def fetch(spec: LiveProviderSpec, *, source: SourceEntry):
+            try:
+                payload = fetcher(spec)
+            except Exception:
+                return ()
+            if not payload:
+                return ()
+            try:
+                return parser(payload, source=source, transport=spec.transport)
+            except FeedParserError:
+                return ()
+
+        return fetch
+
+    return factory
+
+
+def register_safe_feed_providers(
+    registry: Any,
+    *,
+    bytes_fetcher_factory: Callable[[Mapping[str, str]], BytesFetcher],
+    transports: Tuple[ProviderTransport, ...] = (
+        ProviderTransport.RSS,
+        ProviderTransport.ATOM,
+        ProviderTransport.GITHUB_RELEASES_ATOM,
+    ),
+) -> Tuple[ProviderTransport, ...]:
+    """Register the parser-backed live factory on each of *transports*.
+
+    Returns the transports that were actually registered. Skips any
+    transport that is not in the registry rather than raising — the
+    operator can choose a subset (e.g. atom-only) without having to
+    pre-trim the registry.
+    """
+
+    factory = make_feed_live_factory(bytes_fetcher_factory)
+    registered: list[ProviderTransport] = []
+    for transport in transports:
+        if transport not in registry:
+            continue
+        registry.register_live(transport, live_factory=factory)
+        registered.append(transport)
+    return tuple(registered)
+
+
+__all__ = [
+    "BytesFetcher",
+    "FeedFetchOutcome",
+    "FeedParserError",
+    "make_feed_live_factory",
+    "parse_atom_bytes",
+    "parse_feed_bytes",
+    "parse_rss_bytes",
+    "register_safe_feed_providers",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
@@ -1,0 +1,514 @@
+"""Auth + availability registry for live knowledge providers.
+
+The :mod:`.providers` module owns the *transport spec* — given a
+:class:`SourceEntry`, :func:`provider_spec_for` returns the
+:class:`LiveProviderSpec` describing how the bytes arrive (RSS / Atom
+/ Sitemap / HTML / GitHub Releases / GitHub API / Manual).
+
+This module owns the *registry* layer that complements that spec:
+
+  * Which provider implementations actually exist for each transport.
+  * What env contract each provider requires before it may dispatch
+    a live call (mirrors the decision-classifier dual gate — env keys
+    *and* an explicit enable flag must both be set).
+  * Whether the configured implementation is currently
+    ``available`` / ``disabled_by_flag`` / ``missing_env`` /
+    ``no_live_impl`` / ``manual_only`` for the operator's environment.
+  * A deterministic fake (:class:`FakeKnowledgeProvider`) that every
+    transport falls back to when live dispatch is not authorised.
+
+Strict offline. Live HTTP / API code lives in a follow-up — this
+module defines the *seam* without importing urllib / requests /
+socket / sqlite / vault. Tests pin the seam so the contract can't
+silently regress when the live impl lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from .models import EngineeringKnowledgeItem, SourceEntry
+from .providers import (
+    FakeKnowledgeProvider,
+    LiveProviderSpec,
+    LiveSourceFetcher,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth requirement
+# ---------------------------------------------------------------------------
+
+
+_TRUTHY = {"1", "true", "yes", "on", "y"}
+
+
+@dataclass(frozen=True)
+class ProviderAuthRequirement:
+    """Env contract a provider must satisfy before live dispatch.
+
+    Two-part dual gate, intentionally identical in shape to the
+    decision-classifier env policy:
+
+      1. ``env_keys`` — every key listed here must resolve to a
+         non-empty value in the operator env mapping.
+      2. ``enable_flag`` — the boolean flag that the operator flips
+         after manual cost / safety review. ``None`` means the
+         transport has no dedicated flag (e.g. ``MANUAL`` — there is
+         no live call to gate).
+
+    Both conditions are necessary; either alone leaves the registry
+    in fallback (fake / stub) mode. This matches the project's
+    "key found ≠ enabled" rule from .env.example §classifier.
+    """
+
+    env_keys: Tuple[str, ...] = ()
+    enable_flag: Optional[str] = None
+    notes: str = ""
+
+    def env_keys_present(self, env: Mapping[str, str]) -> bool:
+        """All required keys map to a non-blank value in *env*."""
+
+        for key in self.env_keys:
+            value = (env.get(key) or "").strip()
+            if not value:
+                return False
+        return True
+
+    def enable_flag_set(self, env: Mapping[str, str]) -> bool:
+        """The enable flag is explicitly truthy (or unset → True)."""
+
+        if not self.enable_flag:
+            return True
+        value = (env.get(self.enable_flag) or "").strip().lower()
+        return value in _TRUTHY
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "env_keys": list(self.env_keys),
+            "enable_flag": self.enable_flag,
+            "notes": self.notes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+class ProviderAvailability(str, Enum):
+    """Live-or-fallback decision for a provider entry.
+
+    Distinguishes the *reason* a provider isn't currently live so the
+    operator dashboard can call out exactly the env / flag / impl
+    that's missing instead of a generic "fake".
+    """
+
+    AVAILABLE = "available"
+    DISABLED_BY_FLAG = "disabled_by_flag"
+    MISSING_ENV = "missing_env"
+    NO_LIVE_IMPL = "no_live_impl"
+    MANUAL_ONLY = "manual_only"
+
+
+# ---------------------------------------------------------------------------
+# Registration row
+# ---------------------------------------------------------------------------
+
+
+# A live factory takes the env mapping and returns a fetcher.
+# Concretely the live impl needs to thread through user-agent +
+# rate-limit + auth headers, all of which depend on env. The factory
+# pattern keeps the registry purely declarative — no live object is
+# constructed unless availability resolves to AVAILABLE.
+LiveFetcherFactory = Callable[[Mapping[str, str]], LiveSourceFetcher]
+
+
+@dataclass(frozen=True)
+class KnowledgeProviderRegistration:
+    """One row in the provider registry — transport → provider seat.
+
+    The fake fetcher is required (offline default for tests + dev +
+    cost-safe operator); the live factory is optional and only fires
+    if availability resolves to ``AVAILABLE``. ``manual=True`` marks
+    the slot where there is no live call by design (the operator
+    enters items by hand) — availability collapses to
+    ``MANUAL_ONLY`` regardless of env.
+    """
+
+    provider_id: str
+    transport: ProviderTransport
+    auth: ProviderAuthRequirement
+    fake_fetcher: LiveSourceFetcher
+    live_factory: Optional[LiveFetcherFactory] = None
+    manual: bool = False
+    description: str = ""
+
+    def has_live_impl(self) -> bool:
+        return self.live_factory is not None and not self.manual
+
+    def evaluate_availability(
+        self, env: Mapping[str, str]
+    ) -> ProviderAvailability:
+        """Resolve the env into an availability state.
+
+        Order matters: ``manual=True`` short-circuits to
+        ``MANUAL_ONLY``; absence of a live impl is checked next so
+        that "no impl" is not masked by a fully-set env. Then env
+        keys, then enable flag. The first failing condition wins so
+        the operator dashboard can fix exactly that one thing.
+        """
+
+        if self.manual:
+            return ProviderAvailability.MANUAL_ONLY
+        if self.live_factory is None:
+            return ProviderAvailability.NO_LIVE_IMPL
+        if not self.auth.env_keys_present(env):
+            return ProviderAvailability.MISSING_ENV
+        if not self.auth.enable_flag_set(env):
+            return ProviderAvailability.DISABLED_BY_FLAG
+        return ProviderAvailability.AVAILABLE
+
+    def select_fetcher(self, env: Mapping[str, str]) -> LiveSourceFetcher:
+        """Return the fetcher to use right now for this transport.
+
+        ``AVAILABLE`` → live factory output; everything else → fake.
+        The caller never has to branch on availability when it just
+        needs a callable.
+        """
+
+        if self.evaluate_availability(env) is ProviderAvailability.AVAILABLE:
+            assert self.live_factory is not None  # narrowed by guard above
+            return self.live_factory(env)
+        return self.fake_fetcher
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "transport": self.transport.value,
+            "auth": self.auth.to_payload(),
+            "manual": self.manual,
+            "has_live_impl": self.has_live_impl(),
+            "description": self.description,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeProviderRegistry:
+    """Mutable provider registry keyed on :class:`ProviderTransport`.
+
+    Designed for explicit construction:
+
+      * :func:`default_registry` produces the baseline seed (one
+        registration per transport with ``fake`` only and the env
+        contract attached).
+      * Tests / a future live-wiring PR call ``register_live`` to
+        plug a factory for one transport. No global mutation —
+        callers thread the registry through.
+    """
+
+    def __init__(
+        self,
+        registrations: Iterable[KnowledgeProviderRegistration] = (),
+    ) -> None:
+        self._by_transport: dict[
+            ProviderTransport, KnowledgeProviderRegistration
+        ] = {}
+        for reg in registrations:
+            self._by_transport[reg.transport] = reg
+
+    # -- mutation ------------------------------------------------------
+
+    def register(self, registration: KnowledgeProviderRegistration) -> None:
+        """Replace any existing entry for ``registration.transport``."""
+
+        self._by_transport[registration.transport] = registration
+
+    def register_live(
+        self,
+        transport: ProviderTransport,
+        *,
+        live_factory: LiveFetcherFactory,
+    ) -> None:
+        """Attach a live factory to an existing registration.
+
+        Raises :class:`KeyError` if the transport is unknown — keeps
+        a typo from silently producing a registry that never goes
+        live. Reuses the existing auth contract / fake; the operator
+        only has to write the live factory in their PR.
+        """
+
+        existing = self._by_transport.get(transport)
+        if existing is None:
+            raise KeyError(
+                f"cannot attach live factory: transport "
+                f"{transport.value!r} not in registry"
+            )
+        if existing.manual:
+            raise ValueError(
+                f"transport {transport.value!r} is manual-only — "
+                f"refusing to attach live factory"
+            )
+        self._by_transport[transport] = replace(
+            existing, live_factory=live_factory
+        )
+
+    # -- read-only ----------------------------------------------------
+
+    def __contains__(self, transport: ProviderTransport) -> bool:
+        return transport in self._by_transport
+
+    def get(
+        self, transport: ProviderTransport
+    ) -> KnowledgeProviderRegistration:
+        try:
+            return self._by_transport[transport]
+        except KeyError as exc:  # pragma: no cover — defensive
+            raise KeyError(
+                f"no provider registered for transport "
+                f"{transport.value!r}"
+            ) from exc
+
+    def iter_registrations(
+        self,
+    ) -> Tuple[KnowledgeProviderRegistration, ...]:
+        # Sorted on transport.value for deterministic iteration in
+        # tests + audit dumps.
+        return tuple(
+            sorted(
+                self._by_transport.values(),
+                key=lambda r: r.transport.value,
+            )
+        )
+
+    def evaluate(
+        self,
+        transport: ProviderTransport,
+        *,
+        env: Mapping[str, str],
+    ) -> ProviderAvailability:
+        return self.get(transport).evaluate_availability(env)
+
+    def select_fetcher_for(
+        self,
+        source: SourceEntry,
+        *,
+        env: Mapping[str, str],
+    ) -> Tuple[LiveProviderSpec, LiveSourceFetcher, ProviderAvailability]:
+        """Resolve a :class:`SourceEntry` into (spec, fetcher, availability).
+
+        Encapsulates the "build spec + look up registration + decide
+        availability + pick fetcher" sequence so a future scheduler
+        runner just calls one helper per source.
+        """
+
+        spec = provider_spec_for(source)
+        registration = self.get(spec.transport)
+        availability = registration.evaluate_availability(env)
+        fetcher = (
+            registration.live_factory(env)
+            if availability is ProviderAvailability.AVAILABLE
+            and registration.live_factory is not None
+            else registration.fake_fetcher
+        )
+        return spec, fetcher, availability
+
+    def availability_report(
+        self, env: Mapping[str, str]
+    ) -> Mapping[str, str]:
+        """``transport.value → availability.value`` for the dashboard."""
+
+        return {
+            reg.transport.value: reg.evaluate_availability(env).value
+            for reg in self.iter_registrations()
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default registry seed
+# ---------------------------------------------------------------------------
+
+
+# Env contract per transport — keys are "necessary" and the flag is
+# the dual-gate "sufficient" half. None of these are read by the
+# registry; they're declared here so the operator dashboard + tests
+# pin the contract independently of the live impl.
+_KNOWLEDGE_LIVE_ENABLED_FLAG = "YULE_KNOWLEDGE_{transport}_LIVE_ENABLED"
+
+
+def _flag_for(transport: ProviderTransport) -> str:
+    return _KNOWLEDGE_LIVE_ENABLED_FLAG.format(
+        transport=transport.value.upper()
+    )
+
+
+def default_registry(
+    *,
+    fake_fixture: Optional[
+        Mapping[str, Sequence[EngineeringKnowledgeItem]]
+    ] = None,
+) -> KnowledgeProviderRegistry:
+    """Baseline registry: one entry per transport, fake-only by default.
+
+    *fake_fixture* — optional ``source_id → items`` map for the fake
+    fetcher. If ``None``, the registry uses :class:`StubLiveSourceFetcher`
+    everywhere (records calls, returns empty). Tests that want
+    deterministic items wired through the registry pass a fixture
+    once at construction.
+    """
+
+    fake = (
+        FakeKnowledgeProvider(fake_fixture)
+        if fake_fixture is not None
+        else StubLiveSourceFetcher()
+    )
+
+    rss = KnowledgeProviderRegistration(
+        provider_id="rss-feed",
+        transport=ProviderTransport.RSS,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.RSS),
+            notes="Public RSS — no auth, only the operator enable flag.",
+        ),
+        fake_fetcher=fake,
+        description="Generic RSS 2.0 / RDF feed parser.",
+    )
+    atom = KnowledgeProviderRegistration(
+        provider_id="atom-feed",
+        transport=ProviderTransport.ATOM,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.ATOM),
+            notes="Public Atom 1.0 — no auth, only the operator enable flag.",
+        ),
+        fake_fetcher=fake,
+        description="Atom 1.0 feed parser.",
+    )
+    github_releases = KnowledgeProviderRegistration(
+        provider_id="github-releases-atom",
+        transport=ProviderTransport.GITHUB_RELEASES_ATOM,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.GITHUB_RELEASES_ATOM),
+            notes=(
+                "Public Atom feed exposed by github.com/<owner>/<repo>/"
+                "releases.atom — keep cadence ≤ 20/min to stay under the "
+                "unauthenticated rate limit."
+            ),
+        ),
+        fake_fetcher=fake,
+        description="GitHub releases atom (no auth).",
+    )
+    sitemap = KnowledgeProviderRegistration(
+        provider_id="sitemap-walker",
+        transport=ProviderTransport.SITEMAP,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.SITEMAP),
+            notes="Sitemap walks are heavier; cadence pinned low in the spec.",
+        ),
+        fake_fetcher=fake,
+        description="sitemap.xml walker (lastmod-aware).",
+    )
+    html_list = KnowledgeProviderRegistration(
+        provider_id="html-list",
+        transport=ProviderTransport.HTML_LIST,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.HTML_LIST),
+            notes="Index-page scrape — link + summary only per content_policy.",
+        ),
+        fake_fetcher=fake,
+        description="HTML index / list page scraper.",
+    )
+    html_detail = KnowledgeProviderRegistration(
+        provider_id="html-detail",
+        transport=ProviderTransport.HTML_DETAIL,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=_flag_for(ProviderTransport.HTML_DETAIL),
+            notes="Detail page fetch — slowest path; called only when index missed.",
+        ),
+        fake_fetcher=fake,
+        description="HTML detail-page scraper.",
+    )
+    github_api = KnowledgeProviderRegistration(
+        provider_id="github-api-repo-activity",
+        transport=ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+        auth=ProviderAuthRequirement(
+            # Reuse the existing GitHub App env triple — no new secret
+            # surface area. Knowledge fetcher will share the App
+            # installation with the GitHub agent.
+            env_keys=(
+                "YULE_GITHUB_APP_ID",
+                "YULE_GITHUB_APP_INSTALLATION_ID",
+                "YULE_GITHUB_APP_PRIVATE_KEY_PATH",
+            ),
+            enable_flag=_flag_for(
+                ProviderTransport.GITHUB_API_REPO_ACTIVITY
+            ),
+            notes=(
+                "Backed by the existing GitHub App. Private repo "
+                "endpoints fail closed without the App env triple."
+            ),
+        ),
+        fake_fetcher=fake,
+        description="GitHub REST: issues / releases / commits via App.",
+    )
+    manual = KnowledgeProviderRegistration(
+        provider_id="manual",
+        transport=ProviderTransport.MANUAL,
+        auth=ProviderAuthRequirement(
+            env_keys=(),
+            enable_flag=None,
+            notes=(
+                "MANUAL — no live call. Operator enters knowledge items "
+                "directly via the vault / Discord intake."
+            ),
+        ),
+        fake_fetcher=fake,
+        manual=True,
+        description="Manual entry slot — no transport.",
+    )
+
+    return KnowledgeProviderRegistry(
+        registrations=(
+            rss,
+            atom,
+            github_releases,
+            sitemap,
+            html_list,
+            html_detail,
+            github_api,
+            manual,
+        )
+    )
+
+
+__all__ = [
+    "FakeKnowledgeProvider",
+    "KnowledgeProviderRegistration",
+    "KnowledgeProviderRegistry",
+    "LiveFetcherFactory",
+    "ProviderAuthRequirement",
+    "ProviderAvailability",
+    "default_registry",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_registry.py
@@ -340,6 +340,148 @@ class KnowledgeProviderRegistry:
             for reg in self.iter_registrations()
         }
 
+    def availability_summary(
+        self, env: Mapping[str, str]
+    ) -> "ProviderAvailabilitySummary":
+        """Structured ``transport → state + diagnostics`` summary.
+
+        Builds one :class:`ProviderAvailabilityRow` per registration —
+        the row includes the env contract (which keys, which flag),
+        which keys are still empty, and whether the flag is set.
+        Operators get a single object they can render as a table on
+        the dashboard or feed into the background refresh planner so
+        a tick log explains exactly *why* a transport fell back to
+        the fake.
+        """
+
+        rows = tuple(
+            ProviderAvailabilityRow.from_registration(reg, env=env)
+            for reg in self.iter_registrations()
+        )
+        return ProviderAvailabilitySummary(rows=rows)
+
+
+# ---------------------------------------------------------------------------
+# Operator-facing availability summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderAvailabilityRow:
+    """One transport's resolved availability + the diagnostics behind it.
+
+    Designed for "render as a table on the operator dashboard"
+    rather than for the runner — the runner already calls
+    :meth:`KnowledgeProviderRegistry.select_fetcher_for`. This row
+    answers *why* a transport is in its current state so the
+    operator can fix exactly the missing piece (env key vs flag vs
+    live impl).
+    """
+
+    transport: str
+    provider_id: str
+    availability: str
+    has_live_impl: bool
+    manual: bool
+    env_keys: Tuple[str, ...]
+    enable_flag: Optional[str]
+    missing_env_keys: Tuple[str, ...]
+    enable_flag_set: bool
+    description: str
+    notes: str
+
+    @classmethod
+    def from_registration(
+        cls,
+        registration: "KnowledgeProviderRegistration",
+        *,
+        env: Mapping[str, str],
+    ) -> "ProviderAvailabilityRow":
+        missing = tuple(
+            key
+            for key in registration.auth.env_keys
+            if not (env.get(key) or "").strip()
+        )
+        return cls(
+            transport=registration.transport.value,
+            provider_id=registration.provider_id,
+            availability=registration.evaluate_availability(env).value,
+            has_live_impl=registration.has_live_impl(),
+            manual=registration.manual,
+            env_keys=tuple(registration.auth.env_keys),
+            enable_flag=registration.auth.enable_flag,
+            missing_env_keys=missing,
+            enable_flag_set=registration.auth.enable_flag_set(env),
+            description=registration.description,
+            notes=registration.auth.notes,
+        )
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "transport": self.transport,
+            "provider_id": self.provider_id,
+            "availability": self.availability,
+            "has_live_impl": bool(self.has_live_impl),
+            "manual": bool(self.manual),
+            "env_keys": list(self.env_keys),
+            "enable_flag": self.enable_flag,
+            "missing_env_keys": list(self.missing_env_keys),
+            "enable_flag_set": bool(self.enable_flag_set),
+            "description": self.description,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderAvailabilitySummary:
+    """All :class:`ProviderAvailabilityRow` rows + small grouping helpers.
+
+    Pure data — no I/O. Three convenience views the dashboard /
+    background refresh planner reach for the most:
+
+      * :meth:`by_state` — ``state → rows`` for a "live / blocked /
+        manual" tabbed view.
+      * :meth:`states_count` — quick "5 available, 2 missing_env"
+        headline number.
+      * :meth:`needs_attention` — rows the operator can fix:
+        MISSING_ENV / DISABLED_BY_FLAG. NO_LIVE_IMPL is not in this
+        bucket (the operator can't write the live impl from the
+        dashboard).
+    """
+
+    rows: Tuple[ProviderAvailabilityRow, ...]
+
+    def by_state(self) -> Mapping[str, Tuple[ProviderAvailabilityRow, ...]]:
+        buckets: dict[str, list[ProviderAvailabilityRow]] = {}
+        for row in self.rows:
+            buckets.setdefault(row.availability, []).append(row)
+        return {
+            state: tuple(rows_in_state)
+            for state, rows_in_state in buckets.items()
+        }
+
+    def states_count(self) -> Mapping[str, int]:
+        counts: dict[str, int] = {}
+        for row in self.rows:
+            counts[row.availability] = counts.get(row.availability, 0) + 1
+        return counts
+
+    def needs_attention(self) -> Tuple[ProviderAvailabilityRow, ...]:
+        actionable = {
+            ProviderAvailability.MISSING_ENV.value,
+            ProviderAvailability.DISABLED_BY_FLAG.value,
+        }
+        return tuple(row for row in self.rows if row.availability in actionable)
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "rows": [row.to_payload() for row in self.rows],
+            "states_count": dict(self.states_count()),
+            "needs_attention": [
+                row.to_payload() for row in self.needs_attention()
+            ],
+        }
+
 
 # ---------------------------------------------------------------------------
 # Default registry seed
@@ -510,5 +652,7 @@ __all__ = [
     "LiveFetcherFactory",
     "ProviderAuthRequirement",
     "ProviderAvailability",
+    "ProviderAvailabilityRow",
+    "ProviderAvailabilitySummary",
     "default_registry",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from .models import SourceAxis, SourceEntry, SourceTier
+from .models import CollectionMode, SourceAxis, SourceEntry, SourceTier
 from .provider_registry import (
     KnowledgeProviderRegistration,
     KnowledgeProviderRegistry,
     ProviderAvailability,
+    ProviderAvailabilitySummary,
     default_registry,
 )
 from .providers import (
@@ -52,6 +53,12 @@ class RoutedRefreshCandidate:
     Plus the original :class:`RefreshPlanEntry` decision so the
     caller can still distinguish ``due`` vs ``skipped_*`` without
     re-running the planner.
+
+    ``transport_reason`` and ``availability_reason`` are short human
+    sentences explaining *why* this transport / availability was
+    picked. They land here so the operator dashboard + tick log can
+    answer "why did the runner pick rss-feed over manual?" without
+    re-deriving the heuristic.
     """
 
     source: SourceEntry
@@ -61,6 +68,8 @@ class RoutedRefreshCandidate:
     decision: str
     reason: str
     next_eligible_at: Optional[str] = None
+    transport_reason: str = ""
+    availability_reason: str = ""
 
     @property
     def axes(self) -> Tuple[SourceAxis, ...]:
@@ -69,6 +78,17 @@ class RoutedRefreshCandidate:
     @property
     def transport(self) -> ProviderTransport:
         return self.spec.transport
+
+    @property
+    def routing_reason(self) -> str:
+        """One-line ``transport=… availability=…`` explanation."""
+
+        parts: list[str] = []
+        if self.transport_reason:
+            parts.append(f"transport={self.transport_reason}")
+        if self.availability_reason:
+            parts.append(f"availability={self.availability_reason}")
+        return "; ".join(parts)
 
     def to_payload(self) -> Mapping[str, Any]:
         return {
@@ -81,7 +101,82 @@ class RoutedRefreshCandidate:
             "next_eligible_at": self.next_eligible_at,
             "axes": [axis.value for axis in self.axes],
             "auth": self.provider.auth.to_payload(),
+            "transport_reason": self.transport_reason,
+            "availability_reason": self.availability_reason,
+            "routing_reason": self.routing_reason,
         }
+
+
+# ---------------------------------------------------------------------------
+# Reasoning helpers — explain transport + availability choices
+# ---------------------------------------------------------------------------
+
+
+def _explain_transport_choice(source: SourceEntry) -> str:
+    """One-line "why this transport" for *source*.
+
+    Mirrors the dispatch order inside :func:`provider_spec_for` so
+    operators can map a routed candidate back to the heuristic that
+    picked it without re-reading the dispatcher source.
+    """
+
+    mode = source.collection_mode
+    url = source.base_url
+    if mode is CollectionMode.MANUAL:
+        return "manual (collection_mode=manual)"
+    if mode is CollectionMode.GITHUB_API:
+        return "github_api_repo_activity (collection_mode=github_api)"
+    if mode is CollectionMode.RSS:
+        if "github.com/" in url and "/releases" in url:
+            return "github_releases_atom (rss + github releases URL)"
+        if ".atom" in url or url.endswith("/atom"):
+            return "atom (rss + atom URL heuristic)"
+        return "rss (collection_mode=rss)"
+    if mode is CollectionMode.SITEMAP:
+        return "sitemap (collection_mode=sitemap)"
+    if mode is CollectionMode.HTML_LIST:
+        return "html_list (collection_mode=html_list)"
+    return "html_detail (fallback transport)"
+
+
+def _explain_availability(
+    registration: KnowledgeProviderRegistration,
+    *,
+    env: Mapping[str, str],
+    state: ProviderAvailability,
+) -> str:
+    """One-line "why this availability state" for *registration*.
+
+    The reason mentions the actionable thing first — missing env
+    keys or the disabled flag name — so an operator scanning the
+    dashboard can fix the right knob without opening the registry.
+    """
+
+    if state is ProviderAvailability.MANUAL_ONLY:
+        return "manual (operator enters items by hand)"
+    if state is ProviderAvailability.NO_LIVE_IMPL:
+        return "no live impl (fake fallback)"
+    if state is ProviderAvailability.MISSING_ENV:
+        missing = tuple(
+            key
+            for key in registration.auth.env_keys
+            if not (env.get(key) or "").strip()
+        )
+        keys_repr = ", ".join(missing) if missing else "(none)"
+        return f"missing env keys: {keys_repr}"
+    if state is ProviderAvailability.DISABLED_BY_FLAG:
+        flag = registration.auth.enable_flag or "(no flag)"
+        return f"flag {flag} not truthy"
+    if state is ProviderAvailability.AVAILABLE:
+        bits = []
+        if registration.auth.env_keys:
+            bits.append("env keys present")
+        if registration.auth.enable_flag:
+            bits.append(f"{registration.auth.enable_flag}=true")
+        if not bits:
+            bits.append("no auth contract")
+        return "live (" + ", ".join(bits) + ")"
+    return state.value  # pragma: no cover — defensive
 
 
 # ---------------------------------------------------------------------------
@@ -136,11 +231,90 @@ def route_refresh_plan(
             decision=entry.decision,
             reason=entry.reason,
             next_eligible_at=getattr(entry, "next_eligible_at", None),
+            transport_reason=_explain_transport_choice(source),
+            availability_reason=_explain_availability(
+                registration, env=env_map, state=availability
+            ),
         )
 
     due_routed = tuple(c for c in (_build(e) for e in plan.due) if c)
     skipped_routed = tuple(c for c in (_build(e) for e in plan.skipped) if c)
     return due_routed, skipped_routed
+
+
+# ---------------------------------------------------------------------------
+# refresh_plan_status — operator-friendly bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RefreshPlanStatus:
+    """One-shot bundle of "what's about to run + what's blocked" for a tick.
+
+    Threads three observables together:
+
+      * ``due`` / ``skipped`` — :class:`RoutedRefreshCandidate` lists
+        from :func:`route_refresh_plan`.
+      * ``availability`` — the registry's
+        :class:`ProviderAvailabilitySummary` so the dashboard can
+        show "5 transports live, 2 disabled by flag" alongside the
+        per-source decision.
+
+    The background refresh planner can dump this to JSON for the
+    operator log on every tick — one snapshot answers "will this
+    tick fetch anything? if not, what env is missing?".
+    """
+
+    role: str
+    now_iso: str
+    due: Tuple[RoutedRefreshCandidate, ...]
+    skipped: Tuple[RoutedRefreshCandidate, ...]
+    availability: ProviderAvailabilitySummary
+
+    @property
+    def transports_due(self) -> Tuple[str, ...]:
+        # Sorted unique transports the runner will actually call.
+        return tuple(
+            sorted({c.transport.value for c in self.due})
+        )
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "role": self.role,
+            "now": self.now_iso,
+            "transports_due": list(self.transports_due),
+            "due": [c.to_payload() for c in self.due],
+            "skipped": [c.to_payload() for c in self.skipped],
+            "availability": self.availability.to_payload(),
+        }
+
+
+def refresh_plan_status(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+) -> RefreshPlanStatus:
+    """Pure helper: route *plan* and bundle the registry availability.
+
+    Single call point for the background refresh planner — it gets
+    routed candidates *and* the registry summary in one go without
+    having to thread the registry/env through twice.
+    """
+
+    reg = registry if registry is not None else default_registry()
+    env_map: Mapping[str, str] = dict(env or {})
+    due, skipped = route_refresh_plan(
+        plan, role_id=role_id, registry=reg, env=env_map
+    )
+    return RefreshPlanStatus(
+        role=role_id,
+        now_iso=getattr(plan, "now_iso", ""),
+        due=due,
+        skipped=skipped,
+        availability=reg.availability_summary(env_map),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -250,8 +424,10 @@ def select_routed_due(
 
 
 __all__ = [
+    "RefreshPlanStatus",
     "RoutedRefreshCandidate",
     "axis_priority_order",
+    "refresh_plan_status",
     "route_refresh_plan",
     "select_routed_due",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/provider_routing.py
@@ -1,0 +1,257 @@
+"""Refresh-plan → provider routing.
+
+Given a :class:`RefreshPlan` from :mod:`.scheduler` and a
+:class:`KnowledgeProviderRegistry` from :mod:`.provider_registry`,
+this module annotates each entry with the transport, provider, and
+availability the orchestrator will dispatch to. It also offers a
+small re-ranker that prefers axes the role hasn't covered recently —
+so when a tick quota is tight, a chronically-unhealthy axis gets the
+slot instead of being starved by an axis that's already fresh.
+
+Strict offline. Pure functions. Tests pin behaviour deterministically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .models import SourceAxis, SourceEntry, SourceTier
+from .provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    ProviderAvailability,
+    default_registry,
+)
+from .providers import (
+    LiveProviderSpec,
+    ProviderTransport,
+    provider_spec_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Routed refresh candidate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutedRefreshCandidate:
+    """A due / skipped source enriched with provider routing.
+
+    Bundles four facts the tick runner needs for one source:
+
+      * ``source`` — the registry row (axes / role tags / content
+        policy travel with the candidate).
+      * ``spec`` — the :class:`LiveProviderSpec` (transport, endpoint,
+        parser, rate limit).
+      * ``provider`` — the registry row (auth contract, fetcher).
+      * ``availability`` — the resolved
+        :class:`ProviderAvailability` for the operator's env.
+
+    Plus the original :class:`RefreshPlanEntry` decision so the
+    caller can still distinguish ``due`` vs ``skipped_*`` without
+    re-running the planner.
+    """
+
+    source: SourceEntry
+    spec: LiveProviderSpec
+    provider: KnowledgeProviderRegistration
+    availability: ProviderAvailability
+    decision: str
+    reason: str
+    next_eligible_at: Optional[str] = None
+
+    @property
+    def axes(self) -> Tuple[SourceAxis, ...]:
+        return self.source.axes
+
+    @property
+    def transport(self) -> ProviderTransport:
+        return self.spec.transport
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "source_id": self.source.source_id,
+            "transport": self.transport.value,
+            "provider_id": self.provider.provider_id,
+            "availability": self.availability.value,
+            "decision": self.decision,
+            "reason": self.reason,
+            "next_eligible_at": self.next_eligible_at,
+            "axes": [axis.value for axis in self.axes],
+            "auth": self.provider.auth.to_payload(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+def route_refresh_plan(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+) -> Tuple[
+    Tuple[RoutedRefreshCandidate, ...],
+    Tuple[RoutedRefreshCandidate, ...],
+]:
+    """Annotate every entry of *plan* with provider routing.
+
+    Returns ``(due_candidates, skipped_candidates)`` — both tuples of
+    :class:`RoutedRefreshCandidate`. Skipped entries also carry the
+    transport + availability so a "would have been due but provider
+    is blocked" combination is visible without recomputing.
+
+    *registry* defaults to :func:`default_registry` so the simplest
+    call site (``route_refresh_plan(plan, role_id=role)``) still
+    resolves to the seeded contract.
+
+    Pure function. The orchestrator threads a registry it constructed
+    once at startup plus the env mapping it already evaluated for
+    other components.
+    """
+
+    from .source_registry import role_sources  # local import keeps cycles out
+
+    reg = registry if registry is not None else default_registry()
+    sources_by_id = {s.source_id: s for s in role_sources(role_id)}
+    env_map: Mapping[str, str] = dict(env or {})
+
+    def _build(entry: Any) -> Optional[RoutedRefreshCandidate]:
+        source = sources_by_id.get(entry.source_id)
+        if source is None:
+            return None
+        spec = provider_spec_for(source)
+        registration = reg.get(spec.transport)
+        availability = registration.evaluate_availability(env_map)
+        return RoutedRefreshCandidate(
+            source=source,
+            spec=spec,
+            provider=registration,
+            availability=availability,
+            decision=entry.decision,
+            reason=entry.reason,
+            next_eligible_at=getattr(entry, "next_eligible_at", None),
+        )
+
+    due_routed = tuple(c for c in (_build(e) for e in plan.due) if c)
+    skipped_routed = tuple(c for c in (_build(e) for e in plan.skipped) if c)
+    return due_routed, skipped_routed
+
+
+# ---------------------------------------------------------------------------
+# axis_priority_order
+# ---------------------------------------------------------------------------
+
+
+_AVAILABILITY_RANK: Mapping[ProviderAvailability, int] = {
+    ProviderAvailability.AVAILABLE: 0,
+    ProviderAvailability.NO_LIVE_IMPL: 1,
+    ProviderAvailability.MANUAL_ONLY: 2,
+    ProviderAvailability.DISABLED_BY_FLAG: 3,
+    ProviderAvailability.MISSING_ENV: 4,
+}
+
+
+_TIER_RANK: Mapping[SourceTier, int] = {
+    SourceTier.TIER_1: 0,
+    SourceTier.TIER_2: 1,
+    SourceTier.TIER_3: 2,
+    SourceTier.TIER_4: 3,
+}
+
+
+def axis_priority_order(
+    candidates: Sequence[RoutedRefreshCandidate],
+    *,
+    overdue_axes: Sequence[str] = (),
+) -> Tuple[RoutedRefreshCandidate, ...]:
+    """Re-rank *candidates* so axes that are overdue come first.
+
+    Goal: when tick quota is tight, the slot goes to a source whose
+    axis hasn't been refreshed in the longest time. A chronically
+    broken axis surfaces fresh items first instead of being starved
+    by an already-healthy axis.
+
+    Tie-breakers (after axis health):
+      * provider availability — ``AVAILABLE`` first (keep live
+        bandwidth hot once it's actually live).
+      * source tier — Tier 1 first (officially-trusted wins ties).
+      * source_id alphabetical — for determinism in tests / replay.
+
+    Pass :func:`scheduler.overdue_axes_for_role` output directly as
+    *overdue_axes* — those are the axis values (string form) the
+    planner already considers stale.
+    """
+
+    overdue_set = set(overdue_axes)
+
+    def _hits_overdue_axis(c: RoutedRefreshCandidate) -> int:
+        # 0 = at least one axis is overdue (rank first), 1 otherwise.
+        for axis in c.axes:
+            if axis.value in overdue_set:
+                return 0
+        return 1
+
+    def _key(c: RoutedRefreshCandidate) -> Tuple[int, int, int, str]:
+        return (
+            _hits_overdue_axis(c),
+            _AVAILABILITY_RANK.get(c.availability, 99),
+            _TIER_RANK.get(c.source.tier, 99),
+            c.source.source_id,
+        )
+
+    return tuple(sorted(candidates, key=_key))
+
+
+# ---------------------------------------------------------------------------
+# Convenience: plan + route + axis priority + quota in one call
+# ---------------------------------------------------------------------------
+
+
+def select_routed_due(
+    plan: Any,
+    *,
+    role_id: str,
+    registry: Optional[KnowledgeProviderRegistry] = None,
+    env: Mapping[str, str] = (),  # type: ignore[assignment]
+    overdue_axes: Sequence[str] = (),
+    tick_quota: Optional[int] = None,
+) -> Tuple[
+    Tuple[RoutedRefreshCandidate, ...],
+    Tuple[RoutedRefreshCandidate, ...],
+]:
+    """One-call helper: route *plan*, axis-prioritise, then truncate.
+
+    Returns ``(selected_due, deferred_due)`` — *selected_due* are the
+    candidates that fit under *tick_quota* after axis priority,
+    *deferred_due* are the rest (still due, but not picked this tick).
+
+    *tick_quota* is the cap applied *after* axis prioritisation. When
+    ``None`` no cap is applied (the planner already truncated). When
+    set, the operator can run ``compute_refresh_plan(..., tick_quota=-1)``
+    to disable the planner's cap and re-cap here using axis-aware
+    ordering. Skipped entries from the original plan are returned
+    separately via :func:`route_refresh_plan`; this helper focuses on
+    the "due" side only.
+    """
+
+    due, _ = route_refresh_plan(
+        plan, role_id=role_id, registry=registry, env=env
+    )
+    ordered = axis_priority_order(due, overdue_axes=overdue_axes)
+    if tick_quota is None or tick_quota < 0:
+        return ordered, ()
+    return ordered[:tick_quota], ordered[tick_quota:]
+
+
+__all__ = [
+    "RoutedRefreshCandidate",
+    "axis_priority_order",
+    "route_refresh_plan",
+    "select_routed_due",
+]

--- a/src/yule_orchestrator/agents/engineering_intelligence/providers.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/providers.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Mapping, Optional, Protocol, Tuple
+from typing import Any, List, Mapping, Optional, Protocol, Sequence, Tuple
 
 from .models import (
     CollectionMode,
@@ -310,7 +310,57 @@ class StubLiveSourceFetcher:
         return ()
 
 
+# ---------------------------------------------------------------------------
+# Deterministic fixture-based fake — used by the provider registry seed
+# ---------------------------------------------------------------------------
+
+
+class FakeKnowledgeProvider:
+    """Fixture-based fake fetcher — returns items keyed on source_id.
+
+    Sits between :class:`StubLiveSourceFetcher` (records, returns empty)
+    and a real live provider (network). Tests / dev / cost-safe
+    operator runs use this so the registry resolves to a *fetcher
+    that produces predictable items* even when no live impl is
+    wired.
+
+    The contract intentionally matches :class:`LiveSourceFetcher`:
+    the orchestrator tick code calls one Protocol regardless of
+    whether bytes came from disk, fixture, or HTTP.
+    """
+
+    def __init__(
+        self,
+        payload: Optional[Mapping[str, Sequence[EngineeringKnowledgeItem]]] = None,
+    ) -> None:
+        self._payload: dict[str, Tuple[EngineeringKnowledgeItem, ...]] = {
+            source_id: tuple(items)
+            for source_id, items in (payload or {}).items()
+        }
+        self.calls: List[Tuple[str, ProviderTransport]] = []
+
+    def with_fixture(
+        self,
+        source_id: str,
+        items: Sequence[EngineeringKnowledgeItem],
+    ) -> "FakeKnowledgeProvider":
+        """Add / replace the fixture for *source_id*. Returns self."""
+
+        self._payload[source_id] = tuple(items)
+        return self
+
+    def __call__(
+        self,
+        spec: LiveProviderSpec,
+        *,
+        source: SourceEntry,
+    ) -> Tuple[EngineeringKnowledgeItem, ...]:
+        self.calls.append((source.source_id, spec.transport))
+        return self._payload.get(source.source_id, ())
+
+
 __all__ = [
+    "FakeKnowledgeProvider",
     "LiveProviderSpec",
     "LiveSourceFetcher",
     "ProviderTransport",

--- a/tests/engineering_intelligence/test_feed_parser.py
+++ b/tests/engineering_intelligence/test_feed_parser.py
@@ -1,0 +1,387 @@
+"""Feed parser: deterministic Atom / RSS / GitHub releases atom decode."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.feed_parser import (
+    BytesFetcher,
+    FeedParserError,
+    make_feed_live_factory,
+    parse_atom_bytes,
+    parse_feed_bytes,
+    parse_rss_bytes,
+    register_safe_feed_providers,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    find_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample payloads — small enough to read inline
+# ---------------------------------------------------------------------------
+
+
+_ATOM_FIXTURE = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Engineering Blog</title>
+  <updated>2026-05-09T10:00:00Z</updated>
+  <entry>
+    <title>Latency-aware retries</title>
+    <link rel="alternate" href="https://example.com/posts/latency-aware-retries"/>
+    <id>tag:example.com,2026:post-1</id>
+    <updated>2026-05-09T09:30:00Z</updated>
+    <summary>How retry budgets interact with p99 latency.</summary>
+  </entry>
+  <entry>
+    <title>Schema migration tactics</title>
+    <link href="https://example.com/posts/schema-migration"/>
+    <id>tag:example.com,2026:post-2</id>
+    <published>2026-05-08T08:00:00Z</published>
+    <content>Three patterns for online schema migration.</content>
+  </entry>
+</feed>
+"""
+
+
+_RSS_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Releases</title>
+    <link>https://example.com/releases</link>
+    <description>Release notes</description>
+    <item>
+      <title>v1.2.0</title>
+      <link>https://example.com/releases/v1.2.0</link>
+      <description>Adds OAuth refresh handling.</description>
+      <pubDate>Mon, 09 May 2026 12:00:00 GMT</pubDate>
+      <guid>https://example.com/releases/v1.2.0</guid>
+    </item>
+    <item>
+      <title>v1.1.5</title>
+      <link>https://example.com/releases/v1.1.5</link>
+      <description>Security patch for CVE-2026-0001.</description>
+      <pubDate>Fri, 02 May 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+_GITHUB_RELEASES_ATOM_FIXTURE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>tag:github.com,2008:https://github.com/example/proj/releases</id>
+  <title>Release notes from proj</title>
+  <updated>2026-05-09T10:00:00Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Repository/123/v2.0.0</id>
+    <updated>2026-05-09T09:00:00Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/example/proj/releases/tag/v2.0.0"/>
+    <title>v2.0.0</title>
+    <content type="html">&lt;p&gt;Major release.&lt;/p&gt;</content>
+  </entry>
+</feed>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Atom parser
+# ---------------------------------------------------------------------------
+
+
+class AtomParserTests(unittest.TestCase):
+    def setUp(self) -> None:
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        self.source = spring
+
+    def test_parses_two_entries_with_titles_and_links(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        self.assertEqual(len(items), 2)
+        titles = [i.title for i in items]
+        self.assertIn("Latency-aware retries", titles)
+        self.assertIn("Schema migration tactics", titles)
+        urls = {i.source_url for i in items}
+        self.assertIn(
+            "https://example.com/posts/latency-aware-retries", urls
+        )
+        self.assertIn("https://example.com/posts/schema-migration", urls)
+
+    def test_prefers_alternate_link_over_first_link(self) -> None:
+        # The Atom fixture has rel="alternate" on entry 1; entry 2 only
+        # has a bare <link href>. Both should be picked up.
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        latency = next(i for i in items if i.title == "Latency-aware retries")
+        self.assertEqual(
+            latency.source_url,
+            "https://example.com/posts/latency-aware-retries",
+        )
+
+    def test_falls_back_to_published_when_updated_missing(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        migration = next(
+            i for i in items if i.title == "Schema migration tactics"
+        )
+        self.assertEqual(migration.published_at, "2026-05-08T08:00:00Z")
+
+    def test_falls_back_to_content_when_summary_missing(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        migration = next(
+            i for i in items if i.title == "Schema migration tactics"
+        )
+        self.assertIn("schema migration", migration.summary.lower())
+
+    def test_inherits_source_metadata(self) -> None:
+        items = parse_atom_bytes(_ATOM_FIXTURE, source=self.source)
+        for item in items:
+            self.assertEqual(item.source_name, self.source.name)
+            self.assertEqual(item.source_kind, self.source.source_kind)
+            self.assertEqual(item.role, self.source.role_tags[0])
+            self.assertEqual(tuple(item.stack_tags), self.source.stack_tags)
+
+    def test_malformed_xml_raises_feed_parser_error(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_atom_bytes(b"<feed><entry></feed>", source=self.source)
+
+    def test_empty_feed_returns_empty_tuple(self) -> None:
+        empty = b'<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"/>'
+        self.assertEqual(parse_atom_bytes(empty, source=self.source), ())
+
+
+# ---------------------------------------------------------------------------
+# RSS parser
+# ---------------------------------------------------------------------------
+
+
+class RssParserTests(unittest.TestCase):
+    def setUp(self) -> None:
+        nvd = find_source("backend-engineer", "cve-nvd")
+        assert nvd is not None
+        self.source = nvd
+
+    def test_parses_two_items_with_titles_and_links(self) -> None:
+        items = parse_rss_bytes(_RSS_FIXTURE, source=self.source)
+        self.assertEqual(len(items), 2)
+        titles = [i.title for i in items]
+        self.assertIn("v1.2.0", titles)
+        self.assertIn("v1.1.5", titles)
+
+    def test_pubdate_normalised_to_iso_z(self) -> None:
+        items = parse_rss_bytes(_RSS_FIXTURE, source=self.source)
+        v120 = next(i for i in items if i.title == "v1.2.0")
+        self.assertEqual(v120.published_at, "2026-05-09T12:00:00Z")
+
+    def test_summary_truncated_to_safe_quotation(self) -> None:
+        long_desc = "A" * 800
+        rss = (
+            b'<?xml version="1.0"?>'
+            b"<rss version=\"2.0\"><channel>"
+            b"<title>x</title><link>https://x</link>"
+            b"<description>x</description>"
+            b"<item><title>t</title><link>https://x/1</link>"
+            b"<description>" + long_desc.encode() + b"</description>"
+            b"</item></channel></rss>"
+        )
+        items = parse_rss_bytes(rss, source=self.source)
+        self.assertEqual(len(items), 1)
+        self.assertLessEqual(len(items[0].summary), 500)
+        self.assertTrue(items[0].summary.endswith("…"))
+
+    def test_malformed_rss_raises_feed_parser_error(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_rss_bytes(b"<rss><channel><item>", source=self.source)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class ParseFeedDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.atom_source = find_source("backend-engineer", "spring-blog")
+        self.rss_source = find_source("backend-engineer", "cve-nvd")
+        assert self.atom_source is not None
+        assert self.rss_source is not None
+
+    def test_atom_transport_uses_atom_parser(self) -> None:
+        items = parse_feed_bytes(
+            _ATOM_FIXTURE,
+            source=self.atom_source,
+            transport=ProviderTransport.ATOM,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_github_releases_atom_uses_atom_parser(self) -> None:
+        items = parse_feed_bytes(
+            _GITHUB_RELEASES_ATOM_FIXTURE,
+            source=self.atom_source,
+            transport=ProviderTransport.GITHUB_RELEASES_ATOM,
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].title, "v2.0.0")
+        self.assertEqual(
+            items[0].source_url,
+            "https://github.com/example/proj/releases/tag/v2.0.0",
+        )
+
+    def test_rss_transport_with_atom_payload_sniffs_and_dispatches(self) -> None:
+        # Edge case: an "rss-mode" source endpoint actually serves Atom.
+        # The sniff routes the bytes to the atom parser instead of failing.
+        items = parse_feed_bytes(
+            _ATOM_FIXTURE,
+            source=self.rss_source,
+            transport=ProviderTransport.RSS,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_rss_transport_with_rss_payload_uses_rss_parser(self) -> None:
+        items = parse_feed_bytes(
+            _RSS_FIXTURE,
+            source=self.rss_source,
+            transport=ProviderTransport.RSS,
+        )
+        self.assertEqual(len(items), 2)
+
+    def test_unsupported_transport_raises(self) -> None:
+        with self.assertRaises(FeedParserError):
+            parse_feed_bytes(
+                b"",
+                source=self.rss_source,
+                transport=ProviderTransport.MANUAL,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Live factory glue
+# ---------------------------------------------------------------------------
+
+
+class LiveFactoryGlueTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source = find_source("backend-engineer", "spring-blog")
+        assert self.source is not None
+        self.spec = provider_spec_for(self.source)
+
+    def test_factory_calls_parser_through_bytes_fetcher(self) -> None:
+        seen_specs: list = []
+
+        def factory(env: Mapping[str, str]) -> BytesFetcher:
+            def fetcher(spec):
+                seen_specs.append(spec.transport)
+                return _ATOM_FIXTURE
+            return fetcher
+
+        live_factory = make_feed_live_factory(factory)
+        fetcher = live_factory({})
+        items = fetcher(self.spec, source=self.source)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(seen_specs, [ProviderTransport.ATOM])
+
+    def test_factory_swallows_transport_errors(self) -> None:
+        def factory(env: Mapping[str, str]) -> BytesFetcher:
+            def fetcher(spec):
+                raise ConnectionError("simulated")
+            return fetcher
+
+        live_factory = make_feed_live_factory(factory)
+        items = live_factory({})(self.spec, source=self.source)
+        self.assertEqual(items, ())
+
+    def test_factory_swallows_parser_errors(self) -> None:
+        def factory(env):
+            return lambda spec: b"<not really xml"
+
+        live_factory = make_feed_live_factory(factory)
+        items = live_factory({})(self.spec, source=self.source)
+        self.assertEqual(items, ())
+
+    def test_factory_returns_empty_for_empty_payload(self) -> None:
+        def factory(env):
+            return lambda spec: b""
+
+        items = make_feed_live_factory(factory)({})(
+            self.spec, source=self.source
+        )
+        self.assertEqual(items, ())
+
+
+# ---------------------------------------------------------------------------
+# register_safe_feed_providers
+# ---------------------------------------------------------------------------
+
+
+class RegisterSafeFeedProvidersTests(unittest.TestCase):
+    def test_registers_three_default_transports(self) -> None:
+        registry = default_registry()
+
+        def factory(env):
+            return lambda spec: _ATOM_FIXTURE
+
+        registered = register_safe_feed_providers(
+            registry, bytes_fetcher_factory=factory
+        )
+        self.assertEqual(
+            set(registered),
+            {
+                ProviderTransport.RSS,
+                ProviderTransport.ATOM,
+                ProviderTransport.GITHUB_RELEASES_ATOM,
+            },
+        )
+        # All three now resolve to AVAILABLE when their flag is set.
+        env = {
+            "YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true",
+            "YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true",
+            "YULE_KNOWLEDGE_GITHUB_RELEASES_ATOM_LIVE_ENABLED": "true",
+        }
+        for transport in registered:
+            with self.subTest(transport=transport):
+                self.assertEqual(
+                    registry.evaluate(transport, env=env),
+                    ProviderAvailability.AVAILABLE,
+                )
+        # And other transports stay unaffected.
+        self.assertEqual(
+            registry.evaluate(ProviderTransport.SITEMAP, env=env),
+            ProviderAvailability.NO_LIVE_IMPL,
+        )
+
+    def test_skips_transports_not_in_registry(self) -> None:
+        from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+            KnowledgeProviderRegistry,
+        )
+
+        empty = KnowledgeProviderRegistry()
+
+        def factory(env):
+            return lambda spec: b""
+
+        # Empty registry — nothing is registered, so the helper returns ().
+        # No KeyError leaks out.
+        self.assertEqual(
+            register_safe_feed_providers(empty, bytes_fetcher_factory=factory),
+            (),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_provider_availability_summary.py
+++ b/tests/engineering_intelligence/test_provider_availability_summary.py
@@ -1,0 +1,394 @@
+"""Provider availability summary + routing reason + status bundle."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    ProviderAvailabilityRow,
+    ProviderAvailabilitySummary,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_routing import (
+    RefreshPlanStatus,
+    RoutedRefreshCandidate,
+    refresh_plan_status,
+    route_refresh_plan,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+)
+from yule_orchestrator.agents.engineering_intelligence.scheduler import (
+    compute_refresh_plan,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# ProviderAvailabilitySummary
+# ---------------------------------------------------------------------------
+
+
+class AvailabilitySummaryTests(unittest.TestCase):
+    def test_summary_has_one_row_per_transport(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        transports = {row.transport for row in summary.rows}
+        for t in ProviderTransport:
+            self.assertIn(t.value, transports)
+
+    def test_default_env_is_no_live_impl_or_manual_only(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        for row in summary.rows:
+            self.assertIn(
+                row.availability,
+                {
+                    ProviderAvailability.NO_LIVE_IMPL.value,
+                    ProviderAvailability.MANUAL_ONLY.value,
+                },
+                f"unexpected availability for {row.transport}",
+            )
+
+    def test_missing_env_keys_listed_for_github_api(self) -> None:
+        registry = default_registry()
+        # Plug a live factory for github_api so availability is gated
+        # on the env triple rather than NO_LIVE_IMPL.
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        summary = registry.availability_summary(env={})
+        github = next(
+            row
+            for row in summary.rows
+            if row.transport
+            == ProviderTransport.GITHUB_API_REPO_ACTIVITY.value
+        )
+        self.assertEqual(
+            github.availability, ProviderAvailability.MISSING_ENV.value
+        )
+        self.assertIn("YULE_GITHUB_APP_ID", github.missing_env_keys)
+
+    def test_disabled_by_flag_when_keys_present_but_flag_off(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {
+            "YULE_GITHUB_APP_ID": "1",
+            "YULE_GITHUB_APP_INSTALLATION_ID": "2",
+            "YULE_GITHUB_APP_PRIVATE_KEY_PATH": "/tmp/k.pem",
+        }
+        summary = registry.availability_summary(env=env)
+        github = next(
+            row
+            for row in summary.rows
+            if row.transport
+            == ProviderTransport.GITHUB_API_REPO_ACTIVITY.value
+        )
+        self.assertEqual(
+            github.availability,
+            ProviderAvailability.DISABLED_BY_FLAG.value,
+        )
+        self.assertEqual(github.missing_env_keys, ())
+        self.assertFalse(github.enable_flag_set)
+
+    def test_available_when_env_and_flag_set(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.RSS,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        summary = registry.availability_summary(env=env)
+        rss = next(
+            row
+            for row in summary.rows
+            if row.transport == ProviderTransport.RSS.value
+        )
+        self.assertEqual(
+            rss.availability, ProviderAvailability.AVAILABLE.value
+        )
+        self.assertTrue(rss.enable_flag_set)
+        self.assertTrue(rss.has_live_impl)
+
+    def test_by_state_groups_rows_into_buckets(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        buckets = summary.by_state()
+        # MANUAL_ONLY must contain exactly one row (the manual transport).
+        manual_bucket = buckets.get(ProviderAvailability.MANUAL_ONLY.value, ())
+        self.assertEqual(
+            [row.transport for row in manual_bucket],
+            [ProviderTransport.MANUAL.value],
+        )
+        # All non-manual transports land under NO_LIVE_IMPL by default.
+        no_live_bucket = buckets.get(
+            ProviderAvailability.NO_LIVE_IMPL.value, ()
+        )
+        self.assertEqual(
+            len(no_live_bucket), len(ProviderTransport) - 1
+        )
+
+    def test_states_count_totals_match_row_count(self) -> None:
+        registry = default_registry()
+        summary = registry.availability_summary(env={})
+        counts = summary.states_count()
+        self.assertEqual(sum(counts.values()), len(summary.rows))
+
+    def test_needs_attention_excludes_no_live_impl_and_manual(self) -> None:
+        registry = default_registry()
+        # Plug live impl for github_api, leave env empty → MISSING_ENV
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        summary = registry.availability_summary(env={})
+        attention = summary.needs_attention()
+        # Only github_api appears (MISSING_ENV); RSS/ATOM/etc still
+        # NO_LIVE_IMPL and excluded.
+        self.assertEqual(
+            [row.transport for row in attention],
+            [ProviderTransport.GITHUB_API_REPO_ACTIVITY.value],
+        )
+
+    def test_payload_round_trip_has_states_count_and_needs_attention(
+        self,
+    ) -> None:
+        registry = default_registry()
+        payload = registry.availability_summary(env={}).to_payload()
+        self.assertIn("rows", payload)
+        self.assertIn("states_count", payload)
+        self.assertIn("needs_attention", payload)
+        self.assertEqual(
+            len(payload["rows"]), len(ProviderTransport)
+        )
+
+    def test_row_from_registration_carries_description_and_notes(self) -> None:
+        registry = default_registry()
+        rss = registry.get(ProviderTransport.RSS)
+        row = ProviderAvailabilityRow.from_registration(rss, env={})
+        self.assertEqual(row.provider_id, "rss-feed")
+        self.assertTrue(row.description)
+        self.assertIn("RSS", row.description.upper())
+
+
+# ---------------------------------------------------------------------------
+# Routing reasoning
+# ---------------------------------------------------------------------------
+
+
+class RoutingReasonTests(unittest.TestCase):
+    def test_every_routed_candidate_has_transport_and_availability_reasons(
+        self,
+    ) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, skipped = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        for cand in due + skipped:
+            self.assertTrue(
+                cand.transport_reason,
+                f"{cand.source.source_id} missing transport_reason",
+            )
+            self.assertTrue(
+                cand.availability_reason,
+                f"{cand.source.source_id} missing availability_reason",
+            )
+
+    def test_atom_url_heuristic_explained_in_transport_reason(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        # Spring blog is registered as RSS-mode but uses an .atom URL —
+        # the transport reason must call that out.
+        spring = next(
+            (c for c in due if c.source.source_id == "spring-blog"), None
+        )
+        self.assertIsNotNone(spring)
+        self.assertIn("atom", spring.transport_reason)
+
+    def test_no_live_impl_explained_in_availability_reason(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        rss_or_atom = next(
+            (
+                c
+                for c in due
+                if c.transport
+                in (ProviderTransport.RSS, ProviderTransport.ATOM)
+            ),
+            None,
+        )
+        self.assertIsNotNone(rss_or_atom)
+        self.assertIn("no live impl", rss_or_atom.availability_reason)
+        self.assertIn("transport=", rss_or_atom.routing_reason)
+        self.assertIn("availability=", rss_or_atom.routing_reason)
+
+    def test_missing_env_reason_lists_missing_keys(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        # tech-lead has the adr-github source (collection_mode=github_api,
+        # auto_collect=False, review_required=True) — include both gates
+        # so the planner surfaces it.
+        plan = compute_refresh_plan(
+            "tech-lead",
+            now=_now(),
+            states={},
+            tick_quota=99,
+            include_review_required=True,
+            include_auto_collect_disabled=True,
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="tech-lead", registry=registry, env={}
+        )
+        github = next(
+            (
+                c
+                for c in due
+                if c.transport
+                is ProviderTransport.GITHUB_API_REPO_ACTIVITY
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            github, "expected at least one github_api source on tech-lead"
+        )
+        self.assertIn(
+            "missing env keys", github.availability_reason
+        )
+        self.assertIn(
+            "YULE_GITHUB_APP_ID", github.availability_reason
+        )
+
+    def test_available_reason_mentions_flag_truthy(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        atom = next(
+            (c for c in due if c.transport is ProviderTransport.ATOM),
+            None,
+        )
+        self.assertIsNotNone(atom)
+        self.assertIn("live", atom.availability_reason)
+        self.assertIn(
+            "YULE_KNOWLEDGE_ATOM_LIVE_ENABLED", atom.availability_reason
+        )
+
+    def test_routing_reason_payload_round_trips(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        sample = due[0].to_payload()
+        self.assertIn("transport_reason", sample)
+        self.assertIn("availability_reason", sample)
+        self.assertIn("routing_reason", sample)
+
+
+# ---------------------------------------------------------------------------
+# RefreshPlanStatus bundle
+# ---------------------------------------------------------------------------
+
+
+class RefreshPlanStatusTests(unittest.TestCase):
+    def test_status_bundles_routed_candidates_with_summary(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan, role_id="backend-engineer", env={}
+        )
+        self.assertIsInstance(status, RefreshPlanStatus)
+        self.assertGreater(len(status.due), 0)
+        self.assertEqual(status.role, "backend-engineer")
+        self.assertIsInstance(
+            status.availability, ProviderAvailabilitySummary
+        )
+        # transports_due is sorted unique.
+        self.assertEqual(
+            list(status.transports_due),
+            sorted(set(status.transports_due)),
+        )
+
+    def test_status_payload_has_full_round_trip(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan, role_id="backend-engineer", env={}
+        )
+        payload = status.to_payload()
+        self.assertIn("transports_due", payload)
+        self.assertIn("availability", payload)
+        self.assertIn("rows", payload["availability"])
+        self.assertIn("states_count", payload["availability"])
+
+    def test_status_uses_passed_registry_when_provided(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.RSS,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        status = refresh_plan_status(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        rss_rows = [
+            row
+            for row in status.availability.rows
+            if row.transport == ProviderTransport.RSS.value
+        ]
+        self.assertEqual(len(rss_rows), 1)
+        self.assertEqual(
+            rss_rows[0].availability,
+            ProviderAvailability.AVAILABLE.value,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_provider_registry.py
+++ b/tests/engineering_intelligence/test_provider_registry.py
@@ -1,0 +1,350 @@
+"""Provider registry: auth contract, availability, fake fixture."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    EngineeringKnowledgeItem,
+    Importance,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    FakeKnowledgeProvider,
+    ProviderTransport,
+    StubLiveSourceFetcher,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    KnowledgeProviderRegistration,
+    KnowledgeProviderRegistry,
+    ProviderAuthRequirement,
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    find_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _knowledge_item(source_id: str) -> EngineeringKnowledgeItem:
+    return EngineeringKnowledgeItem(
+        item_id=f"{source_id}-1",
+        topic_key=f"{source_id}-topic",
+        title=f"item from {source_id}",
+        role="backend-engineer",
+        stack_tags=("test",),
+        source_name=source_id,
+        source_url=f"https://example.com/{source_id}",
+        source_kind=SourceKind.RELEASE_NOTES,
+        collected_at="2026-05-09T12:00:00Z",
+        importance=Importance.MEDIUM,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ProviderAuthRequirement
+# ---------------------------------------------------------------------------
+
+
+class AuthRequirementTests(unittest.TestCase):
+    def test_no_keys_no_flag_is_always_satisfied(self) -> None:
+        req = ProviderAuthRequirement()
+        self.assertTrue(req.env_keys_present({}))
+        self.assertTrue(req.enable_flag_set({}))
+
+    def test_blank_value_counts_as_missing(self) -> None:
+        req = ProviderAuthRequirement(env_keys=("FOO",))
+        self.assertFalse(req.env_keys_present({}))
+        self.assertFalse(req.env_keys_present({"FOO": ""}))
+        self.assertFalse(req.env_keys_present({"FOO": "   "}))
+        self.assertTrue(req.env_keys_present({"FOO": "x"}))
+
+    def test_enable_flag_recognises_truthy_strings(self) -> None:
+        req = ProviderAuthRequirement(enable_flag="GO")
+        self.assertFalse(req.enable_flag_set({}))
+        self.assertFalse(req.enable_flag_set({"GO": "false"}))
+        self.assertFalse(req.enable_flag_set({"GO": "0"}))
+        self.assertFalse(req.enable_flag_set({"GO": "no"}))
+        for truthy in ("1", "true", "True", "TRUE", "yes", "on"):
+            with self.subTest(value=truthy):
+                self.assertTrue(req.enable_flag_set({"GO": truthy}))
+
+
+# ---------------------------------------------------------------------------
+# Registration availability resolution
+# ---------------------------------------------------------------------------
+
+
+class AvailabilityResolutionTests(unittest.TestCase):
+    def test_manual_collapses_to_manual_only(self) -> None:
+        reg = KnowledgeProviderRegistration(
+            provider_id="manual",
+            transport=ProviderTransport.MANUAL,
+            auth=ProviderAuthRequirement(),
+            fake_fetcher=StubLiveSourceFetcher(),
+            manual=True,
+        )
+        # Even with a perfectly-set env, manual stays manual.
+        self.assertEqual(
+            reg.evaluate_availability({"YULE_GO": "true"}),
+            ProviderAvailability.MANUAL_ONLY,
+        )
+
+    def test_no_live_impl_short_circuits_before_env(self) -> None:
+        # Auth is fully satisfied; missing live factory still wins.
+        reg = KnowledgeProviderRegistration(
+            provider_id="rss-feed",
+            transport=ProviderTransport.RSS,
+            auth=ProviderAuthRequirement(
+                env_keys=("FOO",), enable_flag="GO"
+            ),
+            fake_fetcher=StubLiveSourceFetcher(),
+            live_factory=None,
+        )
+        env = {"FOO": "x", "GO": "true"}
+        self.assertEqual(
+            reg.evaluate_availability(env),
+            ProviderAvailability.NO_LIVE_IMPL,
+        )
+
+    def test_missing_env_before_disabled_flag(self) -> None:
+        # When both env and flag are off, the env reason is more
+        # actionable for the operator (you must fill the secret first
+        # before flipping the flag is even meaningful).
+        live_calls: list = []
+
+        def factory(env):
+            return lambda spec, *, source: live_calls.append(spec)
+
+        reg = KnowledgeProviderRegistration(
+            provider_id="github-api",
+            transport=ProviderTransport.GITHUB_API_REPO_ACTIVITY,
+            auth=ProviderAuthRequirement(
+                env_keys=("APP_ID",), enable_flag="GO"
+            ),
+            fake_fetcher=StubLiveSourceFetcher(),
+            live_factory=factory,
+        )
+        self.assertEqual(
+            reg.evaluate_availability({}),
+            ProviderAvailability.MISSING_ENV,
+        )
+        self.assertEqual(
+            reg.evaluate_availability({"APP_ID": "x"}),
+            ProviderAvailability.DISABLED_BY_FLAG,
+        )
+        self.assertEqual(
+            reg.evaluate_availability(
+                {"APP_ID": "x", "GO": "true"}
+            ),
+            ProviderAvailability.AVAILABLE,
+        )
+
+    def test_select_fetcher_respects_availability(self) -> None:
+        live_seen: list = []
+
+        def factory(env):
+            def fetch(spec, *, source):
+                live_seen.append((source.source_id, env.get("FLAG")))
+                return ()
+
+            return fetch
+
+        fake = StubLiveSourceFetcher()
+        reg = KnowledgeProviderRegistration(
+            provider_id="rss",
+            transport=ProviderTransport.RSS,
+            auth=ProviderAuthRequirement(enable_flag="FLAG"),
+            fake_fetcher=fake,
+            live_factory=factory,
+        )
+
+        # Disabled → fake.
+        f1 = reg.select_fetcher({})
+        self.assertIs(f1, fake)
+        # Enabled → live.
+        f2 = reg.select_fetcher({"FLAG": "true"})
+        self.assertIsNot(f2, fake)
+
+
+# ---------------------------------------------------------------------------
+# default_registry seed
+# ---------------------------------------------------------------------------
+
+
+class DefaultRegistrySeedTests(unittest.TestCase):
+    def test_every_transport_has_a_registration(self) -> None:
+        reg = default_registry()
+        registered = {r.transport for r in reg.iter_registrations()}
+        for transport in ProviderTransport:
+            self.assertIn(
+                transport, registered, f"missing registration: {transport}"
+            )
+
+    def test_default_registry_is_no_live_impl_everywhere(self) -> None:
+        reg = default_registry()
+        report = dict(reg.availability_report({}))
+        # Manual is manual_only by design; everything else is no_live_impl
+        # until the live PR plugs a factory in.
+        self.assertEqual(report[ProviderTransport.MANUAL.value], "manual_only")
+        for transport in ProviderTransport:
+            if transport is ProviderTransport.MANUAL:
+                continue
+            with self.subTest(transport=transport):
+                self.assertEqual(
+                    report[transport.value], "no_live_impl"
+                )
+
+    def test_github_api_requires_app_env_triple(self) -> None:
+        reg = default_registry()
+        github = reg.get(ProviderTransport.GITHUB_API_REPO_ACTIVITY)
+        self.assertIn("YULE_GITHUB_APP_ID", github.auth.env_keys)
+        self.assertIn(
+            "YULE_GITHUB_APP_INSTALLATION_ID", github.auth.env_keys
+        )
+        self.assertIn(
+            "YULE_GITHUB_APP_PRIVATE_KEY_PATH", github.auth.env_keys
+        )
+
+    def test_public_feeds_have_only_enable_flag_no_env_keys(self) -> None:
+        reg = default_registry()
+        for transport in (
+            ProviderTransport.RSS,
+            ProviderTransport.ATOM,
+            ProviderTransport.GITHUB_RELEASES_ATOM,
+            ProviderTransport.SITEMAP,
+            ProviderTransport.HTML_LIST,
+            ProviderTransport.HTML_DETAIL,
+        ):
+            with self.subTest(transport=transport):
+                row = reg.get(transport)
+                self.assertEqual(row.auth.env_keys, ())
+                self.assertTrue(row.auth.enable_flag)
+                self.assertTrue(
+                    row.auth.enable_flag.startswith("YULE_KNOWLEDGE_")
+                )
+
+    def test_manual_registration_has_no_enable_flag(self) -> None:
+        reg = default_registry()
+        manual = reg.get(ProviderTransport.MANUAL)
+        self.assertTrue(manual.manual)
+        self.assertIsNone(manual.auth.enable_flag)
+        self.assertFalse(manual.has_live_impl())
+
+    def test_register_live_attaches_factory(self) -> None:
+        reg = default_registry()
+
+        seen: list = []
+
+        def factory(env):
+            return lambda spec, *, source: (seen.append(spec.transport) or ())
+
+        reg.register_live(
+            ProviderTransport.RSS,
+            live_factory=factory,
+        )
+        # With env / flag set, RSS becomes available.
+        env = {"YULE_KNOWLEDGE_RSS_LIVE_ENABLED": "true"}
+        self.assertEqual(
+            reg.evaluate(ProviderTransport.RSS, env=env),
+            ProviderAvailability.AVAILABLE,
+        )
+        # Without the flag, falls back to fake.
+        self.assertEqual(
+            reg.evaluate(ProviderTransport.RSS, env={}),
+            ProviderAvailability.DISABLED_BY_FLAG,
+        )
+
+    def test_register_live_refuses_manual_transport(self) -> None:
+        reg = default_registry()
+        with self.assertRaises(ValueError):
+            reg.register_live(
+                ProviderTransport.MANUAL,
+                live_factory=lambda env: (lambda spec, *, source: ()),
+            )
+
+    def test_register_live_unknown_transport_raises_keyerror(self) -> None:
+        reg = KnowledgeProviderRegistry()  # empty registry
+        with self.assertRaises(KeyError):
+            reg.register_live(
+                ProviderTransport.RSS,
+                live_factory=lambda env: (lambda spec, *, source: ()),
+            )
+
+
+# ---------------------------------------------------------------------------
+# FakeKnowledgeProvider
+# ---------------------------------------------------------------------------
+
+
+class FakeKnowledgeProviderTests(unittest.TestCase):
+    def test_returns_fixture_items_keyed_on_source_id(self) -> None:
+        items = (_knowledge_item("foo"), _knowledge_item("foo"))
+        fake = FakeKnowledgeProvider({"foo": items})
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        # Source id "spring-blog" has no fixture → empty.
+        self.assertEqual(fake(provider_spec_for(spring), source=spring), ())
+        # Source whose source_id matches the fixture key → returns items.
+        # We synthesise one by editing source_id via a copy.
+        from dataclasses import replace as _replace
+        fake_source = _replace(spring, source_id="foo")
+        produced = fake(provider_spec_for(fake_source), source=fake_source)
+        self.assertEqual(produced, items)
+
+    def test_records_calls_with_transport(self) -> None:
+        fake = FakeKnowledgeProvider()
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        fake(provider_spec_for(spring), source=spring)
+        self.assertEqual(
+            fake.calls,
+            [("spring-blog", ProviderTransport.ATOM)],
+        )
+
+    def test_with_fixture_can_be_chained_after_construction(self) -> None:
+        fake = FakeKnowledgeProvider().with_fixture(
+            "x", (_knowledge_item("x"),)
+        )
+        self.assertEqual(len(fake._payload["x"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# select_fetcher_for + route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+class SelectFetcherForSourceTests(unittest.TestCase):
+    def test_returns_spec_fetcher_and_availability_in_one_call(self) -> None:
+        reg = default_registry()
+        spring = find_source("backend-engineer", "spring-blog")
+        assert spring is not None
+        spec, fetcher, availability = reg.select_fetcher_for(spring, env={})
+        self.assertEqual(spec.transport, ProviderTransport.ATOM)
+        self.assertEqual(availability, ProviderAvailability.NO_LIVE_IMPL)
+        # fetcher fall-back is the registry's fake.
+        self.assertIs(
+            fetcher, reg.get(ProviderTransport.ATOM).fake_fetcher
+        )
+
+    def test_routes_owasp_to_manual_only(self) -> None:
+        reg = default_registry()
+        owasp = find_source("backend-engineer", "owasp-top-10")
+        assert owasp is not None
+        _, _, availability = reg.select_fetcher_for(owasp, env={})
+        self.assertEqual(availability, ProviderAvailability.MANUAL_ONLY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering_intelligence/test_provider_routing.py
+++ b/tests/engineering_intelligence/test_provider_routing.py
@@ -1,0 +1,319 @@
+"""Refresh-plan → provider routing + axis priority + tick selection."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    SourceAxis,
+)
+from yule_orchestrator.agents.engineering_intelligence.providers import (
+    ProviderTransport,
+    provider_spec_for,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_registry import (
+    ProviderAvailability,
+    default_registry,
+)
+from yule_orchestrator.agents.engineering_intelligence.provider_routing import (
+    RoutedRefreshCandidate,
+    axis_priority_order,
+    route_refresh_plan,
+    select_routed_due,
+)
+from yule_orchestrator.agents.engineering_intelligence.scheduler import (
+    compute_refresh_plan,
+)
+from yule_orchestrator.agents.engineering_intelligence.source_registry import (
+    SUPPORTED_ROLES,
+    role_sources,
+)
+
+
+def _now() -> datetime:
+    # Pinned anchor — keeps "never_attempted" classification stable.
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# route_refresh_plan
+# ---------------------------------------------------------------------------
+
+
+class RouteRefreshPlanTests(unittest.TestCase):
+    def test_due_candidates_carry_transport_axes_and_availability(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=99,  # don't truncate — we want every source
+        )
+        due, skipped = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        self.assertGreater(len(due), 0)
+        for cand in due:
+            self.assertIsInstance(cand, RoutedRefreshCandidate)
+            self.assertEqual(cand.decision, "due")
+            self.assertTrue(cand.axes)
+            self.assertEqual(
+                cand.transport, provider_spec_for(cand.source).transport
+            )
+            # No live impl wired → fakes everywhere.
+            self.assertIn(
+                cand.availability,
+                {
+                    ProviderAvailability.NO_LIVE_IMPL,
+                    ProviderAvailability.MANUAL_ONLY,
+                },
+            )
+        # Skipped entries (auto_collect=False / review_required) annotated too.
+        skipped_ids = {c.source.source_id for c in skipped}
+        # OWASP Top 10 is auto_collect=False on backend → ends up in skipped.
+        self.assertIn("owasp-top-10", skipped_ids)
+
+    def test_skipped_candidate_carries_manual_only_availability(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=99,
+            include_auto_collect_disabled=True,
+            include_review_required=True,
+        )
+        # When both gates opted-in, OWASP appears in due and routing
+        # surfaces its MANUAL transport + MANUAL_ONLY availability so
+        # the runner knows there is no live call to make.
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        owasp = next(
+            (c for c in due if c.source.source_id == "owasp-top-10"),
+            None,
+        )
+        self.assertIsNotNone(owasp)
+        self.assertEqual(owasp.transport, ProviderTransport.MANUAL)
+        self.assertEqual(
+            owasp.availability, ProviderAvailability.MANUAL_ONLY
+        )
+
+    def test_routing_with_partial_live_factory_marks_available(self) -> None:
+        registry = default_registry()
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        atom_candidates = [
+            c for c in due if c.transport is ProviderTransport.ATOM
+        ]
+        self.assertTrue(atom_candidates, "expected at least one atom source")
+        for c in atom_candidates:
+            self.assertEqual(c.availability, ProviderAvailability.AVAILABLE)
+        # Non-atom sources still no_live_impl (env flag only enables atom).
+        non_atom = [
+            c for c in due if c.transport is not ProviderTransport.ATOM
+        ]
+        for c in non_atom:
+            self.assertNotEqual(c.availability, ProviderAvailability.AVAILABLE)
+
+    def test_payload_round_trip_contains_axes_and_auth_keys(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        sample = due[0].to_payload()
+        self.assertIn("transport", sample)
+        self.assertIn("provider_id", sample)
+        self.assertIn("availability", sample)
+        self.assertIn("axes", sample)
+        self.assertIn("auth", sample)
+        self.assertIn("env_keys", sample["auth"])
+        self.assertIn("enable_flag", sample["auth"])
+
+
+# ---------------------------------------------------------------------------
+# axis_priority_order
+# ---------------------------------------------------------------------------
+
+
+class AxisPriorityOrderTests(unittest.TestCase):
+    def test_overdue_axis_candidates_rank_first(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        ordered = axis_priority_order(
+            due, overdue_axes=(SourceAxis.SECURITY.value,)
+        )
+        # Every leading candidate (until the first non-security one) must
+        # carry SECURITY in its axes.
+        leading_security = []
+        for c in ordered:
+            if SourceAxis.SECURITY in c.axes:
+                leading_security.append(c)
+            else:
+                break
+        self.assertTrue(leading_security)
+        self.assertIn(SourceAxis.SECURITY, leading_security[0].axes)
+
+    def test_available_provider_beats_fake_within_same_axis_bucket(self) -> None:
+        registry = default_registry()
+        # Make ATOM live; RSS stays no-live-impl.
+        registry.register_live(
+            ProviderTransport.ATOM,
+            live_factory=lambda env: (lambda spec, *, source: ()),
+        )
+        env = {"YULE_KNOWLEDGE_ATOM_LIVE_ENABLED": "true"}
+
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan,
+            role_id="backend-engineer",
+            registry=registry,
+            env=env,
+        )
+        ordered = axis_priority_order(due, overdue_axes=())
+        # The leading candidates should include AVAILABLE atom sources.
+        leading_avail = {
+            ordered[i].availability for i in range(min(2, len(ordered)))
+        }
+        self.assertIn(ProviderAvailability.AVAILABLE, leading_avail)
+
+    def test_tier_breaks_ties_when_no_overdue_and_same_availability(self) -> None:
+        # All due candidates here have NO_LIVE_IMPL availability, so the
+        # tier_rank tie-breaker decides ordering. Tier 1 sources should
+        # precede Tier 2 / 3.
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        ordered = axis_priority_order(due, overdue_axes=())
+        # Within the same availability bucket the order must be tier-monotonic.
+        same_bucket = [
+            c for c in ordered
+            if c.availability == ProviderAvailability.NO_LIVE_IMPL
+        ]
+        tiers = [c.source.tier.value for c in same_bucket]
+        # tier_1 < tier_2 < tier_3 alphabetically (the enum values are
+        # "tier_1_official_docs", "tier_2_official_release", ...) so a
+        # non-decreasing sequence verifies Tier 1 wins ties.
+        self.assertEqual(sorted(tiers), tiers)
+
+    def test_deterministic_for_fixed_inputs(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        due, _ = route_refresh_plan(
+            plan, role_id="backend-engineer", env={}
+        )
+        a = axis_priority_order(due, overdue_axes=(SourceAxis.SECURITY.value,))
+        b = axis_priority_order(due, overdue_axes=(SourceAxis.SECURITY.value,))
+        self.assertEqual(
+            [c.source.source_id for c in a],
+            [c.source.source_id for c in b],
+        )
+
+
+# ---------------------------------------------------------------------------
+# select_routed_due — plan + route + axis priority + tick quota in one
+# ---------------------------------------------------------------------------
+
+
+class SelectRoutedDueTests(unittest.TestCase):
+    def test_quota_truncates_to_axis_priority_head(self) -> None:
+        # Disable planner cap (tick_quota=-1) so axis priority decides
+        # the head; then take just 1 candidate. Backend-engineer only
+        # carries one SECURITY-tagged auto-collectable source (the
+        # cve-nvd common-core feed), so quota=1 verifies the overdue
+        # axis bucket fills the slot.
+        plan = compute_refresh_plan(
+            "backend-engineer",
+            now=_now(),
+            states={},
+            tick_quota=-1,
+        )
+        selected, deferred = select_routed_due(
+            plan,
+            role_id="backend-engineer",
+            env={},
+            overdue_axes=(SourceAxis.SECURITY.value,),
+            tick_quota=1,
+        )
+        self.assertEqual(len(selected), 1)
+        self.assertIn(SourceAxis.SECURITY, selected[0].axes)
+        # The rest are deferred — none lost.
+        self.assertEqual(
+            len(selected) + len(deferred),
+            len(plan.due),
+        )
+
+    def test_no_quota_keeps_full_ordered_list(self) -> None:
+        plan = compute_refresh_plan(
+            "backend-engineer", now=_now(), states={}, tick_quota=99
+        )
+        selected, deferred = select_routed_due(
+            plan, role_id="backend-engineer", env={}, tick_quota=None
+        )
+        self.assertEqual(deferred, ())
+        self.assertEqual(len(selected), len(plan.due))
+
+
+# ---------------------------------------------------------------------------
+# Cross-role: every role's plan resolves to routed candidates without raising
+# ---------------------------------------------------------------------------
+
+
+class CrossRoleRoutingTests(unittest.TestCase):
+    def test_every_role_has_routable_candidates(self) -> None:
+        for role in SUPPORTED_ROLES:
+            with self.subTest(role=role):
+                plan = compute_refresh_plan(
+                    role,
+                    now=_now(),
+                    states={},
+                    tick_quota=99,
+                    include_review_required=True,
+                    include_auto_collect_disabled=True,
+                )
+                due, skipped = route_refresh_plan(
+                    plan, role_id=role, env={}
+                )
+                # Total candidates equal the role's full source list.
+                expected = len(role_sources(role))
+                self.assertEqual(len(due) + len(skipped), expected)
+                for cand in due + skipped:
+                    self.assertTrue(cand.spec.endpoint)
+                    self.assertTrue(cand.provider.provider_id)
+                    self.assertIn(
+                        cand.availability,
+                        set(ProviderAvailability),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- derived from #73
- stacked on #75

## ✨ 과제 내용
- knowledge provider registry / auth-env contract 추가
- fake provider와 future live provider 경계 명확화
- refresh-plan -> provider routing / axis priority 연결

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- role-based background ingestion의 live-ready provider 기반을 강화
- runtime/job_queue 쪽은 건드리지 않음