### PR TITLE
✨ #81 통합 polish — cross-axis 회귀 + Obsidian 4종 노트 + 마스터 플랜 3 갱신

### DIFF
--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -42,13 +42,21 @@ Yule가 도달해야 하는 최종 상태는 아래와 같다.
 
 이 수치는 운영 판단 기준으로 유지한다.
 
-| 영역 | 현재 추정 |
-| --- | --- |
-| 운영 골격 | 65~75% |
-| Discord 기술 토의 능력 | 40~50% |
-| 완전 자율 코딩 루프 | 45~55% |
-| 역할별 자료 수집/정형화 루프 | 25~35% |
-| 실제 회사처럼 굴러가는 종합 수준 | 45~55% |
+| 영역 | 현재 추정 (2026-05-11) | 이전 추정 |
+| --- | --- | --- |
+| 운영 골격 | 80~85% | 65~75% |
+| Discord 기술 토의 능력 | 50~60% | 40~50% |
+| 완전 자율 코딩 루프 | 70~80% | 45~55% |
+| 역할별 자료 수집/정형화 루프 | 50~60% | 25~35% |
+| 실제 회사처럼 굴러가는 종합 수준 | 60~70% | 45~55% |
+
+2026-05-11 갱신 근거 — issue #81 통합 polish (`feature/issue-81-integration-polish`) 의 cross-axis 회귀 (3493 + 160 cases 모두 OK) 와 Round 4 / 4-bis / 4-ter / 4 마무리 / Round 4 후속 시리즈 land 결과. 자세한 결정은 [[notes/vault-mirror/10-projects/yule-studio-agent/decisions/2026-05-11_issue-81-decision-integration-polish.md]] § D-81-3 ~ D-81-7. 상한이 100% 가 아닌 이유:
+
+- 운영 골격 상한 85% — autonomy producer / decision seam / status surface / operator actions 까지 land. 잔여: live LLM editor / live decision provider 활성화, Discord escalation alert 자동화.
+- Discord 기술 토의 상한 60% — discussion_followup + context_pack + retrieval slot land. 잔여: `feature/issue-81-discussion-gateway` (commit `512ce7c`) 미머지, gateway / tech-lead 경계 가독성 PR 필요.
+- 완전 자율 코딩 루프 상한 80% — dispatcher + executor live (RecordOnly) + CI orchestrator + retry guard + producer + funnel + claude subprocess seam land. 잔여: live LLM editor (운영자 승인 + cost + secret 정책 별도 PR).
+- 역할별 자료 수집/정형화 상한 60% — provider registry + routing + retrieval + feed parser + role feed digest + provenance land. 잔여: urllib `BytesFetcher`, sitemap / html_list / html_detail / github_api 라이브 fetcher, `eng-research-collector` runtime service spawn, `SourceRefreshState` 영속화.
+- 종합 상한 70% — 세 축이 cross-axis 회귀로 충돌 없음 확인, 그러나 #81 worktree split 3 축 (discussion-gateway / autonomy-execution / knowledge-geeknews) 미머지 + § 14 시나리오 6~8 단계가 live LLM editor 없이는 end-to-end 자동 불가.
 
 이 문서의 목표는 위 4개 축이 서로 충돌하지 않게 나누어 100%에 수렴하도록 만드는 것이다.
 

