### PR TITLE
✨ #81 engineering-knowledge 수집 노트 visible title GeekNews 스타일 정리

### DIFF
--- a/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/feed_parser.py
@@ -36,6 +36,7 @@ the BytesFetcher in.
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -57,6 +58,25 @@ from .providers import LiveProviderSpec, ProviderTransport
 
 _ATOM_NS = "{http://www.w3.org/2005/Atom}"
 _SUMMARY_LIMIT = 500
+_TITLE_LIMIT = 72
+
+# Leading label noise an operator surface (Discord 이슈방, GeekNews-style
+# digest, Obsidian title) wouldn't want to read: ``[Release]``, ``[번역]``,
+# ``(공지)``, ``1.``, ``2)``, ``#``, ``-``, ``•`` and combinations of those.
+# We allow whitespace *between* prefixes so compound noise like
+# ``"1. [번역] Foo"`` strips down to ``"Foo"`` in one pass.
+_TITLE_PREFIX_RE = re.compile(
+    r"^(?:\s*(?:\[[^\]]+\]|\([^)]+\)|\d+[.)]|#+|[\-–—:•]))+\s*"
+)
+# Trailing site markers: " | GitHub", " - Engineering Blog", " — Release Notes",
+# etc. Anchored to the end so we don't munch separators inside the title.
+_TRAILING_SITE_RE = re.compile(
+    r"\s+(?:\||·|—|-)\s+"
+    r"(?:engineering blog|release notes?|github|gitlab|medium|substack|blog)"
+    r"\b.*$",
+    re.IGNORECASE,
+)
+_WS_RE = re.compile(r"\s+")
 
 
 class FeedParserError(Exception):
@@ -136,6 +156,50 @@ def _trim(value: str, *, limit: int = _SUMMARY_LIMIT) -> str:
     return value[: limit - 1].rstrip() + "…"
 
 
