### PR TITLE
✨ #75 knowledge surface and share boundary

### DIFF
--- a/policies/runtime/agents/engineering-agent/research-collector.md
+++ b/policies/runtime/agents/engineering-agent/research-collector.md
@@ -229,7 +229,29 @@ scheduler 자체는 env를 읽지 않는다. 다만 **runtime 가 본 모듈을 
 - GitHub API spec의 `requires_auth_env=("YULE_GITHUB_APP_ID",)` 는 "App env 3종 중 하나라도 비어 있으면 fetch 시도 자체를 차단해야 한다" 는 신호다. fetcher impl 가 아직 land 하지 않았으므로, 본 PR scope 에서는 `StubLiveSourceFetcher` 만 제공한다.
 - request_headers_seed에는 token 헤더가 없다. fetcher impl 가 env를 읽어 별도로 합성해야 한다.
 
-### 13.3 후속 wiring (별도 PR)
+### 13.3 share_scope — 외부 surface 인용 boundary
+
+`engineering_intelligence.KnowledgeShareScope` 가 한 자료 항목이 어디까지 외부 surface(Discord digest, PR body, 합성 응답)에 인용 가능한지를 결정한다. 코드 진실 소스: `models.KnowledgeShareScope` + `obsidian.shareable_external_payload` + `discord_summary._format_line`.
+
+| share_scope | 외부 surface 노출 | Obsidian note 본문 | 사용 예 |
+| --- | --- | --- | --- |
+| `public` | 제목 + 요약 + source link 인용 가능 | 14 섹션 전부 렌더 | 공식 docs / release notes / 엔지니어링 블로그 |
+| `team_internal` | 제목 + source link 만 노출 (요약 차단) | 14 섹션 전부 렌더, 다만 외부 합성 응답에 본문은 사용 금지 | 사내 ADR / private repo 의 PR / 사내 advisory |
+| `restricted` | "🔒 공개 제한된 자료" 신호만 노출 | 학습 본문 섹션은 placeholder, 메타데이터 + share_scope_reason 만 보존 | 보안 incident / 고객 데이터가 섞인 자료 |
+
+규칙:
+
+- 기본값은 `public`. collector 가 명시하지 않으면 `public` 으로 처리한다.
+- `restricted` 자료는 반드시 `share_scope_reason` 을 채워야 한다 — quality gate 가 막는다 (`missing:share_scope_reason_for_restricted`).
+- `team_internal` 자료는 chat 합성 응답의 본문 인용에 사용하지 않는다. ContextPack `relevant_knowledge` 의 `summary` 가 `team_internal` 인 경우 evidence 블록은 자동으로 요약 라인을 생략한다.
+- `restricted` 자료는 ContextPack evidence 블록에서도 제목/링크가 모두 마스킹되고 `topic_key` + `share_scope_reason` 만 surface 에 남는다.
+
+운영자 관점:
+
+- vault 안에서는 share_scope 와 무관하게 본문(자료 형태에 따라 placeholder 가 박힌 채로) 이 다 보인다 — Obsidian 은 운영 채널이지 외부 surface 가 아니다.
+- 외부 surface 로 보낼 페이로드를 만들 때는 `obsidian.shareable_external_payload(item)` 결과만 사용한다. raw `EngineeringKnowledgeItem.to_payload()` 는 vault 전용.
+
+### 13.4 후속 wiring (별도 PR)
 
 1. `providers_live.py` — urllib 기반 fetcher 구현 (RSS / Atom / Sitemap / HTML_LIST / GitHub Releases / GitHub API).
 2. fetcher rate limiter — `LiveProviderSpec.rate_limit_per_minute` 를 token bucket으로 강제.

--- a/policies/runtime/agents/engineering-agent/research-profiles.md
+++ b/policies/runtime/agents/engineering-agent/research-profiles.md
@@ -159,3 +159,39 @@ discussion request-time retrieval은 위의 `_ROLE_RESEARCH_PROFILES` 가중치 
 | (그 외 / `unknown` / `None`) | (없음 — 기본 role 가중치만 사용) |
 
 이 표를 변경하면 해당 매트릭스를 코드(`_TASK_TYPE_AXIS_HINTS`)와 함께 업데이트해야 한다 — 두 위치가 따로 놀면 retrieval에서 생기는 미스매치를 디버그하기가 까다로워진다.
+
+## 부록 C — knowledge note share_scope 와 evidence surface
+
+`engineering_intelligence.KnowledgeShareScope` 는 한 knowledge note 가 외부 surface(Discord digest, PR body, 합성 응답)에 어디까지 인용될 수 있는지를 결정하는 boundary 플래그다. 본 부록은 retrieval surface 에 share_scope 가 어떻게 노출되는지를 정리한다 — 운영자 관점에서 "이 자료가 chat 응답에 그대로 인용되어도 되는가?" 를 빠르게 판단하기 위한 표.
+
+### C.1 share_scope 별 surface 동작
+
+| share_scope | retrieval surface (`relevant_knowledge` 블록) | Discord 일별 digest |
+| --- | --- | --- |
+| `public` | 제목 + 출처 링크 + 요약 1줄 + 점수/근거 표시 | 제목 + importance badge + source link |
+| `team_internal` | 제목 + 출처 링크 + 점수/근거 표시 (요약 자동 차단) + `🔒 team-internal` 라벨 | 제목 + source link + `🔒 team-internal` 라벨 |
+| `restricted` | `🔒 공개 제한된 자료` + `share_scope_reason` 만 노출 (제목/URL/요약 모두 마스킹) | `🔒 공개 제한된 자료 (topic_key)` 라벨만 |
+
+코드 진실 소스: `discussion.context_pack.format_knowledge_evidence_block` + `engineering_intelligence.discord_summary._format_line`.
+
+### C.2 retrieval evidence 라벨
+
+`KnowledgeMatch.evidence_labels()` 가 score signal 토큰을 사람이 읽을 수 있는 한국어 라벨로 변환한다. 합성 응답이나 Obsidian decision note 의 "근거 자료" 블록은 본 라벨을 그대로 사용한다.
+
+| signal token | 한국어 라벨 |
+| --- | --- |
+| `role_primary_match` | 요청 역할과 정확히 일치 |
+| `role_secondary_match` | 요청 역할이 보조 역할로 등록됨 |
+| `axis_overlap:<axes>` | task_type 축 일치 (`<axes>`) |
+| `topic_overlap:<n>` | 질문 토큰 겹침 (+`n`) |
+| `importance_critical` / `importance_high` | 중요도 critical / high |
+| `importance_low` | 중요도 low (감점) |
+| `fresh_7d` / `fresh_30d` | 최근 7일 / 30일 이내 수집 |
+| `empty_body_penalty` | 본문/태그 비어 있음 (감점) |
+
+새 signal 을 추가하면 `engineering_intelligence.retrieval._KNOWN_SIGNAL_LABELS` 에 한국어 라벨을 함께 넣을 것 — 비어 있으면 surface 가 raw token 을 그대로 노출한다.
+
+### C.3 운영 가드
+
+- ContextPack 빌더는 retriever 가 `with_signals` 를 노출하면 우선 사용해서 score + signals 를 surface 에 끌고 들어온다. 라이트한 fallback retriever 만 줘도 되지만 score/signal 트레이스가 없으면 evidence 블록은 점수/근거 없이 제목/요약만 보인다.
+- `share_scope=restricted` 자료가 `relevant_knowledge` 에 들어 있으면 합성 응답은 자동으로 본문을 마스킹한다. 운영자가 직접 본문을 합성 응답에 넣는 코드를 추가할 일이 생기면 `format_knowledge_evidence_block` 결과만 사용하거나 `obsidian.shareable_external_payload` 페이로드만 사용한다 — raw `EngineeringKnowledgeRef.summary` 를 직접 인용하지 않는다.

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -107,6 +107,16 @@ class EngineeringKnowledgeRef:
     동일하지만, 본 모듈은 engineering_intelligence 를 import 하지 않는다
     (서로 독립적으로 import-able 해야 한다는 운영 원칙). 합성 어댑터는
     ``ContextPackBuilder._coerce_knowledge_ref`` 가 담당.