--- a/notes/vault-mirror/10-projects/yule-studio-agent/decisions/2026-05-11_issue-81-decision-integration-polish.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/decisions/2026-05-11_issue-81-decision-integration-polish.md
@@ -1,0 +1,126 @@
+---
+title: "issue #81 통합 polish — 의사결정"
+kind: decision
+issue: 81
+parent_issue: 73
+session_id: issue-81-integration-polish
+project: yule-studio-agent
+created_at: 2026-05-11T00:00:00+09:00
+status: decided
+branch: feature/issue-81-integration-polish
+approval_required: false
+tags: [decision, issue-81, integration, regression, handoff]
+contract: research-forum-export/v0
+---
+
+# 합의안
+
+`feature/issue-81-integration-polish` 는 코드 변경 없이 *회귀 + 산출물 정리 + 후속 이슈 분리* 만 land 한다. 머지된 main (HEAD `4acb160`) 위에서 #81 의 세 갈래 worktree split 이 결합할 때 cross-axis 충돌이 없음을 확인했고, 그 위에 master plan § 3 의 완료도 수치를 한 단계씩 상향한다. 남은 100% 갭은 10 종 후속 이슈로 분리한다.
+
+# 핵심 결정 (D-81-1 ~ D-81-10)
+
+## D-81-1. 회귀 범위 — full discover + cross-axis 슈트 두 단계
+
+`python3 -m unittest discover -s tests -t .` (3493 cases) 전수 + autonomy / knowledge / discussion / runtime 13 모듈 160 cases 추가 슈트.
+
+**왜**: full discover 만으로는 cross-axis 라우팅이 *어느 슈트* 에서 검증되는지 운영자가 한눈에 못 봄. 두 번째 슈트가 통합점 자체를 명시화.
+
+## D-81-2. 코드 변경 없음
+
+본 worktree 에서는 `src/` / `tests/` / `policies/` / `.env.example` 어느 곳도 손대지 않는다.
+
+**왜**: 통합 worktree 의 책임은 cross-axis regression / 문서 / handoff 다. 새 기능 추가는 #81 의 다른 worktree (gateway / execution / geeknews) 또는 후속 이슈가 담당.
+
+## D-81-3. § 3 완료도 수치 갱신 폭
+
+| 영역 | 갱신 |
+| --- | --- |
+| 운영 골격 | 65~75% → 80~85% |
+| Discord 기술 토의 | 40~50% → 50~60% |
+| 완전 자율 코딩 루프 | 45~55% → 70~80% |
+| 역할별 자료 수집/정형화 | 25~35% → 50~60% |
+| 종합 | 45~55% → 60~70% |
+
+**왜**: Round 4 / 4-bis / 4-ter / 4 마무리 / Round 4 후속 시리즈가 main 에 land 된 폭이 § 3 의 이전 추정보다 분명히 위로 옮겨갔다. 다만 #81 worktree split 3축 (discussion-gateway / autonomy-execution / knowledge-geeknews) 은 미머지 → 모든 축의 상한을 70~85% 로 묶어 100% 선언을 유보.
+
+## D-81-4. 자율 코딩 루프 상한이 80% 인 이유
+
+live LLM 코드 편집기 활성화가 잔여이고 — `RecordOnlyCodeEditor` 가 plan markdown 만 작성, 실제 source 변경 없음. 활성화는 운영자 승인 + cost 검토 + secret 정책 + LLM provider 어댑터 별도 PR.
+
+**왜**: hard rail (마스터 플랜 § 16-bis.6 / § 16-ter.6) 그대로 — 두 단계 opt-in 미설정 시 행동 변화 0.
+
+## D-81-5. 자료 수집 루프 상한이 60% 인 이유
+
+provider registry / routing / retrieval / feed_parser 까지 land 했지만 urllib `BytesFetcher` 한 조각 + sitemap / html_list / html_detail / github_api_repo_activity 4 transport 의 라이브 fetcher + `eng-research-collector` runtime service spawn + `SourceRefreshState` 영속화 4 종이 미land.
+
+**왜**: 4 종 모두 *별도 PR* 로 land 가능하지만 본 worktree 책임 밖. 각 후속 이슈 (§ 후속 이슈 드래프트 참조) 에서 처리.
+
+## D-81-6. discussion 축 상한이 60% 인 이유
+
+`feature/issue-81-discussion-gateway` (commit `512ce7c`) 이 PR 미생성, main 미머지. discussion_followup / context_pack / retrieval slot 은 land 했으나 gateway 가독성 + Discord operator surface 강화는 아직 작업 분기에만 존재.
+
+**왜**: 머지 가시성 (`gh pr list` / `git branch --contains`) 이 단일 진실. PR 미생성 분기는 main 수치 계산에서 제외.
+
+## D-81-7. 종합 70% 상한
+
+세 축이 cross-axis 회귀로 충돌 없음 확인. 그러나 #81 worktree split 3 축 미머지 + live LLM editor / live decision provider 미land → 100% 선언은 운영자 명시 승인 + 라이브 활성화가 모두 끝난 뒤로 유보.
+
+**왜**: 마스터 플랜 § 14 "회사형 runtime 완성 시나리오" 10 단계 중 6 ~ 8 단계 (실 코드 수정 / CI 결과 수신 / 후속 처리) 가 라이브 LLM editor 없이는 end-to-end 자동 진행 불가.
+
+## D-81-8. 머지 순서 권장
+
+(1) `discussion-gateway` PR 생성 → 회귀 통과 → 머지, (2) `knowledge-geeknews` PR #83 머지, (3) `autonomy-execution` PR 생성 → 머지, (4) 본 integration-polish PR 머지.
+
+**왜**: (1)이 가독성 / operator surface 변경을 먼저 흡수해야 (2)(3)(4)의 status surface 텍스트 회귀가 안 깨짐. 단, cross-axis 회귀가 충돌을 이미 통과시켰으므로 순서가 바뀌어도 머지 자체는 가능 — 본 PR 의 § 3 수치만 후행 갱신 PR 으로 한 번 더 올라가야 한다.
+
+## D-81-9. 후속 이슈 분리 기준
+
+본 PR 의 task-log § "본 worktree 비범위 → 후속 이슈 매핑" 10 종이 후속 이슈 분리 후보. 이 중 (1)(2)(3) 은 이미 worktree branch 가 존재 → PR 생성만 필요. (4)~(10) 은 신규 worktree + 별도 PR.
+
+**왜**: 이슈 단위가 작아야 운영자가 cost 검토 + 승인 게이트를 빠르게 통과시킨다. 마스터 플랜 § 12.1 PR 분리 원칙 (한 PR 안에 하나의 중심 목표) 그대로.
+
+## D-81-10. progress comment 본문은 운영자가 직접 post
+
+본 worktree 가 `gh issue comment` 를 직접 호출하지 않고 — 본 PR body / 별도 파일에 본문만 남긴다.
+
+**왜**: issue post 는 외부 surface 변경이고 (사용자 / 팀에 visible), 운영자 명시 승인 게이트 유지가 핵심 안전 규칙 (CLAUDE.md "human approval is required before destructive commands, production deployments, or secret access" 와 같은 결.
+
+# 후속 이슈 드래프트
+
+이 결정에서 분리할 10 종 후속 이슈는 [[2026-05-11_issue-81-task-log-integration-polish]] § "본 worktree 비범위 → 후속 이슈 매핑" 에 1:1 매핑된다.
+
+| # | 제목 (가안) | 핵심 산출물 | 비고 |
+| --- | --- | --- | --- |
+| F-81-1 | discussion-gateway PR 생성 + 머지 | `src/yule_orchestrator/discord/*`, `agents/discussion/*`, `tests/discord/*` | branch 이미 존재 (commit `512ce7c`). PR description 작성 + 회귀 / 머지. |
+| F-81-2 | autonomy-execution PR 생성 + 머지 | 역할별 반복 실수 ledger + preflight seam round 1 | branch 이미 존재 (commit `38e9332`). PR description 작성 + 회귀 / 머지. |
+| F-81-3 | knowledge-geeknews PR #83 머지 | engineering-knowledge canonical title | PR 이미 OPEN. 회귀 통과 / 머지. |
+| F-81-4 | live LLM 코드 편집기 활성화 | `RecordOnlyCodeEditor` → 실제 LLM 어댑터 | 운영자 승인 + cost 검토 + secret 정책 별도. |
+| F-81-5 | urllib `BytesFetcher` 한 조각 | RSS / Atom / GitHub releases atom 라이브 전환 | `register_safe_feed_providers(registry, bytes_fetcher_factory=...)` 한 호출로 3 transport 동시 활성. |
+| F-81-6 | sitemap / html_list / html_detail / github_api 라이브 fetcher | 4 transport NO_LIVE_IMPL 해소 | 각 parser 추가 필요. |
+| F-81-7 | runtime service spawn `eng-research-collector` | scheduler tick → routing → fetcher → adapter → vault writer | 서비스 spec 등록 + auto-spawn opt-in env flag. |
+| F-81-8 | `SourceRefreshState` 영속화 | sqlite or vault sidecar | 재시작 후 backoff 상태 유지. |
+| F-81-9 | `next_task_selector` 의 `DECISION_KIND_NEXT_TASK` 호출 | decision seam 의 두 번째 콜사이트 | `consult_decision_port` 헬퍼 재사용. |
+| F-81-10 | Discord escalation alert | `blocked` / `needs_approval` N 분 지속 시 운영자 직접 멘션 | 현재는 dedup 게이트 / banner 만. |
+
+# 보류
+
+- live Anthropic / OpenAI SDK 활성화 (vs. `claude -p` 서브프로세스) — F-81-4 의 하위 결정. 별도 PR.
+- vault git auto-commit 정책 (`yule obsidian sync --git-commit`) 확장 (push 자동화 / Obsidian 동기화 플러그인 연동) — 마스터 플랜 § 11 정책 그대로 보류.
+
+# 비도입
+
+- producer 가 큐 직접 enqueue — 큐 dedup 단일 지점 원칙 (§ 16-ter.6) 위배, 도입 안 함.
+- protected branch 직접 push / force push — 가드 그대로.
+- live LLM editor 의 record/replay 모드 — F-81-4 별도 PR 까지 보류.
+
+# 승인 필요 여부
+
+no — 본 PR 은 코드 변경 없이 문서 / 회귀 결과 / 후속 이슈 드래프트만 포함. 운영자가 후속 이슈 (F-81-1 ~ F-81-10) 각각의 PR 생성 / 머지 시점에서 자체 승인 게이트를 진행.
+
+# 관련 문서
+
+- [[2026-05-11_issue-81-task-log-integration-polish]]
+- [[2026-05-11_issue-81-research-integration-polish]]
+- [[2026-05-09_issue-73-decision-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-research-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-task-log-tech-lead-runtime-loop]]

--- a/notes/vault-mirror/10-projects/yule-studio-agent/reports/2026-05-11_issue-81-report-integration-polish.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/reports/2026-05-11_issue-81-report-integration-polish.md
@@ -1,0 +1,132 @@
+---
+title: "issue #81 통합 polish — 회귀 리포트"
+kind: report
+issue: 81
+parent_issue: 73
+session_id: issue-81-integration-polish
+project: yule-studio-agent
+created_at: 2026-05-11T00:00:00+09:00
+status: captured
+branch: feature/issue-81-integration-polish
+tags: [report, issue-81, integration, regression, handoff]
+contract: research-forum-export/v0
+---
+
+# 한 줄 요약
+
+머지된 main (HEAD `4acb160`) 기준 전체 unittest 3493/3493 OK + cross-axis 통합 슈트 160/160 OK. #81 worktree split 3 축은 충돌 없이 결합되며, 100% 까지 잔여 작업 10 종을 후속 이슈로 분리.
+
+# 회귀 결과
+
+| 슈트 | 명령 | 결과 |
+| --- | --- | --- |
+| 전체 unittest discover | `PYTHONPATH=src python3 -m unittest discover -s tests -t .` | **3493 OK, skip 5, 8.13s** |
+| Cross-axis 통합 슈트 (13 모듈) | `PYTHONPATH=src python3 -m unittest -v tests.job_queue.test_autonomy_producer ... tests.runtime.test_run_service_coding_executor` | **160 OK, 0.254s** |
+
+skip 5 의 출처: 환경 의존 (Anthropic / Ollama / GitHub App live) 테스트. 본 회귀의 의도된 skip.
+
+negative-path 로그 (예: `RuntimeError: status=401`, `claude backend exploded`, `audit pipeline down`, `unclosed event loop`) 는 *provider failure → fallback* / *audit writer raise → swallow* / *Python 3.9 asyncio ResourceWarning* 의 의도된 출력 — 회귀 차단 없음.
+
+# Cross-axis 통합점
+
+| 결합 | 확인된 흐름 | 회귀 슈트 |
+| --- | --- | --- |
+| autonomy ↔ discussion | producer tick 이 `discussion_followup.dispatch_unresolved` 를 호출, follow-up 결과를 `session.extra['discussion_followup']['by_turn']` 마커로 dedup | `test_autonomy_producer`, `test_discussion_followup`, `test_completion_funnel` |
+| autonomy ↔ knowledge | retrieval evidence 는 read-only — producer 가 큐 직접 enqueue 하지 않음 (§ 16-ter.6) | `test_provider_routing`, `test_provider_availability_summary` |
+| knowledge ↔ discussion | `ContextPack.relevant_knowledge` slot 가 `KnowledgeRetriever.with_signals` 결과를 받음 | `test_discussion_context_pack`, `test_retrieval` |
+| 세 축 wiring | `runtime.run_service` 가 producer / executor / status / decision port 합성, supervisor watch loop 가 같은 tick 으로 호출 | `test_run_service*`, `test_supervisor_autonomy_tick`, `test_status_autonomy_surface`, `test_decision_port_run_service_wiring` |
+
+cross-axis 충돌 없음 — 세 축은 같은 `session.extra` schema + 같은 4-state vocabulary + 같은 `RuntimeStatusReport` shape 을 공유.
+
+# main 머지 상태 (snapshot)
+
+머지된 PR: #75 / #76 / #77 / #78 / #79 / #80 / #82.
+열린 PR: #83 (knowledge-geeknews canonical title).
+PR 미생성 branch: `feature/issue-81-discussion-gateway` (`512ce7c`), `feature/issue-81-autonomy-execution` (`38e9332`).
+
+# 마스터 플랜 § 3 완료도 수치 — 갱신
+
+| 영역 | 이전 | 갱신 |
+| --- | --- | --- |
+| 운영 골격 | 65~75% | **80~85%** |
+| Discord 기술 토의 능력 | 40~50% | **50~60%** |
+| 완전 자율 코딩 루프 | 45~55% | **70~80%** |
+| 역할별 자료 수집/정형화 루프 | 25~35% | **50~60%** |
+| 실제 회사처럼 굴러가는 종합 수준 | 45~55% | **60~70%** |
+
+근거 / 상한 유보 사유는 [[2026-05-11_issue-81-decision-integration-polish]] § D-81-3 ~ D-81-7 참조.
+
+# Hard rails 보존
+
+- protected branch 직접 push / force push: 가드 그대로.
+- live LLM 코드 편집기: 본 worktree 비활성, F-81-4 별도.
+- live Claude decision provider: 본 worktree 비활성, 두 단계 env opt-in 미설정 시 deterministic-only.
+- 큐 dedup 단일 지점 원칙: producer 가 큐 직접 enqueue 하지 않음.
+- secret / API key 누출: 회귀 슈트에 가드 (provider 어댑터 테스트) 그대로 통과.
+
+# 후속 이슈 (10 종)
+
+F-81-1 ~ F-81-10 — [[2026-05-11_issue-81-decision-integration-polish]] § "후속 이슈 드래프트" 표 그대로.
+
+# Issue #81 progress comment 본문 (운영자가 직접 post)
+
+```markdown
+## 📈 Progress — #81 통합 polish (2026-05-11)
+
+머지된 main 기준으로 #81 worktree split 3 축 (discussion / autonomy / knowledge) 의 cross-axis 결합을 단일 worktree (`feature/issue-81-integration-polish`) 에서 회귀 검증하고, master plan 의 완료도 수치를 갱신했습니다.
+
+### 회귀
+
+- 전체 unittest discover: 3493/3493 OK (skip 5), 8.13s.
+- Cross-axis 통합 슈트 (autonomy / knowledge / discussion / runtime 13 모듈): 160/160 OK, 0.254s.
+- 세 축은 같은 `session.extra` schema + 4-state vocabulary + `RuntimeStatusReport` shape 을 공유하며 충돌 없이 결합.
+
+### main 머지 상태
+
+- 머지: PR #75 #76 #77 #78 #79 #80 #82 (autonomy / knowledge 축, Round 4 / 4-bis / 4-ter / 4 마무리 시리즈).
+- OPEN: PR #83 (knowledge-geeknews canonical title).
+- PR 미생성: `feature/issue-81-discussion-gateway` (`512ce7c`), `feature/issue-81-autonomy-execution` (`38e9332`).
+
+### Master plan § 3 완료도 수치 갱신
+
+| 영역 | 이전 | 본 PR 갱신 |
+| --- | --- | --- |
+| 운영 골격 | 65~75% | **80~85%** |
+| Discord 기술 토의 | 40~50% | **50~60%** |
+| 완전 자율 코딩 루프 | 45~55% | **70~80%** |
+| 자료 수집/정형화 | 25~35% | **50~60%** |
+| 종합 | 45~55% | **60~70%** |
+
+상한 유보 사유는 통합 polish PR 의 decision 노트 참조.
+
+### 후속 이슈 (10 종)
+
+본 PR 비범위 → 후속 이슈 분리.
+
+1. discussion-gateway PR 생성 + 머지 (branch ready)
+2. autonomy-execution PR 생성 + 머지 (branch ready)
+3. knowledge-geeknews PR #83 머지
+4. live LLM 코드 편집기 활성화 (운영자 승인 + cost)
+5. urllib `BytesFetcher` 한 조각 (RSS/Atom/GH releases 동시 라이브)
+6. sitemap / html_list / html_detail / github_api 라이브 fetcher
+7. runtime service spawn `eng-research-collector`
+8. `SourceRefreshState` 영속화 (sqlite or vault sidecar)
+9. `next_task_selector` 의 `DECISION_KIND_NEXT_TASK` 호출
+10. Discord escalation alert (blocked N 분 지속)
+
+상세는 본 PR 의 task-log / decision 노트 참조.
+```
+
+# 운영자 다음 액션
+
+1. 본 PR (`feature/issue-81-integration-polish`) 검토 + 머지.
+2. 위 progress comment 본문을 issue #81 에 post (운영자 직접).
+3. F-81-1 / F-81-2 / F-81-3 부터 PR 생성 (회귀 / 머지 순서는 decision § D-81-8 권장).
+4. F-81-4 ~ F-81-10 은 별도 worktree + 새 이슈로 분리.
+
+# 관련 문서
+
+- [[2026-05-11_issue-81-task-log-integration-polish]]
+- [[2026-05-11_issue-81-decision-integration-polish]]
+- [[2026-05-11_issue-81-research-integration-polish]]
+- [[2026-05-09_issue-73-task-log-tech-lead-runtime-loop]]

--- a/notes/vault-mirror/10-projects/yule-studio-agent/research/2026-05-11_issue-81-research-integration-polish.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/research/2026-05-11_issue-81-research-integration-polish.md
@@ -1,0 +1,78 @@
+---
+title: "issue #81 통합 polish — 사전 조사"
+kind: research
+issue: 81
+parent_issue: 73
+session_id: issue-81-integration-polish
+project: yule-studio-agent
+created_at: 2026-05-11T00:00:00+09:00
+status: captured
+branch: feature/issue-81-integration-polish
+tags: [research, issue-81, integration, regression]
+contract: research-forum-export/v0
+---
+
+# 배경
+
+#81 (엔지니어 에이전트 팀 단위 자동화) 은 worktree split plan 에 따라 세 갈래로 갈라졌다.
+
+- `feature/issue-81-discussion-gateway` — gateway / tech-lead 경계, Discord 기술 토의 surface 가독성, discussion_mode operator surface.
+- `feature/issue-81-autonomy-execution` — next-task auto handoff, completion funnel, coding executor live path, CI failure → retry/blocked/approval 강화.
+- `feature/issue-81-knowledge-geeknews` — 역할별 상시 자료 수집, request-time retrieval, canonical title / share boundary / Obsidian knowledge contract.
+
+세 축이 main 위에서 *동시에* 굴러갈 때 (a) cross-axis 충돌 / (b) 운영자 surface 일관성 / (c) handoff 누락 이 없는지 한 곳에서 검증하는 게 본 worktree 의 목적이다.
+
+# 통합 시점 main 의 진실 (2026-05-11)
+
+| 머지 영역 | 핵심 모듈 | 회귀 진입점 |
+| --- | --- | --- |
+| autonomy 축 (Round 4 / 4-bis / 4-ter / 4 마무리) | `agents/job_queue/{autonomy_producer,autonomy_lock,discussion_followup,completion_funnel,claude_decision_seam,claude_subprocess_adapter}.py` + `runtime/run_service.py` + `runtime/status.py` | `tests.job_queue.test_autonomy_producer`, `test_discussion_followup`, `test_completion_funnel`, `test_decision_port_run_service_wiring`, `tests.runtime.test_supervisor_autonomy_tick`, `test_status_autonomy_surface` |
+| knowledge 축 (Round 4 시리즈) | `agents/engineering_intelligence/{provider_registry,provider_routing,providers,retrieval,feed_parser,scheduler,source_registry,role_feed_digest,share_scope}.py` | `tests.engineering_intelligence.*` |
+| discussion seam | `agents/discussion/context_pack.py`, `agents/job_queue/discussion_followup.py` | `tests.engineering.test_discussion_context_pack`, `tests.job_queue.test_discussion_followup` |
+| executor / CI | `agents/job_queue/{coding_executor_worker,coding_executor_live,coding_execute_dispatcher,coding_execute_progress,ci_retry_orchestrator,ci_status}.py` | `tests.agents.test_coding_executor_*`, `tests.job_queue.test_coding_execute_*`, `tests.job_queue.test_ci_retry_orchestrator`, `tests.agents.test_ci_status` |
+
+미머지 (branch 만 존재):
+
+- `feature/issue-81-discussion-gateway` (commit `512ce7c`) — Discord 토의 surface 가독성 향상 + gateway/tech-lead 경계 정렬.
+- `feature/issue-81-autonomy-execution` (commit `38e9332`) — 역할별 반복 실수 ledger + preflight seam round 1.
+- `feature/issue-81-knowledge-geeknews` (commit `baa1c93`, PR #83) — engineering-knowledge 수집 노트 visible title GeekNews 스타일.
+
+# 세 축이 결합하는 단일 신호 표면
+
+세 축이 동시에 운영자에게 도달하는 한 화면은 `runtime.status.RuntimeStatusReport` + `runtime.status_poster.post_runtime_status_summary` 두 함수의 결과다 (Round 4 마무리, 마스터 플랜 § 16-ter / Round 4 후속 / Round 4 마무리). 본 회귀에서 검증한 결합은 아래와 같다.
+
+1. **autonomy 가 만든 dispatch** → `RuntimeAutonomyJournal` ring buffer (16 entry) → `RuntimeStatusReport.autonomy_recent` → `render_runtime_status_text` / Discord post / JSON.
+2. **completion funnel decision** → `session.extra['completion_funnel']['history']` 32 cap → `collect_recent_completion_funnel(session_lister=...)` → `RuntimeStatusReport.completion_funnel_recent` → 같은 surface.
+3. **knowledge retrieval evidence** → `KnowledgeRetriever.with_signals` → `discussion.context_pack.ContextPack.relevant_knowledge` slot → discussion follow-up 의 `DecisionRequest.facts` 또는 prompt context.
+4. **decision seam 의 verdict** → `consult_decision_port(port, request) -> (DecisionResponse, DecisionInvocationTrace)` → `AutonomyDispatch.payload['decision_invocation']` → status surface 의 `errored/locked/dispatched` 카운터.
+
+이 흐름이 cross-axis 회귀 (160 케이스) 에서 한 번에 통과했다는 것은, 세 축이 *같은 session.extra schema* + *같은 4-state vocabulary* + *같은 RuntimeStatusReport shape* 을 공유함을 의미한다.
+
+# 잔여 회귀 위험 식별
+
+cross-axis 통과는 했지만 머지 안 된 #81 분기들이 추가로 들어올 때 다시 봐야 할 지점.
+
+| 위험 | 어디서 | 대응 |
+| --- | --- | --- |
+| discussion-gateway 가 Discord 채널 router 의 정책 텍스트를 바꾸면 `tests.discord.*` 변경 필요 | `src/yule_orchestrator/discord/*`, `tests/discord/*` | gateway PR 안에서 회귀 같이 land |
+| autonomy-execution 의 ledger / preflight seam 이 producer 에 새 sub-producer 를 추가하면 `AutonomyProducer.tick()` payload schema 변경 가능 | `agents/job_queue/autonomy_producer.py` | producer 직접 enqueue 금지 원칙 (마스터 플랜 § 16-ter.6) 유지 — 새 dispatcher 한 곳만 추가 |
+| knowledge-geeknews canonical title 이 frontmatter `topic` 키와 정렬되지 않으면 인덱서 회귀 | `agents/engineering_intelligence/obsidian*`, `tests.engineering_intelligence.test_obsidian` | PR #83 의 48 cases 회귀로 가드. 본 회귀에서도 통과 확인 |
+| live LLM editor 활성화 시 `coding_executor_live` 의 `RecordOnlyCodeEditor` 교체로 verdict 가 actionable 로 surface | `coding_executor_live.py`, `coding_executor_worker.py` | 본 worktree 비범위. 운영자 승인 + 별도 PR 게이트 필요 (Round 2 매핑 그대로) |
+
+# 운영자 handoff 요구
+
+- 운영자가 `yule runtime status` / Discord `#봇-상태` / Obsidian task-log / GitHub PR 댓글 어디에서 봐도 4-state + 9 종 operator action 이 같은 라벨로 보여야 한다 (Round 4 마무리 land 완료).
+- 세 축이 머지될 때마다 마스터 플랜 § 3 수치 / § 16-ter / § 16-quater 를 한 번씩 갱신해야 한다. 본 PR 은 § 3 만 갱신.
+- live LLM editor / live decision provider 두 개는 *반드시* 운영자 명시 opt-in 환경변수 양쪽이 켜져 있을 때만 surface — 두 단계 opt-in 정책 (마스터 플랜 § 16-quater.2 / § 16-bis.5) 그대로.
+
+# 본 PR 의 결정 — [[2026-05-11_issue-81-decision-integration-polish]]
+
+회귀 범위 / 수치 갱신 폭 / 후속 이슈 분리 기준은 본 노트 옆 decision 노트에서 확정한다.
+
+# 관련 문서
+
+- [[2026-05-11_issue-81-task-log-integration-polish]]
+- [[2026-05-11_issue-81-decision-integration-polish]]
+- [[2026-05-09_issue-73-research-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-decision-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-task-log-tech-lead-runtime-loop]]

--- a/notes/vault-mirror/10-projects/yule-studio-agent/task-logs/2026-05-11_issue-81-task-log-integration-polish.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/task-logs/2026-05-11_issue-81-task-log-integration-polish.md
@@ -1,0 +1,156 @@
+---
+title: "issue #81 통합 정리 — 작업 로그"
+kind: task-log
+issue: 81
+parent_issue: 73
+session_id: issue-81-integration-polish
+project: yule-studio-agent
+created_at: 2026-05-11T00:00:00+09:00
+status: in-progress
+branch: feature/issue-81-integration-polish
+worktree: /Users/masterway/local-dev/yule-studio-agent-worktrees/yule-studio-agent-worktrees/issue-81-integration-polish
+mode: integration-mediated (회귀 + 정리 + 후속 이슈 분리)
+tags: [task-log, issue-81, integration, regression, handoff]
+---
+
+# 목표
+
+#81 (엔지니어 에이전트 팀 단위 자동화) 의 worktree split — `discussion-gateway` / `autonomy-execution` / `knowledge-geeknews` — 가 #73 Round 1~Round 4 마무리 시리즈 위에서 어떻게 결합하는지 단일 worktree (`feature/issue-81-integration-polish`) 에서 한 번에 검증하고, 운영자에게 넘기기 전 마지막 정리를 수행한다.
+
+자세한 결정은 [[2026-05-11_issue-81-decision-integration-polish]], 분석은 [[2026-05-11_issue-81-research-integration-polish]].
+
+# 통합 시점 main 상태 (2026-05-11 09:40 KST)
+
+| PR | 축 | 머지 여부 |
+| --- | --- | --- |
+| #75 knowledge-loop | knowledge | 머지됨 |
+| #76 autonomy-loop | autonomy | 머지됨 |
+| #77 knowledge-providers | knowledge | 머지됨 |
+| #78 autonomy-decision | autonomy | 머지됨 |
+| #79 knowledge-surface | knowledge | 머지됨 |
+| #80 autonomy-surface | autonomy | 머지됨 |
+| #82 knowledge-providers (rebase) | knowledge | 머지됨 |
+| #83 knowledge-geeknews | knowledge | **OPEN** (canonical title 정리) |
+| (없음) discussion-gateway | discussion | **branch only** (commit `512ce7c`, PR 미생성) |
+| (없음) autonomy-execution | autonomy 후속 | **branch only** (commit `38e9332`, PR 미생성) |
+
+머지된 축의 main HEAD: `4acb160`. 본 integration worktree는 그 위에서 시작 — 즉 검증 대상은 *현재 main 에 합쳐진 autonomy + knowledge 흐름이 서로 충돌 없이 도는지* 와 *세 갈래 worktree 가 다음 단계로 진행할 때 어디서 진입해야 하는지* 다.
+
+# 진행 단계 (실시간 갱신)
+
+| 시점 | 단계 | 상세 |
+| --- | --- | --- |
+| 2026-05-11 kickoff | worktree 확인 + main HEAD 동기화 | `feature/issue-81-integration-polish` clean, origin/main 동기화 |
+| 2026-05-11 회귀-1 | 전체 unittest discover | `PYTHONPATH=src python3 -m unittest discover -s tests -t .` → **3493/3493 OK** (skip 5), 8.13s |
+| 2026-05-11 회귀-2 | cross-axis 통합 슈트 | autonomy + knowledge + discussion seam 13 모듈 160 테스트 → **160/160 OK**, 0.254s |
+| 2026-05-11 정리-1 | Obsidian 산출물 4종 land | research / decision / task-log / 본 PR report |
+| 2026-05-11 정리-2 | 마스터 플랜 § 3 완료도 수치 갱신 | autonomy / knowledge / 종합 축 한 단계 상향 |
+| 2026-05-11 정리-3 | progress comment body + 후속 이슈 드래프트 작성 | 운영자 검토 후 issue/PR 생성 |
+
+# 회귀 검증 — main 기준
+
+## 1. 전체 unittest discover
+
+명령:
+
+```
+PYTHONPATH=src python3 -m unittest discover -s tests -t .
+```
+
+결과: **Ran 3493 tests in 8.129s, OK (skipped=5)**.
+
+- skip 5 는 환경 의존 (Anthropic / Ollama / GitHub App live) — 본 회귀에서는 의도된 skip.
+- 표준 출력의 `RuntimeError: status=401`, `claude backend exploded` 같은 라인은 negative-path 테스트 (provider failure → fallback) 의 의도된 로그 — 모두 assertion 통과.
+- ResourceWarning 1 건 (`unclosed event loop`) — Python 3.9 asyncio 한정 잡음, 회귀 차단 없음.
+
+## 2. Cross-axis 통합 슈트
+
+명령:
+
+```
+PYTHONPATH=src python3 -m unittest -v \
+  tests.job_queue.test_autonomy_producer \
+  tests.job_queue.test_discussion_followup \
+  tests.job_queue.test_completion_funnel \
+  tests.job_queue.test_decision_port_run_service_wiring \
+  tests.engineering_intelligence.test_provider_routing \
+  tests.engineering_intelligence.test_provider_availability_summary \
+  tests.engineering_intelligence.test_retrieval \
+  tests.engineering.test_discussion_context_pack \
+  tests.runtime.test_supervisor_autonomy_tick \
+  tests.runtime.test_status_autonomy_surface \
+  tests.runtime.test_run_service \
+  tests.runtime.test_run_service_builder \
+  tests.runtime.test_run_service_coding_executor
+```
+
+결과: **Ran 160 tests in 0.254s, OK**.
+
+| 통합점 | 모듈 | 통과 |
+| --- | --- | --- |
+| autonomy ↔ discussion | `test_autonomy_producer`, `test_discussion_followup`, `test_completion_funnel` | ✅ |
+| autonomy ↔ knowledge | `test_provider_routing`, `test_provider_availability_summary` (autonomy 가 retrieval 결과를 read 만) | ✅ |
+| knowledge ↔ discussion | `test_discussion_context_pack`, `test_retrieval` | ✅ |
+| 세 축 wiring | `test_run_service*`, `test_supervisor_autonomy_tick`, `test_status_autonomy_surface`, `test_decision_port_run_service_wiring` | ✅ |
+
+cross-axis 충돌 없음 — autonomy producer 의 tick 이 discussion follow-up 과 knowledge retrieval evidence slot 양쪽을 같은 session.extra schema 로 읽고, status surface 가 한 화면에서 4-state + 9 종 operator action 으로 통합 렌더된다는 점을 회귀가 그대로 보장.
+
+# Hard rails 보존 확인 (통합 시점)
+
+- producer / lock / completion funnel / decision seam 4 영역 모두 hard-rail 안에서 land (Round 4 / 4-bis / 4-ter / 4 마무리 그대로).
+- live LLM 코드 편집기 / live Claude API SDK 활성화 **없음** — 두 단계 env opt-in 만 존재.
+- protected branch / force push / 무한 재시도 / API key 누출 / vault path traversal 가드 변경 없음.
+- discussion-gateway / autonomy-execution / knowledge-geeknews 각 branch 는 main 미머지 → 운영자가 PR 단위로 승인 게이트 유지.
+
+# Round 4 마무리 → #81 통합 polish 까지의 누적 산출물
+
+| 영역 | 현재 land 된 위치 | 다음 진입점 |
+| --- | --- | --- |
+| 자율 producer / scheduler | `agents/job_queue/autonomy_producer.py`, `autonomy_lock.py` | 추가 sub-producer 등록 시 같은 dispatcher 한 곳 경유 (큐 dedup 단일 지점 원칙) |
+| discussion follow-up | `agents/job_queue/discussion_followup.py` | implementation_candidate / actionable advance fast-path (현재는 SKIPPED) |
+| completion funnel | `agents/job_queue/completion_funnel.py` | 4-state 외 fine-grained signal 필요 시만 확장 |
+| decision seam 3-tier | `agents/job_queue/claude_decision_seam.py`, `claude_subprocess_adapter.py` | `next_task_selector` 의 `DECISION_KIND_NEXT_TASK` 호출 |
+| coding executor (worker / live / dispatcher / progress) | `agents/job_queue/coding_executor_*`, `coding_execute_*` | live LLM editor 활성화 (운영자 승인 필요) |
+| CI retry orchestrator | `agents/job_queue/ci_retry_orchestrator.py`, `ci_status.py` | supervisor watch loop interval polling 통합 |
+| knowledge provider registry / routing | `agents/engineering_intelligence/{provider_registry,provider_routing,providers,feed_parser}.py` | urllib `BytesFetcher` 한 조각 + sitemap / html_list / html_detail / github_api_repo_activity 라이브 fetcher |
+| knowledge retrieval / context pack | `agents/engineering_intelligence/retrieval.py`, `agents/discussion/context_pack.py` | discussion synthesizer 가 `relevant_knowledge` 를 prompt 에 어떻게 짜 넣을지 |
+| status surface / operator actions | `runtime/status.py`, `status_poster.py`, `coding_execute_progress.py` | Discord escalation alert (blocked N 분 지속 시 직접 멘션) |
+
+# 본 worktree 비범위 → 후속 이슈 매핑
+
+본 worktree 는 코드 변경을 하지 않고 통합 검증 / 문서 / handoff 만 다룬다. 100% 까지 남은 일은 아래 후속 이슈로 분리한다 (자세한 본문은 [[2026-05-11_issue-81-decision-integration-polish]] § "후속 이슈 드래프트" 참고).
+
+1. **discussion-gateway PR 생성 + 머지** — 로컬/원격 branch (`feature/issue-81-discussion-gateway`, commit `512ce7c`) 만 존재. gateway/tech-lead 경계 + Discord 토의 surface 가독성 변경을 PR 로 묶어 머지.
+2. **autonomy-execution PR 생성 + 머지** — `feature/issue-81-autonomy-execution` commit `38e9332` (역할별 반복 실수 ledger + preflight seam round 1) 머지.
+3. **knowledge-geeknews PR #83 머지** — engineering-knowledge 수집 노트 visible title GeekNews 스타일 정규화. 본 회귀 후 머지 안전.
+4. **live LLM 코드 편집기 활성화** — `RecordOnlyCodeEditor` 를 실제 LLM 어댑터로 교체. 운영자 승인 + cost 검토 + secret 정책 별도.
+5. **urllib `BytesFetcher` 한 조각** — RSS / Atom / GitHub releases atom 동시 라이브 전환. 마스터 플랜 § 9.3 후속.
+6. **sitemap / html_list / html_detail / github_api_repo_activity 라이브 fetcher + parser** — 현재 NO_LIVE_IMPL.
+7. **runtime service spawn (`eng-research-collector`)** — scheduler tick → `refresh_plan_status` → `select_routed_due` → registry fetcher → adapter → vault writer 한 줄 wiring.
+8. **`SourceRefreshState` persistence** — sqlite or vault sidecar.
+9. **`next_task_selector` 의 `DECISION_KIND_NEXT_TASK` 호출** — decision seam 의 두 번째 콜사이트.
+10. **Discord escalation alert** — `blocked` / `needs_approval` 상태가 N 분 이상 지속될 때 운영자 직접 멘션. 현재는 dedup 게이트 / banner 만.
+
+# 마스터 플랜 § 3 수치 갱신
+
+| 영역 | 이전 | 본 PR 갱신 | 근거 |
+| --- | --- | --- | --- |
+| 운영 골격 | 65~75% | **80~85%** | autonomy producer + decision seam + status surface + operator actions land |
+| Discord 기술 토의 능력 | 40~50% | **50~60%** | discussion_followup + context_pack + retrieval slot land. discussion-gateway PR 미머지 → 상한 유지 |
+| 완전 자율 코딩 루프 | 45~55% | **70~80%** | dispatcher + executor live (RecordOnly) + CI orchestrator + retry guard + producer + funnel + claude subprocess seam land. live LLM editor 만 잔여 |
+| 역할별 자료 수집/정형화 루프 | 25~35% | **50~60%** | provider registry + routing + retrieval + feed parser + role feed digest + provenance land. urllib BytesFetcher / sitemap / html / github_api 라이브 fetcher 잔여 |
+| 실제 회사처럼 굴러가는 종합 수준 | 45~55% | **60~70%** | 4 축 결합이 cross-axis 회귀에서 충돌 없이 통과, 그러나 #81 worktree split 3축 (gateway / execution / geeknews) 미머지 → 70% 상한 유지 |
+
+# 운영자 handoff
+
+- `feature/issue-81-integration-polish` 는 본 task-log + decision + research + report + master plan § 3 갱신만 포함. 코드 변경 없음.
+- 머지 순서 권장: (1) `discussion-gateway` PR 생성 → 회귀 통과 → 머지, (2) `knowledge-geeknews` PR #83 머지, (3) `autonomy-execution` PR 생성 → 머지, (4) 본 통합 polish PR 머지.
+- 위 순서가 아니라도 cross-axis 충돌은 회귀로 검증된 상태 — 단지 본 PR 의 § 3 수치가 (4) 머지 후 후행 갱신 PR 으로 한 번 더 올라가야 한다.
+
+# 관련 문서
+
+- [[2026-05-11_issue-81-research-integration-polish]]
+- [[2026-05-11_issue-81-decision-integration-polish]]
+- [[2026-05-09_issue-73-task-log-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-research-tech-lead-runtime-loop]]
+- [[2026-05-09_issue-73-decision-tech-lead-runtime-loop]]


### PR DESCRIPTION
## 📌 관련 이슈
- refs #81
- follows #83
- follows #84
- follows #85

## ✨ 과제 내용
- issue #81의 knowledge / autonomy / discussion 축을 merge한 뒤, 통합 관점에서 회귀와 운영 문서를 정리했습니다.
- 마스터 플랜의 현재 완성도 수치를 갱신하고, 남은 100% 미달 영역을 후속 작업 기준으로 정리했습니다.
- Obsidian shared note 4종(research / decision / task-log / report)을 추가해 다음 세션에서도 그대로 이어갈 수 있게 했습니다.
- 이번 PR은 새 기능 추가보다 integration polish와 운영 handoff를 위한 마감 PR입니다.

## :camera_with_flash: 스크린샷(선택)
- 없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs/engineering-company-runtime-master-plan.md
- notes/vault-mirror/10-projects/yule-studio-agent/research/2026-05-11_issue-81-research-integration-polish.md
- notes/vault-mirror/10-projects/yule-studio-agent/decisions/2026-05-11_issue-81-decision-integration-polish.md
- notes/vault-mirror/10-projects/yule-studio-agent/task-logs/2026-05-11_issue-81-task-log-integration-polish.md
- notes/vault-mirror/10-projects/yule-studio-agent/reports/2026-05-11_issue-81-report-integration-polish.md
- 성격: integration / regression / operator handoff 중심