+def canonicalize_feed_title(
+    title: str,
+    *,
+    fallback: str = "",
+    max_chars: int = _TITLE_LIMIT,
+) -> str:
+    """Convert a raw feed headline into a short human-facing title.
+
+    The Discord 이슈방 / GeekNews-style engineering-knowledge surface
+    needs titles that are easy to scan, not raw feed prefixes or site
+    suffixes. This is deterministic and conservative:
+
+    - drop leading label noise (``[Release]`` / ``[번역]`` / ``(공지)`` /
+      ``1.`` / ``#``)
+    - strip obvious trailing site markers (``| GitHub``, ``- Engineering
+      Blog``, ``— Release Notes``)
+    - collapse whitespace and trim leftover punctuation
+    - phrase-truncate over-long titles on a separator or word boundary
+      without inventing wording
+
+    Falls back to *fallback* when the title is empty after scrubbing so
+    a label-only entry like ``"[공지]"`` still produces a usable title.
+    """
+
+    cleaned = (title or "").replace("\r", " ").replace("\n", " ").strip()
+    cleaned = _TITLE_PREFIX_RE.sub("", cleaned)
+    cleaned = _TRAILING_SITE_RE.sub("", cleaned)
+    cleaned = _WS_RE.sub(" ", cleaned).strip(" -–—:;,.|·")
+    if not cleaned:
+        cleaned = (fallback or "").strip()
+    if not cleaned or len(cleaned) <= max_chars:
+        return cleaned
+
+    head = cleaned[:max_chars]
+    pivot = max(head.rfind(" · "), head.rfind(" — "), head.rfind(" - "))
+    if pivot >= max_chars // 2:
+        head = head[:pivot]
+    else:
+        space = head.rfind(" ")
+        if space >= max_chars // 2:
+            head = head[:space]
+    return head.rstrip(" -–—:;,.|·") + "…"
+
+
 def _build_item(
     source: SourceEntry,
     *,
@@ -152,7 +216,10 @@ def _build_item(
     """
 
     role = source.role_tags[0] if source.role_tags else "tech-lead"
-    final_title = title or url or source.name
+    final_title = canonicalize_feed_title(
+        title,
+        fallback=(url or source.name),
+    )
     final_url = url or source.base_url
     item_id = _hash_id(source.source_id, final_title, final_url)
     topic_key = _hash_id("topic", source.source_id, final_title.lower())
@@ -421,6 +488,7 @@ __all__ = [
     "BytesFetcher",
     "FeedFetchOutcome",
     "FeedParserError",
+    "canonicalize_feed_title",
     "make_feed_live_factory",
     "parse_atom_bytes",
     "parse_feed_bytes",

--- a/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
+++ b/src/yule_orchestrator/agents/engineering_intelligence/obsidian.py
@@ -284,6 +284,7 @@ def build_engineering_knowledge_write_request(
         "engineering_intelligence": {
             "topic_key": item.topic_key,
             "role": item.role,
+            "canonical_display_title": item.title,
             "stack_tags": list(item.stack_tags),
             "rag_tags": list(item.rag_tags),
             "cag_context_key": item.cag_context_key,

--- a/tests/engineering_intelligence/test_feed_parser.py
+++ b/tests/engineering_intelligence/test_feed_parser.py
@@ -13,6 +13,7 @@ except ModuleNotFoundError:
 from yule_orchestrator.agents.engineering_intelligence.feed_parser import (
     BytesFetcher,
     FeedParserError,
+    canonicalize_feed_title,
     make_feed_live_factory,
     parse_atom_bytes,
     parse_feed_bytes,
@@ -165,6 +166,21 @@ class AtomParserTests(unittest.TestCase):
         empty = b'<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"/>'
         self.assertEqual(parse_atom_bytes(empty, source=self.source), ())
 
+    def test_title_is_canonicalized_for_operator_surface(self) -> None:
+        atom = b"""<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>[Release] Spring 6.2 Virtual Thread defaults | Engineering Blog</title>
+    <link rel="alternate" href="https://example.com/posts/vt"/>
+    <updated>2026-05-09T09:30:00Z</updated>
+    <summary>summary</summary>
+  </entry>
+</feed>
+"""
+        items = parse_atom_bytes(atom, source=self.source)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].title, "Spring 6.2 Virtual Thread defaults")
+
 
 # ---------------------------------------------------------------------------
 # RSS parser
@@ -268,6 +284,67 @@ class ParseFeedDispatchTests(unittest.TestCase):
                 source=self.rss_source,
                 transport=ProviderTransport.MANUAL,
             )
+
+
+# ---------------------------------------------------------------------------
+# Title canonicalization
+# ---------------------------------------------------------------------------
+
+
+class CanonicalTitleTests(unittest.TestCase):
+    """Discord 이슈방 / GeekNews surface needs short, prefix-free titles."""
+
+    def test_strips_bracketed_prefix_and_trailing_site_marker(self) -> None:
+        raw = "[번역] Kubernetes probe edge cases | GitHub"
+        self.assertEqual(
+            canonicalize_feed_title(raw),
+            "Kubernetes probe edge cases",
+        )
+
+    def test_strips_paren_notice_and_numeric_prefix(self) -> None:
+        raw = "1. (공지) Node 22 LTS 변경점 - Engineering Blog"
+        self.assertEqual(
+            canonicalize_feed_title(raw),
+            "Node 22 LTS 변경점",
+        )
+
+    def test_release_prefix_and_engineering_blog_suffix(self) -> None:
+        raw = "[Release] Spring 6.2 Virtual Thread defaults | Engineering Blog"
+        self.assertEqual(
+            canonicalize_feed_title(raw),
+            "Spring 6.2 Virtual Thread defaults",
+        )
+
+    def test_collapses_internal_whitespace(self) -> None:
+        raw = "  [번역]\tKubernetes  probe  edge  cases  "
+        self.assertEqual(
+            canonicalize_feed_title(raw),
+            "Kubernetes probe edge cases",
+        )
+
+    def test_falls_back_when_title_is_empty_after_scrub(self) -> None:
+        self.assertEqual(
+            canonicalize_feed_title("[공지]", fallback="Node 22 LTS 변경점"),
+            "Node 22 LTS 변경점",
+        )
+
+    def test_truncates_long_titles_on_phrase_boundary(self) -> None:
+        raw = (
+            "How to tune retry budgets for cross-region failover without "
+            "breaking p99 latency or saturating workers"
+        )
+        out = canonicalize_feed_title(raw, max_chars=48)
+        self.assertTrue(out.endswith("…"))
+        self.assertLessEqual(len(out), 49)
+        # Truncation happens on a word boundary — never mid-word.
+        self.assertFalse(out.rstrip("…").endswith(" "))
+
+    def test_short_title_passes_through_unchanged(self) -> None:
+        raw = "Spring 6.2 가상 스레드"
+        self.assertEqual(canonicalize_feed_title(raw), raw)
+
+    def test_empty_title_with_empty_fallback_stays_empty(self) -> None:
+        self.assertEqual(canonicalize_feed_title("", fallback=""), "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engineering_intelligence/test_obsidian.py
+++ b/tests/engineering_intelligence/test_obsidian.py
@@ -113,6 +113,10 @@ class GatePassTests(unittest.TestCase):
         ei = request.metadata["engineering_intelligence"]
         self.assertEqual(ei["topic_key"], "spring-6-2-virtual-thread")
         self.assertEqual(ei["role"], "backend-engineer")
+        self.assertEqual(
+            ei["canonical_display_title"],
+            "Spring 6.2 Virtual Thread 최신 권장",
+        )
         self.assertIn("rag_tags", ei)
         # L1 autonomy hint.
         self.assertEqual(


### PR DESCRIPTION
## 📌 관련 이슈
- refs #81

## ✨ 과제 내용
- engineering-knowledge 수집 노트의 visible title을 GeekNews 스타일로 정리했습니다.
- 파일명 날짜 규칙은 유지하고, 사람이 보는 제목만 deterministic하게 canonical title로 정규화합니다.
- raw feed headline의 prefix/suffix 제거, phrase-boundary truncate, Obsidian metadata의 canonical display title stamp를 추가했습니다.
- 범위는 engineering_intelligence 축으로만 제한했습니다.

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- tests.engineering_intelligence.test_feed_parser
- tests.engineering_intelligence.test_obsidian
- 검증: 48 tests OK
- 후속: Discord digest / retrieval surface에도 같은 canonical title contract를 더 넓게 연결할 수 있음