+
+    ``share_scope`` / ``share_scope_reason`` 는 외부 surface (Discord,
+    합성 응답, PR 본문) 가 어디까지 인용해도 되는지를 결정하는 boundary
+    플래그다. 값이 없으면 ``"public"`` 으로 간주한다 — collector 가
+    명시하지 않은 자료는 운영자 합의로 PUBLIC default 로 처리한다.
+
+    ``score`` / ``signals`` / ``evidence_labels`` 은 retrieval 이 왜 이
+    자료를 골랐는지를 사람이 읽을 수 있는 형태로 surface 에 남기기
+    위한 슬롯이다. 합성 응답 / Obsidian decision note 가 "근거 자료"
+    블록을 만들 때 그대로 사용한다.
     """
 
     title: str
@@ -122,6 +132,9 @@ class EngineeringKnowledgeRef:
     note_path: Optional[str] = None
     score: Optional[float] = None
     signals: Sequence[str] = field(default_factory=tuple)
+    evidence_labels: Sequence[str] = field(default_factory=tuple)
+    share_scope: str = "public"
+    share_scope_reason: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +243,9 @@ class ContextPack:
                     "note_path": k.note_path,
                     "score": k.score,
                     "signals": list(k.signals),
+                    "evidence_labels": list(k.evidence_labels),
+                    "share_scope": k.share_scope,
+                    "share_scope_reason": k.share_scope_reason,
                 }
                 for k in self.relevant_knowledge
             ],
@@ -249,6 +265,40 @@ class ContextPack:
             "blockers": list(self.blockers),
             "extra": dict(self.extra),
         }
+
+    def format_knowledge_evidence_block(
+        self,
+        *,
+        max_items: int = 5,
+        heading: str = "근거 자료 (engineering_intelligence)",
+    ) -> str:
+        """``relevant_knowledge`` 를 마크다운 evidence 블록으로 렌더한다.
+
+        합성 응답 / Obsidian decision note / PR body footer 가 "이번
+        토의에서 어떤 사내 자료가 근거로 쓰였는가" 를 사람에게 보여주기
+        위한 구조화된 출력이다. 빈 리스트일 때는 빈 문자열을 반환해
+        호출자가 if-string-truthy 로 분기할 수 있다.
+
+        규칙:
+
+        - ``share_scope=public`` — 제목 + 출처 링크 + summary 한 줄.
+        - ``share_scope=team_internal`` — 제목 + 출처 링크 + 'team-
+          internal' 라벨, summary 는 의도적으로 생략. vault 외부에서는
+          본문 합성에 인용하지 않는다는 정책을 따른다.
+        - ``share_scope=restricted`` — 제목/링크/summary 모두 가리고
+          topic_key + share_scope_reason 만 노출. 외부에 자료가 있다는
+          신호만 남긴다.
+
+        retrieval 점수 / signal 은 ``evidence_labels`` 가 채워져 있으면
+        한국어 라벨로, 아니면 raw signal 문자열로 노출한다.
+        """
+
+        if not self.relevant_knowledge:
+            return ""
+        lines: list[str] = [f"### {heading}"]
+        for ref in list(self.relevant_knowledge)[: max(max_items, 0)]:
+            lines.extend(_format_knowledge_evidence_lines(ref))
+        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +609,34 @@ class ContextPackBuilder:
             picked = (same_role + other)[: self.max_knowledge]
             return tuple(picked)
 
+        # Prefer the retriever's ``with_signals`` form so we can carry
+        # the score + signals through to the surface. The plain
+        # ``__call__`` form just returns records and loses the "왜 이
+        # 자료가 골라졌는가" trace, which is exactly what this PR is
+        # trying to surface.
+        with_signals = getattr(self.knowledge_retriever, "with_signals", None)
+        if callable(with_signals):
+            try:
+                matches = with_signals(
+                    candidates=raw,
+                    query=query,
+                    role=role,
+                    task_type=task_type,
+                    limit=self.max_knowledge,
+                )
+            except Exception:  # noqa: BLE001
+                matches = ()
+            normalized: list[EngineeringKnowledgeRef] = []
+            for match in matches:
+                ref = self._coerce_knowledge_ref(match)
+                if ref is not None:
+                    normalized.append(ref)
+            if normalized:
+                return tuple(normalized[: self.max_knowledge])
+            # Fall through to the plain retriever — sometimes
+            # ``with_signals`` returns nothing while the plain call
+            # would, and we'd rather show *something* than nothing.
+
         try:
             picked = self.knowledge_retriever(
                 candidates=raw,
@@ -583,12 +661,49 @@ class ContextPackBuilder:
 
     @staticmethod
     def _coerce_knowledge_ref(value: Any) -> Optional[EngineeringKnowledgeRef]:
-        """Best-effort projection of vault row / KnowledgeRecord / dict."""
+        """Best-effort projection of vault row / KnowledgeRecord / dict.
+
+        Accepts:
+
+        - ``EngineeringKnowledgeRef`` — passthrough.
+        - ``KnowledgeMatch`` (duck-typed: has ``record`` / ``score`` /
+          ``signals`` attrs; bonus: ``evidence_labels()`` method) — the
+          score / signal trace is unpacked onto the resulting ref so
+          the synthesizer can show "왜 이 자료가 골라졌는가" without a
+          second lookup.
+        - ``KnowledgeRecord`` / ``EngineeringKnowledgeItem`` — flat
+          attribute walk.
+        - Plain mapping — the dict carries the same field names.
+        """
 
         if value is None:
             return None
         if isinstance(value, EngineeringKnowledgeRef):
             return value
+
+        # KnowledgeMatch duck-typing: unwrap into (record, score, signals).
+        score: Optional[float] = None
+        signals_seq: tuple[str, ...] = ()
+        evidence_labels_seq: tuple[str, ...] = ()
+        record_attr = getattr(value, "record", None)
+        if (
+            record_attr is not None
+            and not isinstance(value, Mapping)
+            and hasattr(value, "signals")
+        ):
+            try:
+                score = float(getattr(value, "score"))
+            except (TypeError, ValueError):
+                score = None
+            signals_seq = tuple(getattr(value, "signals", ()) or ())
+            label_method = getattr(value, "evidence_labels", None)
+            if callable(label_method):
+                try:
+                    evidence_labels_seq = tuple(label_method())
+                except Exception:  # noqa: BLE001
+                    evidence_labels_seq = ()
+            value = record_attr
+
         # KnowledgeRecord 와 EngineeringKnowledgeItem (engineering_intelligence
         # 패키지) 둘 다 있으면 직접 import 하지 않고 duck typing 으로 처리.
         title = getattr(value, "title", None)
@@ -602,6 +717,9 @@ class ContextPackBuilder:
                     axes_seq.append(str(axis_value))
             importance_attr = getattr(value, "importance", None)
             importance_value = getattr(importance_attr, "value", importance_attr)
+            share_attr = getattr(value, "share_scope", None)
+            share_value = getattr(share_attr, "value", share_attr)
+            share_scope = str(share_value) if share_value else "public"
             return EngineeringKnowledgeRef(
                 title=str(title),
                 role=str(role),
@@ -614,6 +732,13 @@ class ContextPackBuilder:
                 importance=str(importance_value) if importance_value else None,
                 collected_at=getattr(value, "collected_at", None) or None,
                 note_path=getattr(value, "note_path", None),
+                score=score if score is not None else getattr(value, "score", None),
+                signals=signals_seq,
+                evidence_labels=evidence_labels_seq,
+                share_scope=share_scope,
+                share_scope_reason=str(
+                    getattr(value, "share_scope_reason", "") or ""
+                ),
             )
         if isinstance(value, Mapping):
             title_v = str(value.get("title") or "").strip()
@@ -622,6 +747,9 @@ class ContextPackBuilder:
                 return None
             axes_raw = value.get("axes") or ()
             axes_seq = [str(a) for a in axes_raw if a]
+            mapping_signals = tuple(value.get("signals") or ()) or signals_seq
+            mapping_labels = tuple(value.get("evidence_labels") or ()) or evidence_labels_seq
+            mapping_score = value.get("score")
             return EngineeringKnowledgeRef(
                 title=title_v,
                 role=role_v,
@@ -634,8 +762,11 @@ class ContextPackBuilder:
                 importance=value.get("importance"),
                 collected_at=value.get("collected_at"),
                 note_path=value.get("note_path"),
-                score=value.get("score"),
-                signals=tuple(value.get("signals") or ()),
+                score=mapping_score if mapping_score is not None else score,
+                signals=mapping_signals,
+                evidence_labels=mapping_labels,
+                share_scope=str(value.get("share_scope") or "public"),
+                share_scope_reason=str(value.get("share_scope_reason") or ""),
             )
         return None
 
@@ -694,6 +825,50 @@ class ContextPackBuilder:
         if not bits:
             return None
         return ", ".join(bits)
+
+
+_RESTRICTED_LINE_FALLBACK = "🔒 공개 제한된 자료"
+
+
+def _format_knowledge_evidence_lines(ref: EngineeringKnowledgeRef) -> list[str]:
+    """Format one ``EngineeringKnowledgeRef`` as evidence bullet lines.
+
+    Splits into a heading bullet + an optional indented signal bullet
+    so the operator can scan title-first and only drop into "왜 이
+    자료가 골라졌는가" details when needed.
+    """
+
+    scope = (ref.share_scope or "public").lower()
+    lines: list[str] = []
+    if scope == "restricted":
+        marker = _RESTRICTED_LINE_FALLBACK
+        if ref.share_scope_reason:
+            marker = f"{marker} — {ref.share_scope_reason}"
+        else:
+            marker = f"{marker} (`{ref.topic_key}`)"
+        lines.append(f"- {marker}")
+    else:
+        title = ref.title or "(제목 없음)"
+        if ref.source_url:
+            head = f"- **{title}** — [{ref.source_name or '출처'}]({ref.source_url})"
+        else:
+            head = f"- **{title}**"
+        if scope == "team_internal":
+            head = f"{head} · 🔒 team-internal"
+        lines.append(head)
+        if scope == "public" and ref.summary:
+            lines.append(f"  - 요약: {ref.summary}")
+    detail_bits: list[str] = []
+    if ref.role:
+        detail_bits.append(f"role={ref.role}")
+    if ref.score is not None:
+        detail_bits.append(f"score={ref.score:.1f}")
+    labels = list(ref.evidence_labels) if ref.evidence_labels else list(ref.signals)
+    if labels:
+        detail_bits.append("근거: " + ", ".join(labels))
+    if detail_bits:
+        lines.append(f"  - {' · '.join(detail_bits)}")
+    return lines
 
 
 def _summarize_thread(messages: Sequence[ThreadMessage]) -> str:

--- a/src/yule_orchestrator/agents/discussion/context_pack.py
+++ b/src/yule_orchestrator/agents/discussion/context_pack.py
@@ -300,6 +300,69 @@ class ContextPack:
             lines.extend(_format_knowledge_evidence_lines(ref))
         return "\n".join(lines)
 
+    def share_boundary_breakdown(self) -> Mapping[str, int]:
+        """``relevant_knowledge`` 항목 수를 share_scope 별로 집계한다.
+
+        외부 surface (Discord 다이제스트 / 합성 응답 / PR body) 가
+        "이번 응답에 인용한 자료가 어떤 boundary 안에 있는지" 를
+        한 눈에 보여줄 때 쓴다. 키는 항상 4 종 (`public`,
+        `team_internal`, `restricted`, `total`) 이 모두 들어 있고
+        값은 정수다 — 호출자가 dict[k] 접근으로 바로 쓸 수 있다.
+        """
+
+        counts = {"public": 0, "team_internal": 0, "restricted": 0}
+        for ref in self.relevant_knowledge:
+            scope = (ref.share_scope or "public").lower()
+            if scope not in counts:
+                scope = "public"
+            counts[scope] += 1
+        counts["total"] = sum(counts.values())
+        return counts
+
+    def knowledge_short_summary(self, *, max_topics: int = 2) -> str:
+        """근거 자료를 한 줄로 요약한다 — 합성 응답 / 운영 dashboard 용.
+
+        - 총 건수 + share_scope 별 카운트 (0 인 scope 는 생략).
+        - 상위 ``max_topics`` 건의 제목 / topic_key — share_scope 정책을
+          그대로 따른다 (restricted 는 topic_key 만, team_internal/public
+          은 제목).
+        - relevant_knowledge 가 비어 있으면 빈 문자열.
+
+        예시 출력:
+        ``"근거 자료 3건 (public 2 · team_internal 1) — Spring Security 인증 흐름 외 1건"``
+        """
+
+        refs = list(self.relevant_knowledge)
+        if not refs:
+            return ""
+        breakdown = self.share_boundary_breakdown()
+        scope_bits: list[str] = []
+        for scope_key in ("public", "team_internal", "restricted"):
+            value = breakdown.get(scope_key, 0)
+            if value:
+                scope_bits.append(f"{scope_key} {value}")
+        scope_part = f" ({' · '.join(scope_bits)})" if scope_bits else ""
+        topic_labels: list[str] = []
+        for ref in refs[: max(max_topics, 0)]:
+            scope = (ref.share_scope or "public").lower()
+            if scope == "restricted":
+                topic_labels.append(f"🔒 `{ref.topic_key or 'restricted'}`")
+            else:
+                title = (ref.title or "(제목 없음)").strip()
+                if scope == "team_internal":
+                    topic_labels.append(f"{title} (🔒 team-internal)")
+                else:
+                    topic_labels.append(title)
+        topic_part = ""
+        if topic_labels:
+            extra = max(len(refs) - len(topic_labels), 0)
+            preview = ", ".join(topic_labels)
+            if extra:
+                topic_part = f" — {preview} 외 {extra}건"
+            else:
+                topic_part = f" — {preview}"
+        return f"근거 자료 {breakdown['total']}건{scope_part}{topic_part}"
+
 
 # ---------------------------------------------------------------------------
 # Builder — 외부 source는 callable seam으로 주입

--- a/src/yule_orchestrator/agents/discussion/synthesizer.py
+++ b/src/yule_orchestrator/agents/discussion/synthesizer.py
@@ -64,6 +64,16 @@ class DiscussionSynthesis:
     - ``role_perspectives``: 영역별 관점 (backend/frontend/...) — 설계
       논의 출력에 사용.
     - ``blockers``: pack의 blocker + synthesizer가 발견한 blocker.
+    - ``knowledge_evidence_block``: ``ContextPack.format_knowledge_evidence_block``
+      결과를 미리 만들어 둔 마크다운 블록. operator-facing surface 가
+      response_text 외에 따로 PR body / Obsidian decision note 등에
+      그대로 끼워 넣을 수 있도록 노출한다.
+    - ``knowledge_short_summary``: 한 줄 요약 ("근거 자료 N건 (public ...) — ...").
+      운영자가 본문 펼치기 전에 share_scope 분포 + 상위 자료를 한 눈에
+      보게 하는 용도. response_text 안에도 같은 한 줄이 포함된다.
+    - ``share_boundary``: ``ContextPack.share_boundary_breakdown()`` 결과
+      그대로. 외부 publisher (status poster / digest hook) 가 이 turn 의
+      자료 boundary 분포를 그대로 쓸 수 있도록 carries through.
     """
 
     mode: DiscussionMode
@@ -76,6 +86,9 @@ class DiscussionSynthesis:
     role_perspectives: Mapping[str, str] = field(default_factory=dict)
     blockers: Sequence[str] = field(default_factory=tuple)
     suggested_handoff_role: Optional[str] = None
