### PR TITLE
✨ #81 역할별 반복 실수 ledger + preflight seam — round 1

### DIFF
--- a/agents/engineering-agent/hooks/README.md
+++ b/agents/engineering-agent/hooks/README.md
@@ -81,11 +81,12 @@ related_skills:
 
 본 markdown 정의가 *아무리* `blocking=true` 라고 선언해도, 실제 **secret 출력 / pem 노출 / protected branch / merge / push** 같은 가드는 코드 수준 (autonomy_policy + github_writer + redact_secret_like) 에서 1 차 차단된다. hook 은 정책 추적·감사용이지 보안 1 차 line 이 아니다.
 
-## 7. 디렉터리 인벤토리 (2026-05-08 시점)
+## 7. 디렉터리 인벤토리 (2026-05-10 시점)
 
 | hook | fires_on | phase | sync | 상태 |
 | --- | --- | --- | --- | --- |
 | [`research-first-gate`](research-first-gate.md) | deliberation | pre | blocking | 정의 (reference manifest) |
+| [`role-mistake-preflight`](role-mistake-preflight.md) | coding_authorization_pending | pre | advisory | 정의 + pure-python seam + tests |
 
 새 hook 추가:
 

--- a/agents/engineering-agent/hooks/role-mistake-preflight.md
+++ b/agents/engineering-agent/hooks/role-mistake-preflight.md
@@ -1,0 +1,121 @@
+---
+id: role-mistake-preflight
+title: 역할별 반복 실수 preflight 게이트
+fires_on: coding_authorization_pending
+phase: pre
+sync: advisory
+owner_role: tech-lead
+applicable_roles:
+  - tech-lead
+  - backend-engineer
+  - frontend-engineer
+  - qa-engineer
+  - product-designer
+  - devops
+output_contract:
+  - verdict: pass | advisory | warning | block
+  - role_id: str
+  - action: str
+  - triggered_mistake_keys: list[str]
+  - checklist: list[str]
+  - headline: str
+side_effects:
+  - 운영자/다음 worker 프롬프트에 preflight checklist 노출
+  - block 판정 시 lifecycle 단계 진입 보류 (gateway 가 사유 surface)
+preconditions:
+  - workflow_session 존재
+  - role_id 와 action(예: coding_execute / discussion_handoff)이 정해져 있음
+references:
+  - src/yule_orchestrator/agents/lifecycle/mistake_ledger.py
+  - src/yule_orchestrator/agents/lifecycle/preflight_judgement.py
+  - src/yule_orchestrator/agents/lifecycle/hook_candidate.py
+  - src/yule_orchestrator/agents/lifecycle/mistake_surface.py
+related_skills: []
+---
+
+# Hook: role-mistake-preflight
+
+> **현재 단계:** Foundation 정의 + pure-python seam + tests. 자동 호출 dispatcher 는 후속 PR (이슈 #81 의 후속 live wiring).
+
+## 트리거 조건
+
+다음 모두를 만족하는 시점에 fire (= 역할별 작업 진입 직전 evaluator):
+
+1. workflow_session 의 lifecycle stage 가 다음 중 하나로 이동 직전:
+   - `coding_authorization_pending` / `coding_job_ready` (coding-execute 직전)
+   - `obsidian_preview` 의 discussion handoff
+   - 이 외에도 역할이 명시적으로 결정된 모든 분배 시점에서 호출 가능
+2. session 에 대해 role_id 가 정해져 있다 (예: backend-engineer, qa-engineer, devops 등).
+3. session.extra 의 `role_mistake_ledger` 가 비어 있지 않다 (없으면 즉시 PASS).
+
+## 동작
+
+```
+역할 분배 직전
+    │
+    ▼
+[1] mistake_ledger 에서 role_id 의 mistakes_for_role 호출
+    │
+    ▼
+[2] preflight_judgement.evaluate_preflight 호출 — verdict 산출
+    │
+    ▼
+[3] verdict 별 routing
+    │
+    ├─ pass     → 통과 (signal 없음)
+    ├─ advisory → 다음 worker 프롬프트 / 운영자 surface 에 checklist 추가
+    ├─ warning  → 위 + #봇-상태 markdown block 에 강조
+    └─ block    → lifecycle 진행 보류 + 게이트웨이가 사유 surface
+```
+
+## 차단 / 통과 매트릭스
+
+| 조건 (occurrence_count, severity) | verdict | 사용자/operator 응답 |
+| --- | --- | --- |
+| 0회 (해당 role 의 mistake 없음) | ✅ pass | (응답 없음) |
+| 2회 이상 (모든 severity) | 💡 advisory | 다음 worker 프롬프트에 prevention checklist 첨부 |
+| 3회 이상 (모든 severity) | ⚠️ warning | advisory + `#봇-상태` 게시판 강조 |
+| 5회 이상 (모든 severity) | ⛔ block | lifecycle 보류 + "같은 실수가 5회 발생했습니다" surface |
+| 3회 이상 + severity = high | ⛔ block | 위와 같음 (예: protected branch push 누적) |
+
+threshold 는 `PreflightThresholds` 로 호출 측에서 바꿀 수 있다.
+
+## 실패 시 routing
+
+- `verdict = block` 이면:
+  1. lifecycle 단계는 직전 stage 로 보류, 게이트웨이가 운영자에게 "어떤 mistake_key 가 한도를 넘었는지" 알린다.
+  2. 운영자가 hook 후보 promotion 을 결정하면 `hook_candidate.promote_postmortem_to_hook_candidate` 로 deterministic id 를 받아 후속 hook markdown 을 만든다.
+  3. 사용자가 명시적으로 override 하면 `L2_AUTO_POST_REPORT` autonomy_policy 로 강제 (자동 audit 필수).
+- `verdict ∈ {advisory, warning}` 이면 lifecycle 진행, surface 에 checklist 만 추가.
+
+## 관련 audit 기록
+
+본 hook 자체는 read-only seam. 다음 audit 가 함께 남는다:
+
+- 진입 시점에 `agent_ops_audit` 에 (action=preflight_judgement, autonomy_level=L1_AUTO_RECORD_REQUIRED, summary="role={role_id} action={action} verdict={verdict}") 기록 (live wiring 후속 단계).
+- 차단 시 `coding_execute` 직전이면 게이트웨이가 사용자 surface 발화도 함께 audit.
+
+## 코드 수준 enforcement
+
+본 markdown 은 정책 명시화. 실제 코드 측면 enforcement 는 다음에 존재한다:
+
+- `src/yule_orchestrator/agents/lifecycle/mistake_ledger.py::record_mistake / read_mistake_ledger` — ledger 기록/조회
+- `src/yule_orchestrator/agents/lifecycle/preflight_judgement.py::evaluate_preflight` — verdict 산출 (pure-python, side-effect 없음)
+- `src/yule_orchestrator/agents/lifecycle/hook_candidate.py::promote_record_to_hook_candidate` — 반복 실수 → 후보 hook 승격
+- `src/yule_orchestrator/agents/lifecycle/mistake_surface.py::build_operator_surface` — 운영자 surface (preflight + ledger + 후보 hook 합본)
+
+이 hook 의 dispatcher 가 land 하면 위 함수들을 호출하는 wiring 만 추가하면 됨. 새 enforcement 코드 작성 불필요.
+
+## Hard rails
+
+- 본 hook 은 "역할별 반복 실수" 를 surface 하는 뉴얼 게이트지 secret / branch protection 같은 1 차 line 이 아니다. 1 차 line 은 그대로 `autonomy_policy + github_writer + redact_secret_like` 가 책임.
+- `block` 판정도 silent failure 없이 한국어로 사유를 surface 한다.
+
+## 검증 / 회귀
+
+| 테스트 | 위치 | 상태 |
+| --- | --- | --- |
+| 반복 실수 count 누적 + threshold 격상 | `tests/agents/test_mistake_ledger.py`, `tests/agents/test_preflight_judgement.py` | ✅ 통과 |
+| postmortem → hook candidate 변환 | `tests/agents/test_hook_candidate.py` | ✅ 통과 |
+| operator surface render | `tests/agents/test_mistake_surface.py` | ✅ 통과 |
+| dispatcher 가 본 hook 을 lifecycle stage 직전에 호출 | (후속 live wiring PR) | ⏳ 대기 |

--- a/src/yule_orchestrator/agents/lifecycle/hook_candidate.py
+++ b/src/yule_orchestrator/agents/lifecycle/hook_candidate.py
@@ -1,0 +1,243 @@
+"""Hook-candidate promotion seam — issue #81 round 1.
+
+When a postmortem / blocked completion / CI retry exhaustion produces
+a recurring failure reason, a follow-up engineer should be able to
+ask "should this become a future blocking hook?" without re-deriving
+the answer by hand. This module owns the deterministic projection:
+
+  recurring mistake → :class:`HookCandidate`
+
+Round 1 stops at *contract* — the helper does NOT yet generate the
+markdown spec under ``agents/engineering-agent/hooks/``. That live
+wiring lands in a follow-up. The deterministic ``future_hook_id`` is
+the contract follow-up wiring depends on, so producers can reference
+the candidate now and the live writer can pick up the same id when it
+lands.
+
+ID shape:
+
+  ``preflight-<role-id>-<mistake-key-slug>``
+
+Examples:
+  * role=devops, key=ci:protected_branch_blocked →
+    ``preflight-devops-ci-protected-branch-blocked``
+  * role=qa-engineer, key=missing_regression_check →
+    ``preflight-qa-engineer-missing-regression-check``
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+from .mistake_ledger import (
+    MistakeRecord,
+    SEVERITY_MEDIUM,
+    SOURCE_POSTMORTEM,
+)
+
+
+HOOK_CANDIDATE_ID_PREFIX: str = "preflight"
+
+
+# The minimum evidence we want before nominating a recurring mistake
+# as a hook candidate. Single occurrences are surfaced through the
+# normal preflight advisory; we only suggest *a hook* once a pattern
+# has bitten more than once.
+DEFAULT_MIN_EVIDENCE: int = 2
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HookCandidate:
+    """Deterministic projection of a recurring mistake into a future hook.
+
+    ``future_hook_id`` is stable across runs given the same
+    ``(role_id, mistake_key)`` so the live wiring can recognise an
+    already-promoted candidate and avoid duplicate hook spec files.
+
+    ``source_kind`` mirrors the originating mistake row so an audit
+    reader can follow the candidate back to its evidence without
+    re-querying the ledger.
+    """
+
+    future_hook_id: str
+    role_id: str
+    mistake_key: str
+    summary: str
+    prevention_hint: str
+    source_kind: str
+    severity: str
+    evidence_count: int
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "future_hook_id": self.future_hook_id,
+            "role_id": self.role_id,
+            "mistake_key": self.mistake_key,
+            "summary": self.summary,
+            "prevention_hint": self.prevention_hint,
+            "source_kind": self.source_kind,
+            "severity": self.severity,
+            "evidence_count": self.evidence_count,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def slugify_hook_id(role_id: str, mistake_key: str) -> str:
+    """Derive the deterministic ``future_hook_id`` for *(role, key)*.
+
+    Idempotent: two callers with the same inputs always produce the
+    same id. The output is kebab-case ASCII lowercase so it is safe
+    to use as a markdown filename or HTTP path segment.
+    """
+
+    role = _slug(role_id)
+    key = _slug(mistake_key)
+    if not role:
+        role = "role"
+    if not key:
+        key = "mistake"
+    return f"{HOOK_CANDIDATE_ID_PREFIX}-{role}-{key}"
+
+
+def promote_record_to_hook_candidate(
+    record: MistakeRecord,
+    *,
+    min_evidence: int = DEFAULT_MIN_EVIDENCE,
+) -> Optional[HookCandidate]:
+    """Promote a :class:`MistakeRecord` to a hook candidate.
+
+    Returns ``None`` when the record doesn't meet the evidence bar so
+    the caller can iterate over the entire ledger and filter
+    candidates in one pass.
+    """
+
+    if record.occurrence_count < max(1, int(min_evidence)):
+        return None
+    return HookCandidate(
+        future_hook_id=slugify_hook_id(record.role_id, record.mistake_key),
+        role_id=record.role_id,
+        mistake_key=record.mistake_key,
+        summary=record.summary,
+        prevention_hint=record.prevention_hint,
+        source_kind=record.source_kind,
+        severity=record.severity,
+        evidence_count=record.occurrence_count,
+    )
+
+
+def promote_postmortem_to_hook_candidate(
+    *,
+    role_id: str,
+    mistake_key: str,
+    summary: str,
+    prevention_hint: str,
+    severity: str = SEVERITY_MEDIUM,
+    evidence_count: int = 1,
+    source_kind: str = SOURCE_POSTMORTEM,
+) -> HookCandidate:
+    """Build a hook candidate directly from postmortem inputs.
+
+    Used by the failure-postmortem producer and the CI retry
+    exhaustion path. Unlike :func:`promote_record_to_hook_candidate`
+    this never returns ``None`` — the caller has decided the postmortem
+    *is* worth promoting; this helper just stamps the deterministic id.
+    """
+
+    role = str(role_id or "").strip()
+    key = str(mistake_key or "").strip()
+    if not role or not key:
+        raise ValueError("role_id and mistake_key are required")
+    return HookCandidate(
+        future_hook_id=slugify_hook_id(role, key),
+        role_id=role,
+        mistake_key=key,
+        summary=summary.strip(),
+        prevention_hint=prevention_hint.strip(),
+        source_kind=source_kind,
+        severity=severity,
+        evidence_count=max(1, int(evidence_count)),
+    )
+
+
+def collect_hook_candidates(
+    records: Iterable[MistakeRecord],
+    *,
+    min_evidence: int = DEFAULT_MIN_EVIDENCE,
+) -> Tuple[HookCandidate, ...]:
+    """Filter the ledger down to its hook-candidate-worthy rows.
+
+    Returned tuple is sorted by ``evidence_count`` descending then by
+    ``future_hook_id`` so the operator surface always shows the
+    strongest candidates at the top.
+    """
+
+    out: list[HookCandidate] = []
+    for record in records:
+        candidate = promote_record_to_hook_candidate(
+            record, min_evidence=min_evidence
+        )
+        if candidate is not None:
+            out.append(candidate)
+    out.sort(
+        key=lambda c: (-c.evidence_count, c.future_hook_id)
+    )
+    return tuple(out)
+
+
+def render_hook_candidate_block(
+    candidates: Sequence[HookCandidate],
+) -> str:
+    """One-line-per-candidate operator-readable block.
+
+    Returns the empty string when *candidates* is empty so the caller
+    can append unconditionally without growing the surface.
+    """
+
+    if not candidates:
+        return ""
+    lines: list[str] = ["hook 후보:"]
+    for candidate in candidates:
+        lines.append(
+            f"  - `{candidate.future_hook_id}` "
+            f"role=`{candidate.role_id}` "
+            f"({candidate.evidence_count}회, {candidate.severity}) "
+            f"— {candidate.summary}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = _SLUG_RE.sub("-", text)
+    return text.strip("-")
+
+
+__all__ = (
+    "DEFAULT_MIN_EVIDENCE",
+    "HOOK_CANDIDATE_ID_PREFIX",
+    "HookCandidate",
+    "collect_hook_candidates",
+    "promote_postmortem_to_hook_candidate",
+    "promote_record_to_hook_candidate",
+    "render_hook_candidate_block",
+    "slugify_hook_id",
+)

--- a/src/yule_orchestrator/agents/lifecycle/mistake_ledger.py
+++ b/src/yule_orchestrator/agents/lifecycle/mistake_ledger.py
@@ -1,0 +1,492 @@
+"""Role-specific mistake ledger — issue #81 round 1.
+
+Hookify the engineering-agent runtime by surfacing repeated role-level
+mistakes (CI failure / blocked completion / postmortem reason) so the
+preflight judgement seam can warn or block before the same mistake is
+attempted again.
+
+Storage model — round 1 stage:
+
+  * Records land on ``session.extra['role_mistake_ledger']`` as a list
+    of payload-friendly dicts so a single SQLite write of the existing
+    session row carries the ledger forward.
+  * **No persistent DB yet** — by design (see issue #81). Once we have
+    a stable contract, a follow-up can lift the same shape into a
+    cross-session table without changing producer call sites.
+
+The ledger is keyed by ``(role_id, mistake_key)``: re-recording the
+same mistake increments ``occurrence_count`` and bumps
+``last_seen_at`` instead of appending a new row. That keeps the
+ledger small even on long-lived sessions and makes
+``preflight_judgement.evaluate_preflight`` cheap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+SESSION_EXTRA_KEY: str = "role_mistake_ledger"
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+SOURCE_CI_FAILURE: str = "ci_failure"
+SOURCE_BLOCKED_COMPLETION: str = "blocked_completion"
+SOURCE_POSTMORTEM: str = "postmortem"
+SOURCE_MANUAL_NOTE: str = "manual_note"
+
+SOURCE_KINDS: Tuple[str, ...] = (
+    SOURCE_CI_FAILURE,
+    SOURCE_BLOCKED_COMPLETION,
+    SOURCE_POSTMORTEM,
+    SOURCE_MANUAL_NOTE,
+)
+
+
+SEVERITY_LOW: str = "low"
+SEVERITY_MEDIUM: str = "medium"
+SEVERITY_HIGH: str = "high"
+
+SEVERITIES: Tuple[str, ...] = (SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH)
+
+
+_SEVERITY_ORDER: Mapping[str, int] = {
+    SEVERITY_LOW: 0,
+    SEVERITY_MEDIUM: 1,
+    SEVERITY_HIGH: 2,
+}
+
+
+def _normalise_severity(value: Any) -> str:
+    raw = (str(value or "").strip() or SEVERITY_LOW).lower()
+    if raw not in _SEVERITY_ORDER:
+        return SEVERITY_LOW
+    return raw
+
+
+def _normalise_source_kind(value: Any) -> str:
+    raw = (str(value or "").strip() or SOURCE_MANUAL_NOTE).lower()
+    if raw not in SOURCE_KINDS:
+        return SOURCE_MANUAL_NOTE
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MistakeRecord:
+    """One ``(role_id, mistake_key)`` row in the ledger.
+
+    The dataclass is frozen so producers can pass it across boundaries
+    without worrying about accidental mutation. Mutation = build a new
+    record via :meth:`bump`.
+    """
+
+    role_id: str
+    mistake_key: str
+    summary: str
+    severity: str
+    prevention_hint: str
+    source_kind: str
+    first_seen_at: str
+    last_seen_at: str
+    occurrence_count: int = 1
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "role_id": self.role_id,
+            "mistake_key": self.mistake_key,
+            "summary": self.summary,
+            "severity": self.severity,
+            "prevention_hint": self.prevention_hint,
+            "source_kind": self.source_kind,
+            "first_seen_at": self.first_seen_at,
+            "last_seen_at": self.last_seen_at,
+            "occurrence_count": self.occurrence_count,
+        }
+
+    @classmethod
+    def from_payload(
+        cls, data: Optional[Mapping[str, Any]]
+    ) -> Optional["MistakeRecord"]:
+        if not isinstance(data, Mapping):
+            return None
+        role_id = str(data.get("role_id") or "").strip()
+        mistake_key = str(data.get("mistake_key") or "").strip()
+        if not role_id or not mistake_key:
+            return None
+        try:
+            count = int(data.get("occurrence_count") or 1)
+        except (TypeError, ValueError):
+            count = 1
+        return cls(
+            role_id=role_id,
+            mistake_key=mistake_key,
+            summary=str(data.get("summary") or ""),
+            severity=_normalise_severity(data.get("severity")),
+            prevention_hint=str(data.get("prevention_hint") or ""),
+            source_kind=_normalise_source_kind(data.get("source_kind")),
+            first_seen_at=str(data.get("first_seen_at") or ""),
+            last_seen_at=str(data.get("last_seen_at") or ""),
+            occurrence_count=max(1, count),
+        )
+
+    def bump(
+        self,
+        *,
+        when: str,
+        summary: Optional[str] = None,
+        prevention_hint: Optional[str] = None,
+        severity: Optional[str] = None,
+        source_kind: Optional[str] = None,
+    ) -> "MistakeRecord":
+        """Return a new record with ``occurrence_count`` incremented.
+
+        Severity can only escalate (low → medium → high); a recurring
+        mistake whose new evidence is *milder* keeps the previous
+        severity so the ledger never silently relaxes a prior risk
+        signal. Summary / prevention_hint update opportunistically:
+        the latest non-empty value wins.
+        """
+
+        next_severity = self.severity
+        if severity is not None:
+            normalised = _normalise_severity(severity)
+            if _SEVERITY_ORDER[normalised] > _SEVERITY_ORDER[self.severity]:
+                next_severity = normalised
+        return MistakeRecord(
+            role_id=self.role_id,
+            mistake_key=self.mistake_key,
+            summary=(summary or self.summary).strip() or self.summary,
+            severity=next_severity,
+            prevention_hint=(
+                (prevention_hint or self.prevention_hint).strip()
+                or self.prevention_hint
+            ),
+            source_kind=(
+                _normalise_source_kind(source_kind)
+                if source_kind is not None
+                else self.source_kind
+            ),
+            first_seen_at=self.first_seen_at,
+            last_seen_at=when,
+            occurrence_count=self.occurrence_count + 1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers (session.extra round trip)
+# ---------------------------------------------------------------------------
+
+
+def record_mistake(
+    extra: Optional[Mapping[str, Any]],
+    *,
+    role_id: str,
+    mistake_key: str,
+    summary: str,
+    prevention_hint: str,
+    source_kind: str = SOURCE_MANUAL_NOTE,
+    severity: str = SEVERITY_LOW,
+    when: Optional[str] = None,
+    max_entries: int = 64,
+) -> Tuple[Mapping[str, Any], MistakeRecord]:
+    """Append (or bump) a mistake on the role-mistake ledger.
+
+    Returns ``(new_extra, record)`` where ``new_extra`` is a new dict
+    the caller persists via the same path the existing audit log uses
+    (``workflow_state.update_session``). The original *extra* is not
+    mutated.
+
+    Resolution rule for repeats:
+      * same ``(role_id, mistake_key)`` → ``occurrence_count += 1``,
+        ``last_seen_at`` advances, severity can only escalate.
+      * new key → fresh record with ``occurrence_count == 1``.
+
+    The ledger is capped at *max_entries*; oldest-by-``last_seen_at``
+    entries fall off so a long-lived session row never grows
+    unbounded. Defaults to 64 because preflight judgement only needs
+    "what has bitten this role recently", not a full failure history.
+    """
+
+    role_id = str(role_id or "").strip()
+    mistake_key = str(mistake_key or "").strip()
+    if not role_id or not mistake_key:
+        raise ValueError("role_id and mistake_key are required")
+
+    when_iso = (when or _utc_now_iso()).strip() or _utc_now_iso()
+    severity_norm = _normalise_severity(severity)
+    source_norm = _normalise_source_kind(source_kind)
+
+    new_extra: dict = dict(extra or {})
+    raw = new_extra.get(SESSION_EXTRA_KEY)
+    existing: list[MistakeRecord] = []
+    if isinstance(raw, list):
+        for item in raw:
+            entry = MistakeRecord.from_payload(item)
+            if entry is not None:
+                existing.append(entry)
+
+    updated: Optional[MistakeRecord] = None
+    output: list[MistakeRecord] = []
+    for entry in existing:
+        if entry.role_id == role_id and entry.mistake_key == mistake_key:
+            updated = entry.bump(
+                when=when_iso,
+                summary=summary,
+                prevention_hint=prevention_hint,
+                severity=severity_norm,
+                source_kind=source_norm,
+            )
+            output.append(updated)
+        else:
+            output.append(entry)
+    if updated is None:
+        updated = MistakeRecord(
+            role_id=role_id,
+            mistake_key=mistake_key,
+            summary=summary.strip(),
+            severity=severity_norm,
+            prevention_hint=prevention_hint.strip(),
+            source_kind=source_norm,
+            first_seen_at=when_iso,
+            last_seen_at=when_iso,
+            occurrence_count=1,
+        )
+        output.append(updated)
+
+    output.sort(key=lambda r: r.last_seen_at)
+    if len(output) > max_entries:
+        output = output[-max_entries:]
+    new_extra[SESSION_EXTRA_KEY] = [dict(r.to_payload()) for r in output]
+    return new_extra, updated
+
+
+def read_mistake_ledger(source: Any) -> Tuple[MistakeRecord, ...]:
+    """Read mistake records out of a session-shaped object or extra dict.
+
+    Returns oldest-first (ordered by ``last_seen_at`` ascending).
+    Empty tuple when nothing recorded — never raises.
+    """
+
+    if source is None:
+        return ()
+    if isinstance(source, Mapping):
+        extra = source
+    else:
+        extra = getattr(source, "extra", None)
+    if not isinstance(extra, Mapping):
+        return ()
+    raw = extra.get(SESSION_EXTRA_KEY)
+    if not isinstance(raw, list):
+        return ()
+    out: list[MistakeRecord] = []
+    for item in raw:
+        entry = MistakeRecord.from_payload(item)
+        if entry is not None:
+            out.append(entry)
+    out.sort(key=lambda r: r.last_seen_at)
+    return tuple(out)
+
+
+def mistakes_for_role(source: Any, role_id: str) -> Tuple[MistakeRecord, ...]:
+    """Subset of the ledger filtered to a single role."""
+
+    role_id = str(role_id or "").strip()
+    if not role_id:
+        return ()
+    return tuple(
+        r for r in read_mistake_ledger(source) if r.role_id == role_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregations + derivations
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoleMistakeSummary:
+    """Per-role projection used by the operator surface."""
+
+    role_id: str
+    total_mistakes: int
+    high_severity_count: int
+    medium_severity_count: int
+    low_severity_count: int
+    total_occurrences: int
+    top_recurring: Tuple[MistakeRecord, ...] = ()
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "role_id": self.role_id,
+            "total_mistakes": self.total_mistakes,
+            "high_severity_count": self.high_severity_count,
+            "medium_severity_count": self.medium_severity_count,
+            "low_severity_count": self.low_severity_count,
+            "total_occurrences": self.total_occurrences,
+            "top_recurring": [dict(r.to_payload()) for r in self.top_recurring],
+        }
+
+
+def summarize_role_mistakes(
+    source: Any,
+    *,
+    top_recurring: int = 3,
+) -> Tuple[RoleMistakeSummary, ...]:
+    """Aggregate the ledger into per-role summaries.
+
+    Returned tuple is ordered alphabetically by ``role_id`` so the
+    operator surface renders deterministically.
+    """
+
+    records = read_mistake_ledger(source)
+    grouped: dict[str, list[MistakeRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.role_id, []).append(record)
+
+    summaries: list[RoleMistakeSummary] = []
+    for role_id in sorted(grouped):
+        entries = grouped[role_id]
+        high = sum(1 for r in entries if r.severity == SEVERITY_HIGH)
+        medium = sum(1 for r in entries if r.severity == SEVERITY_MEDIUM)
+        low = sum(1 for r in entries if r.severity == SEVERITY_LOW)
+        occurrences = sum(r.occurrence_count for r in entries)
+        ranked = sorted(
+            entries,
+            key=lambda r: (
+                -r.occurrence_count,
+                -_SEVERITY_ORDER[r.severity],
+                r.mistake_key,
+            ),
+        )
+        summaries.append(
+            RoleMistakeSummary(
+                role_id=role_id,
+                total_mistakes=len(entries),
+                high_severity_count=high,
+                medium_severity_count=medium,
+                low_severity_count=low,
+                total_occurrences=occurrences,
+                top_recurring=tuple(ranked[: max(0, int(top_recurring))]),
+            )
+        )
+    return tuple(summaries)
+
+
+def derive_mistake_from_completion(
+    *,
+    event: Any,
+) -> Optional[Mapping[str, Any]]:
+    """Project a :class:`JobCompletionEvent` into mistake-record kwargs.
+
+    Returns ``None`` when the event isn't surface-worthy (success,
+    pending approval, or missing role). Otherwise returns the kwargs
+    the caller hands to :func:`record_mistake`.
+
+    The producer (e.g. a completion-funnel wrapper) decides *when* to
+    persist; this helper only owns the projection so the caller can
+    audit-route or no-op without depending on extra-mutation order.
+    """
+
+    if event is None:
+        return None
+    status = str(getattr(event, "status", "") or "").strip().lower()
+    if status not in {"blocked", "failed_terminal", "manual"}:
+        return None
+    role = str(getattr(event, "role", "") or "").strip()
+    if not role:
+        return None
+    reason = str(getattr(event, "reason", "") or "").strip()
+    job_type = str(getattr(event, "job_type", "") or "").strip()
+    mistake_key = (reason or job_type or "blocked_completion").lower()
+    mistake_key = mistake_key.replace(" ", "_")[:64]
+    summary = reason or f"{job_type} 작업이 blocked 상태로 종료됨"
+    return {
+        "role_id": role,
+        "mistake_key": mistake_key,
+        "summary": summary,
+        "prevention_hint": (
+            "blocked 사유 점검 후 재진입 전 동일 reason 패턴이 반복되는지 "
+            "확인하라."
+        ),
+        "source_kind": SOURCE_BLOCKED_COMPLETION,
+        "severity": SEVERITY_MEDIUM,
+    }
+
+
+def derive_mistake_from_ci_exhaustion(
+    *,
+    role_id: str,
+    failing_runs: Sequence[str],
+    pr_number: Optional[int] = None,
+    attempts: int = 0,
+) -> Optional[Mapping[str, Any]]:
+    """Project a CI retry-exhaustion event into mistake-record kwargs.
+
+    Returns ``None`` if *role_id* is empty (the role is the ledger
+    primary key — no role, no row).
+    """
+
+    role = str(role_id or "").strip()
+    if not role:
+        return None
+    failing = tuple(str(r) for r in failing_runs if r)
+    name = failing[0] if failing else "ci_failure"
+    mistake_key = f"ci:{name}".lower().replace(" ", "_")[:64]
+    pr_part = f" PR #{pr_number}" if pr_number else ""
+    summary = (
+        f"CI '{name}' 가{pr_part} {attempts}회 재시도 후에도 실패 — "
+        "재진입 전 동일 실패 패턴 확인 필요"
+    )
+    return {
+        "role_id": role,
+        "mistake_key": mistake_key,
+        "summary": summary,
+        "prevention_hint": (
+            "동일 CI job 이 반복 실패하는 경우 PR diff 와 가장 최근 실패 "
+            "로그를 확인한 뒤 변경 후 재실행하라."
+        ),
+        "source_kind": SOURCE_CI_FAILURE,
+        "severity": SEVERITY_HIGH if attempts >= 3 else SEVERITY_MEDIUM,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+__all__ = (
+    "MistakeRecord",
+    "RoleMistakeSummary",
+    "SESSION_EXTRA_KEY",
+    "SEVERITIES",
+    "SEVERITY_HIGH",
+    "SEVERITY_LOW",
+    "SEVERITY_MEDIUM",
+    "SOURCE_BLOCKED_COMPLETION",
+    "SOURCE_CI_FAILURE",
+    "SOURCE_KINDS",
+    "SOURCE_MANUAL_NOTE",
+    "SOURCE_POSTMORTEM",
+    "derive_mistake_from_ci_exhaustion",
+    "derive_mistake_from_completion",
+    "mistakes_for_role",
+    "read_mistake_ledger",
+    "record_mistake",
+    "summarize_role_mistakes",
+)

--- a/src/yule_orchestrator/agents/lifecycle/mistake_surface.py
+++ b/src/yule_orchestrator/agents/lifecycle/mistake_surface.py
@@ -1,0 +1,195 @@
+"""Operator-readable surface for the role mistake ledger — issue #81.
+
+The ledger + preflight + hook-candidate modules each own a piece of
+the data; the operator surface joins them into one short summary
+that runtime/status renderers and completion metadata can splice
+without re-importing each producer.
+
+This module deliberately stays text-only. The runtime status
+renderer in :mod:`runtime.status` already owns the markdown / JSON
+shape for service health and completion-funnel rows; mistake-ledger
+content joins as a string block so we don't have to widen
+:class:`RuntimeStatusReport` (and its many tests) to land round 1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .hook_candidate import (
+    HookCandidate,
+    collect_hook_candidates,
+    render_hook_candidate_block,
+)
+from .mistake_ledger import (
+    MistakeRecord,
+    RoleMistakeSummary,
+    read_mistake_ledger,
+    summarize_role_mistakes,
+)
+from .preflight_judgement import (
+    PREFLIGHT_PASS,
+    PreflightAdvisory,
+    render_preflight_advisory_block,
+)
+
+
+@dataclass(frozen=True)
+class MistakeOperatorSurface:
+    """Joined view: per-role summaries + preflight + hook candidates.
+
+    Each producer can build this once per surface tick (status post,
+    completion-funnel stamp, gateway response) and either render it
+    or persist its payload alongside the existing audit / funnel
+    blocks.
+    """
+
+    summaries: Tuple[RoleMistakeSummary, ...]
+    preflight: Optional[PreflightAdvisory] = None
+    hook_candidates: Tuple[HookCandidate, ...] = ()
+
+    def is_empty(self) -> bool:
+        if self.summaries:
+            return False
+        if self.hook_candidates:
+            return False
+        if self.preflight is not None and self.preflight.has_signal():
+            return False
+        return True
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "summaries": [s.to_payload() for s in self.summaries],
+            "preflight": (
+                self.preflight.to_payload()
+                if self.preflight is not None
+                else None
+            ),
+            "hook_candidates": [c.to_payload() for c in self.hook_candidates],
+            "summary_line": self.summary_line(),
+        }
+
+    def summary_line(self) -> str:
+        """One-line digest — fits runtime/status banners and funnel rows.
+
+        Returns the empty string when there is no signal so producers
+        can append unconditionally without growing the surface. Shape:
+
+          ``"역할 N건 (총 M회) · preflight=<verdict> · hook 후보 K건"``
+
+        The preflight clause is dropped when no advisory is attached or
+        when it didn't trigger; the hook-candidate clause is dropped
+        when there are no candidates. The role-count clause is dropped
+        when the ledger is empty.
+        """
+
+        parts: list[str] = []
+        if self.summaries:
+            occurrences = sum(s.total_occurrences for s in self.summaries)
+            parts.append(
+                f"역할 {len(self.summaries)}건 (총 {occurrences}회)"
+            )
+        if self.preflight is not None and self.preflight.has_signal():
+            parts.append(f"preflight={self.preflight.verdict}")
+        if self.hook_candidates:
+            parts.append(f"hook 후보 {len(self.hook_candidates)}건")
+        return " · ".join(parts)
+
+
+def build_operator_surface(
+    source: Any,
+    *,
+    preflight: Optional[PreflightAdvisory] = None,
+    min_evidence: int = 2,
+    top_recurring: int = 3,
+) -> MistakeOperatorSurface:
+    """Project the ledger on *source* into the operator-friendly view.
+
+    *preflight* is optional — supply it when the surface tick coincides
+    with a role-specific preflight evaluation (e.g. before a
+    coding-execute dispatch). Otherwise the surface still renders the
+    per-role summary + hook candidates, just without the preflight
+    headline.
+
+    *min_evidence* propagates to :func:`collect_hook_candidates` so
+    callers can decide how aggressive the "this should become a hook"
+    suggestion is. Default 2 matches the candidate module's policy.
+    """
+
+    summaries = summarize_role_mistakes(source, top_recurring=top_recurring)
+    records = read_mistake_ledger(source)
+    candidates = collect_hook_candidates(records, min_evidence=min_evidence)
+    return MistakeOperatorSurface(
+        summaries=summaries,
+        preflight=preflight,
+        hook_candidates=candidates,
+    )
+
+
+def render_operator_surface_block(
+    surface: MistakeOperatorSurface,
+    *,
+    title: str = "역할별 반복 실수",
+) -> str:
+    """Render *surface* as a short, copy-pasteable text block.
+
+    Returns the empty string when *surface* has no signal so callers
+    can append unconditionally to a status post / funnel summary
+    without growing the surface.
+    """
+
+    if surface.is_empty():
+        return ""
+
+    lines: list[str] = [f"### {title}"]
+    if not surface.summaries:
+        lines.append("  (역할별 반복 실수 기록 없음)")
+    else:
+        for summary in surface.summaries:
+            lines.append(_format_role_summary_line(summary))
+            for record in summary.top_recurring:
+                lines.append(_format_top_record_line(record))
+
+    if (
+        surface.preflight is not None
+        and surface.preflight.verdict != PREFLIGHT_PASS
+    ):
+        block = render_preflight_advisory_block(surface.preflight)
+        if block:
+            lines.append("")
+            lines.append("preflight 판정:")
+            for chunk in block.split("\n"):
+                lines.append("  " + chunk if chunk else "")
+
+    if surface.hook_candidates:
+        lines.append("")
+        block = render_hook_candidate_block(surface.hook_candidates)
+        if block:
+            for chunk in block.split("\n"):
+                lines.append(chunk)
+
+    return "\n".join(lines).rstrip()
+
+
+def _format_role_summary_line(summary: RoleMistakeSummary) -> str:
+    return (
+        f"- `{summary.role_id}` — 누적 실수 {summary.total_mistakes}건 "
+        f"({summary.total_occurrences}회 발생, "
+        f"high={summary.high_severity_count} med={summary.medium_severity_count} "
+        f"low={summary.low_severity_count})"
+    )
+
+
+def _format_top_record_line(record: MistakeRecord) -> str:
+    return (
+        f"    · `{record.mistake_key}` x{record.occurrence_count} "
+        f"({record.severity}, {record.source_kind}) — {record.summary}"
+    )
+
+
+__all__ = (
+    "MistakeOperatorSurface",
+    "build_operator_surface",
+    "render_operator_surface_block",
+)

--- a/src/yule_orchestrator/agents/lifecycle/preflight_judgement.py
+++ b/src/yule_orchestrator/agents/lifecycle/preflight_judgement.py
@@ -1,0 +1,302 @@
+"""Preflight judgement seam — issue #81 round 1.
+
+Hook point that fires *just before* a role-scoped action so the agent
+can surface "you've made this mistake before" warnings (or, for
+critical patterns, refuse to start the action). Reads from the
+session-extras ledger built by :mod:`agents.lifecycle.mistake_ledger`
+— no DB, no external state.
+
+The seam intentionally returns one of four verdicts so callers can
+ladder the response (e.g. coding-execute pre-dispatch can pass advisories
+through to the operator surface but block on a high verdict, while
+discussion handoff might just record the advisory and proceed).
+
+Threshold rules (default; producers can override via
+:class:`PreflightThresholds`):
+
+  * ``high`` severity AND ``occurrence_count >= 3`` → block
+  * ``occurrence_count >= 5`` → block (any severity — 5x is enough
+    evidence even for a low-severity mistake)
+  * ``occurrence_count >= 3`` → warning
+  * ``occurrence_count >= 2`` → advisory
+  * else → pass
+
+Hard rails (secret access / branch protection / merge) live in
+:mod:`agents.lifecycle.autonomy_policy` — this seam is purely about
+*recurring role mistakes*, not first-time destructive guards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .mistake_ledger import (
+    MistakeRecord,
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    mistakes_for_role,
+)
+
+
+# ---------------------------------------------------------------------------
+# Verdict vocabulary
+# ---------------------------------------------------------------------------
+
+
+PREFLIGHT_PASS: str = "pass"
+PREFLIGHT_ADVISORY: str = "advisory"
+PREFLIGHT_WARNING: str = "warning"
+PREFLIGHT_BLOCK: str = "block"
+
+
+PREFLIGHT_VERDICTS: Tuple[str, ...] = (
+    PREFLIGHT_PASS,
+    PREFLIGHT_ADVISORY,
+    PREFLIGHT_WARNING,
+    PREFLIGHT_BLOCK,
+)
+
+
+_VERDICT_ORDER: Mapping[str, int] = {
+    PREFLIGHT_PASS: 0,
+    PREFLIGHT_ADVISORY: 1,
+    PREFLIGHT_WARNING: 2,
+    PREFLIGHT_BLOCK: 3,
+}
+
+
+def _max_verdict(*verdicts: str) -> str:
+    return max(verdicts, key=lambda v: _VERDICT_ORDER.get(v, 0))
+
+
+# ---------------------------------------------------------------------------
+# Thresholds
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreflightThresholds:
+    """Threshold curve a role / action can override.
+
+    Defaults match the policy in the module docstring.
+    """
+
+    advisory_at: int = 2
+    warning_at: int = 3
+    block_at: int = 5
+    high_severity_block_at: int = 3
+
+    def verdict_for(self, *, occurrence_count: int, severity: str) -> str:
+        if (
+            severity == SEVERITY_HIGH
+            and occurrence_count >= max(1, int(self.high_severity_block_at))
+        ):
+            return PREFLIGHT_BLOCK
+        if occurrence_count >= max(1, int(self.block_at)):
+            return PREFLIGHT_BLOCK
+        if occurrence_count >= max(1, int(self.warning_at)):
+            return PREFLIGHT_WARNING
+        if occurrence_count >= max(1, int(self.advisory_at)):
+            return PREFLIGHT_ADVISORY
+        return PREFLIGHT_PASS
+
+
+# ---------------------------------------------------------------------------
+# Verdict dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreflightAdvisory:
+    """Result of one preflight evaluation.
+
+    ``verdict`` is the highest verdict triggered by any matched
+    mistake. ``triggered_mistakes`` is the subset of role-mistakes
+    that contributed to the verdict (i.e. produced an
+    advisory-or-stronger). ``checklist`` are the human-readable
+    prevention hints the producer should surface to the operator (or
+    the next worker prompt).
+    """
+
+    verdict: str
+    role_id: str
+    action: str
+    triggered_mistakes: Tuple[MistakeRecord, ...] = ()
+    checklist: Tuple[str, ...] = ()
+    headline: str = ""
+
+    def is_block(self) -> bool:
+        return self.verdict == PREFLIGHT_BLOCK
+
+    def has_signal(self) -> bool:
+        """True when the verdict isn't a clean pass."""
+
+        return self.verdict != PREFLIGHT_PASS
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "role_id": self.role_id,
+            "action": self.action,
+            "headline": self.headline,
+            "triggered_mistake_keys": [
+                m.mistake_key for m in self.triggered_mistakes
+            ],
+            "checklist": list(self.checklist),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_preflight(
+    source: Any,
+    *,
+    role_id: str,
+    action: str,
+    thresholds: Optional[PreflightThresholds] = None,
+    only_keys: Optional[Sequence[str]] = None,
+) -> PreflightAdvisory:
+    """Evaluate the role-mistake ledger against an upcoming *action*.
+
+    *source* may be either a session-shaped object (with ``.extra``)
+    or a raw extra mapping. *only_keys* lets the caller scope the
+    evaluation to a specific subset of mistake keys (e.g. only
+    ``ci:`` mistakes for a coding-executor preflight); the default
+    considers every mistake recorded against the role.
+
+    The returned advisory is always non-None, even when no mistake
+    triggered — callers can branch on
+    :meth:`PreflightAdvisory.has_signal`.
+    """
+
+    thresholds = thresholds or PreflightThresholds()
+    role_id = str(role_id or "").strip()
+    action = str(action or "").strip()
+
+    records = mistakes_for_role(source, role_id) if role_id else ()
+    if only_keys:
+        keep = {k for k in only_keys if k}
+        records = tuple(r for r in records if r.mistake_key in keep)
+
+    triggered: list[MistakeRecord] = []
+    final_verdict = PREFLIGHT_PASS
+    for record in records:
+        verdict = thresholds.verdict_for(
+            occurrence_count=record.occurrence_count,
+            severity=record.severity,
+        )
+        if verdict == PREFLIGHT_PASS:
+            continue
+        triggered.append(record)
+        final_verdict = _max_verdict(final_verdict, verdict)
+
+    triggered_sorted = tuple(
+        sorted(
+            triggered,
+            key=lambda r: (-r.occurrence_count, r.mistake_key),
+        )
+    )
+    checklist = tuple(
+        _format_checklist_item(record) for record in triggered_sorted
+    )
+    headline = _build_headline(
+        verdict=final_verdict,
+        role_id=role_id,
+        action=action,
+        triggered=triggered_sorted,
+    )
+    return PreflightAdvisory(
+        verdict=final_verdict,
+        role_id=role_id,
+        action=action,
+        triggered_mistakes=triggered_sorted,
+        checklist=checklist,
+        headline=headline,
+    )
+
+
+def render_preflight_advisory_block(advisory: PreflightAdvisory) -> str:
+    """Compact, operator-friendly text summary.
+
+    Returns the empty string when *advisory* has no signal so the
+    caller can append unconditionally without growing the surface.
+    """
+
+    if not advisory.has_signal():
+        return ""
+
+    lines: list[str] = [advisory.headline]
+    for item in advisory.checklist:
+        lines.append(f"  - {item}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+_VERDICT_ICON: Mapping[str, str] = {
+    PREFLIGHT_ADVISORY: "💡",
+    PREFLIGHT_WARNING: "⚠️",
+    PREFLIGHT_BLOCK: "⛔",
+}
+
+
+def _build_headline(
+    *,
+    verdict: str,
+    role_id: str,
+    action: str,
+    triggered: Sequence[MistakeRecord],
+) -> str:
+    if verdict == PREFLIGHT_PASS:
+        return ""
+    icon = _VERDICT_ICON.get(verdict, "•")
+    role_part = f"`{role_id}`" if role_id else "(role 미지정)"
+    action_part = f"`{action}`" if action else "(action 미지정)"
+    count = len(triggered)
+    label = {
+        PREFLIGHT_ADVISORY: "advisory",
+        PREFLIGHT_WARNING: "warning",
+        PREFLIGHT_BLOCK: "block",
+    }.get(verdict, verdict)
+    return (
+        f"{icon} preflight {label} — {role_part} 가 {action_part} 진입 전, "
+        f"이전에 반복된 실수 {count}건을 확인하라"
+    )
+
+
+def _format_checklist_item(record: MistakeRecord) -> str:
+    severity_tag = {
+        SEVERITY_HIGH: "[high]",
+        SEVERITY_MEDIUM: "[med]",
+        SEVERITY_LOW: "[low]",
+    }.get(record.severity, "[?]")
+    hint = record.prevention_hint.strip()
+    summary = record.summary.strip()
+    base = (
+        f"{severity_tag} `{record.mistake_key}` ({record.occurrence_count}회) "
+        f"— {summary}"
+    )
+    if hint:
+        base += f" · 예방: {hint}"
+    return base
+
+
+__all__ = (
+    "PREFLIGHT_ADVISORY",
+    "PREFLIGHT_BLOCK",
+    "PREFLIGHT_PASS",
+    "PREFLIGHT_VERDICTS",
+    "PREFLIGHT_WARNING",
+    "PreflightAdvisory",
+    "PreflightThresholds",
+    "evaluate_preflight",
+    "render_preflight_advisory_block",
+)

--- a/tests/agents/test_hook_candidate.py
+++ b/tests/agents/test_hook_candidate.py
@@ -1,0 +1,222 @@
+"""hook_candidate — issue #81 round 1.
+
+Pin the postmortem → future-hook contract:
+
+  * ``slugify_hook_id`` is deterministic + idempotent across calls.
+  * ``promote_record_to_hook_candidate`` returns ``None`` when the
+    record's evidence count is below ``min_evidence``.
+  * ``promote_postmortem_to_hook_candidate`` always returns a
+    candidate (the postmortem author has decided promotion is
+    warranted) and stamps the same id as the record-based path for
+    matching ``(role, key)``.
+  * ``collect_hook_candidates`` filters and ranks the ledger.
+  * ``render_hook_candidate_block`` produces the empty string when
+    nothing matches so the operator surface stays compact.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.lifecycle.hook_candidate import (
+    HOOK_CANDIDATE_ID_PREFIX,
+    collect_hook_candidates,
+    promote_postmortem_to_hook_candidate,
+    promote_record_to_hook_candidate,
+    render_hook_candidate_block,
+    slugify_hook_id,
+)
+from yule_orchestrator.agents.lifecycle.mistake_ledger import (
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    SOURCE_BLOCKED_COMPLETION,
+    SOURCE_CI_FAILURE,
+    SOURCE_POSTMORTEM,
+    record_mistake,
+    read_mistake_ledger,
+)
+
+
+class SlugifyTests(unittest.TestCase):
+    def test_basic_slug(self) -> None:
+        self.assertEqual(
+            slugify_hook_id("devops", "ci:protected_branch_blocked"),
+            f"{HOOK_CANDIDATE_ID_PREFIX}-devops-ci-protected-branch-blocked",
+        )
+
+    def test_idempotent(self) -> None:
+        a = slugify_hook_id("qa-engineer", "missing_regression_check")
+        b = slugify_hook_id("qa-engineer", "missing_regression_check")
+        self.assertEqual(a, b)
+
+    def test_collapses_special_characters(self) -> None:
+        self.assertEqual(
+            slugify_hook_id("Backend Engineer", "FAIL!!  test ::case"),
+            f"{HOOK_CANDIDATE_ID_PREFIX}-backend-engineer-fail-test-case",
+        )
+
+    def test_falls_back_when_blank(self) -> None:
+        self.assertEqual(
+            slugify_hook_id("", ""),
+            f"{HOOK_CANDIDATE_ID_PREFIX}-role-mistake",
+        )
+
+
+class PromoteFromRecordTests(unittest.TestCase):
+    def test_below_min_evidence_returns_none(self) -> None:
+        extra, record = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="ci:lint",
+            summary="lint",
+            prevention_hint="lint 먼저",
+            severity=SEVERITY_LOW,
+            when="2026-05-10T00:00:00+00:00",
+        )
+        self.assertIsNone(
+            promote_record_to_hook_candidate(record, min_evidence=2)
+        )
+
+    def test_at_min_evidence_promotes(self) -> None:
+        extra = None
+        for i in range(2):
+            extra, record = record_mistake(
+                extra,
+                role_id="devops",
+                mistake_key="ci:lint",
+                summary="lint 실패",
+                prevention_hint="lint 먼저",
+                severity=SEVERITY_MEDIUM,
+                source_kind=SOURCE_CI_FAILURE,
+                when=f"2026-05-10T00:0{i}:00+00:00",
+            )
+        candidate = promote_record_to_hook_candidate(record, min_evidence=2)
+        assert candidate is not None
+        self.assertEqual(candidate.role_id, "devops")
+        self.assertEqual(candidate.mistake_key, "ci:lint")
+        self.assertEqual(candidate.evidence_count, 2)
+        self.assertEqual(candidate.source_kind, SOURCE_CI_FAILURE)
+        self.assertEqual(
+            candidate.future_hook_id,
+            slugify_hook_id("devops", "ci:lint"),
+        )
+
+
+class PromotePostmortemTests(unittest.TestCase):
+    def test_postmortem_always_promotes(self) -> None:
+        candidate = promote_postmortem_to_hook_candidate(
+            role_id="qa-engineer",
+            mistake_key="regression_check_skipped",
+            summary="회귀 시나리오 누락 — 사용자가 직접 발견",
+            prevention_hint="QA 체크리스트에 회귀 시나리오 항목 추가",
+            severity=SEVERITY_HIGH,
+            evidence_count=1,
+            source_kind=SOURCE_POSTMORTEM,
+        )
+        self.assertEqual(candidate.evidence_count, 1)
+        self.assertEqual(candidate.source_kind, SOURCE_POSTMORTEM)
+        self.assertEqual(
+            candidate.future_hook_id,
+            slugify_hook_id("qa-engineer", "regression_check_skipped"),
+        )
+
+    def test_postmortem_id_matches_record_id(self) -> None:
+        # Verify deterministic alignment between the postmortem-driven
+        # path and the ledger-driven path so the live wiring later can
+        # dedupe candidates without consulting both paths.
+        postmortem = promote_postmortem_to_hook_candidate(
+            role_id="devops",
+            mistake_key="ci:protected_branch_blocked",
+            summary="x",
+            prevention_hint="y",
+        )
+        extra = None
+        for i in range(3):
+            extra, record = record_mistake(
+                extra,
+                role_id="devops",
+                mistake_key="ci:protected_branch_blocked",
+                summary="x",
+                prevention_hint="y",
+                severity=SEVERITY_HIGH,
+                source_kind=SOURCE_BLOCKED_COMPLETION,
+                when=f"2026-05-10T00:0{i}:00+00:00",
+            )
+        from_record = promote_record_to_hook_candidate(record, min_evidence=2)
+        assert from_record is not None
+        self.assertEqual(postmortem.future_hook_id, from_record.future_hook_id)
+
+    def test_blank_role_or_key_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            promote_postmortem_to_hook_candidate(
+                role_id="", mistake_key="x", summary="s",
+                prevention_hint="p",
+            )
+
+
+class CollectAndRenderTests(unittest.TestCase):
+    def _populate(self):
+        extra = None
+        for i in range(4):
+            extra, _ = record_mistake(
+                extra,
+                role_id="devops",
+                mistake_key="ci:protected_branch_blocked",
+                summary="x",
+                prevention_hint="y",
+                severity=SEVERITY_HIGH,
+                when=f"2026-05-09T00:0{i}:00+00:00",
+            )
+        for i in range(2):
+            extra, _ = record_mistake(
+                extra,
+                role_id="qa-engineer",
+                mistake_key="regression_skip",
+                summary="x",
+                prevention_hint="y",
+                severity=SEVERITY_MEDIUM,
+                when=f"2026-05-10T00:0{i}:00+00:00",
+            )
+        # Single occurrence — should NOT promote.
+        extra, _ = record_mistake(
+            extra,
+            role_id="backend-engineer",
+            mistake_key="forgot_to_run_tests",
+            summary="x",
+            prevention_hint="y",
+            when="2026-05-10T01:00:00+00:00",
+        )
+        return read_mistake_ledger(extra)
+
+    def test_collect_filters_and_ranks(self) -> None:
+        records = self._populate()
+        candidates = collect_hook_candidates(records, min_evidence=2)
+        ids = [c.future_hook_id for c in candidates]
+        self.assertEqual(len(candidates), 2)
+        # Ranked by evidence_count desc — devops 4x first.
+        self.assertEqual(
+            ids[0],
+            slugify_hook_id("devops", "ci:protected_branch_blocked"),
+        )
+        self.assertEqual(
+            ids[1], slugify_hook_id("qa-engineer", "regression_skip"),
+        )
+
+    def test_render_block_empty_for_no_candidates(self) -> None:
+        self.assertEqual(render_hook_candidate_block(()), "")
+
+    def test_render_block_lists_each_candidate(self) -> None:
+        candidates = collect_hook_candidates(self._populate(), min_evidence=2)
+        block = render_hook_candidate_block(candidates)
+        for candidate in candidates:
+            self.assertIn(candidate.future_hook_id, block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_mistake_ledger.py
+++ b/tests/agents/test_mistake_ledger.py
@@ -1,0 +1,376 @@
+"""mistake_ledger — issue #81 round 1.
+
+Pin the role-specific mistake ledger contract:
+
+  * ``record_mistake`` accumulates the same ``(role, key)`` instead
+    of appending a duplicate row, and the original *extra* dict is
+    not mutated.
+  * Severity escalates one-way (low → medium → high); a milder later
+    occurrence does not relax the recorded severity.
+  * The ledger is bounded so a long-lived session row stays small.
+  * Derivation helpers (``derive_mistake_from_completion`` and
+    ``derive_mistake_from_ci_exhaustion``) emit kwargs the caller
+    can hand straight to ``record_mistake``, and they no-op on
+    surface-irrelevant inputs (success completion, missing role).
+  * The summary projection groups by role and ranks the most
+    recurring mistakes first.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.completion_hook import (
+    JobCompletionEvent,
+)
+from yule_orchestrator.agents.lifecycle.mistake_ledger import (
+    SESSION_EXTRA_KEY,
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    SOURCE_BLOCKED_COMPLETION,
+    SOURCE_CI_FAILURE,
+    SOURCE_POSTMORTEM,
+    derive_mistake_from_ci_exhaustion,
+    derive_mistake_from_completion,
+    mistakes_for_role,
+    read_mistake_ledger,
+    record_mistake,
+    summarize_role_mistakes,
+)
+
+
+class RecordMistakeAccumulationTests(unittest.TestCase):
+    def test_first_record_is_count_one(self) -> None:
+        new_extra, record = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="protected_branch_push",
+            summary="main 브랜치 push 가 차단됨",
+            prevention_hint="PR 흐름으로 push 금지 — 리베이스 후 PR 생성",
+            source_kind=SOURCE_BLOCKED_COMPLETION,
+            severity=SEVERITY_MEDIUM,
+            when="2026-05-10T10:00:00+00:00",
+        )
+        self.assertEqual(record.occurrence_count, 1)
+        self.assertEqual(record.first_seen_at, record.last_seen_at)
+        ledger = read_mistake_ledger(new_extra)
+        self.assertEqual(len(ledger), 1)
+
+    def test_repeat_increments_count_and_advances_last_seen(self) -> None:
+        extra, _ = record_mistake(
+            None,
+            role_id="qa-engineer",
+            mistake_key="missing_regression_check",
+            summary="회귀 체크 누락",
+            prevention_hint="회귀 시나리오 포함 여부 점검",
+            severity=SEVERITY_LOW,
+            when="2026-05-09T10:00:00+00:00",
+        )
+        extra, second = record_mistake(
+            extra,
+            role_id="qa-engineer",
+            mistake_key="missing_regression_check",
+            summary="회귀 체크 누락 (두 번째 발생)",
+            prevention_hint="회귀 시나리오 점검 강화",
+            severity=SEVERITY_LOW,
+            when="2026-05-10T10:00:00+00:00",
+        )
+        self.assertEqual(second.occurrence_count, 2)
+        self.assertEqual(second.first_seen_at, "2026-05-09T10:00:00+00:00")
+        self.assertEqual(second.last_seen_at, "2026-05-10T10:00:00+00:00")
+        ledger = read_mistake_ledger(extra)
+        self.assertEqual(len(ledger), 1)
+        self.assertEqual(ledger[0].occurrence_count, 2)
+
+    def test_different_keys_create_distinct_rows(self) -> None:
+        extra, _ = record_mistake(
+            None,
+            role_id="qa-engineer",
+            mistake_key="missing_regression_check",
+            summary="x",
+            prevention_hint="y",
+            when="2026-05-08T00:00:00+00:00",
+        )
+        extra, _ = record_mistake(
+            extra,
+            role_id="qa-engineer",
+            mistake_key="flaky_test_ignored",
+            summary="x",
+            prevention_hint="y",
+            when="2026-05-09T00:00:00+00:00",
+        )
+        ledger = read_mistake_ledger(extra)
+        self.assertEqual(
+            sorted(r.mistake_key for r in ledger),
+            ["flaky_test_ignored", "missing_regression_check"],
+        )
+
+    def test_different_roles_have_independent_keys(self) -> None:
+        extra, _ = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="ci:lint_failure",
+            summary="lint 실패",
+            prevention_hint="lint 실행 후 push",
+            when="2026-05-10T00:00:00+00:00",
+        )
+        extra, _ = record_mistake(
+            extra,
+            role_id="backend-engineer",
+            mistake_key="ci:lint_failure",
+            summary="lint 실패",
+            prevention_hint="lint 실행 후 push",
+            when="2026-05-10T00:01:00+00:00",
+        )
+        ledger = read_mistake_ledger(extra)
+        self.assertEqual(len(ledger), 2)
+        self.assertEqual(
+            sorted(r.role_id for r in ledger),
+            ["backend-engineer", "devops"],
+        )
+
+    def test_severity_only_escalates(self) -> None:
+        extra, _ = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="ci:protected_branch_blocked",
+            summary="protected branch push 시도",
+            prevention_hint="PR 흐름으로",
+            severity=SEVERITY_HIGH,
+            when="2026-05-09T00:00:00+00:00",
+        )
+        extra, second = record_mistake(
+            extra,
+            role_id="devops",
+            mistake_key="ci:protected_branch_blocked",
+            summary="protected branch 차단 (재발)",
+            prevention_hint="PR 흐름으로",
+            severity=SEVERITY_LOW,
+            when="2026-05-10T00:00:00+00:00",
+        )
+        self.assertEqual(second.severity, SEVERITY_HIGH)
+
+    def test_extra_input_is_not_mutated(self) -> None:
+        original = {"foo": "bar"}
+        new_extra, _ = record_mistake(
+            original,
+            role_id="devops",
+            mistake_key="x",
+            summary="y",
+            prevention_hint="z",
+            when="2026-05-10T00:00:00+00:00",
+        )
+        self.assertEqual(original, {"foo": "bar"})
+        self.assertEqual(new_extra["foo"], "bar")
+        self.assertIn(SESSION_EXTRA_KEY, new_extra)
+
+    def test_ledger_capped_to_max_entries(self) -> None:
+        extra: Optional[Mapping[str, Any]] = None
+        for i in range(10):
+            extra, _ = record_mistake(
+                extra,
+                role_id="devops",
+                mistake_key=f"key_{i}",
+                summary="s",
+                prevention_hint="p",
+                when=f"2026-05-10T00:{i:02d}:00+00:00",
+                max_entries=3,
+            )
+        ledger = read_mistake_ledger(extra)
+        self.assertEqual(len(ledger), 3)
+        # Oldest entries dropped first.
+        self.assertEqual(
+            sorted(r.mistake_key for r in ledger),
+            ["key_7", "key_8", "key_9"],
+        )
+
+    def test_blank_role_or_key_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            record_mistake(
+                None,
+                role_id="",
+                mistake_key="x",
+                summary="s",
+                prevention_hint="p",
+            )
+        with self.assertRaises(ValueError):
+            record_mistake(
+                None,
+                role_id="devops",
+                mistake_key="",
+                summary="s",
+                prevention_hint="p",
+            )
+
+
+class MistakesForRoleTests(unittest.TestCase):
+    def test_filters_by_role(self) -> None:
+        extra, _ = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="a",
+            summary="x",
+            prevention_hint="y",
+            when="2026-05-10T00:00:00+00:00",
+        )
+        extra, _ = record_mistake(
+            extra,
+            role_id="qa-engineer",
+            mistake_key="b",
+            summary="x",
+            prevention_hint="y",
+            when="2026-05-10T00:01:00+00:00",
+        )
+        out = mistakes_for_role(extra, "devops")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].role_id, "devops")
+
+    def test_unknown_role_returns_empty(self) -> None:
+        self.assertEqual(mistakes_for_role({}, "ghost"), ())
+
+
+class DerivationTests(unittest.TestCase):
+    def test_completion_done_is_skipped(self) -> None:
+        event = JobCompletionEvent(
+            job_id="j", job_type="role_take", session_id="s",
+            status="done", role="devops",
+        )
+        self.assertIsNone(derive_mistake_from_completion(event=event))
+
+    def test_completion_blocked_with_role_emits_kwargs(self) -> None:
+        event = JobCompletionEvent(
+            job_id="j",
+            job_type="coding_execute",
+            session_id="s",
+            status="blocked",
+            reason="protected branch push refused",
+            role="devops",
+        )
+        kwargs = derive_mistake_from_completion(event=event)
+        assert kwargs is not None
+        self.assertEqual(kwargs["role_id"], "devops")
+        self.assertEqual(kwargs["source_kind"], SOURCE_BLOCKED_COMPLETION)
+        self.assertIn("protected", kwargs["mistake_key"])
+
+    def test_completion_blocked_without_role_returns_none(self) -> None:
+        event = JobCompletionEvent(
+            job_id="j", job_type="coding_execute", session_id="s",
+            status="blocked", reason="x", role=None,
+        )
+        self.assertIsNone(derive_mistake_from_completion(event=event))
+
+    def test_ci_exhaustion_marks_high_severity_after_three(self) -> None:
+        kwargs = derive_mistake_from_ci_exhaustion(
+            role_id="devops",
+            failing_runs=("test", "lint"),
+            pr_number=42,
+            attempts=3,
+        )
+        assert kwargs is not None
+        self.assertEqual(kwargs["severity"], SEVERITY_HIGH)
+        self.assertEqual(kwargs["source_kind"], SOURCE_CI_FAILURE)
+        self.assertTrue(kwargs["mistake_key"].startswith("ci:"))
+
+    def test_ci_exhaustion_below_three_is_medium(self) -> None:
+        kwargs = derive_mistake_from_ci_exhaustion(
+            role_id="devops", failing_runs=("test",), attempts=1,
+        )
+        assert kwargs is not None
+        self.assertEqual(kwargs["severity"], SEVERITY_MEDIUM)
+
+    def test_ci_exhaustion_blank_role_returns_none(self) -> None:
+        self.assertIsNone(
+            derive_mistake_from_ci_exhaustion(
+                role_id="", failing_runs=("test",), attempts=3,
+            )
+        )
+
+
+class SummariseTests(unittest.TestCase):
+    def _populate(self) -> Mapping[str, Any]:
+        extra: Optional[Mapping[str, Any]] = None
+        # devops: two distinct mistakes, one is high severity + recurring.
+        for i in range(3):
+            extra, _ = record_mistake(
+                extra,
+                role_id="devops",
+                mistake_key="ci:protected_branch_blocked",
+                summary="protected branch push refused",
+                prevention_hint="PR 흐름",
+                severity=SEVERITY_HIGH,
+                source_kind=SOURCE_CI_FAILURE,
+                when=f"2026-05-09T00:0{i}:00+00:00",
+            )
+        extra, _ = record_mistake(
+            extra,
+            role_id="devops",
+            mistake_key="missing_secret_lookup",
+            summary="env 누락",
+            prevention_hint="env 점검",
+            severity=SEVERITY_LOW,
+            when="2026-05-10T00:00:00+00:00",
+        )
+        # qa-engineer: one mistake.
+        extra, _ = record_mistake(
+            extra,
+            role_id="qa-engineer",
+            mistake_key="missing_regression_check",
+            summary="회귀 체크 누락",
+            prevention_hint="회귀 시나리오 점검",
+            severity=SEVERITY_MEDIUM,
+            when="2026-05-08T00:00:00+00:00",
+        )
+        return extra  # type: ignore[return-value]
+
+    def test_groups_per_role_and_ranks_top_recurring(self) -> None:
+        summaries = summarize_role_mistakes(self._populate())
+        by_role = {s.role_id: s for s in summaries}
+        self.assertEqual(set(by_role), {"devops", "qa-engineer"})
+
+        devops = by_role["devops"]
+        self.assertEqual(devops.total_mistakes, 2)
+        self.assertEqual(devops.high_severity_count, 1)
+        self.assertEqual(devops.low_severity_count, 1)
+        self.assertEqual(devops.total_occurrences, 4)
+        # Top recurring leads with the high-severity x3 row.
+        self.assertEqual(
+            devops.top_recurring[0].mistake_key,
+            "ci:protected_branch_blocked",
+        )
+        self.assertEqual(devops.top_recurring[0].occurrence_count, 3)
+
+        qa = by_role["qa-engineer"]
+        self.assertEqual(qa.total_mistakes, 1)
+        self.assertEqual(qa.medium_severity_count, 1)
+
+
+class PayloadRoundTripTests(unittest.TestCase):
+    def test_record_can_be_payloaded_and_back(self) -> None:
+        extra, original = record_mistake(
+            None,
+            role_id="devops",
+            mistake_key="ci:lint",
+            summary="lint",
+            prevention_hint="lint 먼저",
+            severity=SEVERITY_MEDIUM,
+            source_kind=SOURCE_CI_FAILURE,
+            when="2026-05-10T00:00:00+00:00",
+        )
+        payload = original.to_payload()
+        # Mimic the SQLite round trip: dump → load → re-read.
+        reloaded = read_mistake_ledger(
+            {SESSION_EXTRA_KEY: [dict(payload)]}
+        )
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded[0], original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_mistake_surface.py
+++ b/tests/agents/test_mistake_surface.py
@@ -1,0 +1,221 @@
+"""mistake_surface — issue #81 round 1.
+
+Pin the operator-readable surface that joins:
+
+  * per-role mistake summaries
+  * preflight advisory (optional)
+  * hook candidates
+
+The surface is the seam runtime/status renderers and completion
+metadata splice into; this module verifies the contract is small,
+deterministic, and "does not write when there is nothing to say".
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.lifecycle.mistake_ledger import (
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    record_mistake,
+)
+from yule_orchestrator.agents.lifecycle.mistake_surface import (
+    build_operator_surface,
+    render_operator_surface_block,
+)
+from yule_orchestrator.agents.lifecycle.preflight_judgement import (
+    PREFLIGHT_BLOCK,
+    PREFLIGHT_PASS,
+    evaluate_preflight,
+)
+
+
+def _populate(extra=None, *, role, key, times, severity=SEVERITY_LOW):
+    base = extra
+    for i in range(times):
+        base, _ = record_mistake(
+            base,
+            role_id=role,
+            mistake_key=key,
+            summary="x",
+            prevention_hint="y",
+            severity=severity,
+            when=f"2026-05-10T00:{i:02d}:00+00:00",
+        )
+    return base
+
+
+class BuildSurfaceTests(unittest.TestCase):
+    def test_empty_ledger_is_empty_surface(self) -> None:
+        surface = build_operator_surface({})
+        self.assertTrue(surface.is_empty())
+        self.assertEqual(surface.summaries, ())
+        self.assertEqual(surface.hook_candidates, ())
+
+    def test_passing_preflight_does_not_make_surface_signal(self) -> None:
+        # No mistakes recorded → preflight passes → surface stays empty.
+        preflight = evaluate_preflight(
+            {}, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(preflight.verdict, PREFLIGHT_PASS)
+        surface = build_operator_surface({}, preflight=preflight)
+        self.assertTrue(surface.is_empty())
+
+    def test_summaries_grouped_per_role(self) -> None:
+        extra = _populate(role="devops", key="a", times=2)
+        extra = _populate(role="qa-engineer", key="b", times=1, extra=extra)
+        surface = build_operator_surface(extra)
+        self.assertEqual(
+            sorted(s.role_id for s in surface.summaries),
+            ["devops", "qa-engineer"],
+        )
+
+    def test_hook_candidates_promoted_when_recurring(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:protected_branch",
+            times=3,
+            severity=SEVERITY_HIGH,
+        )
+        extra = _populate(
+            role="qa-engineer", key="single_mistake", times=1, extra=extra
+        )
+        surface = build_operator_surface(extra)
+        ids = [c.future_hook_id for c in surface.hook_candidates]
+        # Recurring devops mistake promoted, single qa mistake not.
+        self.assertEqual(len(ids), 1)
+        self.assertIn("devops", ids[0])
+        self.assertIn("ci-protected-branch", ids[0])
+
+    def test_preflight_block_carried_through(self) -> None:
+        extra = _populate(
+            role="devops", key="ci:lint", times=5,
+        )
+        preflight = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(preflight.verdict, PREFLIGHT_BLOCK)
+        surface = build_operator_surface(extra, preflight=preflight)
+        self.assertIsNotNone(surface.preflight)
+        assert surface.preflight is not None
+        self.assertTrue(surface.preflight.is_block())
+
+
+class RenderTests(unittest.TestCase):
+    def test_empty_surface_renders_empty_string(self) -> None:
+        surface = build_operator_surface({})
+        self.assertEqual(render_operator_surface_block(surface), "")
+
+    def test_render_includes_role_summary_and_top_recurring(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=3)
+        surface = build_operator_surface(extra)
+        block = render_operator_surface_block(surface)
+        self.assertIn("devops", block)
+        self.assertIn("ci:lint", block)
+        self.assertIn("3", block)  # occurrence count surfaces somewhere
+
+    def test_render_includes_preflight_when_signal(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=3)
+        preflight = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        surface = build_operator_surface(extra, preflight=preflight)
+        block = render_operator_surface_block(surface)
+        self.assertIn("preflight", block)
+        self.assertIn("coding_execute", block)
+
+    def test_render_includes_hook_candidate_section(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:protected_branch",
+            times=3,
+            severity=SEVERITY_HIGH,
+        )
+        surface = build_operator_surface(extra)
+        block = render_operator_surface_block(surface)
+        self.assertIn("hook 후보", block)
+        self.assertIn("preflight-devops-ci-protected-branch", block)
+
+
+class PayloadTests(unittest.TestCase):
+    def test_to_payload_round_trip_shape(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:lint",
+            times=3,
+            severity=SEVERITY_MEDIUM,
+        )
+        preflight = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        surface = build_operator_surface(extra, preflight=preflight)
+        payload = surface.to_payload()
+        self.assertIn("summaries", payload)
+        self.assertIn("preflight", payload)
+        self.assertIn("hook_candidates", payload)
+        # Preflight payload nests the verdict.
+        self.assertEqual(
+            payload["preflight"]["verdict"], preflight.verdict
+        )
+        # Each hook candidate has its deterministic id.
+        for candidate in payload["hook_candidates"]:
+            self.assertTrue(candidate["future_hook_id"].startswith("preflight-"))
+
+
+class SummaryLineTests(unittest.TestCase):
+    def test_empty_surface_is_empty_string(self) -> None:
+        surface = build_operator_surface({})
+        self.assertEqual(surface.summary_line(), "")
+
+    def test_passing_preflight_does_not_show_clause(self) -> None:
+        # Empty ledger + passing preflight → summary line is empty.
+        preflight = evaluate_preflight(
+            {}, role_id="devops", action="coding_execute"
+        )
+        surface = build_operator_surface({}, preflight=preflight)
+        self.assertEqual(surface.summary_line(), "")
+
+    def test_summary_includes_role_count_and_occurrences(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=3)
+        extra = _populate(role="qa-engineer", key="b", times=2, extra=extra)
+        surface = build_operator_surface(extra)
+        line = surface.summary_line()
+        self.assertIn("역할 2건", line)
+        self.assertIn("총 5회", line)
+
+    def test_summary_includes_preflight_verdict_when_signal(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=5)
+        preflight = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        surface = build_operator_surface(extra, preflight=preflight)
+        line = surface.summary_line()
+        self.assertIn("preflight=block", line)
+
+    def test_summary_includes_hook_candidate_count(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:protected_branch",
+            times=3,
+            severity=SEVERITY_HIGH,
+        )
+        surface = build_operator_surface(extra)
+        line = surface.summary_line()
+        self.assertIn("hook 후보 1건", line)
+
+    def test_payload_carries_summary_line(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=3)
+        surface = build_operator_surface(extra)
+        payload = surface.to_payload()
+        self.assertEqual(payload["summary_line"], surface.summary_line())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_preflight_judgement.py
+++ b/tests/agents/test_preflight_judgement.py
@@ -1,0 +1,223 @@
+"""preflight_judgement — issue #81 round 1.
+
+Pin the preflight seam contract:
+
+  * No mistakes → ``PREFLIGHT_PASS`` (no signal).
+  * 2x recurring → ``PREFLIGHT_ADVISORY``.
+  * 3x recurring → ``PREFLIGHT_WARNING``.
+  * 5x recurring → ``PREFLIGHT_BLOCK`` (any severity).
+  * High severity + 3x → ``PREFLIGHT_BLOCK`` (escalates earlier).
+  * ``only_keys`` filter limits which mistakes are evaluated.
+  * The advisory's checklist surfaces every prevention hint, sorted
+    by recurrence count descending.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.lifecycle.mistake_ledger import (
+    SEVERITY_HIGH,
+    SEVERITY_LOW,
+    SEVERITY_MEDIUM,
+    record_mistake,
+)
+from yule_orchestrator.agents.lifecycle.preflight_judgement import (
+    PREFLIGHT_ADVISORY,
+    PREFLIGHT_BLOCK,
+    PREFLIGHT_PASS,
+    PREFLIGHT_WARNING,
+    PreflightThresholds,
+    evaluate_preflight,
+    render_preflight_advisory_block,
+)
+
+
+def _populate(
+    *,
+    role: str,
+    key: str,
+    times: int,
+    severity: str = SEVERITY_LOW,
+    extra: Optional[Mapping[str, Any]] = None,
+    summary: str = "x",
+    prevention_hint: str = "다음에는 점검 후 진입",
+) -> Mapping[str, Any]:
+    base = extra
+    for i in range(times):
+        base, _ = record_mistake(
+            base,
+            role_id=role,
+            mistake_key=key,
+            summary=summary,
+            prevention_hint=prevention_hint,
+            severity=severity,
+            when=f"2026-05-10T00:{i:02d}:00+00:00",
+        )
+    return base  # type: ignore[return-value]
+
+
+class VerdictThresholdTests(unittest.TestCase):
+    def test_no_mistakes_passes(self) -> None:
+        advisory = evaluate_preflight(
+            None, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_PASS)
+        self.assertFalse(advisory.has_signal())
+        self.assertEqual(advisory.checklist, ())
+
+    def test_two_occurrences_is_advisory(self) -> None:
+        extra = _populate(role="devops", key="missing_lint", times=2)
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_ADVISORY)
+        self.assertEqual(len(advisory.triggered_mistakes), 1)
+        self.assertEqual(len(advisory.checklist), 1)
+
+    def test_three_occurrences_is_warning(self) -> None:
+        extra = _populate(role="qa-engineer", key="regression_skip", times=3)
+        advisory = evaluate_preflight(
+            extra, role_id="qa-engineer", action="discussion_handoff"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_WARNING)
+
+    def test_five_occurrences_blocks(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=5)
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_BLOCK)
+        self.assertTrue(advisory.is_block())
+
+    def test_high_severity_blocks_at_three(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:protected_branch_blocked",
+            times=3,
+            severity=SEVERITY_HIGH,
+        )
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_BLOCK)
+
+    def test_high_severity_below_threshold_is_advisory(self) -> None:
+        # 2x high severity falls into advisory bucket, not block.
+        extra = _populate(
+            role="devops",
+            key="ci:secret_lookup_failed",
+            times=2,
+            severity=SEVERITY_HIGH,
+        )
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_ADVISORY)
+
+    def test_only_keys_scopes_evaluation(self) -> None:
+        extra = _populate(
+            role="devops", key="ci:protected_branch", times=5
+        )
+        extra = _populate(
+            role="devops",
+            key="missing_regression_check",
+            times=5,
+            extra=extra,
+        )
+        advisory = evaluate_preflight(
+            extra,
+            role_id="devops",
+            action="coding_execute",
+            only_keys=("ci:protected_branch",),
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_BLOCK)
+        self.assertEqual(
+            tuple(m.mistake_key for m in advisory.triggered_mistakes),
+            ("ci:protected_branch",),
+        )
+
+    def test_other_role_is_ignored(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=10)
+        advisory = evaluate_preflight(
+            extra, role_id="qa-engineer", action="discussion_handoff"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_PASS)
+
+    def test_blank_role_is_safe_pass(self) -> None:
+        advisory = evaluate_preflight(
+            {}, role_id="", action="coding_execute"
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_PASS)
+
+
+class CustomThresholdsTests(unittest.TestCase):
+    def test_thresholds_can_be_customised(self) -> None:
+        extra = _populate(role="devops", key="x", times=2)
+        thresholds = PreflightThresholds(
+            advisory_at=2, warning_at=2, block_at=2,
+        )
+        advisory = evaluate_preflight(
+            extra,
+            role_id="devops",
+            action="coding_execute",
+            thresholds=thresholds,
+        )
+        self.assertEqual(advisory.verdict, PREFLIGHT_BLOCK)
+
+
+class ChecklistShapeTests(unittest.TestCase):
+    def test_checklist_sorted_by_recurrence_desc(self) -> None:
+        extra = _populate(role="devops", key="b", times=2)
+        extra = _populate(role="devops", key="a", times=4, extra=extra)
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        keys = [r.mistake_key for r in advisory.triggered_mistakes]
+        self.assertEqual(keys, ["a", "b"])
+
+    def test_render_block_empty_when_pass(self) -> None:
+        advisory = evaluate_preflight(
+            None, role_id="devops", action="coding_execute"
+        )
+        self.assertEqual(render_preflight_advisory_block(advisory), "")
+
+    def test_render_block_includes_keys_and_hint(self) -> None:
+        extra = _populate(
+            role="devops",
+            key="ci:protected_branch",
+            times=3,
+            severity=SEVERITY_HIGH,
+            prevention_hint="PR 흐름으로 push",
+        )
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        block = render_preflight_advisory_block(advisory)
+        self.assertIn("ci:protected_branch", block)
+        self.assertIn("PR 흐름", block)
+        self.assertIn("preflight", block)
+
+
+class PayloadShapeTests(unittest.TestCase):
+    def test_payload_carries_keys_and_verdict(self) -> None:
+        extra = _populate(role="devops", key="ci:lint", times=3)
+        advisory = evaluate_preflight(
+            extra, role_id="devops", action="coding_execute"
+        )
+        payload = advisory.to_payload()
+        self.assertEqual(payload["verdict"], PREFLIGHT_WARNING)
+        self.assertEqual(payload["role_id"], "devops")
+        self.assertEqual(payload["action"], "coding_execute")
+        self.assertEqual(payload["triggered_mistake_keys"], ["ci:lint"])
+        self.assertEqual(len(payload["checklist"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- refs #81

## ✨ 과제 내용
- Harness/Hookify 성격의 역할별 반복 실수 ledger와 preflight judgement seam을 round 1로 추가했습니다.
- blocked completion / CI failure / postmortem reason을 역할별 mistake ledger로 축적할 수 있게 했습니다.
- 다음 작업 직전 advisory / warning / block verdict를 줄 수 있는 preflight helper와, future hook candidate 승격 contract를 추가했습니다.
- operator가 읽을 수 있는 mistake surface와 hook markdown seed도 같이 넣었습니다.

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- tests.agents.test_hook_candidate
- tests.agents.test_mistake_ledger
- tests.agents.test_mistake_surface
- tests.agents.test_preflight_judgement
- 검증: 60 tests OK
- 후속: runtime live dispatcher / cross-session persistence / discussion preflight wiring
