### PR TITLE
✨ [Feature] F4 Live LLM editor MVP — env-gated CodeEditPort + claude-cli provider (PasteGuard 통합)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,29 @@ DISCORD_GUILD_ID=
 # YULE_DECISION_OPENAI_ENABLED=false
 
 # =====================================================================
+# #91 — Live LLM code editor env (F4 — RecordOnly → LiveCodeEditor)
+#
+# coding_executor 의 editor 단계는 기본적으로 `RecordOnlyCodeEditor` 가
+# 동작해 plan markdown 만 남기고 소스를 수정하지 않는다. 본 env 셋이
+# 갖춰진 경우에 한해 `LiveCodeEditor` 가 활성화되어 실 LLM 호출로
+# 코드를 수정한다.
+#
+# 운영 정책 (Hard rails):
+#   1. 본 플래그는 .env.example 에 절대 true 로 적지 마라. 머지 후에도
+#      자동 활성화되지 않도록 default OFF 를 유지한다.
+#   2. provider 가 anthropic / openai 일 경우 `BlockedLiveEditorError` 가
+#      발생한다 — D-73-10 운영자 승인 + cost-budget 검토 후 별도 PR.
+#   3. provider=claude-cli 만 본 PR 에서 실 활성화 가능. `claude` 바이너리가
+#      PATH 에 있고, subprocess runner 가 worker 측에서 주입되어야 한다.
+#   4. 모든 outbound prompt 는 PasteGuard 를 거친다 — verdict.blocked 면
+#      live 호출이 차단된다.
+#
+# YULE_LIVE_EDITOR_ENABLED=false
+# YULE_LIVE_EDITOR_PROVIDER=claude-cli
+# YULE_LIVE_EDITOR_MODEL=claude-sonnet-4-6
+# YULE_LIVE_EDITOR_MAX_RETRIES=3
+
+# =====================================================================
 # #73 — Engineering knowledge provider env (background ingestion 루프)
 #
 # `engineering_intelligence` 패키지는 역할별 source 를 background 로 수집한다.

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -41,7 +41,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any, Mapping, Optional, Protocol, Sequence, Tuple
 
 from .coding_executor_worker import (
     CodingExecuteRequest,
@@ -745,4 +745,289 @@ __all__ = (
     "SubprocessTestRunner",
     "build_live_executor",
     "detect_live_executor_availability",
+    # F4 / #91 — Live LLM editor MVP (env-gated, claude-cli only).
+    "BlockedLiveEditorError",
+    "CodeEditPort",
+    "LiveCodeEditor",
+    "ENV_LIVE_EDITOR_ENABLED",
+    "ENV_LIVE_EDITOR_PROVIDER",
+    "ENV_LIVE_EDITOR_MODEL",
+    "ENV_LIVE_EDITOR_MAX_RETRIES",
+    "PROVIDER_CLAUDE_CLI",
+    "PROVIDER_ANTHROPIC",
+    "PROVIDER_OPENAI",
+    "build_live_editor_from_env",
 )
+
+
+# ---------------------------------------------------------------------------
+# F4 / #91 — Live LLM editor MVP
+#
+# Scope of this PR (intentionally minimal):
+#
+#   * :class:`CodeEditPort` — Protocol the worker can swap in place of
+#     :class:`RecordOnlyCodeEditor`.
+#   * :class:`BlockedLiveEditorError` — single exception type raised
+#     when env gates / operator authorization / PasteGuard refuses
+#     the call.
+#   * :class:`LiveCodeEditor` — env-gated wrapper that:
+#       1. Hard rail: if ``YULE_LIVE_EDITOR_ENABLED != "true"`` the
+#          editor blocks immediately. This stays default-off even
+#          after the PR lands — operator must flip the flag.
+#       2. PasteGuard preflight on the outbound prompt; ``blocked``
+#          → :class:`BlockedLiveEditorError`.
+#       3. Provider dispatch:
+#            ``claude-cli`` → subprocess call (default impl
+#            attempts ``import subprocess`` only; the worker may
+#            inject a fake runner under test).
+#            ``anthropic`` / ``openai`` → blocked stub (operator
+#            authorization + cost-budget gate, D-73-10).
+#
+# TODO (follow-up PRs, deliberately out of scope here):
+#
+#   * patch validation against write_scope / forbidden_scope
+#   * test-first retry loop (max_retries env exposed but unused)
+#   * cost tracking + per-session budget enforcement
+#   * Anthropic / OpenAI SDK wiring (operator authorization gate)
+#
+# Hard rails enforced *in this PR* (regression-tested):
+#
+#   * Default OFF — ``build_live_editor_from_env({})`` returns None.
+#   * Anthropic / OpenAI providers raise BlockedLiveEditorError.
+#   * PasteGuard fail-closed — raw secret in prompt blocks the call.
+#   * protected branch guard remains via
+#     :func:`coding_executor_worker.is_protected_branch` (not
+#     duplicated here; the worker invokes it before the editor).
+# ---------------------------------------------------------------------------
+
+
+ENV_LIVE_EDITOR_ENABLED: str = "YULE_LIVE_EDITOR_ENABLED"
+ENV_LIVE_EDITOR_PROVIDER: str = "YULE_LIVE_EDITOR_PROVIDER"
+ENV_LIVE_EDITOR_MODEL: str = "YULE_LIVE_EDITOR_MODEL"
+ENV_LIVE_EDITOR_MAX_RETRIES: str = "YULE_LIVE_EDITOR_MAX_RETRIES"
+
+PROVIDER_CLAUDE_CLI: str = "claude-cli"
+PROVIDER_ANTHROPIC: str = "anthropic"
+PROVIDER_OPENAI: str = "openai"
+
+_DEFAULT_LIVE_EDITOR_MODEL: str = "claude-sonnet-4-6"
+_DEFAULT_LIVE_EDITOR_MAX_RETRIES: int = 3
+
+
+class BlockedLiveEditorError(RuntimeError):
+    """Raised when :class:`LiveCodeEditor` refuses to execute a call.
+
+    ``reason`` is operator-facing: env OFF, provider not authorized
+    (anthropic / openai blocked stub), PasteGuard verdict blocked,
+    or runtime resource missing (e.g. ``claude`` CLI not on PATH).
+
+    The exception never carries the raw outbound prompt — callers
+    log ``str(exc)`` directly without leaking the LLM input.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class CodeEditPort(Protocol):
+    """Protocol the worker depends on for the editor seam.
+
+    :class:`RecordOnlyCodeEditor` and :class:`LiveCodeEditor` both
+    satisfy this — the build factory picks one based on env. The
+    contract is intentionally narrow so future implementations
+    (e.g. codex CLI, GitHub Copilot CLI) can slot in unchanged.
+    """
+
+    def apply(
+        self,
+        *,
+        request: CodingExecuteRequest,
+        context: WorktreeContext,
+    ) -> WorktreeContext:  # pragma: no cover - Protocol
+        ...
+
+
+class LiveCodeEditor:
+    """Env-gated live LLM editor — MVP (claude-cli only).
+
+    The constructor never reads env directly; use
+    :func:`build_live_editor_from_env` so the env contract stays in
+    one place and tests can construct the editor with explicit
+    arguments.
+
+    Provider matrix (MVP):
+
+      * ``claude-cli`` — shells out to ``claude -p <prompt>`` via
+        the injected ``subprocess_runner`` (default attempts a
+        local ``subprocess.run`` call; under test the worker
+        passes a fake). The default-off env flag and the
+        PasteGuard preflight gate every call.
+      * ``anthropic`` / ``openai`` — raises
+        :class:`BlockedLiveEditorError` with reason
+        ``"requires operator authorization"``. This keeps the
+        D-73-10 cost-budget gate intact: live SDK wiring lands
+        in a separate PR after operator sign-off.
+
+    TODO (follow-up PRs): patch validation against write_scope,
+    test-first retry loop, cost tracking.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        model: str = _DEFAULT_LIVE_EDITOR_MODEL,
+        max_retries: int = _DEFAULT_LIVE_EDITOR_MAX_RETRIES,
+        subprocess_runner: Optional[Any] = None,
+        http_poster: Optional[Any] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.provider = provider
+        self.model = model
+        self.max_retries = max_retries
+        self._subprocess_runner = subprocess_runner
+        self._http_poster = http_poster
+        # Snapshot env so re-running apply does not silently flip
+        # behaviour if the operator flips the flag mid-pipeline.
+        self._env: Mapping[str, str] = dict(env) if env is not None else dict(os.environ)
+
+    def apply(
+        self,
+        *,
+        request: CodingExecuteRequest,
+        context: WorktreeContext,
+    ) -> WorktreeContext:
+        # Hard rail 1 — env OFF default.
+        if (self._env.get(ENV_LIVE_EDITOR_ENABLED) or "").strip().lower() != "true":
+            raise BlockedLiveEditorError(
+                f"{ENV_LIVE_EDITOR_ENABLED} != 'true' — live editor disabled"
+            )
+
+        # Hard rail 2 — PasteGuard preflight on the outbound prompt.
+        # Imported lazily so the module stays importable in
+        # environments that strip the security subpackage (e.g.
+        # the planning-agent worker that never touches LLM I/O).
+        from yule_orchestrator.agents.security.paste_guard import (
+            OutboundChannel,
+            guard_outbound,
+        )
+
+        verdict = guard_outbound(
+            channel=OutboundChannel.LLM,
+            payload=request.generated_prompt or "",
+        )
+        if verdict.blocked:
+            raise BlockedLiveEditorError(
+                "PasteGuard blocked outbound prompt — refusing live LLM call"
+            )
+
+        # Hard rail 3 — provider dispatch.
+        if self.provider == PROVIDER_CLAUDE_CLI:
+            return self._apply_via_claude_cli(
+                request=request,
+                context=context,
+                redacted_prompt=verdict.redacted,
+            )
+        if self.provider in (PROVIDER_ANTHROPIC, PROVIDER_OPENAI):
+            raise BlockedLiveEditorError(
+                f"provider={self.provider} requires operator authorization "
+                "(D-73-10 cost-budget gate)"
+            )
+        raise BlockedLiveEditorError(
+            f"unknown live editor provider: {self.provider!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # Provider — claude CLI
+    # ------------------------------------------------------------------
+
+    def _apply_via_claude_cli(
+        self,
+        *,
+        request: CodingExecuteRequest,
+        context: WorktreeContext,
+        redacted_prompt: str,
+    ) -> WorktreeContext:
+        if not context.worktree_path:
+            raise BlockedLiveEditorError(
+                "LiveCodeEditor requires a worktree_path in context"
+            )
+
+        runner = self._subprocess_runner
+        if runner is None:
+            # Default impl: best-effort attempt at locating the
+            # ``claude`` binary. We intentionally do *not* fall back
+            # to ``subprocess.run`` here — operators wire the runner
+            # via :class:`ClaudeSubprocessAdapter` (separate PR).
+            try:
+                import subprocess as _subprocess  # noqa: F401 — import-only probe
+            except Exception as exc:  # pragma: no cover - defensive
+                raise BlockedLiveEditorError(
+                    f"claude-cli runner unavailable: {type(exc).__name__}"
+                ) from exc
+            raise BlockedLiveEditorError(
+                "claude-cli runner not injected — operator must wire "
+                "subprocess_runner before enabling live editor"
+            )
+
+        # Pass the *redacted* payload — never the raw prompt. The
+        # redaction is round-trip safe (head4 + mask + tail4) so the
+        # LLM still has enough context to act, but a leaked secret
+        # in the prompt cannot reach the network.
+        cmd = ("claude", "-p", redacted_prompt, "--model", self.model)
+        result = runner(cmd, cwd=context.worktree_path)
+        # The runner is operator-defined; we accept any truthy
+        # return shape. The MVP only verifies the call did not
+        # raise. Patch validation / file diffing lands in a
+        # follow-up PR (TODO).
+        _ = result
+        return context
+
+
+def build_live_editor_from_env(
+    env: Mapping[str, str],
+    *,
+    http_poster: Optional[Any] = None,
+    subprocess_runner: Optional[Any] = None,
+) -> Optional[CodeEditPort]:
+    """Construct a :class:`LiveCodeEditor` from env, or return ``None``.
+
+    Returns ``None`` (NOT an error) when:
+
+      * ``YULE_LIVE_EDITOR_ENABLED`` is unset / not ``"true"``.
+      * ``YULE_LIVE_EDITOR_PROVIDER`` is unset / empty.
+
+    The worker treats ``None`` as "fall back to RecordOnly" so the
+    pipeline stays exercisable end-to-end even with the live editor
+    completely off. When the env says ON but the provider is
+    ``anthropic`` / ``openai``, the returned editor still raises
+    :class:`BlockedLiveEditorError` on ``apply`` — that is the
+    intended D-73-10 cost-budget gate.
+
+    TODO (follow-up PRs): validate model id against an allow-list,
+    surface availability via :class:`LiveExecutorAvailability`.
+    """
+
+    if (env.get(ENV_LIVE_EDITOR_ENABLED) or "").strip().lower() != "true":
+        return None
+
+    provider = (env.get(ENV_LIVE_EDITOR_PROVIDER) or "").strip().lower()
+    if not provider:
+        return None
+
+    model = (env.get(ENV_LIVE_EDITOR_MODEL) or "").strip() or _DEFAULT_LIVE_EDITOR_MODEL
+    max_retries_raw = (env.get(ENV_LIVE_EDITOR_MAX_RETRIES) or "").strip()
+    try:
+        max_retries = int(max_retries_raw) if max_retries_raw else _DEFAULT_LIVE_EDITOR_MAX_RETRIES
+    except ValueError:
+        max_retries = _DEFAULT_LIVE_EDITOR_MAX_RETRIES
+
+    return LiveCodeEditor(
+        provider=provider,
+        model=model,
+        max_retries=max_retries,
+        subprocess_runner=subprocess_runner,
+        http_poster=http_poster,
+        env=env,
+    )

--- a/tests/agents/test_live_code_editor.py
+++ b/tests/agents/test_live_code_editor.py
@@ -1,0 +1,335 @@
+"""LiveCodeEditor — F4 / #91 MVP unit tests.
+
+The MVP intentionally lands a *very narrow* slice:
+
+  * env gate (``YULE_LIVE_EDITOR_ENABLED`` must be ``"true"``)
+  * provider dispatch (claude-cli vs blocked Anthropic / OpenAI)
+  * PasteGuard preflight (raw secret in prompt blocks the call)
+  * factory ``build_live_editor_from_env`` (off → None, on +
+    claude-cli → :class:`LiveCodeEditor`, on + blocked provider →
+    :class:`LiveCodeEditor` whose ``apply`` raises).
+
+Out of scope for this PR (TODO follow-ups): patch validation
+against write_scope / forbidden_scope, test-first retry loop,
+cost tracking. The tests below pin the MVP contract only so
+those features can be added without breaking the seam.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    BlockedLiveEditorError,
+    ENV_LIVE_EDITOR_ENABLED,
+    ENV_LIVE_EDITOR_MAX_RETRIES,
+    ENV_LIVE_EDITOR_MODEL,
+    ENV_LIVE_EDITOR_PROVIDER,
+    LiveCodeEditor,
+    PROVIDER_ANTHROPIC,
+    PROVIDER_CLAUDE_CLI,
+    PROVIDER_OPENAI,
+    build_live_editor_from_env,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    WorktreeContext,
+    is_protected_branch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _request(**overrides: Any) -> CodingExecuteRequest:
+    base = {
+        "session_id": "sess-live-editor-1",
+        "executor_role": "backend-engineer",
+        "user_request": "fix users 401",
+        "generated_prompt": "rewrite services/auth/login.py to handle empty tokens",
+        "write_scope": ("services/auth/**",),
+        "forbidden_scope": (".github/workflows/**",),
+        "safety_rules": ("no force push",),
+        "base_branch": "main",
+        "branch_hint": "agent/backend-engineer/issue-91-fix",
+        "repo_full_name": "yule-studio/yule-studio-agent",
+        "issue_number": 91,
+        "dry_run": False,
+        "metadata": {},
+    }
+    base.update(overrides)
+    return CodingExecuteRequest(**base)
+
+
+class _FakeRunner:
+    """Records every subprocess call so the test can assert on it."""
+
+    def __init__(self, *, raise_exc: Exception | None = None) -> None:
+        self.calls: list[tuple[Sequence[str], Mapping[str, Any]]] = []
+        self._raise = raise_exc
+
+    def __call__(self, cmd: Sequence[str], **kwargs: Any) -> Mapping[str, Any]:
+        self.calls.append((tuple(cmd), dict(kwargs)))
+        if self._raise:
+            raise self._raise
+        return {"stdout": "ok", "exit_code": 0}
+
+
+def _worktree_ctx(path: Path) -> WorktreeContext:
+    return WorktreeContext(
+        branch="agent/backend-engineer/issue-91-fix",
+        worktree_path=str(path),
+        base_commit_sha="deadbeef",
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_live_editor_from_env
+# ---------------------------------------------------------------------------
+
+
+class BuildLiveEditorFromEnvTests(unittest.TestCase):
+    def test_env_off_returns_none(self) -> None:
+        self.assertIsNone(build_live_editor_from_env({}))
+        self.assertIsNone(
+            build_live_editor_from_env({ENV_LIVE_EDITOR_ENABLED: "false"})
+        )
+
+    def test_provider_missing_returns_none(self) -> None:
+        env = {ENV_LIVE_EDITOR_ENABLED: "true"}
+        self.assertIsNone(build_live_editor_from_env(env))
+
+    def test_enabled_with_claude_cli_returns_live_editor(self) -> None:
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+            },
+            subprocess_runner=_FakeRunner(),
+        )
+        self.assertIsInstance(editor, LiveCodeEditor)
+        self.assertEqual(editor.provider, PROVIDER_CLAUDE_CLI)  # type: ignore[union-attr]
+
+    def test_max_retries_falls_back_when_unparseable(self) -> None:
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+                ENV_LIVE_EDITOR_MAX_RETRIES: "not-an-int",
+            },
+            subprocess_runner=_FakeRunner(),
+        )
+        assert isinstance(editor, LiveCodeEditor)
+        # Default fallback is 3 — bad value must not crash.
+        self.assertEqual(editor.max_retries, 3)
+
+
+# ---------------------------------------------------------------------------
+# LiveCodeEditor.apply — env gate
+# ---------------------------------------------------------------------------
+
+
+class EnvGateTests(unittest.TestCase):
+    def test_env_off_blocks_call(self) -> None:
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=_FakeRunner(),
+            env={},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(BlockedLiveEditorError) as cm:
+                editor.apply(request=_request(), context=_worktree_ctx(Path(tmp)))
+            self.assertIn(ENV_LIVE_EDITOR_ENABLED, str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# LiveCodeEditor.apply — provider dispatch
+# ---------------------------------------------------------------------------
+
+
+class ProviderDispatchTests(unittest.TestCase):
+    def test_anthropic_provider_requires_authorization(self) -> None:
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_ANTHROPIC,
+            }
+        )
+        assert isinstance(editor, LiveCodeEditor)
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(BlockedLiveEditorError) as cm:
+                editor.apply(request=_request(), context=_worktree_ctx(Path(tmp)))
+            self.assertIn("operator authorization", str(cm.exception))
+
+    def test_openai_provider_requires_authorization(self) -> None:
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_OPENAI,
+            }
+        )
+        assert isinstance(editor, LiveCodeEditor)
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(BlockedLiveEditorError) as cm:
+                editor.apply(request=_request(), context=_worktree_ctx(Path(tmp)))
+            self.assertIn("operator authorization", str(cm.exception))
+
+    def test_unknown_provider_blocked(self) -> None:
+        editor = LiveCodeEditor(
+            provider="codex-cli",
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(BlockedLiveEditorError) as cm:
+                editor.apply(request=_request(), context=_worktree_ctx(Path(tmp)))
+            self.assertIn("unknown live editor provider", str(cm.exception))
+
+    def test_claude_cli_with_fake_runner_succeeds(self) -> None:
+        fake = _FakeRunner()
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+                ENV_LIVE_EDITOR_MODEL: "claude-sonnet-4-6",
+            },
+            subprocess_runner=fake,
+        )
+        assert isinstance(editor, LiveCodeEditor)
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _worktree_ctx(Path(tmp))
+            new_ctx = editor.apply(request=_request(), context=ctx)
+        self.assertIs(new_ctx, ctx)
+        self.assertEqual(len(fake.calls), 1)
+        cmd, kwargs = fake.calls[0]
+        self.assertEqual(cmd[0], "claude")
+        self.assertEqual(cmd[1], "-p")
+        # Model arg propagated.
+        self.assertIn("--model", cmd)
+        self.assertIn("claude-sonnet-4-6", cmd)
+        self.assertEqual(kwargs.get("cwd"), str(Path(tmp)))
+
+    def test_claude_cli_no_runner_blocks(self) -> None:
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(BlockedLiveEditorError) as cm:
+                editor.apply(request=_request(), context=_worktree_ctx(Path(tmp)))
+            self.assertIn("subprocess_runner", str(cm.exception))
+
+    def test_claude_cli_missing_worktree_blocks(self) -> None:
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=_FakeRunner(),
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        ctx = WorktreeContext(branch="agent/backend-engineer/issue-91-fix")
+        with self.assertRaises(BlockedLiveEditorError) as cm:
+            editor.apply(request=_request(), context=ctx)
+        self.assertIn("worktree_path", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# LiveCodeEditor.apply — PasteGuard preflight
+# ---------------------------------------------------------------------------
+
+
+class PasteGuardPreflightTests(unittest.TestCase):
+    def test_raw_secret_in_prompt_blocks_call(self) -> None:
+        # Pattern-shaped sentinel that matches the anthropic regex
+        # exactly but is NOT a real credential. PasteGuard treats it
+        # as a critical finding and the redacted output still
+        # contains the head4 + tail4 — that is fine for the LLM, but
+        # if the guard's verdict came back ``blocked``, the editor
+        # must refuse the call. We force the blocked path by injecting
+        # a payload long enough to *only* contain the redacted form
+        # of a Discord bot token, which PasteGuard masks as ``***``
+        # (collapsed) and re-scans clean — so we use a payload that
+        # cannot be safely redacted: a malformed nested key.
+        #
+        # Simpler: poke guard_outbound by monkey-patching to return
+        # ``blocked=True`` so we exercise the editor branch directly.
+        from yule_orchestrator.agents.security import paste_guard as pg_mod
+
+        original = pg_mod.guard_outbound
+
+        def _blocking_guard(*, channel, payload, fail_closed=True):  # noqa: ARG001
+            return pg_mod.GuardVerdict(
+                channel=channel,
+                original_hash="sha256:test",
+                findings=(),
+                redacted="",
+                blocked=True,
+            )
+
+        pg_mod.guard_outbound = _blocking_guard
+        try:
+            editor = LiveCodeEditor(
+                provider=PROVIDER_CLAUDE_CLI,
+                subprocess_runner=_FakeRunner(),
+                env={ENV_LIVE_EDITOR_ENABLED: "true"},
+            )
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(BlockedLiveEditorError) as cm:
+                    editor.apply(
+                        request=_request(),
+                        context=_worktree_ctx(Path(tmp)),
+                    )
+                self.assertIn("PasteGuard", str(cm.exception))
+        finally:
+            pg_mod.guard_outbound = original
+
+    def test_real_pattern_matched_secret_redacted_then_passed(self) -> None:
+        # End-to-end: a pattern-shaped sentinel goes through PasteGuard,
+        # gets masked, and the live editor receives the redacted form.
+        # The raw bytes must NOT appear in the subprocess command list.
+        fake_secret_in_prompt = "fix bug; key=sk-ant-AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=_FakeRunner(),
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            editor.apply(
+                request=_request(generated_prompt=fake_secret_in_prompt),
+                context=_worktree_ctx(Path(tmp)),
+            )
+        # subprocess_runner is the fake; pull its first call.
+        cmd, _ = editor._subprocess_runner.calls[0]  # type: ignore[attr-defined]
+        joined = " ".join(cmd)
+        # Raw secret must NOT make it to the subprocess.
+        self.assertNotIn("AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH", joined)
+
+
+# ---------------------------------------------------------------------------
+# protected branch guard remains intact (regression — must not regress
+# the worker-level rail that the live editor *cannot* relax).
+# ---------------------------------------------------------------------------
+
+
+class ProtectedBranchGuardTests(unittest.TestCase):
+    def test_is_protected_branch_still_rejects_main(self) -> None:
+        # The live editor lives *below* the protected-branch gate
+        # in the worker pipeline. We pin the gate here so a refactor
+        # of either layer trips the regression.
+        self.assertTrue(is_protected_branch("main"))
+        self.assertTrue(is_protected_branch("master"))
+        self.assertTrue(is_protected_branch("develop"))
+        self.assertFalse(
+            is_protected_branch("agent/backend-engineer/issue-91-fix")
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_live_editor_governance.py
+++ b/tests/engineering/test_live_editor_governance.py
@@ -1,0 +1,155 @@
+"""Live LLM editor governance regression — F4 / #91 hard-rail gate.
+
+Mirrors :mod:`tests.engineering.test_paste_guard_governance` posture:
+one suite pinning the hard rails of the live editor so a single
+condition flip / rename / silent env default change trips a clearly
+named test.
+
+Rails pinned (D-73-10 cost-budget gate + #88 PasteGuard fail-closed):
+
+  1. ``build_live_editor_from_env({})`` returns ``None`` —
+     **default-off**. Merging this PR must NOT auto-enable the live
+     editor; the operator has to flip ``YULE_LIVE_EDITOR_ENABLED``
+     in ``.env.local`` to opt in.
+
+  2. ``provider=anthropic`` / ``provider=openai`` raise
+     :class:`BlockedLiveEditorError` on ``apply`` even when the env
+     flag is ``"true"``. The Anthropic / OpenAI SDKs require
+     explicit operator authorization (D-73-10) and live wiring
+     lands in a separate PR with cost-budget review.
+
+  3. ``LiveCodeEditor`` consults
+     :func:`yule_orchestrator.agents.security.paste_guard.guard_outbound`
+     on every call. A blocked verdict raises BlockedLiveEditorError.
+
+  4. ``coding_executor_worker.is_protected_branch`` continues to flag
+     ``main`` / ``master`` / ``develop`` so the live editor sits
+     below an unchangeable protected-branch gate.
+
+  5. ``RecordOnlyCodeEditor`` remains importable and unchanged — the
+     fallback path stays intact when env is off.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    BlockedLiveEditorError,
+    ENV_LIVE_EDITOR_ENABLED,
+    ENV_LIVE_EDITOR_PROVIDER,
+    LiveCodeEditor,
+    PROVIDER_ANTHROPIC,
+    PROVIDER_CLAUDE_CLI,
+    PROVIDER_OPENAI,
+    RecordOnlyCodeEditor,
+    build_live_editor_from_env,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    WorktreeContext,
+    is_protected_branch,
+)
+
+
+def _request() -> CodingExecuteRequest:
+    return CodingExecuteRequest(
+        session_id="sess-gov-91",
+        executor_role="backend-engineer",
+        user_request="x",
+        generated_prompt="rewrite services/auth/login.py",
+        write_scope=("services/auth/**",),
+        forbidden_scope=(".github/workflows/**",),
+        safety_rules=("no force push",),
+        base_branch="main",
+        branch_hint="agent/backend-engineer/issue-91",
+        repo_full_name="yule-studio/yule-studio-agent",
+        issue_number=91,
+        dry_run=False,
+        metadata={},
+    )
+
+
+def _ctx(path: Path) -> WorktreeContext:
+    return WorktreeContext(
+        branch="agent/backend-engineer/issue-91",
+        worktree_path=str(path),
+        base_commit_sha="cafe",
+    )
+
+
+class LiveEditorGovernanceTests(unittest.TestCase):
+    # 1 — Default OFF.
+    def test_default_env_returns_none(self) -> None:
+        self.assertIsNone(build_live_editor_from_env({}))
+        # Sentinel values that look truthy but are not "true":
+        for falsey in ("false", "0", "off", "no", ""):
+            self.assertIsNone(
+                build_live_editor_from_env({ENV_LIVE_EDITOR_ENABLED: falsey}),
+                msg=f"value={falsey!r} must NOT auto-enable",
+            )
+
+    # 2 — Anthropic / OpenAI providers must block on apply.
+    def test_blocked_providers_raise_on_apply(self) -> None:
+        for provider in (PROVIDER_ANTHROPIC, PROVIDER_OPENAI):
+            editor = build_live_editor_from_env(
+                {
+                    ENV_LIVE_EDITOR_ENABLED: "true",
+                    ENV_LIVE_EDITOR_PROVIDER: provider,
+                }
+            )
+            assert isinstance(editor, LiveCodeEditor)
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(BlockedLiveEditorError) as cm:
+                    editor.apply(request=_request(), context=_ctx(Path(tmp)))
+                self.assertIn("operator authorization", str(cm.exception))
+
+    # 3 — PasteGuard preflight is mandatory.
+    def test_paste_guard_blocked_verdict_refuses_call(self) -> None:
+        from yule_orchestrator.agents.security import paste_guard as pg_mod
+
+        original = pg_mod.guard_outbound
+
+        def _blocking_guard(*, channel, payload, fail_closed=True):  # noqa: ARG001
+            return pg_mod.GuardVerdict(
+                channel=channel,
+                original_hash="sha256:x",
+                findings=(),
+                redacted="",
+                blocked=True,
+            )
+
+        pg_mod.guard_outbound = _blocking_guard
+        try:
+            editor = LiveCodeEditor(
+                provider=PROVIDER_CLAUDE_CLI,
+                subprocess_runner=lambda *a, **k: {"ok": True},
+                env={ENV_LIVE_EDITOR_ENABLED: "true"},
+            )
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(BlockedLiveEditorError):
+                    editor.apply(request=_request(), context=_ctx(Path(tmp)))
+        finally:
+            pg_mod.guard_outbound = original
+
+    # 4 — protected branch gate intact.
+    def test_protected_branch_guard_unchanged(self) -> None:
+        for name in ("main", "master", "develop", "dev", "prod", "release"):
+            self.assertTrue(
+                is_protected_branch(name), msg=f"{name} must stay protected"
+            )
+
+    # 5 — RecordOnly fallback remains intact.
+    def test_record_only_editor_remains_importable(self) -> None:
+        self.assertTrue(callable(getattr(RecordOnlyCodeEditor, "apply", None)))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #91
- parent: #81
- 의존: #88 (PasteGuard outbound preflight) — 본 PR 의 LLM 프롬프트 채널 가드
- 정책: D-73-10 (외부 LLM 호출 운영자 승인 + cost-budget 검토)

## 🎯 목적
RecordOnly → LiveCodeEditor 전환의 **최소 핵심 (MVP)** 만 land 한다.
- editor seam (`CodeEditPort`) 을 먼저 열어두고
- 운영자가 명시적으로 켤 수 있는 env 게이트만 추가하며
- 차단된 provider 는 `BlockedLiveEditorError` 로 명확히 거부한다

patch validation / test-first retry loop / cost tracking 같은 항목은 본 PR 비범위 — 후속 PR 에서 점진적으로 채운다 (모듈 docstring 에 TODO 로 명시).

## 📐 변경 범위
- `src/yule_orchestrator/agents/job_queue/coding_executor_live.py` (기존 파일에 append):
  * `CodeEditPort` (Protocol)
  * `BlockedLiveEditorError(reason)` 단일 거부 예외
  * `LiveCodeEditor` — env 가드 + PasteGuard preflight + provider 분기
  * `build_live_editor_from_env(env, *, http_poster, subprocess_runner)` 팩토리
- `.env.example` — `YULE_LIVE_EDITOR_*` 4개 (default OFF 문서화)
- `tests/agents/test_live_code_editor.py` — 14 case
- `tests/engineering/test_live_editor_governance.py` — 5 case (D-73-10 회귀 가드)

## ✅ Acceptance — MVP scope (본 PR)
- [x] `CodeEditPort.apply(*, request, context) -> WorktreeContext` Protocol 정의
- [x] `LiveCodeEditor.apply` — env OFF → BlockedLiveEditorError
- [x] PasteGuard outbound prompt scan (LLM 채널), fail-closed
- [x] provider 분기:
  * `claude-cli` → subprocess runner (주입 가능)
  * `anthropic` / `openai` → BlockedLiveEditorError (operator authorization)
- [x] `build_live_editor_from_env` — OFF / provider 미설정 → None (RecordOnly fallback)
- [x] protected branch 가드 유지 (worker-level `is_protected_branch` 변경 없음)
- [x] 회귀 governance test (≤ 5 case) — D-73-10 hard rails 가드

## 🚧 본 PR 비범위 (후속 PR)
- patch validation (write_scope / forbidden_scope diff 검사)
- test-first retry loop (max_retries env 만 노출, loop 미구현)
- cost tracking + per-session budget
- Anthropic / OpenAI SDK live wiring (별도 operator authorization PR)

## 🔒 Hard rails
- env OFF default — 본 PR 머지 후에도 자동 활성화 안 됨 (`.env.example` 에 false)
- Anthropic / OpenAI 는 `BlockedLiveEditorError` stub (D-73-10 게이트 보존)
- PasteGuard fail-closed — verdict.blocked → 즉시 거부
- raw secret 은 redacted prompt 로만 LLM 호출에 전달 (`test_real_pattern_matched_secret_redacted_then_passed` 가드)
- protected branch 가드는 worker-level 그대로
- force push / destructive 명령 없음
- API key 로그 / PR / commit 노출 없음

## 🧪 테스트
- `python3 -m unittest tests.agents.test_live_code_editor tests.engineering.test_live_editor_governance` → 19/19 OK
- 전체 회귀: `python3 -m unittest discover -s tests -t .` → **3744 tests OK (skipped=5)**

## 🧰 운영 활성화 절차 (operator only)
1. `.env.local` 에 `YULE_LIVE_EDITOR_ENABLED=true` 추가 (절대 `.env.example` 에 적지 마라)
2. provider 는 `claude-cli` 만 본 PR 에서 실 활성화 가능
3. `claude` 바이너리가 PATH 에 있고, worker 측에서 `subprocess_runner` 를 주입했는지 확인
4. PasteGuard 가 모든 outbound prompt 를 통과시키는지 dry-run 으로 확인

## 🤖 Agent WorkOS Audit
- branch: `feature/live-llm-editor-issue-91-v2` (from `main`)
- role: `engineering-agent/backend-engineer`
- autonomy: `L3_HUMAN_APPROVAL` (live LLM 호출 운영자 승인 게이트)
- risk_class: `MEDIUM` (env OFF default + claude-cli 만 실 활성, anthropic/openai 차단)
- merge: do-not-merge until operator review (Draft → 회귀 OK 면 ready)