+    knowledge_evidence_block: str = ""
+    knowledge_short_summary: str = ""
+    share_boundary: Mapping[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> Mapping[str, object]:
         return {
@@ -89,6 +102,9 @@ class DiscussionSynthesis:
             "role_perspectives": dict(self.role_perspectives),
             "blockers": list(self.blockers),
             "suggested_handoff_role": self.suggested_handoff_role,
+            "knowledge_evidence_block": self.knowledge_evidence_block,
+            "knowledge_short_summary": self.knowledge_short_summary,
+            "share_boundary": dict(self.share_boundary),
         }
 
 
@@ -167,6 +183,7 @@ def _synthesize_clarification(
             "정보가 충분해지면 다시 분류",
         ),
         blockers=tuple(pack.blockers),
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -179,15 +196,24 @@ def _synthesize_research(
     followups = _research_followups(pack)
     body_lines = [
         f"좋아요. \"{topic}\"는 코드 변경 전에 자료부터 모으는 단계로 받겠습니다.",
-        "",
-        "모을 자료 후보:",
     ]
+    short_summary = pack.knowledge_short_summary()
+    if short_summary:
+        body_lines.append(f"_이미 모인 자료: {short_summary}_")
+    body_lines.append("")
+    body_lines.append("모을 자료 후보:")
     if followups:
         body_lines.extend(f"- {item}" for item in followups)
     else:
         body_lines.append(
             "- 우선 사용자 메시지의 키워드로 1차 검색을 돌리고, 결과를 함께 보면서 좁혀 갈게요."
         )
+    evidence_block = pack.format_knowledge_evidence_block(
+        heading="이미 vault 에 있는 근거 자료"
+    )
+    if evidence_block:
+        body_lines.append("")
+        body_lines.append(evidence_block)
     body_lines.append("")
     body_lines.append(
         "정리한 결과는 운영-리서치 thread와 Obsidian에 남기고, 그때 구현 여부를 다시 결정하시면 됩니다."
@@ -209,6 +235,9 @@ def _synthesize_research(
         research_followups=tuple(followups),
         blockers=tuple(pack_blockers),
         suggested_handoff_role=None,
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -221,11 +250,16 @@ def _synthesize_discussion(
     next_actions = _discussion_next_actions(pack)
     research_followups = _research_followups(pack)
 
+    short_summary = pack.knowledge_short_summary()
+    evidence_block = pack.format_knowledge_evidence_block()
+
     body_lines = [
         f"좋아요. \"{topic}\"는 토의로 받아 다음 단계를 함께 정해 보겠습니다.",
     ]
     rationale_short = _truncate(classification.rationale, 140)
     body_lines.append(f"_분류 근거: {rationale_short}_")
+    if short_summary:
+        body_lines.append(f"_{short_summary}_")
     body_lines.append("")
 
     if perspectives:
@@ -254,6 +288,10 @@ def _synthesize_discussion(
             )
         body_lines.append("")
 
+    if evidence_block:
+        body_lines.append(evidence_block)
+        body_lines.append("")
+
     body_lines.append("다음에 할 수 있는 선택:")
     for action in next_actions:
         body_lines.append(f"- {action}")
@@ -266,6 +304,9 @@ def _synthesize_discussion(
         research_followups=tuple(research_followups),
         role_perspectives=dict(perspectives),
         blockers=tuple(pack.blockers),
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 
@@ -274,15 +315,25 @@ def _synthesize_implementation(
     classification: DiscussionModeMatch,
 ) -> DiscussionSynthesis:
     topic = _short_topic(pack.current_message)
+    short_summary = pack.knowledge_short_summary()
+    evidence_block = pack.format_knowledge_evidence_block(
+        heading="이번 결정 근거 자료"
+    )
     body_lines = [
         f"\"{topic}\"는 구현 후보로 보입니다. 곧바로 코드를 만지지는 않고, "
         "권한 제안을 먼저 만들어 보여 드릴게요.",
-        "",
-        "다음 단계:",
-        "- tech-lead가 어느 역할(executor)이 맞을지 추천",
-        "- 사용자가 `수정 승인` 또는 `이대로 구현 진행`이라 답하면 코딩 작업으로 넘김",
-        "- 그 전까지는 어떤 파일도 수정하지 않습니다",
     ]
+    if short_summary:
+        body_lines.append(f"_결정 근거 요약: {short_summary}_")
+    body_lines.extend(
+        [
+            "",
+            "다음 단계:",
+            "- tech-lead가 어느 역할(executor)이 맞을지 추천",
+            "- 사용자가 `수정 승인` 또는 `이대로 구현 진행`이라 답하면 코딩 작업으로 넘김",
+            "- 그 전까지는 어떤 파일도 수정하지 않습니다",
+        ]
+    )
     if pack.write_blocked_reason:
         body_lines.append("")
         body_lines.append(f"_쓰기 차단 사유: {pack.write_blocked_reason}_")
@@ -291,6 +342,9 @@ def _synthesize_implementation(
     if suggested_role:
         body_lines.append("")
         body_lines.append(f"_초기 추천 executor: `{suggested_role}` (권한 제안 단계에서 재계산)_")
+    if evidence_block:
+        body_lines.append("")
+        body_lines.append(evidence_block)
     return DiscussionSynthesis(
         mode=DiscussionMode.IMPLEMENTATION_CANDIDATE,
         rationale=classification.rationale,
@@ -303,6 +357,9 @@ def _synthesize_implementation(
         implementation_ready=True,
         blockers=tuple(blockers),
         suggested_handoff_role=suggested_role,
+        knowledge_evidence_block=evidence_block,
+        knowledge_short_summary=short_summary,
+        share_boundary=dict(pack.share_boundary_breakdown()),
     )
 
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -54,6 +54,7 @@ from .retrieval import (
     KnowledgeMatch,
     KnowledgeRecord,
     KnowledgeRetriever,
+    label_for_signal,
     score_knowledge_record,
 )
 from .scheduler import (
@@ -87,6 +88,7 @@ from .models import (
     ENGINEERING_KNOWLEDGE_CONTRACT,
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     KnowledgeStatus,
     LearningLevel,
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
@@ -103,6 +105,8 @@ from .obsidian import (
     build_engineering_knowledge_write_request,
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
+    shareable_external_payload,
+    vault_only_metadata,
 )
 from .renderer import (
     RendererError,
@@ -145,6 +149,7 @@ __all__ = [
     "KnowledgeMatch",
     "KnowledgeRecord",
     "KnowledgeRetriever",
+    "label_for_signal",
     "score_knowledge_record",
     # scheduler
     "RefreshPlan",
@@ -173,6 +178,7 @@ __all__ = [
     "ENGINEERING_KNOWLEDGE_CONTRACT",
     "EngineeringKnowledgeItem",
     "Importance",
+    "KnowledgeShareScope",
     "KnowledgeStatus",
     "LearningLevel",
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",
@@ -188,6 +194,8 @@ __all__ = [
     "build_engineering_knowledge_write_request",
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
+    "shareable_external_payload",
+    "vault_only_metadata",
     # renderer
     "RendererError",
     "render_engineering_knowledge_note",

--- a/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/__init__.py
@@ -106,6 +106,7 @@ from .obsidian import (
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
     shareable_external_payload,
+    summarize_share_boundary,
     vault_only_metadata,
 )
 from .renderer import (
@@ -195,6 +196,7 @@ __all__ = [
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
     "shareable_external_payload",
+    "summarize_share_boundary",
     "vault_only_metadata",
     # renderer
     "RendererError",

--- a/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
@@ -6,6 +6,10 @@ Produces a short markdown block per role. Rules:
   * Each line carries title / importance / source name + URL.
   * Body refers the reader to the full Obsidian document — Discord
     is *not* where the long-form knowledge note lives.
+  * Each digest carries a share-boundary footer when any
+    `team_internal` or `restricted` items appear so the operator can
+    see "이 채널에 떠 있는 자료 5건 중 1건은 vault 안에서만 본다" 를
+    스크롤 없이 파악할 수 있다.
   * No actual Discord posting happens here. The post-side wiring
     (gateway / status-poster) is left for follow-up so the surface
     stays test-friendly and offline.
@@ -13,7 +17,7 @@ Produces a short markdown block per role. Rules:
 
 from __future__ import annotations
 
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Mapping, Sequence
 
 from .models import EngineeringKnowledgeItem, Importance, KnowledgeShareScope
 
@@ -62,6 +66,56 @@ def _format_line(index: int, item: EngineeringKnowledgeItem) -> str:
     )
 
 
+def share_boundary_breakdown(
+    items: Sequence[EngineeringKnowledgeItem],
+) -> Mapping[str, int]:
+    """Count digest items per ``share_scope``.
+
+    Returns a dict that always carries 4 keys (`public`,
+    `team_internal`, `restricted`, `total`) so callers can dispatch
+    on the value without a missing-key check. Sums to ``len(items)``
+    even when the digest's own daily-limit truncation would hide
+    items downstream — the caller controls truncation, this helper
+    just classifies what it received.
+    """
+
+    counts = {"public": 0, "team_internal": 0, "restricted": 0}
+    for item in items:
+        scope = item.share_scope
+        key = scope.value if isinstance(scope, KnowledgeShareScope) else str(scope or "public").lower()
+        if key not in counts:
+            key = "public"
+        counts[key] += 1
+    counts["total"] = sum(counts.values())
+    return counts
+
+
+def _share_boundary_footer(breakdown: Mapping[str, int]) -> str:
+    """One-line footer summarising the digest's share-boundary mix.
+
+    Empty when everything is `public` (no operator action needed).
+    Otherwise lists the non-public counts so the operator knows the
+    digest contains material that should not be copy-pasted out of
+    Discord verbatim.
+    """
+
+    bits: List[str] = []
+    for key, label in (
+        ("team_internal", "🔒 team-internal"),
+        ("restricted", "🔒 공개 제한"),
+    ):
+        value = breakdown.get(key, 0)
+        if value:
+            bits.append(f"{label} {value}건")
+    if not bits:
+        return ""
+    public_count = breakdown.get("public", 0)
+    return (
+        f"_share boundary — public {public_count}건 · {' · '.join(bits)}. "
+        "외부 채널 복사 시 vault link 로만 참조하세요._"
+    )
+
+
 def render_daily_role_summary(
     role_id: str,
     items: Sequence[EngineeringKnowledgeItem],
@@ -91,6 +145,10 @@ def render_daily_role_summary(
     lines.append(
         "_상세 문서와 실습 가이드는 Obsidian `engineering-knowledge` 노트를 참고하세요._"
     )
+    if visible:
+        footer = _share_boundary_footer(share_boundary_breakdown(visible))
+        if footer:
+            lines.append(footer)
     if extra_note:
         lines.append("")
         lines.append(extra_note)
@@ -117,4 +175,5 @@ def render_multi_role_summary(
 __all__ = [
     "render_daily_role_summary",
     "render_multi_role_summary",
+    "share_boundary_breakdown",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/discord_summary.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Iterable, List, Sequence
 
-from .models import EngineeringKnowledgeItem, Importance
+from .models import EngineeringKnowledgeItem, Importance, KnowledgeShareScope
 
 
 _IMPORTANCE_BADGES = {
@@ -29,11 +29,36 @@ _IMPORTANCE_BADGES = {
 _MAX_PER_ROLE = 5
 
 
+_SHARE_SCOPE_TAGS = {
+    KnowledgeShareScope.PUBLIC: "",
+    KnowledgeShareScope.TEAM_INTERNAL: " · 🔒 team-internal",
+    KnowledgeShareScope.RESTRICTED: " · 🔒 공개 제한",
+}
+
+
 def _format_line(index: int, item: EngineeringKnowledgeItem) -> str:
+    """Format a single digest line, honouring ``share_scope``.
+
+    - ``PUBLIC``: title + badge + source link, identical to the v0
+      output so existing assertions continue to pass.
+    - ``TEAM_INTERNAL``: same surface, plus a ``team-internal`` tag so
+      downstream readers know the body is Obsidian-only.
+    - ``RESTRICTED``: title and source replaced by an opaque
+      ``topic_key`` reference + the share-scope tag — no title, no
+      source URL, no body. The Obsidian footer line still tells the
+      reader where to look up the full record.
+    """
+
     badge = _IMPORTANCE_BADGES.get(item.importance, item.importance.value)
+    scope_tag = _SHARE_SCOPE_TAGS.get(item.share_scope, "")
+    if item.share_scope == KnowledgeShareScope.RESTRICTED:
+        return (
+            f"{index}. **🔒 공개 제한된 자료** "
+            f"(`{item.topic_key}`) — {badge}{scope_tag}"
+        )
     return (
         f"{index}. **{item.title}** — {badge} · "
-        f"[{item.source_name}]({item.source_url})"
+        f"[{item.source_name}]({item.source_url}){scope_tag}"
     )
 
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/models.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/models.py
@@ -81,6 +81,31 @@ class KnowledgeStatus(str, Enum):
     DEPRECATED = "deprecated"
 
 
+class KnowledgeShareScope(str, Enum):
+    """공유 가능 범위 — note/report 출력에 박혀 외부 노출 경계가 된다.
+
+    - ``PUBLIC``: 공식 문서·릴리스 노트·블로그처럼 외부 surface(Discord
+      digest, PR 본문, 합성 응답)에 본문 요약과 함께 그대로 인용해도
+      되는 자료. note 의 모든 섹션이 그대로 렌더된다.
+    - ``TEAM_INTERNAL``: 사내 repo/ADR/private security advisory 처럼
+      Obsidian vault 안에서는 전체 내용을 보지만 외부 surface 로는 제목
+      + 출처 링크 + share_scope 만 노출한다. 본문 요약은 chat 응답에
+      포함하지 말 것.
+    - ``RESTRICTED``: 보안 incident report, customer data 가 섞인 자료
+      처럼 본문은 vault 에도 압축 저장(요약 1~2줄)하고 외부에서는 "공개
+      제한된 자료" 라는 신호만 남긴다. 렌더된 note 의 본문은 link +
+      share_scope_reason 만 남고, common_mistakes / practice 같은 학습
+      섹션도 "내부 채널에서만 공유" 라는 한 줄로 대체된다.
+
+    기본값은 :data:`KnowledgeShareScope.PUBLIC`. 호출자(collector /
+    operator) 가 명시적으로 더 좁힐 수 있다.
+    """
+
+    PUBLIC = "public"
+    TEAM_INTERNAL = "team_internal"
+    RESTRICTED = "restricted"
+
+
 # Tier 1 = official spec/docs; Tier 4 = community. Auto collection
 # defaults to Tier 1~2; Tier 3~4 requires review_required=True or low
 # trust_weight.
@@ -351,6 +376,11 @@ class EngineeringKnowledgeItem:
     review_after_days: int = 90
     staleness_reason: str = ""
 
+    # Share boundary — note/report 출력 시 외부 surface(Discord digest,
+    # PR body, 합성 응답)에 어디까지 인용해도 되는지를 결정한다.
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC
+    share_scope_reason: str = ""
+
     # Project applicability
     project_applicability: Optional[ProjectApplicability] = None
 
@@ -415,6 +445,8 @@ class EngineeringKnowledgeItem:
             "knowledge_status": self.knowledge_status.value,
             "review_after_days": self.review_after_days,
             "staleness_reason": self.staleness_reason,
+            "share_scope": self.share_scope.value,
+            "share_scope_reason": self.share_scope_reason,
             "project_applicability": (
                 self.project_applicability.to_payload()
                 if self.project_applicability is not None
@@ -437,6 +469,7 @@ __all__ = [
     "ENGINEERING_KNOWLEDGE_CONTRACT",
     "EngineeringKnowledgeItem",
     "Importance",
+    "KnowledgeShareScope",
     "KnowledgeStatus",
     "LearningLevel",
     "NOTE_KIND_ENGINEERING_KNOWLEDGE",

--- a/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
@@ -31,6 +31,7 @@ from typing import Any, List, Mapping, Optional, Tuple
 from .models import (
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
     EngineeringKnowledgeItem,
+    KnowledgeShareScope,
 )
 from .renderer import RendererError, render_engineering_knowledge_note
 
@@ -97,8 +98,106 @@ def evaluate_quality_gate(item: EngineeringKnowledgeItem) -> QualityGateResult:
         reasons.append("missing:practice_verification.expected_result")
     if item.review_after_days is None or int(item.review_after_days) <= 0:
         reasons.append("missing:review_after_days")
+    # Share boundary: scope is mandatory (default PUBLIC at the model
+    # layer is acceptable, but it must be a member of the enum). When
+    # an operator scopes an item down to RESTRICTED they must also
+    # explain why, so the operator-facing audit can pin the call.
+    if not isinstance(item.share_scope, KnowledgeShareScope):
+        reasons.append("missing:share_scope")
+    elif (
+        item.share_scope == KnowledgeShareScope.RESTRICTED
+        and not item.share_scope_reason.strip()
+    ):
+        reasons.append("missing:share_scope_reason_for_restricted")
 
     return QualityGateResult(passed=not reasons, reasons=tuple(reasons))
+
+
+# ---------------------------------------------------------------------------
+# Share boundary helpers
+# ---------------------------------------------------------------------------
+
+
+def shareable_external_payload(
+    item: EngineeringKnowledgeItem,
+) -> Mapping[str, Any]:
+    """Return the dict of fields safe to ship to an external surface.
+
+    External surfaces here = Discord digest, PR body, gateway response
+    text — anything that leaves the Obsidian vault. The payload is
+    intentionally minimal:
+
+    - ``PUBLIC``: title + summary + source name/url + topic_key +
+      share_scope (so consumers can label the citation).
+    - ``TEAM_INTERNAL``: title + source name/url + topic_key only —
+      summary deliberately omitted so a downstream copy-paste loop
+      can't accidentally leak the synthesised body to a public channel.
+    - ``RESTRICTED``: only the topic_key + share_scope marker. No
+      title, no source, no summary. Lets external surfaces show
+      "🔒 공개 제한된 자료 1건" without disclosing what topic.
+
+    The mapping is always a fresh dict (caller can mutate without
+    affecting the item). Missing optional fields stay absent rather
+    than carrying empty strings, so consumers can ``if "summary" in
+    payload`` rather than ``if payload["summary"]``.
+    """
+
+    scope = item.share_scope
+    base: dict[str, Any] = {
+        "topic_key": item.topic_key,
+        "share_scope": scope.value,
+    }
+    if scope == KnowledgeShareScope.PUBLIC:
+        base.update(
+            {
+                "title": item.title,
+                "summary": item.summary,
+                "source_name": item.source_name,
+                "source_url": item.source_url,
+            }
+        )
+    elif scope == KnowledgeShareScope.TEAM_INTERNAL:
+        base.update(
+            {
+                "title": item.title,
+                "source_name": item.source_name,
+                "source_url": item.source_url,
+                "internal_only": True,
+            }
+        )
+    else:  # RESTRICTED
+        base["restricted_marker"] = "🔒 공개 제한된 자료"
+        if item.share_scope_reason:
+            base["share_scope_reason"] = item.share_scope_reason
+    return base
+
+
+def vault_only_metadata(
+    item: EngineeringKnowledgeItem,
+) -> Mapping[str, Any]:
+    """Return the dict of fields that should stay inside Obsidian.
+
+    These are the body sections — practice steps, common mistakes,
+    learning extras, project applicability — plus the share_scope so
+    a vault tool can audit "this is internal even though it landed".
+    Used by callers that want to deposit *only* the vault-private
+    chunk into long-term storage without re-exporting body text.
+    """
+
+    return {
+        "share_scope": item.share_scope.value,
+        "share_scope_reason": item.share_scope_reason,
+        "summary": item.summary,
+        "why_it_matters": item.why_it_matters,
+        "what_changed": item.what_changed,
+        "practical_impact": item.practical_impact,
+        "recommended_action": item.recommended_action,
+        "practice_topic": item.practice_topic,
+        "practice_steps": list(item.practice_steps),
+        "practice_checklist": list(item.practice_checklist),
+        "common_mistakes": list(item.common_mistakes),
+        "expected_output": item.expected_output,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -153,8 +252,11 @@ def build_engineering_knowledge_write_request(
             "dedup_key": item.dedup_key,
             "importance": item.importance.value,
             "audience": item.audience.value,
+            "share_scope": item.share_scope.value,
+            "share_scope_reason": item.share_scope_reason,
         },
         "engineering_knowledge_item": dict(item.to_payload()),
+        "shareable_external_payload": dict(shareable_external_payload(item)),
     }
 
     return ObsidianWriteRequest(
@@ -197,4 +299,6 @@ __all__ = [
     "build_engineering_knowledge_write_request",
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
+    "shareable_external_payload",
+    "vault_only_metadata",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
@@ -26,7 +26,7 @@ here (note_kind ``engineering-knowledge`` is not in
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 from .models import (
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
@@ -172,6 +172,51 @@ def shareable_external_payload(
     return base
 
 
+def summarize_share_boundary(
+    items: Sequence[EngineeringKnowledgeItem],
+) -> Mapping[str, Any]:
+    """Operator-facing one-line summary of a digest's share-boundary mix.
+
+    Returns ``{"counts": {public, team_internal, restricted, total},
+    "summary": str}``. The ``summary`` is the same one-line shape used
+    by the Discord digest footer and the discussion synthesizer's
+    ``knowledge_short_summary`` so an operator dashboard / status
+    poster can stamp the same sentence regardless of surface.
+
+    Empty input returns a stable empty payload so the caller can
+    branch on ``payload["counts"]["total"] == 0``.
+    """
+
+    counts = {"public": 0, "team_internal": 0, "restricted": 0}
+    for item in items:
+        scope = item.share_scope
+        key = (
+            scope.value
+            if isinstance(scope, KnowledgeShareScope)
+            else str(scope or "public").lower()
+        )
+        if key not in counts:
+            key = "public"
+        counts[key] += 1
+    counts["total"] = sum(counts.values())
+    if counts["total"] == 0:
+        return {"counts": counts, "summary": ""}
+    bits: list[str] = []
+    for key in ("public", "team_internal", "restricted"):
+        if counts[key]:
+            bits.append(f"{key} {counts[key]}건")
+    summary = (
+        f"근거 자료 {counts['total']}건 ({' · '.join(bits)})."
+        if bits
+        else f"근거 자료 {counts['total']}건."
+    )
+    if counts["restricted"]:
+        summary += " 🔒 공개 제한 자료가 포함돼 있어 외부 채널 인용 금지."
+    elif counts["team_internal"]:
+        summary += " 🔒 team-internal 항목은 vault link 로만 참조."
+    return {"counts": counts, "summary": summary}
+
+
 def vault_only_metadata(
     item: EngineeringKnowledgeItem,
 ) -> Mapping[str, Any]:
@@ -300,5 +345,6 @@ __all__ = [
     "build_rejected_quality_gate_audit",
     "evaluate_quality_gate",
     "shareable_external_payload",
+    "summarize_share_boundary",
     "vault_only_metadata",
 ]

--- a/src/yule_orchestrator/agents/engineering_intelligence/renderer.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/renderer.py
@@ -35,6 +35,7 @@ from typing import List, Optional, Sequence
 from .models import (
     ENGINEERING_KNOWLEDGE_CONTRACT,
     EngineeringKnowledgeItem,
+    KnowledgeShareScope,
 )
 
 
@@ -104,7 +105,14 @@ def _yaml_list(values: Sequence[str]) -> str:
 
 
 def render_frontmatter(item: EngineeringKnowledgeItem) -> str:
-    """Build the YAML frontmatter block (no leading/trailing markers)."""
+    """Build the YAML frontmatter block (no leading/trailing markers).
+
+    ``share_scope`` is stamped into the frontmatter so vault tooling
+    (memory indexer, archive sync, Discord digest) can decide whether
+    an item's body is safe to ship outside the vault. The body
+    renderer separately blanks restricted sections — frontmatter alone
+    is the discovery hint, never the enforcement.
+    """
 
     lines: List[str] = [
         f"title: {_quote(item.title)}",
@@ -122,6 +130,8 @@ def render_frontmatter(item: EngineeringKnowledgeItem) -> str:
         f"retrieval_queries: {_yaml_list(item.retrieval_queries)}",
         f"collected_at: {_quote(item.collected_at)}",
         f"review_after_days: {int(item.review_after_days)}",
+        f"share_scope: {_quote(item.share_scope.value)}",
+        f"share_scope_reason: {_quote(item.share_scope_reason)}",
         f"project: {_quote('yule-studio-agent')}",
         f"contract: {ENGINEERING_KNOWLEDGE_CONTRACT}",
         f"dedup_key: {_quote(item.dedup_key)}",
@@ -147,7 +157,31 @@ _REQUIRED_SECTIONS: tuple[str, ...] = (
     "10. 완료 기준",
     "11. 자주 하는 실수",
     "12. RAG/CAG 메타데이터",
-    "13. 참고 자료",
+    "13. 공유 가능 범위",
+    "14. 참고 자료",
+)
+
+
+# Sections we redact (replace body with a one-line placeholder) when
+# ``share_scope == RESTRICTED``. The L1 vault note still exists so the
+# operator can find it, but external surface payloads that copy any of
+# these sections by index won't accidentally leak content.
+_RESTRICTED_REDACTED_SECTION_INDEXES: tuple[int, ...] = (
+    1,   # 핵심 요약
+    2,   # 배경
+    3,   # 무엇이 바뀌었나
+    4,   # 왜 중요한가
+    5,   # 실무 영향
+    6,   # 권장 대응
+    7,   # 실습 주제
+    8,   # 실습 과정
+    9,   # 완료 기준
+    10,  # 자주 하는 실수
+)
+
+
+_RESTRICTED_PLACEHOLDER = (
+    "_공개 제한된 자료입니다 — 본문은 vault 내부 채널에서만 공유하세요._"
 )
 
 
@@ -341,8 +375,58 @@ def _render_rag_cag(item: EngineeringKnowledgeItem) -> str:
     return "\n".join(parts)
 
 
-def _render_references(item: EngineeringKnowledgeItem) -> str:
+_SHARE_SCOPE_LABELS: dict[KnowledgeShareScope, str] = {
+    KnowledgeShareScope.PUBLIC: (
+        "공개 가능 — 외부 surface(Discord 다이제스트, PR 본문, 합성 응답)에 "
+        "본문 요약과 함께 인용해도 된다"
+    ),
+    KnowledgeShareScope.TEAM_INTERNAL: (
+        "팀 내부 한정 — Obsidian vault 내에서만 본문 열람. 외부 채널에는 "
+        "제목 + 출처 링크 + share_scope 표시까지만 노출"
+    ),
+    KnowledgeShareScope.RESTRICTED: (
+        "공개 제한 — 본문 전체를 외부 surface 로 옮기지 않는다. "
+        "vault 안에서도 요약 1~2줄과 share_scope_reason 만 보존"
+    ),
+}
+
+
+_SHARE_SCOPE_EXTERNAL_RULES: dict[KnowledgeShareScope, tuple[str, ...]] = {
+    KnowledgeShareScope.PUBLIC: (
+        "Discord digest / 합성 응답에 제목·요약·source_url 인용 가능",
+        "PR 본문에 references 항목으로 그대로 추가 가능",
+    ),
+    KnowledgeShareScope.TEAM_INTERNAL: (
+        "외부 surface 에는 제목 + source_url + 'team-internal' 라벨만 노출",
+        "본문 요약은 합성 응답에 직접 인용하지 않는다 — vault link 로 우회",
+        "PR 본문 references 에 포함할 때 'internal-only' 노트와 함께",
+    ),
+    KnowledgeShareScope.RESTRICTED: (
+        "외부 surface 에는 '공개 제한된 자료 1건' 신호만 노출",
+        "본문/실습 단계 어떤 형태로도 chat·PR·로그에 인용 금지",
+        "공유가 필요하면 운영자가 별도 보안 채널에서 수동 전달",
+    ),
+}
+
+
+def _render_share_scope(item: EngineeringKnowledgeItem) -> str:
     parts: List[str] = [_section_header(_REQUIRED_SECTIONS[12])]
+    label = _SHARE_SCOPE_LABELS.get(
+        item.share_scope, item.share_scope.value
+    )
+    parts.append(f"- **share_scope**: `{item.share_scope.value}` — {label}")
+    if item.share_scope_reason:
+        parts.append(
+            f"- **share_scope_reason**: {_redact(item.share_scope_reason)}"
+        )
+    parts.append("- **외부 surface 노출 규칙**:")
+    for rule in _SHARE_SCOPE_EXTERNAL_RULES.get(item.share_scope, ()):
+        parts.append(f"  - {rule}")
+    return "\n".join(parts)
+
+
+def _render_references(item: EngineeringKnowledgeItem) -> str:
+    parts: List[str] = [_section_header(_REQUIRED_SECTIONS[13])]
     parts.append(f"- 출처: [{_redact(item.source_name)}]({_redact(item.source_url)})")
     for ref in item.references:
         if ref:
@@ -386,6 +470,13 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
 
     Raises :class:`RendererError` when the item violates one of the
     hard contracts (empty body, missing source, missing practice).
+
+    When ``item.share_scope == KnowledgeShareScope.RESTRICTED`` the
+    learning-body sections are replaced with a one-line placeholder so
+    the vault note still tracks the topic but no body content can be
+    copied to an external surface. The Overview / RAG-CAG metadata /
+    공유 가능 범위 / References sections still render — they are
+    structural pointers, not body content.
     """
 
     if not item.title.strip():
@@ -402,6 +493,30 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
         m.strip() for m in item.common_mistakes
     ):
         raise RendererError("common_mistakes must have at least 1 non-empty entry")
+    if (
+        item.share_scope == KnowledgeShareScope.RESTRICTED
+        and not item.share_scope_reason.strip()
+    ):
+        raise RendererError(
+            "share_scope=RESTRICTED requires share_scope_reason"
+        )
+
+    body_renderers = [
+        _render_overview,        # 0 — structural, keep
+        _render_summary,         # 1 — body
+        _render_background,      # 2 — body
+        _render_what_changed,    # 3 — body
+        _render_why_important,   # 4 — body
+        _render_practical_impact,# 5 — body
+        _render_recommended,     # 6 — body
+        _render_practice_topic,  # 7 — body
+        _render_practice_steps,  # 8 — body
+        _render_completion,      # 9 — body
+        _render_common_mistakes, # 10 — body
+        _render_rag_cag,         # 11 — metadata, keep
+        _render_share_scope,     # 12 — share-scope, keep
+        _render_references,      # 13 — references, keep
+    ]
 
     blocks: List[str] = []
     blocks.append("---")
@@ -412,32 +527,17 @@ def render_engineering_knowledge_note(item: EngineeringKnowledgeItem) -> str:
     blocks.append("")
     blocks.append(_toc())
     blocks.append("")
-    blocks.append(_render_overview(item))
-    blocks.append("")
-    blocks.append(_render_summary(item))
-    blocks.append("")
-    blocks.append(_render_background(item))
-    blocks.append("")
-    blocks.append(_render_what_changed(item))
-    blocks.append("")
-    blocks.append(_render_why_important(item))
-    blocks.append("")
-    blocks.append(_render_practical_impact(item))
-    blocks.append("")
-    blocks.append(_render_recommended(item))
-    blocks.append("")
-    blocks.append(_render_practice_topic(item))
-    blocks.append("")
-    blocks.append(_render_practice_steps(item))
-    blocks.append("")
-    blocks.append(_render_completion(item))
-    blocks.append("")
-    blocks.append(_render_common_mistakes(item))
-    blocks.append("")
-    blocks.append(_render_rag_cag(item))
-    blocks.append("")
-    blocks.append(_render_references(item))
-    blocks.append("")
+
+    restricted = item.share_scope == KnowledgeShareScope.RESTRICTED
+    for index, renderer in enumerate(body_renderers):
+        if restricted and index in _RESTRICTED_REDACTED_SECTION_INDEXES:
+            blocks.append(
+                f"{_section_header(_REQUIRED_SECTIONS[index])}\n"
+                f"{_RESTRICTED_PLACEHOLDER}"
+            )
+        else:
+            blocks.append(renderer(item))
+        blocks.append("")
     return "\n".join(blocks)
 
 

--- a/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/retrieval.py
@@ -48,6 +48,7 @@ from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 from .models import (
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     SourceAxis,
 )
 from .source_registry import axis_hints_for_task_type
@@ -81,6 +82,8 @@ class KnowledgeRecord:
     note_path: Optional[str] = None
     project: Optional[str] = None
     secondary_roles: Tuple[str, ...] = ()
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC
+    share_scope_reason: str = ""
 
     @classmethod
     def from_item(
@@ -112,6 +115,8 @@ class KnowledgeRecord:
             collected_at=item.collected_at,
             note_path=note_path,
             secondary_roles=tuple(secondary_roles),
+            share_scope=item.share_scope,
+            share_scope_reason=item.share_scope_reason,
         )
 
     def to_payload(self) -> Mapping[str, Any]:
@@ -129,6 +134,8 @@ class KnowledgeRecord:
             "note_path": self.note_path,
             "project": self.project,
             "secondary_roles": list(self.secondary_roles),
+            "share_scope": self.share_scope.value,
+            "share_scope_reason": self.share_scope_reason,
         }
 
 
@@ -144,6 +151,52 @@ class KnowledgeMatch:
     record: KnowledgeRecord
     score: float
     signals: Tuple[str, ...]
+
+    def evidence_labels(self) -> Tuple[str, ...]:
+        """Return the score signals as human-readable Korean labels.
+
+        The raw signals are short tokens optimised for tests
+        (``role_primary_match``, ``axis_overlap:security,...``,
+        ``importance_critical``, ``fresh_7d``). For Obsidian /
+        Discord surfaces we want labels a human can read. This is a
+        deterministic projection — no I/O, no formatting beyond
+        ``label_for_signal``.
+        """
+
+        return tuple(label_for_signal(sig) for sig in self.signals if sig)
+
+
+def label_for_signal(signal: str) -> str:
+    """Map a retrieval signal token to a Korean label.
+
+    Unknown signals fall through with a leading "기타: " prefix so the
+    operator can still see the raw token without mistaking it for a
+    typo. Axis overlap signals carry a comma-separated list of axes;
+    we keep the axis names verbatim because they're structured tokens
+    the operator already understands.
+    """
+
+    if not signal:
+        return ""
+    if signal.startswith("axis_overlap:"):
+        axes = signal.split(":", 1)[1]
+        return f"task_type 축 일치 ({axes})"
+    if signal.startswith("topic_overlap:"):
+        count = signal.split(":", 1)[1]
+        return f"질문 토큰 겹침 (+{count})"
+    return _KNOWN_SIGNAL_LABELS.get(signal, f"기타: {signal}")
+
+
+_KNOWN_SIGNAL_LABELS: Mapping[str, str] = {
+    "role_primary_match": "요청 역할과 정확히 일치",
+    "role_secondary_match": "요청 역할이 보조 역할로 등록됨",
+    "importance_critical": "중요도 critical",
+    "importance_high": "중요도 high",
+    "importance_low": "중요도 low (감점)",
+    "fresh_7d": "최근 7일 이내 수집",
+    "fresh_30d": "최근 30일 이내 수집",
+    "empty_body_penalty": "본문/태그 비어 있음 (감점)",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -399,6 +452,11 @@ def _coerce_record(candidate: Any) -> Optional[KnowledgeRecord]:
             importance = Importance(importance_raw)
         except ValueError:
             importance = Importance.MEDIUM
+        share_raw = candidate.get("share_scope") or "public"
+        try:
+            share_scope = KnowledgeShareScope(share_raw)
+        except ValueError:
+            share_scope = KnowledgeShareScope.PUBLIC
         return KnowledgeRecord(
             topic_key=topic_key,
             title=title,
@@ -413,6 +471,8 @@ def _coerce_record(candidate: Any) -> Optional[KnowledgeRecord]:
             note_path=candidate.get("note_path"),
             project=candidate.get("project"),
             secondary_roles=tuple(candidate.get("secondary_roles") or ()),
+            share_scope=share_scope,
+            share_scope_reason=str(candidate.get("share_scope_reason") or ""),
         )
     return None
 
@@ -421,5 +481,6 @@ __all__ = [
     "KnowledgeMatch",
     "KnowledgeRecord",
     "KnowledgeRetriever",
+    "label_for_signal",
     "score_knowledge_record",
 ]

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -317,5 +317,146 @@ class ContextPackKnowledgeIntegrationTestCase(unittest.TestCase):
         )
 
 
+class ContextPackEvidenceSurfaceTestCase(unittest.TestCase):
+    """``relevant_knowledge`` → 사람이 읽을 수 있는 evidence 블록."""
+
+    def _public_ref(self, **overrides) -> EngineeringKnowledgeRef:
+        base = dict(
+            title="Spring Security 인증 흐름",
+            role="backend-engineer",
+            topic_key="spring-auth",
+            source_url="https://example.com/spring-auth",
+            source_name="Spring Docs",
+            summary="OAuth2 + Filter chain 정리",
+            score=8.0,
+            signals=("role_primary_match", "axis_overlap:api_schema_auth"),
+            evidence_labels=(
+                "요청 역할과 정확히 일치",
+                "task_type 축 일치 (api_schema_auth)",
+            ),
+            share_scope="public",
+        )
+        base.update(overrides)
+        return EngineeringKnowledgeRef(**base)
+
+    def test_empty_relevant_knowledge_returns_empty_string(self) -> None:
+        pack = ContextPack(current_message="hi")
+        self.assertEqual(pack.format_knowledge_evidence_block(), "")
+
+    def test_public_evidence_includes_summary_and_signals(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(self._public_ref(),),
+        )
+        block = pack.format_knowledge_evidence_block()
+        self.assertIn("근거 자료", block)
+        self.assertIn("Spring Security 인증 흐름", block)
+        self.assertIn("OAuth2 + Filter chain 정리", block)
+        # 사람이 읽는 evidence 라벨이 그대로 노출된다.
+        self.assertIn("요청 역할과 정확히 일치", block)
+        self.assertIn("task_type 축 일치", block)
+        self.assertIn("score=8.0", block)
+
+    def test_team_internal_evidence_drops_summary(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                self._public_ref(
+                    share_scope="team_internal",
+                    summary="이 요약은 외부 surface 에 노출되면 안 된다",
+                ),
+            ),
+        )
+        block = pack.format_knowledge_evidence_block()
+        self.assertIn("Spring Security 인증 흐름", block)
+        self.assertIn("team-internal", block)
+        self.assertNotIn("외부 surface 에 노출되면 안 된다", block)
+
+    def test_restricted_evidence_redacts_title_and_url(self) -> None:
+        pack = ContextPack(
+            current_message="incident",
+            relevant_knowledge=(
+                self._public_ref(
+                    share_scope="restricted",
+                    share_scope_reason="customer PII",
+                    title="2026-04-29 customer data leak",
+                    source_url="https://internal.example.com/incidents/2026-04-29",
+                    summary="민감 본문",
+                ),
+            ),
+        )
+        block = pack.format_knowledge_evidence_block()
+        # 제목/URL/요약 어떤 것도 외부에 옮겨지지 않는다.
+        self.assertNotIn("customer data leak", block)
+        self.assertNotIn("internal.example.com/incidents", block)
+        self.assertNotIn("민감 본문", block)
+        self.assertIn("공개 제한된 자료", block)
+        self.assertIn("customer PII", block)
+
+    def test_max_items_caps_block_length(self) -> None:
+        refs = tuple(
+            self._public_ref(topic_key=f"k{i}", title=f"item {i}")
+            for i in range(8)
+        )
+        pack = ContextPack(current_message="x", relevant_knowledge=refs)
+        block = pack.format_knowledge_evidence_block(max_items=3)
+        for visible in ("item 0", "item 1", "item 2"):
+            self.assertIn(visible, block)
+        self.assertNotIn("item 5", block)
+
+    def test_as_dict_carries_share_scope_and_evidence_labels(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(self._public_ref(share_scope="team_internal"),),
+        )
+        payload = pack.as_dict()
+        knowledge = payload["relevant_knowledge"][0]
+        self.assertEqual(knowledge["share_scope"], "team_internal")
+        self.assertEqual(knowledge["score"], 8.0)
+        self.assertIn("요청 역할과 정확히 일치", knowledge["evidence_labels"])
+
+
+class ContextPackKnowledgeMatchUnwrapTestCase(unittest.TestCase):
+    """``KnowledgeRetriever.with_signals`` 가 ContextPack 까지 흘러들어와야 한다."""
+
+    def test_with_signals_path_carries_score_and_labels(self) -> None:
+        candidates = [
+            KnowledgeRecord(
+                topic_key="spring-auth",
+                title="Spring 인증",
+                role="backend-engineer",
+                source_url="https://example.com/spring-auth",
+                source_name="Spring Docs",
+                summary="OAuth2 흐름",
+                axes=(SourceAxis.API_SCHEMA_AUTH,),
+                rag_tags=("auth",),
+                collected_at="2026-05-08T00:00:00Z",
+            ),
+        ]
+        builder = ContextPackBuilder(
+            knowledge_loader=lambda q: candidates,
+            knowledge_retriever=KnowledgeRetriever(min_score=0.0),
+        )
+        pack = builder.build(
+            message_text="spring auth 흐름이 어떻게 되지",
+            session=SimpleNamespace(
+                session_id="abc",
+                task_type="backend-feature",
+                write_requested=False,
+                write_blocked_reason=None,
+                extra={},
+            ),
+            role_for_research="engineering-agent/backend-engineer",
+        )
+        self.assertEqual(len(pack.relevant_knowledge), 1)
+        ref = pack.relevant_knowledge[0]
+        # score 와 signals 가 ContextPack 으로 전달되어 surface 가 가능
+        self.assertIsNotNone(ref.score)
+        self.assertGreater(ref.score, 0.0)
+        self.assertTrue(ref.signals, msg="signals were not propagated")
+        # evidence_labels 도 ContextPack 까지 살아 들어온다 (한국어 라벨).
+        self.assertTrue(ref.evidence_labels)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/engineering/test_discussion_context_pack.py
+++ b/tests/engineering/test_discussion_context_pack.py
@@ -416,6 +416,71 @@ class ContextPackEvidenceSurfaceTestCase(unittest.TestCase):
         self.assertIn("요청 역할과 정확히 일치", knowledge["evidence_labels"])
 
 
+class ContextPackShortSummaryTestCase(unittest.TestCase):
+    """`knowledge_short_summary` + `share_boundary_breakdown` 회귀 가드."""
+
+    def _ref(self, **overrides) -> EngineeringKnowledgeRef:
+        base = dict(
+            title="Spring Security 인증 흐름",
+            role="backend-engineer",
+            topic_key="spring-auth",
+            source_url="https://example.com/spring-auth",
+            source_name="Spring Docs",
+            summary="OAuth2 정리",
+            share_scope="public",
+        )
+        base.update(overrides)
+        return EngineeringKnowledgeRef(**base)
+
+    def test_empty_pack_returns_empty_summary_and_zero_breakdown(self) -> None:
+        pack = ContextPack(current_message="hi")
+        self.assertEqual(pack.knowledge_short_summary(), "")
+        breakdown = pack.share_boundary_breakdown()
+        self.assertEqual(breakdown["public"], 0)
+        self.assertEqual(breakdown["team_internal"], 0)
+        self.assertEqual(breakdown["restricted"], 0)
+        self.assertEqual(breakdown["total"], 0)
+
+    def test_summary_lists_top_titles_and_scope_counts(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                self._ref(),
+                self._ref(
+                    title="사내 OAuth playbook",
+                    topic_key="company-oauth",
+                    share_scope="team_internal",
+                ),
+                self._ref(
+                    title="incident-2026-04-29",
+                    topic_key="incident-2026-04-29",
+                    share_scope="restricted",
+                    share_scope_reason="PII",
+                ),
+            ),
+        )
+        summary = pack.knowledge_short_summary()
+        self.assertIn("근거 자료 3건", summary)
+        self.assertIn("public 1", summary)
+        self.assertIn("team_internal 1", summary)
+        self.assertIn("restricted 1", summary)
+        # 상위 2 건의 제목이 들어가지만 restricted 의 제목/url 은 절대 새지 않는다.
+        self.assertIn("Spring Security 인증 흐름", summary)
+        self.assertIn("사내 OAuth playbook", summary)
+        self.assertIn("team-internal", summary)
+        self.assertNotIn("incident-2026-04-29", summary)
+
+    def test_summary_max_topics_caps_preview(self) -> None:
+        refs = tuple(
+            self._ref(topic_key=f"k{i}", title=f"item {i}") for i in range(4)
+        )
+        pack = ContextPack(current_message="x", relevant_knowledge=refs)
+        summary = pack.knowledge_short_summary(max_topics=1)
+        self.assertIn("외 3건", summary)
+        self.assertIn("item 0", summary)
+        self.assertNotIn("item 1", summary)
+
+
 class ContextPackKnowledgeMatchUnwrapTestCase(unittest.TestCase):
     """``KnowledgeRetriever.with_signals`` 가 ContextPack 까지 흘러들어와야 한다."""
 

--- a/tests/engineering/test_discussion_synthesizer.py
+++ b/tests/engineering/test_discussion_synthesizer.py
@@ -15,6 +15,7 @@ from yule_orchestrator.agents.discussion import (
     DiscussionMode,
     DiscussionModeMatch,
     DiscussionSynthesis,
+    EngineeringKnowledgeRef,
     GithubIssueRef,
     GithubPRRef,
     ObsidianNoteRef,
@@ -149,6 +150,146 @@ class SynthesizeDiscussionTestCase(unittest.TestCase):
         self.assertEqual(payload["mode"], "implementation_candidate")
         self.assertTrue(payload["implementation_ready"])
         self.assertIn("response_text", payload)
+        # share_boundary 는 항상 dict — 빈 pack 이어도 4 키 carries.
+        self.assertEqual(payload["share_boundary"]["total"], 0)
+        self.assertEqual(payload["share_boundary"]["public"], 0)
+        self.assertEqual(payload["knowledge_evidence_block"], "")
+        self.assertEqual(payload["knowledge_short_summary"], "")
+
+
+def _public_ref(**overrides) -> EngineeringKnowledgeRef:
+    base = dict(
+        title="Spring Security 인증 흐름",
+        role="backend-engineer",
+        topic_key="spring-auth",
+        source_url="https://example.com/spring-auth",
+        source_name="Spring Docs",
+        summary="OAuth2 + Filter chain 정리",
+        score=8.0,
+        signals=("role_primary_match",),
+        evidence_labels=("요청 역할과 정확히 일치",),
+        share_scope="public",
+    )
+    base.update(overrides)
+    return EngineeringKnowledgeRef(**base)
+
+
+class SynthesizeKnowledgeEvidenceTestCase(unittest.TestCase):
+    """``relevant_knowledge`` 가 응답 surface 에 그대로 흘러야 한다."""
+
+    def test_discussion_appends_evidence_block_and_summary(self) -> None:
+        pack = ContextPack(
+            current_message="auth 흐름 정리하자",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="사내 OAuth playbook",
+                    topic_key="company-oauth",
+                    share_scope="team_internal",
+                    summary="외부 surface 에는 노출 금지",
+                ),
+            ),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.DISCUSSION),
+        )
+        # Response 본문에 evidence 블록 + 짧은 요약 한 줄이 모두 들어간다.
+        self.assertIn("근거 자료", synth.response_text)
+        self.assertIn("Spring Security 인증 흐름", synth.response_text)
+        self.assertIn("team-internal", synth.response_text)
+        # 짧은 요약 라인 — 운영자가 본문 펼치기 전에 한 눈에 본다.
+        self.assertIn("근거 자료 2건", synth.response_text)
+        # 별도 surface field 도 채워져 있다.
+        self.assertIn("Spring Security", synth.knowledge_evidence_block)
+        self.assertIn("근거 자료 2건", synth.knowledge_short_summary)
+        self.assertEqual(synth.share_boundary["public"], 1)
+        self.assertEqual(synth.share_boundary["team_internal"], 1)
+        self.assertEqual(synth.share_boundary["total"], 2)
+        # team_internal 자료의 본문 요약은 응답에 새지 않는다.
+        self.assertNotIn(
+            "외부 surface 에는 노출 금지", synth.response_text
+        )
+
+    def test_research_response_carries_existing_evidence_when_available(self) -> None:
+        pack = ContextPack(
+            current_message="auth 자료 모아 보자",
+            relevant_knowledge=(_public_ref(),),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.RESEARCH_ONLY),
+        )
+        self.assertIn("이미 모인 자료", synth.response_text)
+        self.assertIn("이미 vault 에 있는 근거 자료", synth.response_text)
+        self.assertIn("Spring Security 인증 흐름", synth.response_text)
+        self.assertEqual(synth.share_boundary["total"], 1)
+
+    def test_implementation_includes_decision_evidence_summary(self) -> None:
+        pack = ContextPack(
+            current_message="API auth 흐름 패치 작성, schema 마이그도 같이",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="incident-2026-04-29",
+                    topic_key="incident-2026-04-29",
+                    share_scope="restricted",
+                    share_scope_reason="customer PII",
+                ),
+            ),
+        )
+        synth = synthesize_discussion(
+            pack=pack,
+            classification=_classification(DiscussionMode.IMPLEMENTATION_CANDIDATE),
+        )
+        self.assertIn("결정 근거 요약", synth.response_text)
+        self.assertIn("이번 결정 근거 자료", synth.response_text)
+        # restricted 자료는 제목 / URL 이 모두 마스킹되고 reason 만 노출.
+        self.assertNotIn("internal.example", synth.response_text)
+        self.assertIn("공개 제한된 자료", synth.response_text)
+        self.assertIn("customer PII", synth.response_text)
+        # share_boundary 는 restricted/public 둘 다 카운트.
+        self.assertEqual(synth.share_boundary["restricted"], 1)
+        self.assertEqual(synth.share_boundary["public"], 1)
+
+    def test_short_summary_orders_scope_breakdown(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                _public_ref(),
+                _public_ref(
+                    title="internal-doc",
+                    topic_key="internal-1",
+                    share_scope="team_internal",
+                ),
+                _public_ref(
+                    title="restricted-doc",
+                    topic_key="restricted-1",
+                    share_scope="restricted",
+                    share_scope_reason="PII",
+                ),
+            ),
+        )
+        summary = pack.knowledge_short_summary()
+        self.assertIn("근거 자료 3건", summary)
+        # public → team_internal → restricted 순으로 축약 카운트가 들어간다.
+        self.assertLess(summary.index("public"), summary.index("team_internal"))
+        self.assertLess(
+            summary.index("team_internal"), summary.index("restricted")
+        )
+
+    def test_share_boundary_breakdown_handles_unknown_scope(self) -> None:
+        pack = ContextPack(
+            current_message="auth",
+            relevant_knowledge=(
+                _public_ref(share_scope="weird-value"),
+            ),
+        )
+        breakdown = pack.share_boundary_breakdown()
+        # Unknown scopes fall back into the public bucket so the
+        # boundary surface never silently drops items.
+        self.assertEqual(breakdown["public"], 1)
+        self.assertEqual(breakdown["total"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/engineering_intelligence/test_discord_summary.py
+++ b/tests/engineering_intelligence/test_discord_summary.py
@@ -12,10 +12,12 @@ except ModuleNotFoundError:
 from yule_orchestrator.agents.engineering_intelligence.discord_summary import (
     render_daily_role_summary,
     render_multi_role_summary,
+    share_boundary_breakdown,
 )
 from yule_orchestrator.agents.engineering_intelligence.models import (
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     SourceKind,
 )
 
@@ -26,6 +28,8 @@ def _it(
     importance: Importance = Importance.MEDIUM,
     source_name: str = "Spring Engineering Blog",
     source_url: str = "https://spring.io/blog/x",
+    share_scope: KnowledgeShareScope = KnowledgeShareScope.PUBLIC,
+    share_scope_reason: str = "",
 ) -> EngineeringKnowledgeItem:
     return EngineeringKnowledgeItem(
         item_id=title,
@@ -38,6 +42,8 @@ def _it(
         source_kind=SourceKind.ENGINEERING_BLOG,
         collected_at="2026-05-08T00:00:00Z",
         importance=importance,
+        share_scope=share_scope,
+        share_scope_reason=share_scope_reason,
     )
 
 
@@ -77,6 +83,65 @@ class DailyRoleSummaryTests(unittest.TestCase):
         )
         self.assertIn("Obsidian", text)
         self.assertIn("engineering-knowledge", text)
+
+
+class ShareBoundaryFooterTests(unittest.TestCase):
+    """Daily digest footer 가 share_scope 분포를 정확히 노출한다."""
+
+    def test_all_public_skips_footer(self) -> None:
+        items = [_it("public-only")]
+        text = render_daily_role_summary("backend-engineer", items)
+        # 정상 footer (Obsidian pointer) 는 그대로 — share boundary
+        # 안내는 일부러 추가하지 않는다.
+        self.assertNotIn("share boundary", text)
+        self.assertIn("Obsidian", text)
+
+    def test_team_internal_item_triggers_footer(self) -> None:
+        items = [
+            _it("public-doc"),
+            _it(
+                "internal-doc",
+                share_scope=KnowledgeShareScope.TEAM_INTERNAL,
+            ),
+        ]
+        text = render_daily_role_summary("backend-engineer", items)
+        self.assertIn("share boundary", text)
+        self.assertIn("public 1건", text)
+        self.assertIn("team-internal 1건", text)
+        self.assertIn("vault link", text)
+
+    def test_restricted_item_marked_in_footer_and_body(self) -> None:
+        items = [
+            _it(
+                "incident",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            ),
+        ]
+        text = render_daily_role_summary("backend-engineer", items)
+        # body 에는 제목/URL 모두 마스킹.
+        self.assertNotIn("https://spring.io/blog/x", text)
+        self.assertIn("🔒 공개 제한된 자료", text)
+        # footer 에 restricted 카운트가 잡힌다.
+        self.assertIn("share boundary", text)
+        self.assertIn("공개 제한 1건", text)
+
+    def test_breakdown_helper_classifies_each_scope(self) -> None:
+        items = [
+            _it("a"),
+            _it("b", share_scope=KnowledgeShareScope.TEAM_INTERNAL),
+            _it(
+                "c",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="needed",
+            ),
+            _it("d"),
+        ]
+        breakdown = share_boundary_breakdown(items)
+        self.assertEqual(breakdown["public"], 2)
+        self.assertEqual(breakdown["team_internal"], 1)
+        self.assertEqual(breakdown["restricted"], 1)
+        self.assertEqual(breakdown["total"], 4)
 
 
 class MultiRoleSummaryTests(unittest.TestCase):

--- a/tests/engineering_intelligence/test_obsidian.py
+++ b/tests/engineering_intelligence/test_obsidian.py
@@ -14,6 +14,7 @@ from yule_orchestrator.agents.engineering_intelligence.models import (
     CagContext,
     EngineeringKnowledgeItem,
     Importance,
+    KnowledgeShareScope,
     LearningLevel,
     NOTE_KIND_ENGINEERING_KNOWLEDGE,
     PracticeVerification,
@@ -23,6 +24,7 @@ from yule_orchestrator.agents.engineering_intelligence.obsidian import (
     build_engineering_knowledge_write_request,
     build_rejected_quality_gate_audit,
     evaluate_quality_gate,
+    summarize_share_boundary,
 )
 
 
@@ -180,6 +182,50 @@ class GateFailTests(unittest.TestCase):
         item = _good_item(review_after_days=0)
         gate = evaluate_quality_gate(item)
         self.assertIn("missing:review_after_days", gate.reasons)
+
+
+class SummarizeShareBoundaryTests(unittest.TestCase):
+    """`summarize_share_boundary` 가 운영자 한 줄 요약을 만든다."""
+
+    def test_empty_input_returns_zero_summary(self) -> None:
+        payload = summarize_share_boundary(())
+        self.assertEqual(payload["counts"]["total"], 0)
+        self.assertEqual(payload["summary"], "")
+
+    def test_public_only_summary_has_no_warning(self) -> None:
+        items = (_good_item(),)
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["public"], 1)
+        self.assertIn("public 1건", payload["summary"])
+        self.assertNotIn("vault link", payload["summary"])
+        self.assertNotIn("외부 채널", payload["summary"])
+
+    def test_team_internal_summary_warns(self) -> None:
+        items = (
+            _good_item(),
+            _good_item(
+                topic_key="company-oauth",
+                share_scope=KnowledgeShareScope.TEAM_INTERNAL,
+                share_scope_reason="사내 ADR",
+            ),
+        )
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["team_internal"], 1)
+        self.assertIn("team_internal 1건", payload["summary"])
+        self.assertIn("vault link", payload["summary"])
+
+    def test_restricted_summary_blocks_external_quotation(self) -> None:
+        items = (
+            _good_item(
+                topic_key="incident-2026-04-29",
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            ),
+        )
+        payload = summarize_share_boundary(items)
+        self.assertEqual(payload["counts"]["restricted"], 1)
+        self.assertIn("restricted 1건", payload["summary"])
+        self.assertIn("외부 채널 인용 금지", payload["summary"])
 
 
 class RejectionAuditTests(unittest.TestCase):

--- a/tests/engineering_intelligence/test_renderer.py
+++ b/tests/engineering_intelligence/test_renderer.py
@@ -134,16 +134,18 @@ class FrontmatterTests(unittest.TestCase):
 
 
 class SectionPresenceTests(unittest.TestCase):
-    def test_all_thirteen_sections_rendered(self) -> None:
+    def test_all_required_sections_rendered(self) -> None:
         body = render_engineering_knowledge_note(_full_item())
         for title in required_sections():
             self.assertIn(f"## {title}", body, msg=f"missing section: {title}")
 
-    def test_toc_lists_thirteen_sections(self) -> None:
+    def test_toc_lists_all_required_sections(self) -> None:
         body = render_engineering_knowledge_note(_full_item())
         self.assertIn("## 목차", body)
-        # The TOC line numbers 1..13 each appear on their own line.
-        for index in range(1, 14):
+        # TOC line numbers 1..N each appear on their own line, where N
+        # is the current required-section count (14 — share_scope was
+        # added between RAG/CAG and References).
+        for index in range(1, len(required_sections()) + 1):
             self.assertRegex(body, rf"\n{index}\. ")
 
     def test_practice_section_includes_steps_checklist_verification(self) -> None:

--- a/tests/engineering_intelligence/test_retrieval.py
+++ b/tests/engineering_intelligence/test_retrieval.py
@@ -19,7 +19,11 @@ from yule_orchestrator.agents.engineering_intelligence.models import (
 from yule_orchestrator.agents.engineering_intelligence.retrieval import (
     KnowledgeRecord,
     KnowledgeRetriever,
+    label_for_signal,
     score_knowledge_record,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    KnowledgeShareScope,
 )
 
 
@@ -276,6 +280,92 @@ class CoercionTests(unittest.TestCase):
             role=None,
         )
         self.assertEqual(picked, ())
+
+
+class EvidenceLabelTests(unittest.TestCase):
+    def test_known_signals_have_korean_labels(self) -> None:
+        self.assertEqual(
+            label_for_signal("role_primary_match"), "요청 역할과 정확히 일치"
+        )
+        self.assertEqual(
+            label_for_signal("importance_critical"), "중요도 critical"
+        )
+        self.assertEqual(label_for_signal("fresh_7d"), "최근 7일 이내 수집")
+
+    def test_axis_overlap_keeps_axis_names(self) -> None:
+        label = label_for_signal("axis_overlap:api_schema_auth,official_docs")
+        self.assertEqual(
+            label, "task_type 축 일치 (api_schema_auth,official_docs)"
+        )
+
+    def test_topic_overlap_extracts_count(self) -> None:
+        self.assertEqual(label_for_signal("topic_overlap:2"), "질문 토큰 겹침 (+2)")
+
+    def test_unknown_signal_falls_through(self) -> None:
+        label = label_for_signal("future_signal_xyz")
+        self.assertTrue(label.startswith("기타: "))
+
+    def test_match_evidence_labels_uses_known_labels(self) -> None:
+        match = score_knowledge_record(
+            _record(),
+            query="auth",
+            role="backend-engineer",
+            task_type="backend-feature",
+            now=_now(),
+        )
+        labels = match.evidence_labels()
+        self.assertIn("요청 역할과 정확히 일치", labels)
+        # axis 매칭이 발생했으면 사람이 읽을 수 있는 라벨로 풀어진다.
+        self.assertTrue(
+            any("task_type 축 일치" in lbl for lbl in labels),
+            f"axis label missing in {labels}",
+        )
+
+
+class ShareScopePropagationTests(unittest.TestCase):
+    def test_share_scope_default_public(self) -> None:
+        rec = _record()
+        self.assertEqual(rec.share_scope, KnowledgeShareScope.PUBLIC)
+        payload = rec.to_payload()
+        self.assertEqual(payload["share_scope"], "public")
+
+    def test_mapping_share_scope_team_internal_coerces(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[
+                {
+                    "topic_key": "k",
+                    "title": "T",
+                    "role": "backend-engineer",
+                    "share_scope": "team_internal",
+                    "share_scope_reason": "private repo",
+                }
+            ],
+            query=None,
+            role="backend-engineer",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(
+            picked[0].share_scope, KnowledgeShareScope.TEAM_INTERNAL
+        )
+        self.assertEqual(picked[0].share_scope_reason, "private repo")
+
+    def test_mapping_unknown_share_scope_falls_back_to_public(self) -> None:
+        retriever = KnowledgeRetriever(min_score=0.0, now=_now())
+        picked = retriever(
+            candidates=[
+                {
+                    "topic_key": "k",
+                    "title": "T",
+                    "role": "backend-engineer",
+                    "share_scope": "future_unknown_value",
+                }
+            ],
+            query=None,
+            role="backend-engineer",
+        )
+        self.assertEqual(len(picked), 1)
+        self.assertEqual(picked[0].share_scope, KnowledgeShareScope.PUBLIC)
 
 
 if __name__ == "__main__":

--- a/tests/engineering_intelligence/test_share_scope.py
+++ b/tests/engineering_intelligence/test_share_scope.py
@@ -1,0 +1,265 @@
+"""Share boundary — renderer / obsidian / discord_summary contract.
+
+새 ``KnowledgeShareScope`` 가 note/report formatting 전반에 어떻게
+반영되는지 한 번에 본다. 한 자료 항목이 share_scope 만 다르게 들어
+왔을 때 surface 별로 어떻게 다르게 노출되는지가 핵심 회귀 보호.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.engineering_intelligence.discord_summary import (
+    render_daily_role_summary,
+)
+from yule_orchestrator.agents.engineering_intelligence.models import (
+    Audience,
+    CagContext,
+    EngineeringKnowledgeItem,
+    Importance,
+    KnowledgeShareScope,
+    LearningLevel,
+    PracticeVerification,
+    SourceKind,
+)
+from yule_orchestrator.agents.engineering_intelligence.obsidian import (
+    build_engineering_knowledge_write_request,
+    evaluate_quality_gate,
+    shareable_external_payload,
+    vault_only_metadata,
+)
+from yule_orchestrator.agents.engineering_intelligence.renderer import (
+    RendererError,
+    render_engineering_knowledge_note,
+    required_sections,
+)
+
+
+def _item(**overrides) -> EngineeringKnowledgeItem:
+    base = dict(
+        item_id="incident-2026-04-29-customer-data-leak",
+        topic_key="customer-data-leak-2026-04-29",
+        title="2026-04-29 고객 데이터 노출 사고 — 내부 분석",
+        role="backend-engineer",
+        stack_tags=("incident",),
+        source_name="Internal Postmortem",
+        source_url="https://internal.example.com/incidents/2026-04-29",
+        source_kind=SourceKind.SECURITY_ADVISORY,
+        collected_at="2026-04-30T01:00:00Z",
+        importance=Importance.CRITICAL,
+        audience=Audience.SENIOR,
+        summary="customer 데이터 1.2k 건이 일시적으로 외부에 노출됨.",
+        why_it_matters="동일 패턴 반복 시 사용자 신뢰 손상 + 규제 노출.",
+        what_changed="audit log 보존 정책 변경 + access guard 강화.",
+        practical_impact="향후 고객 데이터 접근 endpoint 변경 시 추가 검증 필요.",
+        recommended_action="incident-2026-04-29 의 root cause 5가지 점검 항목 확인.",
+        practice_topic="incident replay (내부 한정)",
+        practice_goal="audit log + access guard 수정 흐름을 한 번 따라가 본다",
+        practice_steps=(
+            "audit log 변경 PR 다시 본다",
+            "access guard 새 case 의 unit test 를 본다",
+        ),
+        practice_checklist=("내부 채널에서 incident 카드 닫음",),
+        expected_output="incident retrospective 한 줄 요약",
+        common_mistakes=("동일 패턴 후속 endpoint 에 guard 안 거는 케이스",),
+        practice_verification=PracticeVerification(
+            expected_result="postmortem 마지막 액션 아이템이 close 됨",
+            command_to_run=None,
+        ),
+        rag_tags=("incident", "security"),
+        cag_context_key="incident-2026-04-29-when-similar-spike",
+        cag_context=CagContext(
+            when_to_use="고객 데이터 path 변경 / access guard 회귀 의심 시",
+        ),
+        retrieval_queries=(
+            "incident 2026-04-29 어떤 audit guard 가 새로 들어갔지?",
+            "고객 데이터 노출 회귀 어디서 잡지?",
+        ),
+        retrieval_summary="audit/access guard 회귀 의심 시 incident postmortem 다시 본다",
+        learning_level=LearningLevel.ADVANCED,
+        prerequisites=("audit log 정책",),
+        next_topics=("access-guard-v2",),
+        estimated_practice_time="30분",
+        review_after_days=30,
+        references=(
+            "https://internal.example.com/incidents/2026-04-29",
+        ),
+        confidence=0.9,
+        dedup_key="eng-knowledge:backend-engineer:incident-2026-04-29",
+    )
+    base.update(overrides)
+    return EngineeringKnowledgeItem(**base)
+
+
+class FrontmatterAndSectionTests(unittest.TestCase):
+    def test_share_scope_section_listed_in_required_sections(self) -> None:
+        sections = required_sections()
+        self.assertEqual(len(sections), 14)
+        self.assertIn("13. 공유 가능 범위", sections)
+        self.assertIn("14. 참고 자료", sections)
+
+    def test_frontmatter_carries_share_scope_default_public(self) -> None:
+        body = render_engineering_knowledge_note(_item())
+        self.assertIn('share_scope: "public"', body)
+
+    def test_frontmatter_share_scope_team_internal(self) -> None:
+        body = render_engineering_knowledge_note(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertIn('share_scope: "team_internal"', body)
+        # 본문(요약/실무 영향)은 정상 렌더되지만 share-scope 섹션이 추가
+        # 외부 surface 규칙을 안내한다.
+        self.assertIn("팀 내부 한정", body)
+        self.assertIn("외부 surface 노출 규칙", body)
+
+
+class RestrictedScopeBodyTests(unittest.TestCase):
+    def test_restricted_requires_share_scope_reason(self) -> None:
+        with self.assertRaises(RendererError):
+            render_engineering_knowledge_note(
+                _item(share_scope=KnowledgeShareScope.RESTRICTED)
+            )
+
+    def test_restricted_body_redacts_learning_sections(self) -> None:
+        body = render_engineering_knowledge_note(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII 가 포함된 incident",
+            )
+        )
+        # 핵심 요약 / 권장 대응 / 실습 단계 본문은 placeholder 로 대체된다.
+        self.assertIn("공개 제한된 자료", body)
+        self.assertNotIn("customer 데이터 1.2k 건", body)
+        self.assertNotIn("audit log 변경 PR 다시 본다", body)
+        self.assertNotIn("동일 패턴 반복 시", body)
+        # 그래도 share_scope 섹션 / 참고자료 / RAG/CAG 메타는 살아있다.
+        self.assertIn("share_scope_reason", body)
+        self.assertIn("customer PII 가 포함된 incident", body)
+        self.assertIn("https://internal.example.com/incidents/2026-04-29", body)
+        self.assertIn("rag_tags", body)
+
+
+class QualityGateShareScopeTests(unittest.TestCase):
+    def test_default_public_passes_gate(self) -> None:
+        gate = evaluate_quality_gate(_item())
+        self.assertTrue(gate.passed, msg=f"reasons={gate.reasons}")
+
+    def test_restricted_without_reason_blocks(self) -> None:
+        gate = evaluate_quality_gate(
+            _item(share_scope=KnowledgeShareScope.RESTRICTED)
+        )
+        self.assertFalse(gate.passed)
+        self.assertIn(
+            "missing:share_scope_reason_for_restricted", gate.reasons
+        )
+
+    def test_restricted_with_reason_passes(self) -> None:
+        gate = evaluate_quality_gate(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII 가 포함된 incident",
+            )
+        )
+        self.assertTrue(gate.passed, msg=f"reasons={gate.reasons}")
+
+    def test_write_request_metadata_carries_share_scope(self) -> None:
+        request = build_engineering_knowledge_write_request(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        assert request is not None
+        ei = request.metadata["engineering_intelligence"]
+        self.assertEqual(ei["share_scope"], "team_internal")
+        external = request.metadata["shareable_external_payload"]
+        self.assertEqual(external["share_scope"], "team_internal")
+        # team-internal: title + source 노출, summary 는 surface 차단.
+        self.assertIn("title", external)
+        self.assertIn("source_url", external)
+        self.assertNotIn("summary", external)
+
+
+class ShareablePayloadTests(unittest.TestCase):
+    def test_public_payload_includes_summary(self) -> None:
+        payload = shareable_external_payload(_item())
+        self.assertEqual(payload["share_scope"], "public")
+        self.assertIn("summary", payload)
+        self.assertIn("title", payload)
+
+    def test_team_internal_payload_drops_summary(self) -> None:
+        payload = shareable_external_payload(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertEqual(payload["share_scope"], "team_internal")
+        self.assertNotIn("summary", payload)
+        self.assertTrue(payload.get("internal_only"))
+
+    def test_restricted_payload_only_marker(self) -> None:
+        payload = shareable_external_payload(
+            _item(
+                share_scope=KnowledgeShareScope.RESTRICTED,
+                share_scope_reason="customer PII",
+            )
+        )
+        self.assertEqual(payload["share_scope"], "restricted")
+        # 외부 surface 가 우연히라도 본문/제목/링크를 가져가지 않게 차단.
+        self.assertNotIn("title", payload)
+        self.assertNotIn("source_url", payload)
+        self.assertNotIn("summary", payload)
+        self.assertEqual(payload["restricted_marker"], "🔒 공개 제한된 자료")
+        self.assertEqual(payload["share_scope_reason"], "customer PII")
+
+
+class VaultOnlyMetadataTests(unittest.TestCase):
+    def test_vault_only_carries_practice_body(self) -> None:
+        meta = vault_only_metadata(
+            _item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)
+        )
+        self.assertEqual(meta["share_scope"], "team_internal")
+        self.assertIn("practice_steps", meta)
+        self.assertIn("common_mistakes", meta)
+        self.assertIn("recommended_action", meta)
+
+
+class DiscordSummaryShareScopeTests(unittest.TestCase):
+    def test_public_line_unchanged(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [_item()],
+            today="2026-04-30",
+        )
+        self.assertIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertNotIn("team-internal", text)
+
+    def test_team_internal_keeps_title_with_tag(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [_item(share_scope=KnowledgeShareScope.TEAM_INTERNAL)],
+            today="2026-04-30",
+        )
+        self.assertIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertIn("team-internal", text)
+
+    def test_restricted_line_hides_title_and_url(self) -> None:
+        text = render_daily_role_summary(
+            "backend-engineer",
+            [
+                _item(
+                    share_scope=KnowledgeShareScope.RESTRICTED,
+                    share_scope_reason="customer PII",
+                )
+            ],
+            today="2026-04-30",
+        )
+        # 제목과 URL 은 제거되고 공개 제한 마커 + topic_key 만 남는다.
+        self.assertNotIn("2026-04-29 고객 데이터 노출 사고", text)
+        self.assertNotIn("https://internal.example.com/", text)
+        self.assertIn("공개 제한된 자료", text)
+        self.assertIn("customer-data-leak-2026-04-29", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- derived from #73
- stacked on #75

## ✨ 과제 내용
- engineering knowledge note 출력 contract 명확화
- share boundary/public-internal-restricted 구분 추가
- ContextPack retrieval evidence surface와 정책 보강

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- structured knowledge가 실제 운영 메모리 자산으로 보이도록 surface를 강화
- provider fetch core는 건드리지 않음