### PR TITLE
🔧 .env.example — multi-bot GitHub App per-role 키 패턴 문서화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,41 @@ DISCORD_GUILD_ID=
 # YULE_GITHUB_DEFAULT_DRY_RUN=true
 
 # =====================================================================
+# Multi-bot GitHub Apps (#81~ 후속 PR — 3봇 체제: tech-lead +
+# backend-engineer + frontend-engineer; 이후 qa/devops 확장)
+#
+# 위 default 키(YULE_GITHUB_APP_*) 는 fallback / tech-lead 용이고,
+# 아래 per-role 키가 있으면 role-aware GitHub 클라이언트가 우선 사용.
+# 각 봇 PEM 키 권한은 0600 / 0640 권장.
+#
+# 봇 책임 경계:
+#   tech-lead          — intake / 토의 / scope 정의 / work split / 최종 PR orchestration
+#   backend-engineer   — API / DB / auth / queue / domain logic
+#   frontend-engineer  — UI / state / interaction / accessibility / page structure
+#   qa-engineer        — 회귀 시나리오 / acceptance / failure reproduction
+#   devops-engineer    — runtime / CI/CD / env / deploy / observability
+#
+# 운영 정책:
+#   - .env.example 에는 절대 실제 App ID / Installation ID / pem 경로를 적지 않는다.
+#   - 운영자가 .env.local 에 한해 실제 값을 채운다. .env.local 은 .gitignore.
+#   - placeholder App ID(123456 / 0 등) 는 doctor 가 차단.
+# YULE_GITHUB_APP_TECH_LEAD_APP_ID=
+# YULE_GITHUB_APP_TECH_LEAD_INSTALLATION_ID=
+# YULE_GITHUB_APP_TECH_LEAD_PRIVATE_KEY_PATH=
+# YULE_GITHUB_APP_BACKEND_ENGINEER_APP_ID=
+# YULE_GITHUB_APP_BACKEND_ENGINEER_INSTALLATION_ID=
+# YULE_GITHUB_APP_BACKEND_ENGINEER_PRIVATE_KEY_PATH=
+# YULE_GITHUB_APP_FRONTEND_ENGINEER_APP_ID=
+# YULE_GITHUB_APP_FRONTEND_ENGINEER_INSTALLATION_ID=
+# YULE_GITHUB_APP_FRONTEND_ENGINEER_PRIVATE_KEY_PATH=
+# YULE_GITHUB_APP_QA_ENGINEER_APP_ID=
+# YULE_GITHUB_APP_QA_ENGINEER_INSTALLATION_ID=
+# YULE_GITHUB_APP_QA_ENGINEER_PRIVATE_KEY_PATH=
+# YULE_GITHUB_APP_DEVOPS_ENGINEER_APP_ID=
+# YULE_GITHUB_APP_DEVOPS_ENGINEER_INSTALLATION_ID=
+# YULE_GITHUB_APP_DEVOPS_ENGINEER_PRIVATE_KEY_PATH=
+
+# =====================================================================
 # #73 — coding executor opt-in (engineering profile)
 #
 # eng-coding-executor 는 default 로 auto_spawn=False 다. ``yule runtime


### PR DESCRIPTION
## 📌 관련 이슈

- 후속 #81~ 그룹의 prerequisite chore
- governance: #69 (write-ownership.md — env contract 변경은 별도 분리 PR)

## ✨ 과제 내용

### 작업 목적

3봇 체제(tech-lead / backend-engineer / frontend-engineer) + 향후 qa / devops 확장의 GitHub App per-role 키 env 컨트랙트를 `.env.example` 에 먼저 박는다. 코드 wiring 은 본 PR 비범위 — 후속 F1~F6 PR 들이 사용할 수 있도록 운영자 셋업 가이드만 land.

### 무엇을 변경했는지

`.env.example` 에 multi-bot GitHub App per-role 키 placeholder 블록 추가:

| role | 키 prefix |
| --- | --- |
| tech-lead | `YULE_GITHUB_APP_TECH_LEAD_*` |
| backend-engineer | `YULE_GITHUB_APP_BACKEND_ENGINEER_*` |
| frontend-engineer | `YULE_GITHUB_APP_FRONTEND_ENGINEER_*` |
| qa-engineer (확장) | `YULE_GITHUB_APP_QA_ENGINEER_*` |
| devops-engineer (확장) | `YULE_GITHUB_APP_DEVOPS_ENGINEER_*` |

각 prefix 아래 (APP_ID / INSTALLATION_ID / PRIVATE_KEY_PATH) 3종 키. 봇 책임 경계 + 운영 정책(.env.example placeholder only, .env.local 만 실제 값) 주석 포함.

### 무엇을 아직 하지 않았는지

- role-aware GitHub 클라이언트 코드: 후속 PR
- per-role doctor 검증: 후속 PR
- 코드 sweep 으로 default key 사용처 → per-role 분기: 후속 PR

### 검증

- `.env.local` 은 gitignore 되어 있음(`.env.*` + `!.env.example`).
- `.env.example` diff 만 변경 — 코드 회귀 영향 0.

## 🤖 Agent WorkOS Audit

- audit_id: `chore-multi-bot-env-keys`
- branch: `chore/multi-bot-env-keys` (from `main`)
- role: `engineering-agent/tech-lead`
- autonomy_level: `L2_AUTONOMOUS_RECORD`
- mode: `tech-lead-mediated`