### PR TITLE
✨ [F1/#88] PasteGuard — outbound secret redaction preflight

### DIFF
--- a/src/yule_orchestrator/agents/security/__init__.py
+++ b/src/yule_orchestrator/agents/security/__init__.py
@@ -1,0 +1,39 @@
+"""Security agent layer — PasteGuard outbound redaction (F1 / #88).
+
+This package houses the outbound secret preflight that every
+LLM / Discord / GitHub / Obsidian write must pass through.
+
+  * :mod:`paste_guard` — pattern catalogue + scan + redact +
+    ``guard_outbound`` wrapper. The wrapper is fail-closed: if
+    redaction throws for any reason, the payload is replaced with
+    an empty string and ``GuardVerdict.blocked = True``.
+
+The catalogue must stay loud about hard rails: API keys, PEM
+blocks, OAuth tokens, DB URLs with credentials, and other high-
+entropy secrets are stripped *before* the bytes leave the agent
+process — never logged, never echoed back in
+``GuardVerdict.findings``.
+"""
+
+from .paste_guard import (
+    GuardVerdict,
+    OutboundChannel,
+    PasteGuardError,
+    SecretFinding,
+    SecretPattern,
+    guard_outbound,
+    redact_payload,
+    scan_payload,
+)
+
+
+__all__ = (
+    "GuardVerdict",
+    "OutboundChannel",
+    "PasteGuardError",
+    "SecretFinding",
+    "SecretPattern",
+    "guard_outbound",
+    "redact_payload",
+    "scan_payload",
+)

--- a/src/yule_orchestrator/agents/security/paste_guard.py
+++ b/src/yule_orchestrator/agents/security/paste_guard.py
@@ -1,0 +1,418 @@
+"""PasteGuard — outbound secret redaction preflight (F1 / #88).
+
+Every outbound payload — LLM prompts, Discord webhook posts,
+GitHub issue / PR comments, Obsidian vault writes — must pass
+through :func:`guard_outbound` before the bytes leave the agent
+process. The guard runs three stages:
+
+  1. :func:`scan_payload` walks a deterministic catalogue of
+     :class:`SecretPattern` regexes and returns every match as
+     a :class:`SecretFinding`.
+  2. :func:`redact_payload` rewrites each finding inline using
+     a stable ``head4 + mask + tail4`` shape so the redaction
+     is round-trip safe and replay-friendly for ops review.
+  3. :func:`guard_outbound` composes 1 + 2, attaches the channel
+     and a sha256 hash of the *original* payload, and returns a
+     :class:`GuardVerdict`. When ``fail_closed=True`` (the
+     default) any internal exception causes the payload to be
+     dropped (``redacted = ""``) and ``blocked = True``.
+
+Hard rails (regression-tested in
+``tests/engineering/test_paste_guard_governance.py``):
+
+  * The raw secret never appears in ``GuardVerdict.findings``,
+    ``SecretFinding.suggested_redaction``, repr / str output, or
+    in any log line emitted by this module.
+  * ``guard_outbound`` is fail-closed by default — degraded
+    state must drop the payload, not leak it.
+  * No outbound channel is ever exempted (LLM, Discord, GitHub,
+    and Vault all hit the same wrapper).
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Pattern catalogue
+# ---------------------------------------------------------------------------
+
+
+class SecretPattern(str, enum.Enum):
+    """Catalogue of secret shapes PasteGuard recognises.
+
+    Stored as a string enum so logs / payloads can reference
+    ``finding.pattern.value`` without leaking the literal regex.
+    """
+
+    ANTHROPIC_API_KEY = "anthropic_api_key"
+    OPENAI_API_KEY = "openai_api_key"
+    GITHUB_PAT = "github_pat"
+    DISCORD_BOT_TOKEN = "discord_bot_token"
+    PEM_BLOCK = "pem_block"
+    AWS_ACCESS_KEY = "aws_access_key"
+    DB_URL_WITH_PASSWORD = "db_url_with_password"
+    GENERIC_HIGH_ENTROPY = "generic_high_entropy"
+
+
+# Risk levels — ``critical`` triggers fail-closed redaction
+# semantics for governance regressions; ``advisory`` is best-
+# effort high-entropy detection (false-positive prone).
+RISK_CRITICAL: str = "critical"
+RISK_HIGH: str = "high"
+RISK_ADVISORY: str = "advisory"
+
+
+# Each pattern is paired with its (compiled regex, risk level).
+# Ordering matters: more specific patterns run first so a generic
+# match never preempts a structured one (e.g. ``sk-ant-*`` is
+# matched by anthropic, not by openai).
+_PATTERN_RULES: Tuple[Tuple[SecretPattern, "re.Pattern[str]", str], ...] = (
+    (
+        SecretPattern.ANTHROPIC_API_KEY,
+        re.compile(r"sk-ant-[a-zA-Z0-9_\-]{20,}"),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.GITHUB_PAT,
+        re.compile(r"gh[pousr]_[a-zA-Z0-9]{36,}"),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.AWS_ACCESS_KEY,
+        re.compile(r"AKIA[0-9A-Z]{16}"),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.PEM_BLOCK,
+        re.compile(
+            r"-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]+?-----END [A-Z ]+PRIVATE KEY-----"
+        ),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.DISCORD_BOT_TOKEN,
+        re.compile(r"[MN][A-Za-z0-9]{23,}\.[A-Za-z0-9_\-]{6}\.[A-Za-z0-9_\-]{27,}"),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.DB_URL_WITH_PASSWORD,
+        re.compile(
+            r"(?:postgres|postgresql|mysql|mongodb)(?:\+\w+)?://[^\s:/@]+:[^\s:/@]+@[^\s/]+"
+        ),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.OPENAI_API_KEY,
+        # Match sk-... but NOT sk-ant-... (handled by anthropic
+        # entry above). Accept sk-proj-... variants.
+        re.compile(r"sk-(?!ant-)[a-zA-Z0-9_\-]{20,}"),
+        RISK_CRITICAL,
+    ),
+    (
+        SecretPattern.GENERIC_HIGH_ENTROPY,
+        # Conservative shape: 32+ char base64-ish blob. Tagged as
+        # advisory because false positives are possible.
+        re.compile(r"\b[A-Za-z0-9+/]{32,}={0,2}\b"),
+        RISK_ADVISORY,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses + enums
+# ---------------------------------------------------------------------------
+
+
+class OutboundChannel(str, enum.Enum):
+    """Outbound destinations PasteGuard fronts."""
+
+    LLM = "llm"
+    DISCORD = "discord"
+    GITHUB = "github"
+    VAULT = "vault"
+
+
+class PasteGuardError(RuntimeError):
+    """Raised when an internal PasteGuard invariant is violated.
+
+    Public callers should let :func:`guard_outbound` fail-close
+    instead of catching this directly.
+    """
+
+
+@dataclass(frozen=True)
+class SecretFinding:
+    """A single secret hit inside a payload.
+
+    ``suggested_redaction`` carries the masked replacement only
+    (never the raw secret) so downstream logs / audit trails can
+    quote it without leaking sensitive bytes. ``span`` is the
+    (start, end) index pair into the *original* payload string.
+    """
+
+    pattern: SecretPattern
+    span: Tuple[int, int]
+    risk_level: str
+    suggested_redaction: str
+
+    def __post_init__(self) -> None:
+        start, end = self.span
+        if start < 0 or end < start:
+            raise PasteGuardError(
+                f"invalid finding span ({start}, {end}) for pattern "
+                f"{self.pattern.value}"
+            )
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (
+            "SecretFinding("
+            f"pattern={self.pattern.value!r}, "
+            f"span={self.span}, "
+            f"risk_level={self.risk_level!r}, "
+            f"suggested_redaction={self.suggested_redaction!r})"
+        )
+
+
+@dataclass(frozen=True)
+class GuardVerdict:
+    """Outcome of a :func:`guard_outbound` call.
+
+    * ``channel`` — which outbound surface ran the check.
+    * ``original_hash`` — sha256 of the *original* payload bytes
+      (utf-8 encoded). Lets ops cross-check audit logs without
+      ever needing the raw bytes again.
+    * ``findings`` — tuple of :class:`SecretFinding`. Each entry's
+      ``suggested_redaction`` is already masked.
+    * ``redacted`` — the payload safe to send. Empty string when
+      ``blocked`` is True.
+    * ``blocked`` — True iff PasteGuard refused the send. When a
+      caller passes ``fail_closed=True`` (default) and redaction
+      throws, the verdict comes back blocked + empty.
+    """
+
+    channel: OutboundChannel
+    original_hash: str
+    findings: Tuple[SecretFinding, ...]
+    redacted: str
+    blocked: bool
+
+    def has_critical(self) -> bool:
+        """True if any finding is at ``critical`` risk level."""
+
+        return any(f.risk_level == RISK_CRITICAL for f in self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Scan / redact primitives
+# ---------------------------------------------------------------------------
+
+
+def scan_payload(text: str) -> Tuple[SecretFinding, ...]:
+    """Return every secret pattern hit in ``text``.
+
+    Hits are de-duplicated by span — if two patterns claim
+    overlapping ranges, the higher-priority pattern (earlier in
+    :data:`_PATTERN_RULES`) wins. Generic high-entropy hits are
+    suppressed when a more specific hit already covers the same
+    range to avoid double-counting (e.g. an AWS key would also
+    look base64-ish).
+    """
+
+    if not isinstance(text, str) or not text:
+        return ()
+
+    findings: List[SecretFinding] = []
+    claimed_spans: List[Tuple[int, int]] = []
+
+    for pattern, regex, risk_level in _PATTERN_RULES:
+        for match in regex.finditer(text):
+            span = (match.start(), match.end())
+            if _overlaps_any(span, claimed_spans):
+                continue
+            raw = match.group(0)
+            findings.append(
+                SecretFinding(
+                    pattern=pattern,
+                    span=span,
+                    risk_level=risk_level,
+                    suggested_redaction=_mask(raw),
+                )
+            )
+            claimed_spans.append(span)
+
+    findings.sort(key=lambda f: f.span[0])
+    return tuple(findings)
+
+
+def redact_payload(text: str, *, mask: str = "***") -> str:
+    """Replace every secret in ``text`` with ``head4 + mask + tail4``.
+
+    Round-trip stable: calling :func:`redact_payload` on already-
+    redacted output is a no-op (the mask body itself does not match
+    any pattern). For very short secrets (< 8 chars) the entire run
+    collapses to ``mask`` so we never accidentally surface the
+    bulk of the original.
+    """
+
+    if not isinstance(text, str) or not text:
+        return text or ""
+
+    findings = scan_payload(text)
+    if not findings:
+        return text
+
+    out_parts: List[str] = []
+    cursor = 0
+    for finding in findings:
+        start, end = finding.span
+        if start < cursor:
+            # Defensive: overlapping spans shouldn't happen because
+            # scan_payload suppresses them. Skip rather than corrupt.
+            continue
+        out_parts.append(text[cursor:start])
+        out_parts.append(_mask(text[start:end], mask=mask))
+        cursor = end
+    out_parts.append(text[cursor:])
+    return "".join(out_parts)
+
+
+# ---------------------------------------------------------------------------
+# Guard wrapper
+# ---------------------------------------------------------------------------
+
+
+def guard_outbound(
+    *,
+    channel: OutboundChannel,
+    payload: str,
+    fail_closed: bool = True,
+) -> GuardVerdict:
+    """Run PasteGuard on ``payload`` for the given outbound ``channel``.
+
+    Returns a :class:`GuardVerdict` carrying the masked payload
+    plus an audit-grade ``original_hash``. On any internal error
+    the wrapper honours ``fail_closed``:
+
+      * ``fail_closed=True`` (default) — discard the payload
+        (``redacted=""``) and set ``blocked=True``. Findings are
+        cleared so we never echo back partially-masked data.
+      * ``fail_closed=False`` — re-raise the underlying exception.
+        Callers must catch it before sending.
+    """
+
+    if not isinstance(channel, OutboundChannel):
+        raise PasteGuardError(
+            f"channel must be OutboundChannel, got {type(channel).__name__}"
+        )
+    if payload is None:
+        payload = ""
+    if not isinstance(payload, str):
+        raise PasteGuardError(
+            f"payload must be str, got {type(payload).__name__}"
+        )
+
+    original_hash = _hash_payload(payload)
+
+    try:
+        findings = scan_payload(payload)
+        redacted = redact_payload(payload)
+    except Exception as exc:  # noqa: BLE001 - fail-closed boundary
+        if fail_closed:
+            return GuardVerdict(
+                channel=channel,
+                original_hash=original_hash,
+                findings=(),
+                redacted="",
+                blocked=True,
+            )
+        raise PasteGuardError(
+            f"redact failed for channel={channel.value}: {type(exc).__name__}"
+        ) from exc
+
+    blocked = False
+    # Hard rail: if any critical finding survives into the
+    # redacted payload, something is wrong — drop the payload.
+    if fail_closed and findings:
+        if not _is_safely_redacted(redacted):
+            return GuardVerdict(
+                channel=channel,
+                original_hash=original_hash,
+                findings=(),
+                redacted="",
+                blocked=True,
+            )
+
+    return GuardVerdict(
+        channel=channel,
+        original_hash=original_hash,
+        findings=findings,
+        redacted=redacted,
+        blocked=blocked,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _mask(raw: str, *, mask: str = "***") -> str:
+    """Return ``head4 + mask + tail4`` (or just ``mask`` if too short).
+
+    The ``head4 + tail4`` shape lets operators eyeball-match the
+    masked entry against an inventory key without recovering the
+    full secret. PEM blocks (which always contain newlines and
+    boilerplate) collapse to the bare mask so we never emit the
+    BEGIN/END headers either.
+    """
+
+    if not isinstance(raw, str) or len(raw) < 8:
+        return mask
+    if "\n" in raw or raw.startswith("-----BEGIN"):
+        return mask
+    return f"{raw[:4]}{mask}{raw[-4:]}"
+
+
+def _overlaps_any(span: Tuple[int, int], claimed: Iterable[Tuple[int, int]]) -> bool:
+    start, end = span
+    for c_start, c_end in claimed:
+        if start < c_end and c_start < end:
+            return True
+    return False
+
+
+def _hash_payload(text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _is_safely_redacted(text: str) -> bool:
+    """Sanity check: redacted text must not still match a critical pattern."""
+
+    for pattern, regex, risk_level in _PATTERN_RULES:
+        if risk_level != RISK_CRITICAL:
+            continue
+        if regex.search(text):
+            return False
+    return True
+
+
+__all__ = (
+    "GuardVerdict",
+    "OutboundChannel",
+    "PasteGuardError",
+    "RISK_ADVISORY",
+    "RISK_CRITICAL",
+    "RISK_HIGH",
+    "SecretFinding",
+    "SecretPattern",
+    "guard_outbound",
+    "redact_payload",
+    "scan_payload",
+)

--- a/tests/agents/test_paste_guard.py
+++ b/tests/agents/test_paste_guard.py
@@ -1,0 +1,334 @@
+"""PasteGuard unit tests — pattern catalogue × redaction × channel matrix.
+
+Covers the F1/#88 acceptance criteria:
+
+  * ``SecretPattern`` catalogue (8 entries) — every entry must
+    detect a positive case and let a benign negative through.
+  * ``scan_payload`` returns a deterministic, sorted tuple of
+    :class:`SecretFinding` with masked ``suggested_redaction``.
+  * ``redact_payload`` is round-trip safe (re-running on already
+    redacted output is a no-op) and emits ``head4 + mask + tail4``.
+  * ``guard_outbound`` runs identically across all four
+    :class:`OutboundChannel` values and honours ``fail_closed``.
+  * Unicode-only payloads pass through cleanly (no encoding crash).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.security.paste_guard import (
+    GuardVerdict,
+    OutboundChannel,
+    PasteGuardError,
+    RISK_ADVISORY,
+    RISK_CRITICAL,
+    SecretFinding,
+    SecretPattern,
+    guard_outbound,
+    redact_payload,
+    scan_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample fixtures — non-real, but shaped to match the patterns. Each one
+# is suffixed with a sentinel so a regression that bleeds the raw bytes
+# into a log / repr would show up immediately in the failing assertion.
+# ---------------------------------------------------------------------------
+
+
+ANTHROPIC_RAW = "sk-ant-" + "A" * 40 + "ZZ"
+OPENAI_RAW = "sk-proj-" + "B" * 30 + "ZZ"
+GITHUB_PAT_RAW = "ghp_" + "C" * 40
+GITHUB_INSTALL_RAW = "ghs_" + "D" * 40
+DISCORD_RAW = "M" + "E" * 23 + "." + "F" * 6 + "." + "G" * 30
+PEM_RAW = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEpAIBAAKCAQEA0Z+secretbytes/here==\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+AWS_RAW = "AKIA" + "1" * 16
+DB_URL_RAW = "postgres://yule:supersecret@db.internal:5432/yule"
+GENERIC_RAW = "Z" * 40  # 40 char base64-shape blob
+
+
+class PatternDetectMatrixTests(unittest.TestCase):
+    """Each catalogue pattern must detect a positive sample."""
+
+    def test_anthropic_key_detected(self) -> None:
+        findings = scan_payload(f"prefix {ANTHROPIC_RAW} suffix")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.ANTHROPIC_API_KEY)
+        self.assertEqual(findings[0].risk_level, RISK_CRITICAL)
+
+    def test_openai_key_detected_and_not_misattributed_as_anthropic(self) -> None:
+        findings = scan_payload(f"key={OPENAI_RAW}")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.OPENAI_API_KEY)
+
+    def test_github_pat_detected(self) -> None:
+        findings = scan_payload(f"token: {GITHUB_PAT_RAW} ;")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.GITHUB_PAT)
+
+    def test_github_installation_token_detected(self) -> None:
+        findings = scan_payload(f"install token {GITHUB_INSTALL_RAW}")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.GITHUB_PAT)
+
+    def test_discord_bot_token_detected(self) -> None:
+        findings = scan_payload(f"DISCORD={DISCORD_RAW}")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.DISCORD_BOT_TOKEN)
+
+    def test_pem_block_detected(self) -> None:
+        findings = scan_payload(PEM_RAW + "\n")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.PEM_BLOCK)
+
+    def test_aws_access_key_detected(self) -> None:
+        findings = scan_payload(f"aws id {AWS_RAW}")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.AWS_ACCESS_KEY)
+
+    def test_db_url_with_password_detected(self) -> None:
+        findings = scan_payload(f"DSN={DB_URL_RAW}")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, SecretPattern.DB_URL_WITH_PASSWORD)
+
+    def test_generic_high_entropy_advisory(self) -> None:
+        # 40 char base64 blob is conservative; risk = advisory.
+        findings = scan_payload(f"opaque {GENERIC_RAW} end")
+        self.assertTrue(
+            any(
+                f.pattern is SecretPattern.GENERIC_HIGH_ENTROPY
+                and f.risk_level == RISK_ADVISORY
+                for f in findings
+            )
+        )
+
+
+class PatternNoFalsePositiveTests(unittest.TestCase):
+    """Benign strings shaped like the catalogue keys must NOT match."""
+
+    def test_plain_korean_text_clean(self) -> None:
+        self.assertEqual(scan_payload("안녕하세요, 일반적인 메시지입니다."), ())
+
+    def test_short_sk_string_clean(self) -> None:
+        # ``sk-short`` is far below the 20-char minimum.
+        self.assertEqual(scan_payload("sk-short"), ())
+
+    def test_db_url_without_password_clean(self) -> None:
+        # No credentials means no match.
+        self.assertEqual(scan_payload("postgres://localhost/yule"), ())
+
+    def test_short_base64_is_not_flagged(self) -> None:
+        # 16-char blob is under the 32-char threshold.
+        self.assertEqual(scan_payload("abcd1234EFGH5678"), ())
+
+
+class RedactRoundTripTests(unittest.TestCase):
+    """``redact_payload`` honours ``head4 + mask + tail4`` and is idempotent."""
+
+    def test_redact_uses_head4_mask_tail4_shape(self) -> None:
+        body = f"prefix {ANTHROPIC_RAW} suffix"
+        redacted = redact_payload(body)
+        self.assertNotIn(ANTHROPIC_RAW, redacted)
+        # The structural sentinel ``***`` must be present.
+        self.assertIn("***", redacted)
+        # Head + tail bytes preserved for ops to match audit logs.
+        self.assertIn(ANTHROPIC_RAW[:4], redacted)
+        self.assertIn(ANTHROPIC_RAW[-4:], redacted)
+
+    def test_redact_is_idempotent(self) -> None:
+        body = f"a={GITHUB_PAT_RAW} b={AWS_RAW}"
+        once = redact_payload(body)
+        twice = redact_payload(once)
+        self.assertEqual(once, twice)
+
+    def test_redact_pem_collapses_to_mask(self) -> None:
+        redacted = redact_payload(PEM_RAW)
+        # The redacted body must not contain BEGIN/END headers OR
+        # any of the secret bytes between them.
+        self.assertNotIn("BEGIN RSA PRIVATE KEY", redacted)
+        self.assertNotIn("END RSA PRIVATE KEY", redacted)
+        self.assertNotIn("secretbytes", redacted)
+
+    def test_redact_preserves_surrounding_text(self) -> None:
+        body = f"alpha {AWS_RAW} omega"
+        redacted = redact_payload(body)
+        self.assertTrue(redacted.startswith("alpha "))
+        self.assertTrue(redacted.endswith(" omega"))
+
+
+class MultipleFindingsTests(unittest.TestCase):
+    """Multi-secret payloads return one finding per hit, in order."""
+
+    def test_multiple_findings_sorted_by_position(self) -> None:
+        body = (
+            f"first {ANTHROPIC_RAW} then {GITHUB_PAT_RAW} and finally {AWS_RAW}"
+        )
+        findings = scan_payload(body)
+        self.assertEqual(len(findings), 3)
+        # Ordered left-to-right.
+        starts = [f.span[0] for f in findings]
+        self.assertEqual(starts, sorted(starts))
+        patterns = [f.pattern for f in findings]
+        self.assertIn(SecretPattern.ANTHROPIC_API_KEY, patterns)
+        self.assertIn(SecretPattern.GITHUB_PAT, patterns)
+        self.assertIn(SecretPattern.AWS_ACCESS_KEY, patterns)
+
+    def test_overlapping_specific_pattern_wins_over_generic(self) -> None:
+        # The AWS key shape (AKIA + 16 chars) also passes the generic
+        # base64 heuristic. The specific pattern must win, generic
+        # must be suppressed.
+        findings = scan_payload(f"raw={AWS_RAW}")
+        patterns = [f.pattern for f in findings]
+        self.assertIn(SecretPattern.AWS_ACCESS_KEY, patterns)
+        self.assertNotIn(SecretPattern.GENERIC_HIGH_ENTROPY, patterns)
+
+    def test_no_finding_returns_empty_tuple(self) -> None:
+        self.assertEqual(scan_payload("그냥 평범한 텍스트"), ())
+
+
+class GuardOutboundChannelMatrixTests(unittest.TestCase):
+    """Every :class:`OutboundChannel` runs the same wrapper contract."""
+
+    def _check_channel(self, channel: OutboundChannel) -> GuardVerdict:
+        body = f"hello {ANTHROPIC_RAW} world"
+        verdict = guard_outbound(channel=channel, payload=body)
+        self.assertIsInstance(verdict, GuardVerdict)
+        self.assertEqual(verdict.channel, channel)
+        self.assertTrue(verdict.original_hash.startswith("sha256:"))
+        self.assertEqual(len(verdict.findings), 1)
+        self.assertFalse(verdict.blocked)
+        self.assertNotIn(ANTHROPIC_RAW, verdict.redacted)
+        return verdict
+
+    def test_llm_channel(self) -> None:
+        self._check_channel(OutboundChannel.LLM)
+
+    def test_discord_channel(self) -> None:
+        self._check_channel(OutboundChannel.DISCORD)
+
+    def test_github_channel(self) -> None:
+        self._check_channel(OutboundChannel.GITHUB)
+
+    def test_vault_channel(self) -> None:
+        self._check_channel(OutboundChannel.VAULT)
+
+    def test_clean_payload_returns_no_findings(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.LLM, payload="안녕하세요 운영자님"
+        )
+        self.assertEqual(verdict.findings, ())
+        self.assertFalse(verdict.blocked)
+        self.assertEqual(verdict.redacted, "안녕하세요 운영자님")
+
+
+class GuardFailClosedTests(unittest.TestCase):
+    """``fail_closed=True`` must drop the payload on internal error."""
+
+    def test_fail_closed_returns_empty_redacted_on_exception(self) -> None:
+        import yule_orchestrator.agents.security.paste_guard as pg
+
+        original = pg.redact_payload
+
+        def boom(text: str, *, mask: str = "***") -> str:
+            raise RuntimeError("simulated internal failure")
+
+        pg.redact_payload = boom  # type: ignore[assignment]
+        try:
+            verdict = pg.guard_outbound(
+                channel=OutboundChannel.LLM, payload=f"k={ANTHROPIC_RAW}"
+            )
+        finally:
+            pg.redact_payload = original  # type: ignore[assignment]
+
+        self.assertTrue(verdict.blocked)
+        self.assertEqual(verdict.redacted, "")
+        # Findings cleared so we never echo back partial data.
+        self.assertEqual(verdict.findings, ())
+        # Hash still computed so audit trail keeps continuity.
+        self.assertTrue(verdict.original_hash.startswith("sha256:"))
+
+    def test_fail_open_propagates_exception(self) -> None:
+        import yule_orchestrator.agents.security.paste_guard as pg
+
+        original = pg.scan_payload
+
+        def boom(text: str):
+            raise RuntimeError("scan boom")
+
+        pg.scan_payload = boom  # type: ignore[assignment]
+        try:
+            with self.assertRaises(PasteGuardError):
+                pg.guard_outbound(
+                    channel=OutboundChannel.LLM,
+                    payload="anything",
+                    fail_closed=False,
+                )
+        finally:
+            pg.scan_payload = original  # type: ignore[assignment]
+
+
+class GuardInputValidationTests(unittest.TestCase):
+    def test_non_channel_rejected(self) -> None:
+        with self.assertRaises(PasteGuardError):
+            guard_outbound(channel="llm", payload="hi")  # type: ignore[arg-type]
+
+    def test_none_payload_treated_as_empty(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.GITHUB, payload=None  # type: ignore[arg-type]
+        )
+        self.assertEqual(verdict.redacted, "")
+        self.assertFalse(verdict.blocked)
+        self.assertEqual(verdict.findings, ())
+
+    def test_non_string_payload_rejected(self) -> None:
+        with self.assertRaises(PasteGuardError):
+            guard_outbound(
+                channel=OutboundChannel.GITHUB, payload=12345  # type: ignore[arg-type]
+            )
+
+    def test_finding_negative_span_rejected(self) -> None:
+        with self.assertRaises(PasteGuardError):
+            SecretFinding(
+                pattern=SecretPattern.AWS_ACCESS_KEY,
+                span=(10, 5),
+                risk_level=RISK_CRITICAL,
+                suggested_redaction="AKIA***1111",
+            )
+
+
+class UnicodeSafetyTests(unittest.TestCase):
+    """Unicode + emoji + mixed scripts must not break the guard."""
+
+    def test_korean_with_embedded_anthropic_key(self) -> None:
+        body = f"이 메시지에는 키가 있어요: {ANTHROPIC_RAW} — 끝."
+        verdict = guard_outbound(channel=OutboundChannel.DISCORD, payload=body)
+        self.assertEqual(len(verdict.findings), 1)
+        self.assertNotIn(ANTHROPIC_RAW, verdict.redacted)
+        self.assertIn("이 메시지에는 키가 있어요", verdict.redacted)
+
+    def test_emoji_payload_is_safe(self) -> None:
+        body = "✨ 안녕 🤖 — 비밀 없음"
+        verdict = guard_outbound(channel=OutboundChannel.VAULT, payload=body)
+        self.assertEqual(verdict.findings, ())
+        self.assertEqual(verdict.redacted, body)
+
+    def test_empty_payload(self) -> None:
+        verdict = guard_outbound(channel=OutboundChannel.LLM, payload="")
+        self.assertEqual(verdict.redacted, "")
+        self.assertEqual(verdict.findings, ())
+        self.assertFalse(verdict.blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_paste_guard_governance.py
+++ b/tests/engineering/test_paste_guard_governance.py
@@ -1,0 +1,182 @@
+"""PasteGuard governance regression — outbound secret hard-rail gate.
+
+Mirrors :mod:`tests.engineering.test_issue_73_round2_governance` in
+posture: one suite that pins the most important hard rails of the
+F1 / #88 outbound preflight so a single rename / regex flip / repr
+leak trips a clearly named test.
+
+Rails pinned:
+
+  1. ``guard_outbound(LLM, raw_anthropic_key)`` strips the raw bytes
+     from the redacted payload AND from every public field of
+     :class:`GuardVerdict` / :class:`SecretFinding` (no `__repr__`
+     leak, no `suggested_redaction` leak).
+  2. ``guard_outbound(DISCORD, pem_block)`` drops the entire PEM
+     body and never echoes BEGIN/END header lines.
+  3. ``guard_outbound(GITHUB, db_url_with_password)`` masks the
+     credentials inside a DB URL so a bot comment cannot leak DSNs.
+  4. ``guard_outbound(VAULT, opaque_high_entropy_blob)`` flags
+     advisory-level generic credentials so a vault write cannot
+     silently store an unscanned secret.
+  5. Every public field of every dataclass is scanned for raw
+     secret substrings — this is the catch-all that catches a
+     future field addition that forgets to mask.
+
+Compatibility rail (criterion #5 of #88):
+
+  6. Existing governance imports (``is_protected_branch``,
+     ``RecordOnlyCodeEditor``) remain importable and unchanged
+     — PasteGuard must not regress upstream hard rails.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    RecordOnlyCodeEditor,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    is_protected_branch,
+)
+from yule_orchestrator.agents.security.paste_guard import (
+    GuardVerdict,
+    OutboundChannel,
+    RISK_ADVISORY,
+    RISK_CRITICAL,
+    SecretPattern,
+    guard_outbound,
+)
+
+
+# Fake-but-pattern-shaped sentinels. These are NOT real credentials;
+# they exist purely so a regex flip or repr leak is visible in test
+# output. The strings still match the catalogue so the guard treats
+# them as real secrets.
+ANTHROPIC_RAW = "sk-ant-" + "X" * 40 + "AA"
+PEM_RAW = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    "b3BlbnNzaC1rZXktLXYxAAAAA_secret_payload_here==\n"
+    "-----END OPENSSH PRIVATE KEY-----"
+)
+DB_URL_RAW = "mongodb+srv://yule:hunter2supersecret@cluster0.mongo/yule"
+HIGH_ENTROPY_RAW = "Z" * 50
+
+
+def _all_field_strings(verdict: GuardVerdict) -> str:
+    """Concatenate every public string field on the verdict + findings.
+
+    Used to guarantee no raw secret bytes leak through `__repr__`,
+    `suggested_redaction`, the `redacted` body, or the audit hash.
+    """
+
+    parts = [verdict.channel.value, verdict.original_hash, verdict.redacted, repr(verdict)]
+    for finding in verdict.findings:
+        parts.append(finding.pattern.value)
+        parts.append(finding.risk_level)
+        parts.append(finding.suggested_redaction)
+        parts.append(repr(finding))
+        parts.append(str(finding.span))
+    return "\n".join(parts)
+
+
+class OutboundChannelHardRailTests(unittest.TestCase):
+    """Each outbound channel × representative secret pattern."""
+
+    def test_llm_channel_blocks_raw_anthropic_key(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.LLM,
+            payload=f"please remember my key {ANTHROPIC_RAW} for later",
+        )
+        self.assertEqual(verdict.channel, OutboundChannel.LLM)
+        self.assertNotIn(ANTHROPIC_RAW, verdict.redacted)
+        # Pattern catalogue must recognise the hit as critical.
+        self.assertTrue(verdict.has_critical())
+        self.assertEqual(
+            verdict.findings[0].pattern, SecretPattern.ANTHROPIC_API_KEY
+        )
+
+    def test_discord_channel_strips_pem_block(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.DISCORD, payload=PEM_RAW
+        )
+        self.assertNotIn("BEGIN OPENSSH PRIVATE KEY", verdict.redacted)
+        self.assertNotIn("END OPENSSH PRIVATE KEY", verdict.redacted)
+        self.assertNotIn("secret_payload_here", verdict.redacted)
+        self.assertEqual(
+            verdict.findings[0].pattern, SecretPattern.PEM_BLOCK
+        )
+
+    def test_github_channel_strips_db_url_password(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.GITHUB,
+            payload=f"connection: {DB_URL_RAW} (do not share)",
+        )
+        # The raw URL with password must not survive into the
+        # outbound GitHub comment.
+        self.assertNotIn(DB_URL_RAW, verdict.redacted)
+        self.assertNotIn("hunter2supersecret", verdict.redacted)
+        self.assertEqual(
+            verdict.findings[0].pattern, SecretPattern.DB_URL_WITH_PASSWORD
+        )
+
+    def test_vault_channel_flags_high_entropy_credential(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.VAULT,
+            payload=f"opaque token: {HIGH_ENTROPY_RAW}",
+        )
+        # The generic catch-all must at minimum tag this as advisory
+        # so a vault write does not silently store an unscanned blob.
+        patterns = [f.pattern for f in verdict.findings]
+        self.assertIn(SecretPattern.GENERIC_HIGH_ENTROPY, patterns)
+        advisory = [f for f in verdict.findings if f.risk_level == RISK_ADVISORY]
+        self.assertTrue(advisory)
+        self.assertNotIn(HIGH_ENTROPY_RAW, verdict.redacted)
+
+
+class RawSecretNeverLeaksInVerdictTests(unittest.TestCase):
+    """No public field on any dataclass may contain raw secret bytes."""
+
+    def test_anthropic_key_absent_from_all_verdict_fields(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.LLM, payload=f"k={ANTHROPIC_RAW}"
+        )
+        blob = _all_field_strings(verdict)
+        self.assertNotIn(ANTHROPIC_RAW, blob)
+
+    def test_pem_block_body_absent_from_all_verdict_fields(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.DISCORD, payload=PEM_RAW
+        )
+        blob = _all_field_strings(verdict)
+        self.assertNotIn("secret_payload_here", blob)
+        self.assertNotIn("BEGIN OPENSSH PRIVATE KEY", blob)
+
+    def test_db_url_password_absent_from_all_verdict_fields(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.GITHUB, payload=DB_URL_RAW
+        )
+        blob = _all_field_strings(verdict)
+        self.assertNotIn("hunter2supersecret", blob)
+
+
+class UpstreamHardRailCompatibilityTests(unittest.TestCase):
+    """Round 2 hard rails (#73) must remain intact alongside #88."""
+
+    def test_is_protected_branch_still_blocks_main(self) -> None:
+        self.assertTrue(is_protected_branch("main"))
+        self.assertTrue(is_protected_branch("release/2026-05"))
+
+    def test_record_only_editor_class_still_importable(self) -> None:
+        # PasteGuard sits beside the live executor — the executor's
+        # LLM-edit block must stay in place. Just import + sanity.
+        self.assertTrue(callable(RecordOnlyCodeEditor))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #88
- parent: #81 (엔지니어 에이전트 팀 단위 자동화)
- governance: #69 / #73 round 2 hard rails 확장

## ✨ 과제 내용 (F1 — Tier 1 foundation)
LLM / Discord / GitHub / Obsidian(Vault) 으로 나가는 모든 outbound payload 에 대해 **전송 직전 secret 스캔 + 마스킹** 레이어를 둔다. Anthropic / OpenAI / Ollama 로 API key, PEM, OAuth token, DB URL, GitHub token 이 흘러나가는 회로를 닫는다. F4 live LLM editor 는 본 모듈을 prerequisite 로 호출하게 된다.

## 🔧 변경 사항
- **신규 모듈** `src/yule_orchestrator/agents/security/paste_guard.py`
  - `SecretPattern` (8종): `anthropic_api_key` / `openai_api_key` / `github_pat` / `discord_bot_token` / `pem_block` / `aws_access_key` / `db_url_with_password` / `generic_high_entropy`
  - `SecretFinding(pattern, span, risk_level, suggested_redaction)` — `suggested_redaction` 은 이미 마스킹된 문자열만 carrier
  - `GuardVerdict(channel, original_hash, findings, redacted, blocked)` — `original_hash` 는 sha256 prefix `sha256:<hex>` (raw bytes 미보관)
  - `scan_payload(text)` — 좌→우 정렬, 중복/오버랩 spans 는 specific pattern 우선
  - `redact_payload(text, *, mask="***")` — `head4 + mask + tail4` round-trip 안전 (PEM 은 mask 만)
  - `OutboundChannel.{LLM, DISCORD, GITHUB, VAULT}` — 모두 동일 인터페이스
  - `guard_outbound(*, channel, payload, fail_closed=True)` — 내부 예외 / 마스킹 후에도 critical 패턴이 남아 있으면 payload 를 빈 문자열로 drop + `blocked=True`
- **테스트** (총 43 case)
  - `tests/agents/test_paste_guard.py` — 34 case (패턴 detect / no-detect, redaction round-trip, 4 채널 매트릭스, fail-closed, Unicode)
  - `tests/engineering/test_paste_guard_governance.py` — 9 case (4 채널 × 4 secret family hard rail, `GuardVerdict` raw-secret 미노출 guard, `is_protected_branch` / `RecordOnlyCodeEditor` 호환)

## ✅ 검증
- `python3 -m unittest discover -s tests -t .` — **3620 tests OK** (skipped=5)
- PasteGuard 자체 — **43 tests OK**
- 회귀 가드 (#73 governance) 호환 확인됨

## 🔒 Hard rails (테스트 가드)
- API key / PEM / token / DB URL password 는 `GuardVerdict.findings[*].suggested_redaction`, `GuardVerdict.redacted`, `repr()` 등 **어떤 public field 에도 raw 노출 금지**
- `fail_closed=True` 가 기본 — 재처리/마스킹 실패 시 payload drop + `blocked=True`
- 4 channel (LLM/DISCORD/GITHUB/VAULT) 모두 동일하게 가드 적용 — 예외 없음
- 기존 #73 governance (`is_protected_branch`, `RecordOnlyCodeEditor`) 와 충돌 없음

## 🤖 Agent WorkOS Audit
- branch: `feature/paste-guard-issue-88` (from `main`)
- repo: `yule-studio/yule-studio-agent`
- role: `engineering-agent/backend-engineer`
- autonomy: `L2_AUTONOMOUS_RECORD` (보안 기능 — 운영자 검토 권장)
- mode: draft (do-not-merge until operator review)