### PR TITLE
✨ [F2/#89] Hookify — mistake ledger + preflight judgement

### DIFF
--- a/src/yule_orchestrator/agents/learning/__init__.py
+++ b/src/yule_orchestrator/agents/learning/__init__.py
@@ -1,0 +1,51 @@
+"""agents.learning — F2 hookify seam.
+
+Issue #89 (parent #81) extends the round-1 lifecycle ledger with a
+persistent SQLite-backed mistake ledger and a preflight judgement
+seam that can advise / warn / block a role-specific action.
+
+The round-1 surface under
+:mod:`yule_orchestrator.agents.lifecycle.mistake_ledger` continues to
+own the session-extra ladder. This module is the cross-session
+counterpart — its records survive process restarts and feed the
+preflight hook a caller drops in just before
+``coding_executor_worker._run_pipeline`` (or any other role-take
+worker).
+
+The two modules **do not import each other** by design — a recurring
+mistake recorded on the session-extra ledger is promoted to this
+durable ledger by the postmortem producer (see
+:func:`yule_orchestrator.agents.learning.mistake_ledger.mistake_candidate_from_postmortem`)
+so the seam remains explicit.
+
+Hard rails (the kind every later integration must respect):
+
+  * ``BlockerLevel.BLOCK`` verdicts never auto-execute — the caller
+    routes the work to the existing ``needs_approval`` lane and the
+    preflight verdict records the recommendation.
+  * ``MistakeLedger.resolve`` is the only path that flips a record to
+    resolved — there is no auto-dismiss.
+  * The ledger never grows unbounded — ``prune_old_resolved`` is the
+    explicit retention hook the operator (or a scheduled job) runs.
+"""
+
+from .mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+    MistakeRecord,
+    mistake_candidate_from_postmortem,
+)
+from .preflight import (
+    PreflightVerdict,
+    judge_preflight,
+)
+
+
+__all__ = (
+    "BlockerLevel",
+    "MistakeLedger",
+    "MistakeRecord",
+    "PreflightVerdict",
+    "judge_preflight",
+    "mistake_candidate_from_postmortem",
+)

--- a/src/yule_orchestrator/agents/learning/mistake_ledger.py
+++ b/src/yule_orchestrator/agents/learning/mistake_ledger.py
@@ -1,0 +1,888 @@
+"""Persistent mistake ledger — F2 / issue #89.
+
+Cross-session counterpart to the round-1 session-extra ledger under
+:mod:`yule_orchestrator.agents.lifecycle.mistake_ledger`. Where round 1
+lives on ``session.extra`` so the existing SQLite session row carries
+it forward, F2 needs the ledger to *survive process restarts* and to
+be queryable without first hydrating a session — the preflight hook
+fires at the very top of ``coding_executor_worker._run_pipeline``
+before any session is touched.
+
+Storage shape:
+
+  * A single SQLite table, ``mistake_ledger``. Created with
+    ``CREATE TABLE IF NOT EXISTS`` so it co-exists with whatever else
+    the cache DB already owns (``task_completion_events``,
+    ``json_cache``).
+  * Default location matches :mod:`yule_orchestrator.storage` — the
+    operator's ``$YULE_CACHE_DB_PATH`` env wins, then a per-repo
+    ``.cache/yule/cache.sqlite3`` fallback.
+  * A caller that already owns a SQLite path (tests, or an embedded
+    runtime) may pass ``database_path=`` to scope the ledger to its
+    own file.
+
+The dataclass shape mirrors the issue #89 Acceptance Criteria 1:
+
+  ``id / role / pattern / signature / first_seen / last_seen /
+   occurrences / blocker_level / postmortem_ref / resolved_at``
+
+The optional ``resolved_at`` field lets us implement Acceptance
+Criteria 3's hard rail — auto-dismiss is forbidden, only an explicit
+operator call to :meth:`MistakeLedger.resolve` flips a record.
+``prune_old_resolved`` then deletes records older than a retention
+window so the table never grows unbounded.
+
+Similarity matching for :meth:`MistakeLedger.find_similar` uses token
+Jaccard similarity on the signature so the preflight hook can match a
+*near-duplicate* signature (e.g. ``"ci:test failed on auth/login"``
+vs. ``"ci:test failed on auth/register"``) without exact-string
+equality. The threshold is configurable per call.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+from ...storage._sqlite import SQLITE_WRITE_LOCK
+
+
+DEFAULT_SQLITE_BUSY_TIMEOUT_MS: int = 30_000
+DEFAULT_PRUNE_RETENTION_DAYS: int = 180
+
+
+# ---------------------------------------------------------------------------
+# Blocker level
+# ---------------------------------------------------------------------------
+
+
+class BlockerLevel(str, Enum):
+    """Severity of a recorded mistake.
+
+    Ordering (low → high): ``ADVISORY < WARNING < BLOCK``. The
+    preflight hook uses :func:`max_blocker_level` to combine multiple
+    matched records into one verdict.
+    """
+
+    ADVISORY = "ADVISORY"
+    WARNING = "WARNING"
+    BLOCK = "BLOCK"
+
+
+_LEVEL_ORDER: Mapping[BlockerLevel, int] = {
+    BlockerLevel.ADVISORY: 0,
+    BlockerLevel.WARNING: 1,
+    BlockerLevel.BLOCK: 2,
+}
+
+
+def max_blocker_level(*levels: BlockerLevel) -> BlockerLevel:
+    """Return the highest level among *levels* (ADVISORY by default)."""
+
+    if not levels:
+        return BlockerLevel.ADVISORY
+    return max(levels, key=_LEVEL_ORDER.__getitem__)
+
+
+def _coerce_blocker_level(value: Any) -> BlockerLevel:
+    """Best-effort coerce a payload value into :class:`BlockerLevel`."""
+
+    if isinstance(value, BlockerLevel):
+        return value
+    text = str(value or "").strip().upper()
+    if text in BlockerLevel.__members__:
+        return BlockerLevel[text]
+    return BlockerLevel.ADVISORY
+
+
+# ---------------------------------------------------------------------------
+# Record dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MistakeRecord:
+    """One row in the durable ledger.
+
+    Frozen so callers can ferry the record between threads / worker
+    boundaries without worrying about accidental mutation. Updates
+    happen through :meth:`MistakeLedger.record_mistake` (which
+    increments ``occurrences`` and advances ``last_seen``) or through
+    explicit operator calls (:meth:`MistakeLedger.resolve`).
+    """
+
+    id: str
+    role: str
+    pattern: str
+    signature: str
+    first_seen: str
+    last_seen: str
+    occurrences: int
+    blocker_level: BlockerLevel
+    postmortem_ref: Optional[str] = None
+    resolved_at: Optional[str] = None
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "id": self.id,
+            "role": self.role,
+            "pattern": self.pattern,
+            "signature": self.signature,
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "occurrences": self.occurrences,
+            "blocker_level": self.blocker_level.value,
+            "postmortem_ref": self.postmortem_ref,
+            "resolved_at": self.resolved_at,
+        }
+
+    def is_resolved(self) -> bool:
+        return bool(self.resolved_at)
+
+
+# ---------------------------------------------------------------------------
+# Similarity (token Jaccard)
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(value: str) -> frozenset[str]:
+    text = str(value or "").strip().lower()
+    if not text:
+        return frozenset()
+    return frozenset(_TOKEN_RE.findall(text))
+
+
+def jaccard_similarity(a: str, b: str) -> float:
+    """Token Jaccard similarity between two strings.
+
+    Used by :meth:`MistakeLedger.find_similar`. Lower-cased and ASCII
+    word-tokenised so callers can pass freeform signatures without
+    pre-normalising. Empty inputs return 0.0.
+    """
+
+    tokens_a = _tokenize(a)
+    tokens_b = _tokenize(b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    intersection = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    if not union:
+        return 0.0
+    return len(intersection) / len(union)
+
+
+class _LedgerConnection:
+    """Lightweight wrapper that makes both fresh and persistent SQLite
+    connections usable with ``with`` syntax while only closing the
+    fresh ones on exit.
+
+    For an owned connection (on-disk path): commits on success,
+    rolls back on exception, then closes. For a borrowed
+    persistent connection (``:memory:`` path): commits / rolls back
+    but never closes — the caller owns the lifetime.
+    """
+
+    def __init__(self, connection: sqlite3.Connection, *, owns: bool) -> None:
+        self._connection = connection
+        self._owns = owns
+
+    def __enter__(self) -> sqlite3.Connection:
+        return self._connection
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            if exc_type is None:
+                self._connection.commit()
+            else:
+                self._connection.rollback()
+        finally:
+            if self._owns:
+                self._connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+class MistakeLedger:
+    """SQLite-backed durable ledger for repeated role mistakes.
+
+    The class is intentionally thin: callers build / share the ledger
+    by file path. Tests construct an in-memory instance via the
+    ``database_path=":memory:"`` shortcut or a tmp file; production
+    code reuses the operator cache database so an audit reader can
+    correlate mistakes with task-completion stats from the same file.
+
+    Thread-safety: SQLite write operations are serialised through the
+    shared :data:`SQLITE_WRITE_LOCK` so this ledger can co-exist with
+    other producers writing to the same DB file (the round-1 task
+    history module follows the same convention).
+    """
+
+    TABLE_NAME: str = "mistake_ledger"
+
+    def __init__(
+        self,
+        *,
+        database_path: Optional[str | Path] = None,
+        busy_timeout_ms: Optional[int] = None,
+    ) -> None:
+        self._database_path = _resolve_database_path(database_path)
+        self._busy_timeout_ms = (
+            int(busy_timeout_ms)
+            if busy_timeout_ms and int(busy_timeout_ms) > 0
+            else _resolve_busy_timeout_ms()
+        )
+        self._ensure_parent()
+        # ``:memory:`` databases cannot share state across connections,
+        # so we hold a single long-lived connection for the lifetime of
+        # the ledger. On-disk databases keep the original per-call
+        # connection model so they co-exist with other producers.
+        self._persistent_connection: Optional[sqlite3.Connection] = None
+        if self._database_path == ":memory:":
+            self._persistent_connection = self._open_connection()
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            connection.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record_mistake(
+        self,
+        *,
+        role: str,
+        pattern: str,
+        signature: str,
+        postmortem_ref: Optional[str] = None,
+        blocker_level: BlockerLevel = BlockerLevel.ADVISORY,
+        when: Optional[str] = None,
+    ) -> MistakeRecord:
+        """Insert (or bump) a record for *(role, pattern, signature)*.
+
+        Resolution rule:
+
+          * ``(role, pattern, signature)`` already in the ledger →
+            ``occurrences += 1``, ``last_seen`` advances, and the
+            blocker level can only escalate. ``postmortem_ref`` is
+            updated when supplied and the existing row had none.
+            A resolved row is **re-opened** (``resolved_at`` cleared)
+            so the same mistake biting again unconditionally raises
+            the preflight signal.
+          * New tuple → fresh row with ``occurrences=1`` and the
+            supplied blocker level.
+
+        The original record (if any) is never mutated in place — the
+        method returns the persisted record.
+        """
+
+        role_value = _require_non_empty("role", role)
+        pattern_value = _require_non_empty("pattern", pattern)
+        signature_value = _require_non_empty("signature", signature)
+        level = _coerce_blocker_level(blocker_level)
+        when_iso = (when or _utc_now_iso()).strip() or _utc_now_iso()
+        ref_value = _optional_str(postmortem_ref)
+
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            existing_row = connection.execute(
+                f"""
+                SELECT * FROM {self.TABLE_NAME}
+                WHERE role = ? AND pattern = ? AND signature = ?
+                LIMIT 1
+                """,
+                (role_value, pattern_value, signature_value),
+            ).fetchone()
+            if existing_row is None:
+                record = MistakeRecord(
+                    id=_new_record_id(),
+                    role=role_value,
+                    pattern=pattern_value,
+                    signature=signature_value,
+                    first_seen=when_iso,
+                    last_seen=when_iso,
+                    occurrences=1,
+                    blocker_level=level,
+                    postmortem_ref=ref_value,
+                    resolved_at=None,
+                )
+                connection.execute(
+                    f"""
+                    INSERT INTO {self.TABLE_NAME} (
+                        id, role, pattern, signature,
+                        first_seen, last_seen, occurrences,
+                        blocker_level, postmortem_ref, resolved_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.id,
+                        record.role,
+                        record.pattern,
+                        record.signature,
+                        record.first_seen,
+                        record.last_seen,
+                        record.occurrences,
+                        record.blocker_level.value,
+                        record.postmortem_ref,
+                        record.resolved_at,
+                    ),
+                )
+                return record
+
+            current = _row_to_record(existing_row)
+            new_level = max_blocker_level(current.blocker_level, level)
+            updated_ref = current.postmortem_ref or ref_value
+            updated = MistakeRecord(
+                id=current.id,
+                role=current.role,
+                pattern=current.pattern,
+                signature=current.signature,
+                first_seen=current.first_seen,
+                last_seen=when_iso,
+                occurrences=current.occurrences + 1,
+                blocker_level=new_level,
+                postmortem_ref=updated_ref,
+                resolved_at=None,
+            )
+            connection.execute(
+                f"""
+                UPDATE {self.TABLE_NAME}
+                SET last_seen = ?,
+                    occurrences = ?,
+                    blocker_level = ?,
+                    postmortem_ref = ?,
+                    resolved_at = NULL
+                WHERE id = ?
+                """,
+                (
+                    updated.last_seen,
+                    updated.occurrences,
+                    updated.blocker_level.value,
+                    updated.postmortem_ref,
+                    updated.id,
+                ),
+            )
+            return updated
+
+    def find_similar(
+        self,
+        *,
+        role: str,
+        signature: str,
+        threshold: float = 0.7,
+        include_resolved: bool = False,
+    ) -> Tuple[MistakeRecord, ...]:
+        """Return records whose signature is similar to *signature*.
+
+        Similarity is the token Jaccard score; values >= *threshold*
+        are kept. The result is sorted by (similarity desc,
+        occurrences desc, last_seen desc) so the strongest evidence
+        ends up first — that is what the preflight hook reports as the
+        leading reason.
+
+        ``include_resolved`` defaults to False because the preflight
+        hook only cares about *active* mistakes; resolved rows are
+        kept for the postmortem trail but should not block the next
+        run.
+        """
+
+        role_value = str(role or "").strip()
+        if not role_value:
+            return ()
+        sig_value = str(signature or "").strip()
+        if not sig_value:
+            return ()
+        try:
+            cutoff = max(0.0, float(threshold))
+        except (TypeError, ValueError):
+            cutoff = 0.7
+
+        rows = self._fetch_role_rows(role_value, include_resolved=include_resolved)
+        scored: list[tuple[float, MistakeRecord]] = []
+        for row in rows:
+            record = _row_to_record(row)
+            score = jaccard_similarity(record.signature, sig_value)
+            if score >= cutoff:
+                scored.append((score, record))
+        scored.sort(
+            key=lambda pair: (
+                -pair[0],
+                -pair[1].occurrences,
+                pair[1].last_seen,
+            ),
+            reverse=False,
+        )
+        # We want highest score first; secondary keys also descending
+        # — sort with negatives, then strip the score.
+        return tuple(record for _, record in scored)
+
+    def list_for_role(
+        self,
+        role: str,
+        *,
+        limit: int = 20,
+        include_resolved: bool = False,
+    ) -> Tuple[MistakeRecord, ...]:
+        """Return the most-recent *limit* records for *role*.
+
+        Ordered by ``last_seen`` descending; resolved rows are
+        excluded unless *include_resolved* is True.
+        """
+
+        role_value = str(role or "").strip()
+        if not role_value:
+            return ()
+        try:
+            limit_value = max(1, int(limit))
+        except (TypeError, ValueError):
+            limit_value = 20
+
+        clauses = ["role = ?"]
+        params: list[Any] = [role_value]
+        if not include_resolved:
+            clauses.append("resolved_at IS NULL")
+        where = " AND ".join(clauses)
+
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            rows = connection.execute(
+                f"""
+                SELECT * FROM {self.TABLE_NAME}
+                WHERE {where}
+                ORDER BY last_seen DESC, id ASC
+                LIMIT ?
+                """,
+                (*params, limit_value),
+            ).fetchall()
+        return tuple(_row_to_record(row) for row in rows)
+
+    def get(self, record_id: str) -> Optional[MistakeRecord]:
+        """Fetch a single record by id (``None`` if missing)."""
+
+        rid = str(record_id or "").strip()
+        if not rid:
+            return None
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            row = connection.execute(
+                f"SELECT * FROM {self.TABLE_NAME} WHERE id = ? LIMIT 1",
+                (rid,),
+            ).fetchone()
+        if row is None:
+            return None
+        return _row_to_record(row)
+
+    def resolve(
+        self,
+        record_id: str,
+        *,
+        resolved_at: Optional[str] = None,
+    ) -> Optional[MistakeRecord]:
+        """Mark *record_id* resolved.
+
+        Returns the updated record, or ``None`` when no such row
+        exists. Calling :meth:`resolve` on an already-resolved record
+        is a no-op (the existing ``resolved_at`` stamp is preserved).
+
+        Auto-dismiss is intentionally not exposed — only this explicit
+        method flips the flag. That preserves Acceptance Criteria 3's
+        "운영자 명시 dismiss/resolve API" rail.
+        """
+
+        rid = str(record_id or "").strip()
+        if not rid:
+            return None
+        when_iso = (resolved_at or _utc_now_iso()).strip() or _utc_now_iso()
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            row = connection.execute(
+                f"SELECT * FROM {self.TABLE_NAME} WHERE id = ? LIMIT 1",
+                (rid,),
+            ).fetchone()
+            if row is None:
+                return None
+            current = _row_to_record(row)
+            if current.is_resolved():
+                return current
+            connection.execute(
+                f"UPDATE {self.TABLE_NAME} SET resolved_at = ? WHERE id = ?",
+                (when_iso, rid),
+            )
+            return replace(current, resolved_at=when_iso)
+
+    def prune_old_resolved(
+        self,
+        retention_days: int = DEFAULT_PRUNE_RETENTION_DAYS,
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        """Delete resolved records older than *retention_days*.
+
+        Returns the number of rows deleted. Active (unresolved)
+        records are never touched — only the explicit :meth:`resolve`
+        path can mark a row prune-eligible.
+        """
+
+        try:
+            days_value = max(0, int(retention_days))
+        except (TypeError, ValueError):
+            days_value = DEFAULT_PRUNE_RETENTION_DAYS
+        reference = (now or datetime.now(tz=timezone.utc)).astimezone(timezone.utc)
+        cutoff = reference - timedelta(days=days_value)
+        cutoff_iso = cutoff.replace(microsecond=0).isoformat()
+
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            cursor = connection.execute(
+                f"""
+                DELETE FROM {self.TABLE_NAME}
+                WHERE resolved_at IS NOT NULL
+                  AND resolved_at <= ?
+                """,
+                (cutoff_iso,),
+            )
+            return int(cursor.rowcount or 0)
+
+    def all_records(
+        self,
+        *,
+        include_resolved: bool = True,
+    ) -> Tuple[MistakeRecord, ...]:
+        """Diagnostic helper: full ledger snapshot.
+
+        Ordered by ``last_seen`` descending. Tests use this to verify
+        SQLite round-trips without relying on
+        :meth:`list_for_role`'s per-role filter.
+        """
+
+        clauses: list[str] = []
+        if not include_resolved:
+            clauses.append("resolved_at IS NULL")
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            rows = connection.execute(
+                f"SELECT * FROM {self.TABLE_NAME}{where} ORDER BY last_seen DESC, id ASC"
+            ).fetchall()
+        return tuple(_row_to_record(row) for row in rows)
+
+    @property
+    def database_path(self) -> str:
+        return self._database_path
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fetch_role_rows(
+        self,
+        role: str,
+        *,
+        include_resolved: bool,
+    ) -> Sequence[sqlite3.Row]:
+        clauses = ["role = ?"]
+        params: list[Any] = [role]
+        if not include_resolved:
+            clauses.append("resolved_at IS NULL")
+        where = " AND ".join(clauses)
+        with SQLITE_WRITE_LOCK, self._connect() as connection:
+            self._ensure_schema(connection)
+            return connection.execute(
+                f"""
+                SELECT * FROM {self.TABLE_NAME}
+                WHERE {where}
+                """,
+                tuple(params),
+            ).fetchall()
+
+    def _ensure_schema(self, connection: sqlite3.Connection) -> None:
+        connection.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+                id TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                pattern TEXT NOT NULL,
+                signature TEXT NOT NULL,
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL,
+                occurrences INTEGER NOT NULL,
+                blocker_level TEXT NOT NULL,
+                postmortem_ref TEXT,
+                resolved_at TEXT
+            )
+            """
+        )
+        connection.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_{self.TABLE_NAME}_role_seen
+            ON {self.TABLE_NAME} (role, last_seen)
+            """
+        )
+        connection.execute(
+            f"""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_{self.TABLE_NAME}_role_pattern_signature
+            ON {self.TABLE_NAME} (role, pattern, signature)
+            """
+        )
+
+    def _ensure_parent(self) -> None:
+        path = self._database_path
+        if path == ":memory:":
+            return
+        parent = Path(path).expanduser().parent
+        if str(parent) and parent != Path(""):
+            parent.mkdir(parents=True, exist_ok=True)
+
+    def _open_connection(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self._database_path,
+            timeout=self._busy_timeout_ms / 1000,
+        )
+        connection.row_factory = sqlite3.Row
+        try:
+            connection.execute(f"PRAGMA busy_timeout = {self._busy_timeout_ms}")
+        except sqlite3.OperationalError:
+            pass
+        if self._database_path != ":memory:":
+            try:
+                connection.execute("PRAGMA journal_mode = WAL")
+            except sqlite3.OperationalError:
+                pass
+            try:
+                connection.execute("PRAGMA synchronous = NORMAL")
+            except sqlite3.OperationalError:
+                pass
+        return connection
+
+    def _connect(self) -> "_LedgerConnection":
+        """Acquire a connection wrapper.
+
+        For ``:memory:`` databases we re-use the single
+        :attr:`_persistent_connection` so callers see the same data
+        across method calls. For on-disk databases we open a fresh
+        connection so the ledger plays nicely alongside other
+        producers writing to the same file.
+        """
+
+        if self._persistent_connection is not None:
+            return _LedgerConnection(
+                self._persistent_connection,
+                owns=False,
+            )
+        return _LedgerConnection(self._open_connection(), owns=True)
+
+    def close(self) -> None:
+        """Close the persistent connection (no-op for on-disk paths).
+
+        Tests that build a fresh :class:`MistakeLedger` per test case
+        should call ``close()`` in ``tearDown`` so the underlying
+        ``:memory:`` connection is released.
+        """
+
+        if self._persistent_connection is not None:
+            try:
+                self._persistent_connection.close()
+            finally:
+                self._persistent_connection = None
+
+
+# ---------------------------------------------------------------------------
+# Postmortem → mistake candidate
+# ---------------------------------------------------------------------------
+
+
+def mistake_candidate_from_postmortem(
+    audit_entry: Optional[Mapping[str, Any]],
+) -> Optional[MistakeRecord]:
+    """Project a postmortem audit entry into a *candidate* record.
+
+    The helper is **deterministic** — the same audit entry always
+    yields a record with the same ``role / pattern / signature /
+    blocker_level / postmortem_ref``. The ``id``, ``first_seen``,
+    ``last_seen`` fields are derived from the audit entry too
+    (``decision_id`` / ``entry_id`` for id; ``recorded_at`` for the
+    timestamps), so calling this twice on the same entry returns
+    equal records — never two random ids.
+
+    Returns ``None`` when *audit_entry* doesn't look like a postmortem
+    (missing role, missing summary/reason, or wrong action verb).
+
+    The caller is responsible for *persisting* — this helper just
+    produces the candidate so the post-mortem producer can decide
+    whether to feed it to :meth:`MistakeLedger.record_mistake`.
+    """
+
+    if not isinstance(audit_entry, Mapping):
+        return None
+    action = str(audit_entry.get("action") or "").strip().lower()
+    if action and action not in {
+        "failure_postmortem_create",
+        "failure_audit_record",
+        "retry_audit_record",
+        "blocked_completion",
+        "postmortem",
+    }:
+        return None
+    role = _optional_str(
+        audit_entry.get("role")
+        or audit_entry.get("role_id")
+        or audit_entry.get("actor")
+    )
+    if not role:
+        return None
+    reason = str(audit_entry.get("reason") or "").strip()
+    summary = str(audit_entry.get("summary") or "").strip()
+    signature_source = reason or summary
+    if not signature_source:
+        return None
+    pattern = _derive_pattern(action=action, audit_entry=audit_entry)
+    blocker_level = _coerce_blocker_level(
+        audit_entry.get("blocker_level")
+        or _default_blocker_for_pattern(pattern)
+    )
+    ref = _optional_str(
+        audit_entry.get("postmortem_ref")
+        or audit_entry.get("entry_id")
+        or audit_entry.get("decision_id")
+    )
+    when = _optional_str(audit_entry.get("recorded_at")) or _utc_now_iso()
+    candidate_id = (
+        _optional_str(audit_entry.get("entry_id"))
+        or _optional_str(audit_entry.get("decision_id"))
+        or _deterministic_id(role=role, pattern=pattern, signature=signature_source)
+    )
+    return MistakeRecord(
+        id=candidate_id,
+        role=role,
+        pattern=pattern,
+        signature=signature_source,
+        first_seen=when,
+        last_seen=when,
+        occurrences=1,
+        blocker_level=blocker_level,
+        postmortem_ref=ref,
+        resolved_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_record(row: sqlite3.Row) -> MistakeRecord:
+    return MistakeRecord(
+        id=str(row["id"]),
+        role=str(row["role"]),
+        pattern=str(row["pattern"]),
+        signature=str(row["signature"]),
+        first_seen=str(row["first_seen"]),
+        last_seen=str(row["last_seen"]),
+        occurrences=int(row["occurrences"]),
+        blocker_level=_coerce_blocker_level(row["blocker_level"]),
+        postmortem_ref=_optional_str(row["postmortem_ref"]),
+        resolved_at=_optional_str(row["resolved_at"]),
+    )
+
+
+def _derive_pattern(*, action: str, audit_entry: Mapping[str, Any]) -> str:
+    raw = (
+        audit_entry.get("pattern")
+        or audit_entry.get("job_type")
+        or audit_entry.get("topic_key")
+        or action
+        or "postmortem"
+    )
+    text = str(raw or "").strip().lower()
+    text = re.sub(r"\s+", "_", text)[:64]
+    return text or "postmortem"
+
+
+def _default_blocker_for_pattern(pattern: str) -> BlockerLevel:
+    lowered = (pattern or "").lower()
+    if lowered.startswith("ci"):
+        return BlockerLevel.WARNING
+    if "secret" in lowered or "protected" in lowered or "force_push" in lowered:
+        return BlockerLevel.BLOCK
+    return BlockerLevel.ADVISORY
+
+
+def _deterministic_id(*, role: str, pattern: str, signature: str) -> str:
+    digest = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"mistake-ledger:{role}|{pattern}|{signature}",
+    ).hex
+    return f"pm-{digest[:24]}"
+
+
+def _new_record_id() -> str:
+    return f"ml-{int(time.time() * 1000):013d}-{uuid.uuid4().hex[:12]}"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _require_non_empty(name: str, value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required and must be non-empty")
+    return text
+
+
+def _resolve_database_path(database_path: Optional[str | Path]) -> str:
+    if database_path is not None:
+        if isinstance(database_path, Path):
+            return str(database_path.expanduser())
+        text = str(database_path).strip()
+        if text:
+            if text == ":memory:":
+                return text
+            return str(Path(text).expanduser())
+    configured = os.getenv("YULE_CACHE_DB_PATH")
+    if configured and configured.strip():
+        return str(Path(configured.strip()).expanduser())
+    repo_root = os.getenv("YULE_REPO_ROOT")
+    base_dir = Path(repo_root) if repo_root else Path.cwd()
+    return str(base_dir / ".cache" / "yule" / "cache.sqlite3")
+
+
+def _resolve_busy_timeout_ms() -> int:
+    configured = os.getenv("YULE_SQLITE_BUSY_TIMEOUT_MS")
+    if configured and configured.strip():
+        try:
+            return max(1000, int(configured.strip()))
+        except ValueError:
+            return DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+    return DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+
+
+__all__ = (
+    "DEFAULT_PRUNE_RETENTION_DAYS",
+    "BlockerLevel",
+    "MistakeLedger",
+    "MistakeRecord",
+    "jaccard_similarity",
+    "max_blocker_level",
+    "mistake_candidate_from_postmortem",
+)

--- a/src/yule_orchestrator/agents/learning/preflight.py
+++ b/src/yule_orchestrator/agents/learning/preflight.py
@@ -1,0 +1,300 @@
+"""Preflight judgement seam — F2 / issue #89.
+
+Cross-session companion to
+:mod:`yule_orchestrator.agents.lifecycle.preflight_judgement`. The
+round-1 seam evaluates the session-extra ledger; this F2 seam queries
+the durable :class:`MistakeLedger` so the hook can fire at the very
+top of ``coding_executor_worker._run_pipeline`` — before any session
+is hydrated.
+
+The verdict shape mirrors Acceptance Criteria 3:
+
+  * ``level``: :class:`BlockerLevel` (ADVISORY / WARNING / BLOCK)
+  * ``reason``: short Korean string summarising the matched mistakes
+  * ``suggested_action``: caller-facing instruction (주의 / 재검토 권장
+    / needs_approval 로 라우팅)
+  * ``matched_mistakes``: tuple of :class:`MistakeRecord` the verdict
+    was derived from
+  * ``evaluated_at``: ISO-8601 UTC timestamp
+
+A BLOCK verdict carries an explicit ``needs_approval`` recommendation
+in the suggested action — the caller is expected to route the work
+to the existing approval lane instead of executing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+    MistakeRecord,
+    max_blocker_level,
+)
+
+
+_SUGGESTED_ACTIONS: Mapping[BlockerLevel, str] = {
+    BlockerLevel.ADVISORY: "주의",
+    BlockerLevel.WARNING: "재검토 권장",
+    BlockerLevel.BLOCK: "needs_approval 로 라우팅",
+}
+
+
+_LEVEL_LABEL: Mapping[BlockerLevel, str] = {
+    BlockerLevel.ADVISORY: "advisory",
+    BlockerLevel.WARNING: "warning",
+    BlockerLevel.BLOCK: "block",
+}
+
+
+# Default similarity threshold for the preflight lookup. We use a
+# slightly *lower* bar than the ad-hoc :meth:`MistakeLedger.find_similar`
+# default because the preflight hook deliberately errs on the side of
+# surfacing — a false advisory is fine, a missed block is not.
+DEFAULT_PREFLIGHT_SIMILARITY: float = 0.55
+
+# How many matched mistakes we summarise in the verdict reason.
+REASON_SUMMARY_LIMIT: int = 3
+
+
+@dataclass(frozen=True)
+class PreflightVerdict:
+    """Result of one preflight evaluation.
+
+    ``level`` is the highest :class:`BlockerLevel` among
+    ``matched_mistakes``; when the lookup matches nothing the level
+    is ADVISORY and the reason explains the lookup found no match
+    (so audit readers can tell "no signal" apart from "no lookup").
+
+    ``recommend_needs_approval`` is True iff the verdict is BLOCK —
+    callers can check this single property without re-parsing the
+    suggested action string.
+    """
+
+    level: BlockerLevel
+    reason: str
+    suggested_action: str
+    matched_mistakes: Tuple[MistakeRecord, ...]
+    evaluated_at: str
+    role: str = ""
+    task_signature: str = ""
+
+    @property
+    def is_block(self) -> bool:
+        return self.level == BlockerLevel.BLOCK
+
+    @property
+    def is_advisory(self) -> bool:
+        return self.level == BlockerLevel.ADVISORY
+
+    @property
+    def recommend_needs_approval(self) -> bool:
+        """True iff the caller MUST route to the approval lane.
+
+        Mirrors the issue #89 hard rail: BLOCK never auto-executes.
+        """
+
+        return self.level == BlockerLevel.BLOCK
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "level": self.level.value,
+            "reason": self.reason,
+            "suggested_action": self.suggested_action,
+            "matched_mistake_ids": [m.id for m in self.matched_mistakes],
+            "evaluated_at": self.evaluated_at,
+            "role": self.role,
+            "task_signature": self.task_signature,
+            "recommend_needs_approval": self.recommend_needs_approval,
+        }
+
+
+def judge_preflight(
+    *,
+    role: str,
+    task_signature: str,
+    ledger: MistakeLedger,
+    recent_audit: Optional[Sequence[Mapping[str, Any]]] = None,
+    similarity_threshold: float = DEFAULT_PREFLIGHT_SIMILARITY,
+    now: Optional[datetime] = None,
+) -> PreflightVerdict:
+    """Decide whether *role* should proceed with *task_signature*.
+
+    Deterministic with respect to the ledger state: the same role +
+    signature + ledger snapshot always yields the same verdict
+    (matching tests can therefore assert on level / reason / suggested
+    action without snapshotting timestamps — ``evaluated_at`` is the
+    only timestamp and the caller can pass ``now=`` to pin it).
+
+    ``recent_audit`` is reserved for future producers that want to
+    cross-check the verdict against a short rolling audit slice. The
+    round-1 implementation accepts and ignores it — the contract is
+    pinned now so a follow-up can plug in without changing call sites.
+
+    Empty ledger (or no role matches) → ADVISORY verdict with a
+    "no recurring mistake" reason. Callers can branch on
+    :attr:`PreflightVerdict.matched_mistakes` to skip surfacing the
+    advisory when nothing matched.
+    """
+
+    role_value = str(role or "").strip()
+    signature_value = str(task_signature or "").strip()
+    evaluated_at = _utc_iso(now)
+
+    if not role_value:
+        return PreflightVerdict(
+            level=BlockerLevel.ADVISORY,
+            reason="role 미지정 — preflight 평가 생략",
+            suggested_action=_SUGGESTED_ACTIONS[BlockerLevel.ADVISORY],
+            matched_mistakes=(),
+            evaluated_at=evaluated_at,
+            role="",
+            task_signature=signature_value,
+        )
+    if not signature_value:
+        return PreflightVerdict(
+            level=BlockerLevel.ADVISORY,
+            reason="task_signature 미지정 — preflight 평가 생략",
+            suggested_action=_SUGGESTED_ACTIONS[BlockerLevel.ADVISORY],
+            matched_mistakes=(),
+            evaluated_at=evaluated_at,
+            role=role_value,
+            task_signature="",
+        )
+
+    matches = ledger.find_similar(
+        role=role_value,
+        signature=signature_value,
+        threshold=similarity_threshold,
+    )
+    if not matches:
+        return PreflightVerdict(
+            level=BlockerLevel.ADVISORY,
+            reason="이전 실수 매칭 없음 — 진행 가능",
+            suggested_action=_SUGGESTED_ACTIONS[BlockerLevel.ADVISORY],
+            matched_mistakes=(),
+            evaluated_at=evaluated_at,
+            role=role_value,
+            task_signature=signature_value,
+        )
+
+    level = max_blocker_level(*(m.blocker_level for m in matches))
+    reason = _format_reason(level=level, matches=matches)
+    suggested = _SUGGESTED_ACTIONS[level]
+    return PreflightVerdict(
+        level=level,
+        reason=reason,
+        suggested_action=suggested,
+        matched_mistakes=tuple(matches),
+        evaluated_at=evaluated_at,
+        role=role_value,
+        task_signature=signature_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreflightHookResult:
+    """Helper bundle returned by :func:`preflight_pipeline_hook`.
+
+    The helper is the wiring seam noted in issue #89 Acceptance
+    Criteria 6 — actual integration into ``coding_executor_worker``
+    /  ``role_take_worker`` is a follow-up PR. We land the helper now
+    so the contract is pinned and exercised by regression tests.
+
+    ``should_proceed`` is False iff the verdict is BLOCK. ``stamp``
+    is the dict the caller can splice into ``session.extra`` or the
+    job metadata for audit purposes.
+    """
+
+    verdict: PreflightVerdict
+    should_proceed: bool
+    stamp: Mapping[str, Any]
+
+
+def preflight_pipeline_hook(
+    *,
+    role: str,
+    task_signature: str,
+    ledger: MistakeLedger,
+    recent_audit: Optional[Sequence[Mapping[str, Any]]] = None,
+    similarity_threshold: float = DEFAULT_PREFLIGHT_SIMILARITY,
+    now: Optional[datetime] = None,
+) -> PreflightHookResult:
+    """Convenience wrapper for pipeline producers.
+
+    Returns a :class:`PreflightHookResult` with the verdict, a
+    boolean the caller can branch on, and a small ``stamp`` dict
+    suitable for the job metadata / session extra surface.
+
+    A BLOCK verdict sets ``should_proceed=False`` — the caller is
+    expected to route the work to the existing ``needs_approval``
+    lane (the verdict's ``suggested_action`` documents that).
+    """
+
+    verdict = judge_preflight(
+        role=role,
+        task_signature=task_signature,
+        ledger=ledger,
+        recent_audit=recent_audit,
+        similarity_threshold=similarity_threshold,
+        now=now,
+    )
+    stamp = {
+        "preflight": dict(verdict.to_payload()),
+    }
+    return PreflightHookResult(
+        verdict=verdict,
+        should_proceed=not verdict.is_block,
+        stamp=stamp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _format_reason(
+    *,
+    level: BlockerLevel,
+    matches: Sequence[MistakeRecord],
+) -> str:
+    top = list(matches[:REASON_SUMMARY_LIMIT])
+    label = _LEVEL_LABEL.get(level, level.value.lower())
+    total = len(matches)
+    bullets: list[str] = []
+    for record in top:
+        bullets.append(
+            f"`{record.pattern}` (×{record.occurrences}, {record.blocker_level.value})"
+        )
+    suffix = ""
+    if total > len(top):
+        suffix = f" 외 {total - len(top)}건"
+    joined = ", ".join(bullets) if bullets else "매칭된 실수 없음"
+    return (
+        f"{label} — 동일 role 의 과거 실수 {total}건 중 상위 매칭: "
+        f"{joined}{suffix}"
+    )
+
+
+def _utc_iso(now: Optional[datetime]) -> str:
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    return now.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+__all__ = (
+    "DEFAULT_PREFLIGHT_SIMILARITY",
+    "PreflightHookResult",
+    "PreflightVerdict",
+    "judge_preflight",
+    "preflight_pipeline_hook",
+)

--- a/tests/agents/test_mistake_ledger_persistent.py
+++ b/tests/agents/test_mistake_ledger_persistent.py
@@ -1,0 +1,518 @@
+"""Durable mistake ledger — issue #89 round 1 contract.
+
+Pins the F2 hookify ledger contract:
+
+  * ``record_mistake`` is idempotent on ``(role, pattern, signature)``
+    — repeat calls bump ``occurrences`` and advance ``last_seen``.
+  * Blocker level escalates one-way (ADVISORY → WARNING → BLOCK); a
+    milder later occurrence never relaxes the stored level.
+  * ``find_similar`` is token Jaccard with a configurable threshold;
+    sub-threshold rows are dropped.
+  * ``list_for_role`` returns the most recent unresolved rows.
+  * SQLite persistence round-trip — closing and re-opening the ledger
+    against the same file returns the same records.
+  * ``resolve`` is the only path to flag a row resolved (auto-dismiss
+    is not exposed); calling ``resolve`` twice is a no-op.
+  * ``prune_old_resolved`` deletes resolved-and-aged rows and leaves
+    unresolved rows alone.
+  * ``mistake_candidate_from_postmortem`` is deterministic.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+    MistakeRecord,
+    jaccard_similarity,
+    max_blocker_level,
+    mistake_candidate_from_postmortem,
+)
+
+
+class _LedgerTestBase(unittest.TestCase):
+    """Shared scaffolding — every test gets a fresh ``:memory:`` ledger."""
+
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+
+    def tearDown(self) -> None:
+        self.ledger.close()
+
+
+class RecordMistakeLifecycleTests(_LedgerTestBase):
+    def test_first_record_starts_at_one(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+            when="2026-05-01T00:00:00+00:00",
+        )
+        self.assertEqual(record.occurrences, 1)
+        self.assertEqual(record.role, "backend-engineer")
+        self.assertEqual(record.pattern, "ci_test_fail")
+        self.assertEqual(record.first_seen, record.last_seen)
+        self.assertEqual(record.blocker_level, BlockerLevel.ADVISORY)
+        self.assertIsNone(record.resolved_at)
+        self.assertIsNone(record.postmortem_ref)
+
+    def test_repeat_bumps_occurrences_and_advances_last_seen(self) -> None:
+        first = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+            when="2026-05-01T00:00:00+00:00",
+        )
+        second = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+            when="2026-05-02T00:00:00+00:00",
+        )
+        self.assertEqual(first.id, second.id)
+        self.assertEqual(second.occurrences, 2)
+        self.assertEqual(second.first_seen, "2026-05-01T00:00:00+00:00")
+        self.assertEqual(second.last_seen, "2026-05-02T00:00:00+00:00")
+
+    def test_blocker_level_only_escalates(self) -> None:
+        # Start at WARNING, then a later ADVISORY claim should not relax.
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login failure",
+            blocker_level=BlockerLevel.WARNING,
+        )
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login failure",
+            blocker_level=BlockerLevel.ADVISORY,
+        )
+        self.assertEqual(record.blocker_level, BlockerLevel.WARNING)
+
+        # An explicit BLOCK pushes it the rest of the way.
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login failure",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        self.assertEqual(record.blocker_level, BlockerLevel.BLOCK)
+
+    def test_distinct_tuple_creates_new_row(self) -> None:
+        first = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login failure",
+        )
+        second = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="payments checkout failure",
+        )
+        self.assertNotEqual(first.id, second.id)
+        rows = self.ledger.list_for_role("backend-engineer")
+        self.assertEqual({r.id for r in rows}, {first.id, second.id})
+
+    def test_record_mistake_requires_non_empty_role_and_signature(self) -> None:
+        with self.assertRaises(ValueError):
+            self.ledger.record_mistake(
+                role="",
+                pattern="ci_test_fail",
+                signature="x",
+            )
+        with self.assertRaises(ValueError):
+            self.ledger.record_mistake(
+                role="qa",
+                pattern="ci_test_fail",
+                signature="",
+            )
+
+    def test_record_mistake_postmortem_ref_stored(self) -> None:
+        record = self.ledger.record_mistake(
+            role="qa",
+            pattern="missing_regression",
+            signature="missing regression check on auth flow",
+            postmortem_ref="postmortem://issue-89/audit-1",
+        )
+        fetched = self.ledger.get(record.id)
+        assert fetched is not None
+        self.assertEqual(
+            fetched.postmortem_ref, "postmortem://issue-89/audit-1"
+        )
+
+
+class FindSimilarTests(_LedgerTestBase):
+    def test_exact_signature_match_returns_record(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed on CI",
+        )
+        matches = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login test failed on CI",
+            threshold=0.9,
+        )
+        self.assertEqual(len(matches), 1)
+
+    def test_partial_overlap_matches_at_lower_threshold(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed on CI",
+        )
+        # Different signature with several shared tokens — Jaccard is
+        # high enough at 0.4 but not at 0.9.
+        low = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login regression failed",
+            threshold=0.3,
+        )
+        high = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login regression failed",
+            threshold=0.95,
+        )
+        self.assertGreaterEqual(len(low), 1)
+        self.assertEqual(len(high), 0)
+
+    def test_other_role_signatures_are_not_returned(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+        )
+        self.ledger.record_mistake(
+            role="qa-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+        )
+        backend_matches = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login test failed",
+            threshold=0.5,
+        )
+        self.assertEqual(len(backend_matches), 1)
+        self.assertEqual(backend_matches[0].role, "backend-engineer")
+
+    def test_find_similar_filters_resolved_by_default(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+        )
+        self.ledger.resolve(record.id)
+        matches = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login test failed",
+            threshold=0.5,
+        )
+        self.assertEqual(matches, ())
+        with_resolved = self.ledger.find_similar(
+            role="backend-engineer",
+            signature="auth login test failed",
+            threshold=0.5,
+            include_resolved=True,
+        )
+        self.assertEqual(len(with_resolved), 1)
+
+
+class ListForRoleTests(_LedgerTestBase):
+    def test_returns_most_recent_first(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="a",
+            signature="alpha",
+            when="2026-05-01T00:00:00+00:00",
+        )
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="b",
+            signature="beta",
+            when="2026-05-03T00:00:00+00:00",
+        )
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="c",
+            signature="gamma",
+            when="2026-05-02T00:00:00+00:00",
+        )
+        rows = self.ledger.list_for_role("backend-engineer")
+        self.assertEqual(
+            [r.pattern for r in rows], ["b", "c", "a"]
+        )
+
+    def test_respects_limit(self) -> None:
+        for i in range(5):
+            self.ledger.record_mistake(
+                role="backend-engineer",
+                pattern=f"p{i}",
+                signature=f"signature {i}",
+                when=f"2026-05-{i+1:02d}T00:00:00+00:00",
+            )
+        rows = self.ledger.list_for_role("backend-engineer", limit=2)
+        self.assertEqual(len(rows), 2)
+
+
+class ResolveLifecycleTests(_LedgerTestBase):
+    def test_resolve_marks_row_resolved(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="x",
+            signature="signature here",
+        )
+        resolved = self.ledger.resolve(
+            record.id, resolved_at="2026-05-10T00:00:00+00:00"
+        )
+        assert resolved is not None
+        self.assertEqual(resolved.resolved_at, "2026-05-10T00:00:00+00:00")
+        self.assertTrue(resolved.is_resolved())
+
+    def test_resolve_unknown_id_returns_none(self) -> None:
+        self.assertIsNone(self.ledger.resolve("does-not-exist"))
+
+    def test_resolve_is_idempotent(self) -> None:
+        record = self.ledger.record_mistake(
+            role="qa",
+            pattern="x",
+            signature="y",
+        )
+        first = self.ledger.resolve(
+            record.id, resolved_at="2026-05-10T00:00:00+00:00"
+        )
+        second = self.ledger.resolve(
+            record.id, resolved_at="2026-05-12T00:00:00+00:00"
+        )
+        assert first is not None and second is not None
+        # Second call must preserve the original resolved_at stamp.
+        self.assertEqual(first.resolved_at, second.resolved_at)
+
+    def test_record_again_after_resolve_reopens_row(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="x",
+            signature="alpha signature",
+        )
+        self.ledger.resolve(record.id)
+        bumped = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="x",
+            signature="alpha signature",
+        )
+        self.assertEqual(bumped.id, record.id)
+        self.assertEqual(bumped.occurrences, 2)
+        self.assertIsNone(bumped.resolved_at)
+
+
+class PruneRetentionTests(_LedgerTestBase):
+    def test_prune_removes_old_resolved_rows(self) -> None:
+        record = self.ledger.record_mistake(
+            role="qa",
+            pattern="p",
+            signature="some signature",
+            when="2025-01-01T00:00:00+00:00",
+        )
+        # Resolve at a date well before our `now` reference.
+        self.ledger.resolve(
+            record.id, resolved_at="2025-06-01T00:00:00+00:00"
+        )
+        now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        deleted = self.ledger.prune_old_resolved(
+            retention_days=30, now=now
+        )
+        self.assertEqual(deleted, 1)
+        self.assertEqual(self.ledger.all_records(), ())
+
+    def test_prune_leaves_unresolved_rows_alone(self) -> None:
+        self.ledger.record_mistake(
+            role="qa",
+            pattern="p",
+            signature="alpha",
+            when="2025-01-01T00:00:00+00:00",
+        )
+        now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        deleted = self.ledger.prune_old_resolved(retention_days=30, now=now)
+        self.assertEqual(deleted, 0)
+        self.assertEqual(len(self.ledger.all_records()), 1)
+
+    def test_prune_respects_retention_window(self) -> None:
+        record = self.ledger.record_mistake(
+            role="qa",
+            pattern="p",
+            signature="alpha",
+        )
+        # Resolve recently (within retention window).
+        self.ledger.resolve(
+            record.id, resolved_at="2026-04-25T00:00:00+00:00"
+        )
+        now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        deleted = self.ledger.prune_old_resolved(retention_days=30, now=now)
+        # 6 days < 30 days retention → still kept.
+        self.assertEqual(deleted, 0)
+        self.assertEqual(len(self.ledger.all_records()), 1)
+
+
+class PersistenceRoundTripTests(unittest.TestCase):
+    def test_on_disk_records_survive_reopen(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "mistake.sqlite3"
+            first = MistakeLedger(database_path=db_path)
+            try:
+                first.record_mistake(
+                    role="backend-engineer",
+                    pattern="ci",
+                    signature="auth login failure",
+                    blocker_level=BlockerLevel.WARNING,
+                    when="2026-05-01T00:00:00+00:00",
+                )
+            finally:
+                first.close()
+            second = MistakeLedger(database_path=db_path)
+            try:
+                rows = second.list_for_role("backend-engineer")
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].signature, "auth login failure")
+                self.assertEqual(rows[0].blocker_level, BlockerLevel.WARNING)
+                # Recording the same tuple in the reopened ledger bumps
+                # the existing row — proof the unique index survived.
+                bumped = second.record_mistake(
+                    role="backend-engineer",
+                    pattern="ci",
+                    signature="auth login failure",
+                    when="2026-05-02T00:00:00+00:00",
+                )
+                self.assertEqual(bumped.occurrences, 2)
+            finally:
+                second.close()
+
+
+class JaccardSimilarityTests(unittest.TestCase):
+    def test_identical_strings_score_one(self) -> None:
+        self.assertEqual(
+            jaccard_similarity("auth login fail", "auth login fail"), 1.0
+        )
+
+    def test_disjoint_strings_score_zero(self) -> None:
+        self.assertEqual(
+            jaccard_similarity("alpha", "bravo charlie"), 0.0
+        )
+
+    def test_partial_overlap_is_between_zero_and_one(self) -> None:
+        score = jaccard_similarity("auth login fail", "auth signup fail")
+        self.assertGreater(score, 0.0)
+        self.assertLess(score, 1.0)
+
+
+class PostmortemCandidateTests(unittest.TestCase):
+    def test_returns_record_with_deterministic_id(self) -> None:
+        entry = {
+            "action": "failure_postmortem_create",
+            "role": "backend-engineer",
+            "summary": "auth login regression",
+            "reason": "auth login flow flakiness",
+            "recorded_at": "2026-05-01T00:00:00+00:00",
+            "entry_id": "audit-entry-42",
+            "job_type": "coding_execute",
+        }
+        a = mistake_candidate_from_postmortem(entry)
+        b = mistake_candidate_from_postmortem(entry)
+        assert a is not None and b is not None
+        self.assertEqual(a.id, b.id)
+        self.assertEqual(a.signature, "auth login flow flakiness")
+        self.assertEqual(a.pattern, "coding_execute")
+        self.assertEqual(a.role, "backend-engineer")
+
+    def test_returns_none_when_role_missing(self) -> None:
+        self.assertIsNone(
+            mistake_candidate_from_postmortem(
+                {
+                    "action": "failure_postmortem_create",
+                    "summary": "no role",
+                    "reason": "no role",
+                }
+            )
+        )
+
+    def test_returns_none_when_action_not_postmortem(self) -> None:
+        self.assertIsNone(
+            mistake_candidate_from_postmortem(
+                {
+                    "action": "queue_inspect",
+                    "role": "backend-engineer",
+                    "reason": "should not be a candidate",
+                }
+            )
+        )
+
+    def test_returns_none_when_signature_source_missing(self) -> None:
+        self.assertIsNone(
+            mistake_candidate_from_postmortem(
+                {
+                    "action": "failure_postmortem_create",
+                    "role": "backend-engineer",
+                }
+            )
+        )
+
+    def test_candidate_persists_into_ledger_without_duplicating(self) -> None:
+        entry = {
+            "action": "failure_postmortem_create",
+            "role": "backend-engineer",
+            "reason": "auth login flow flakiness",
+            "recorded_at": "2026-05-01T00:00:00+00:00",
+            "entry_id": "audit-entry-42",
+            "job_type": "coding_execute",
+        }
+        candidate = mistake_candidate_from_postmortem(entry)
+        assert candidate is not None
+        ledger = MistakeLedger(database_path=":memory:")
+        try:
+            first = ledger.record_mistake(
+                role=candidate.role,
+                pattern=candidate.pattern,
+                signature=candidate.signature,
+                postmortem_ref=candidate.postmortem_ref,
+                blocker_level=candidate.blocker_level,
+            )
+            second = ledger.record_mistake(
+                role=candidate.role,
+                pattern=candidate.pattern,
+                signature=candidate.signature,
+                postmortem_ref=candidate.postmortem_ref,
+                blocker_level=candidate.blocker_level,
+            )
+            self.assertEqual(first.id, second.id)
+            self.assertEqual(second.occurrences, 2)
+        finally:
+            ledger.close()
+
+
+class MaxBlockerLevelTests(unittest.TestCase):
+    def test_max_returns_highest_level(self) -> None:
+        self.assertEqual(
+            max_blocker_level(
+                BlockerLevel.ADVISORY,
+                BlockerLevel.BLOCK,
+                BlockerLevel.WARNING,
+            ),
+            BlockerLevel.BLOCK,
+        )
+
+    def test_max_of_empty_defaults_advisory(self) -> None:
+        self.assertEqual(max_blocker_level(), BlockerLevel.ADVISORY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_preflight.py
+++ b/tests/agents/test_preflight.py
@@ -1,0 +1,275 @@
+"""Preflight judgement seam — issue #89 round 1 contract.
+
+Pins the F2 preflight contract:
+
+  * Empty ledger → ADVISORY verdict with no matched mistakes.
+  * Matched ADVISORY-only records → ADVISORY verdict, suggested_action
+    == "주의".
+  * Matched WARNING records → WARNING verdict, suggested_action ==
+    "재검토 권장".
+  * Any matched BLOCK record → BLOCK verdict, suggested_action ==
+    "needs_approval 로 라우팅", ``recommend_needs_approval == True``.
+  * The verdict level is the *maximum* of matched mistake levels.
+  * ``preflight_pipeline_hook`` wraps the verdict in a pipeline-ready
+    bundle that sets ``should_proceed=False`` only on BLOCK.
+  * ``judge_preflight`` is deterministic given a pinned ``now``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.learning.preflight import (
+    DEFAULT_PREFLIGHT_SIMILARITY,
+    PreflightHookResult,
+    PreflightVerdict,
+    judge_preflight,
+    preflight_pipeline_hook,
+)
+
+
+_FIXED_NOW = datetime(2026, 5, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _PreflightTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+
+    def tearDown(self) -> None:
+        self.ledger.close()
+
+
+class EmptyLedgerTests(_PreflightTestBase):
+    def test_empty_ledger_returns_advisory_with_no_matches(self) -> None:
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login regression",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.ADVISORY)
+        self.assertEqual(verdict.matched_mistakes, ())
+        self.assertEqual(verdict.suggested_action, "주의")
+        self.assertFalse(verdict.recommend_needs_approval)
+        self.assertIn("매칭 없음", verdict.reason)
+
+    def test_missing_role_short_circuits_advisory(self) -> None:
+        verdict = judge_preflight(
+            role="",
+            task_signature="auth login regression",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.ADVISORY)
+        self.assertEqual(verdict.matched_mistakes, ())
+        self.assertIn("role 미지정", verdict.reason)
+
+    def test_missing_signature_short_circuits_advisory(self) -> None:
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.ADVISORY)
+        self.assertEqual(verdict.matched_mistakes, ())
+        self.assertIn("task_signature 미지정", verdict.reason)
+
+
+class VerdictMatrixTests(_PreflightTestBase):
+    def test_advisory_only_match_returns_advisory(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failure",
+            blocker_level=BlockerLevel.ADVISORY,
+        )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.ADVISORY)
+        self.assertEqual(verdict.suggested_action, "주의")
+        self.assertEqual(len(verdict.matched_mistakes), 1)
+
+    def test_warning_match_returns_warning(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failure",
+            blocker_level=BlockerLevel.WARNING,
+        )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.WARNING)
+        self.assertEqual(verdict.suggested_action, "재검토 권장")
+        self.assertFalse(verdict.recommend_needs_approval)
+
+    def test_block_match_returns_block_with_needs_approval(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="force push to main branch",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="force push to main branch",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.BLOCK)
+        self.assertEqual(
+            verdict.suggested_action, "needs_approval 로 라우팅"
+        )
+        self.assertTrue(verdict.recommend_needs_approval)
+
+    def test_max_level_is_chosen_across_matches(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failure",
+            blocker_level=BlockerLevel.ADVISORY,
+        )
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="auth login force push violation",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure violation",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+            similarity_threshold=0.2,
+        )
+        # Both records contain "auth login" tokens and beat the lower
+        # threshold; the highest level (BLOCK) must win.
+        self.assertEqual(verdict.level, BlockerLevel.BLOCK)
+        self.assertTrue(verdict.recommend_needs_approval)
+        self.assertEqual(len(verdict.matched_mistakes), 2)
+
+
+class ReasonSurfaceTests(_PreflightTestBase):
+    def test_reason_includes_top_matched_patterns(self) -> None:
+        for i in range(5):
+            self.ledger.record_mistake(
+                role="backend-engineer",
+                pattern=f"ci_fail_{i}",
+                signature=f"auth login flow regression {i}",
+                blocker_level=BlockerLevel.WARNING,
+            )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login flow regression",
+            ledger=self.ledger,
+            similarity_threshold=0.3,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.WARNING)
+        # Reason must mention at least one of the top patterns.
+        self.assertTrue(
+            any(f"ci_fail_{i}" in verdict.reason for i in range(5)),
+            f"reason missing matched pattern reference: {verdict.reason}",
+        )
+
+    def test_resolved_mistakes_do_not_contribute(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failure",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        self.ledger.resolve(record.id)
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(verdict.level, BlockerLevel.ADVISORY)
+        self.assertEqual(verdict.matched_mistakes, ())
+
+
+class DeterminismTests(_PreflightTestBase):
+    def test_same_inputs_yield_equal_verdict_payload(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failure",
+            blocker_level=BlockerLevel.WARNING,
+        )
+        a = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        b = judge_preflight(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(a.to_payload(), b.to_payload())
+
+    def test_default_threshold_constant_is_stable(self) -> None:
+        # Constant pin — if this value is changed the regression
+        # tests above need to be re-verified.
+        self.assertGreaterEqual(DEFAULT_PREFLIGHT_SIMILARITY, 0.0)
+        self.assertLessEqual(DEFAULT_PREFLIGHT_SIMILARITY, 1.0)
+
+
+class PipelineHookTests(_PreflightTestBase):
+    def test_advisory_keeps_should_proceed_true(self) -> None:
+        result = preflight_pipeline_hook(
+            role="backend-engineer",
+            task_signature="auth login test failure",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertIsInstance(result, PreflightHookResult)
+        self.assertTrue(result.should_proceed)
+        self.assertEqual(result.verdict.level, BlockerLevel.ADVISORY)
+        self.assertIn("preflight", result.stamp)
+
+    def test_block_drops_should_proceed_to_false(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="force push to main",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        result = preflight_pipeline_hook(
+            role="backend-engineer",
+            task_signature="force push to main",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertFalse(result.should_proceed)
+        self.assertTrue(result.verdict.recommend_needs_approval)
+        self.assertEqual(
+            result.stamp["preflight"]["suggested_action"],
+            "needs_approval 로 라우팅",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_hookify_governance.py
+++ b/tests/engineering/test_hookify_governance.py
@@ -1,0 +1,226 @@
+"""Hookify (F2 / issue #89) governance regression — hard-rail integrity gate.
+
+Pulls the F2 hard rails into one suite so a single rename / condition
+flip cannot silently regress them:
+
+  1. ``BLOCK`` verdict prevents auto-progress — the verdict carries
+     ``recommend_needs_approval=True`` and the suggested action
+     references the ``needs_approval`` lane.
+  2. The mistake ledger is bounded by an explicit retention API —
+     ``prune_old_resolved`` is the only delete path and it ignores
+     unresolved rows so the ledger does not silently drop a live
+     mistake. Without an explicit operator call the ledger does NOT
+     auto-prune.
+  3. There is no auto-dismiss — every path that flips
+     ``resolved_at`` goes through :meth:`MistakeLedger.resolve`. Bumping
+     a record (or recording it many times) never resolves it.
+  4. ``mistake_candidate_from_postmortem`` is deterministic — the
+     same audit entry always yields the same id / signature, so
+     re-running the postmortem producer never duplicates the row.
+  5. The preflight pipeline helper exposes ``should_proceed=False`` on
+     BLOCK so a caller wiring the hook cannot accidentally enter the
+     pipeline before the operator routes the work to ``needs_approval``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+    mistake_candidate_from_postmortem,
+)
+from yule_orchestrator.agents.learning.preflight import (
+    judge_preflight,
+    preflight_pipeline_hook,
+)
+
+
+_FIXED_NOW = datetime(2026, 5, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _GovTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+
+    def tearDown(self) -> None:
+        self.ledger.close()
+
+
+class BlockVerdictHardRailTests(_GovTestBase):
+    """Hard rail #1 — BLOCK never auto-progresses."""
+
+    def test_block_verdict_recommends_needs_approval(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="force push to main branch",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        verdict = judge_preflight(
+            role="backend-engineer",
+            task_signature="force push to main branch",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        self.assertTrue(verdict.is_block)
+        self.assertTrue(verdict.recommend_needs_approval)
+        self.assertIn("needs_approval", verdict.suggested_action)
+
+    def test_block_pipeline_hook_blocks_should_proceed(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="force push to main",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        result = preflight_pipeline_hook(
+            role="backend-engineer",
+            task_signature="force push to main",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        # The single boolean a wiring caller branches on — must be
+        # False so the worker cannot accidentally enter the pipeline.
+        self.assertFalse(result.should_proceed)
+
+
+class LedgerRetentionHardRailTests(_GovTestBase):
+    """Hard rail #2 — the ledger never grows unbounded but only the
+    explicit ``prune_old_resolved`` API may delete rows."""
+
+    def test_unresolved_rows_are_never_pruned(self) -> None:
+        # Record a *very* old mistake and never resolve it.
+        self.ledger.record_mistake(
+            role="qa-engineer",
+            pattern="missing_regression",
+            signature="missing regression guard on auth flow",
+            when="2020-01-01T00:00:00+00:00",
+        )
+        now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        deleted = self.ledger.prune_old_resolved(retention_days=1, now=now)
+        # Zero deletes — only resolved rows are eligible.
+        self.assertEqual(deleted, 0)
+        self.assertEqual(len(self.ledger.all_records()), 1)
+
+    def test_prune_only_runs_when_called(self) -> None:
+        record = self.ledger.record_mistake(
+            role="qa-engineer",
+            pattern="missing_regression",
+            signature="missing regression guard",
+        )
+        self.ledger.resolve(
+            record.id, resolved_at="2020-01-01T00:00:00+00:00"
+        )
+        # Just recording more mistakes does NOT auto-prune the old one
+        # — the operator must call prune_old_resolved explicitly.
+        for i in range(5):
+            self.ledger.record_mistake(
+                role="qa-engineer",
+                pattern=f"other_{i}",
+                signature=f"unrelated signature {i}",
+            )
+        self.assertEqual(
+            len(self.ledger.all_records(include_resolved=True)), 6
+        )
+        deleted = self.ledger.prune_old_resolved(
+            retention_days=30,
+            now=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        self.assertEqual(deleted, 1)
+
+
+class ResolveExplicitOnlyHardRailTests(_GovTestBase):
+    """Hard rail #3 — ``resolved_at`` only flips via :meth:`resolve`."""
+
+    def test_repeated_record_does_not_resolve_row(self) -> None:
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+            blocker_level=BlockerLevel.WARNING,
+        )
+        for _ in range(10):
+            self.ledger.record_mistake(
+                role="backend-engineer",
+                pattern="ci_test_fail",
+                signature="auth login test failed",
+            )
+        fetched = self.ledger.get(record.id)
+        assert fetched is not None
+        # Even after 10 bumps the row is still unresolved.
+        self.assertIsNone(fetched.resolved_at)
+        self.assertEqual(fetched.occurrences, 11)
+
+    def test_record_after_resolve_clears_resolved_stamp(self) -> None:
+        # The "re-open on recurrence" rule is intentional — the same
+        # mistake biting again must unconditionally raise the
+        # preflight signal regardless of an earlier operator dismiss.
+        # Without this rule a stale dismissal could silently let a
+        # repeating failure through.
+        record = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+        )
+        self.ledger.resolve(record.id)
+        fetched = self.ledger.get(record.id)
+        assert fetched is not None
+        self.assertIsNotNone(fetched.resolved_at)
+        bumped = self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="ci_test_fail",
+            signature="auth login test failed",
+        )
+        self.assertIsNone(bumped.resolved_at)
+
+
+class PostmortemDeterminismHardRailTests(unittest.TestCase):
+    """Hard rail #4 — postmortem → candidate is deterministic."""
+
+    def test_same_audit_entry_yields_equal_candidates(self) -> None:
+        entry = {
+            "action": "failure_postmortem_create",
+            "role": "backend-engineer",
+            "reason": "auth login flow flakiness",
+            "recorded_at": "2026-05-01T00:00:00+00:00",
+            "entry_id": "audit-42",
+            "job_type": "coding_execute",
+        }
+        first = mistake_candidate_from_postmortem(entry)
+        second = mistake_candidate_from_postmortem(entry)
+        assert first is not None and second is not None
+        self.assertEqual(first.to_payload(), second.to_payload())
+
+
+class PreflightHookSurfaceHardRailTests(_GovTestBase):
+    """Hard rail #5 — pipeline helper exposes the BLOCK decision clearly."""
+
+    def test_stamp_payload_contains_needs_approval_recommendation(self) -> None:
+        self.ledger.record_mistake(
+            role="backend-engineer",
+            pattern="force_push",
+            signature="force push to main",
+            blocker_level=BlockerLevel.BLOCK,
+        )
+        result = preflight_pipeline_hook(
+            role="backend-engineer",
+            task_signature="force push to main",
+            ledger=self.ledger,
+            now=_FIXED_NOW,
+        )
+        stamp = result.stamp.get("preflight")
+        assert isinstance(stamp, dict)
+        self.assertTrue(stamp["recommend_needs_approval"])
+        self.assertEqual(stamp["level"], BlockerLevel.BLOCK.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #89 (parent #81)

## ✨ 과제 내용
F2 hookify seam — role-specific 영속 mistake ledger + preflight judgement seam 도입. round-1 session-extra ledger 위에 cross-session 카운터파트를 쌓아 worker pipeline 초입에서도 평가 가능하게 한다.

### 추가된 모듈
- `src/yule_orchestrator/agents/learning/mistake_ledger.py`
  - `MistakeRecord(id/role/pattern/signature/first_seen/last_seen/occurrences/blocker_level/postmortem_ref/resolved_at)` dataclass.
  - `BlockerLevel` enum (`ADVISORY` / `WARNING` / `BLOCK`) — `max_blocker_level` helper.
  - SQLite 영속 `MistakeLedger`: `record_mistake` / `find_similar` (token Jaccard) / `list_for_role` / `resolve` / `prune_old_resolved` / `all_records` / `get`.
  - `mistake_candidate_from_postmortem(audit_entry)` — postmortem audit → hook candidate deterministic 변환.
- `src/yule_orchestrator/agents/learning/preflight.py`
  - `PreflightVerdict(level/reason/suggested_action/matched_mistakes/evaluated_at)` dataclass.
  - `judge_preflight(role, task_signature, ledger, recent_audit)` deterministic 평가.
  - `preflight_pipeline_hook(...) -> PreflightHookResult` 파이프라인 wiring helper (실제 wiring 은 본 PR 비범위).

### 하드 레일
- BLOCK verdict 시 `recommend_needs_approval=True`, `suggested_action='needs_approval 로 라우팅'` — 자동 진행 차단.
- `resolve()` 명시 호출만이 `resolved_at` 을 세팅 — 자동 dismiss 없음.
- `prune_old_resolved(retention_days)` 명시 호출 외에 ledger 삭제 경로 없음 — unresolved 행은 절대 prune 되지 않음.
- 동일 mistake 재발 시 resolved 행이 자동 재오픈 — stale dismiss 가 신호를 가로채지 않음.
- SQLite 스키마는 `CREATE TABLE IF NOT EXISTS` + `CREATE UNIQUE INDEX IF NOT EXISTS` — 기존 cache.sqlite3 connection 손상 없음.

## 🔬 검증
- 신규 회귀 51 케이스:
  - `tests/agents/test_mistake_ledger_persistent.py` (30) — record/find/list/resolve 라이프사이클, Jaccard threshold, prune retention, postmortem deterministic, on-disk 영속 round-trip.
  - `tests/agents/test_preflight.py` (13) — empty ledger advisory, ADVISORY/WARNING/BLOCK 매트릭스, max-level 매칭, pipeline hook, determinism.
  - `tests/engineering/test_hookify_governance.py` (8) — BLOCK 자동 진행 차단, unresolved 무한 보호, dismiss 명시 호출, postmortem deterministic, pipeline stamp.
- 전체 회귀 `python3 -m unittest discover -s tests -t .` → **Ran 3628 tests, OK (skipped=5)**.

## 🗂 Audit
- 신규 모듈 어떤 것도 외부 push / merge / 비밀 접근을 수행하지 않음 — L0/L1 surface 한정.
- `coding_executor_worker._run_pipeline` 실제 wiring 은 후속 PR — 본 PR 은 helper + 회귀 가드만 land.
- branch: `feature/hookify-issue-89` · commit: 576f99f.

## 📚 레퍼런스
- parent 이슈 #81 (round 1 — lifecycle `mistake_ledger.py` / `preflight_judgement.py` / `hook_candidate.py`)
- 본 모듈은 round 1 과 import 의존성 없음 — 두 seam 은 의도적으로 분리 유지.