### PR TITLE
✨ [Feature] F11 Plugin + Agent extension architecture MVP — manifest + registry only

### DIFF
--- a/agents/ai-engineer/manifest.json
+++ b/agents/ai-engineer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "ai-engineer",
+  "name": "AI Engineer",
+  "role": "ai-engineer",
+  "version": "0.1.0",
+  "capabilities": [
+    "prompt-engineering",
+    "model-eval",
+    "retrieval-tuning"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.ai_engineer.v1",
+  "github_app_env_prefix": "GITHUB_APP_AI",
+  "autonomy_level": "supervised",
+  "risk_class": "MEDIUM",
+  "module_path": ""
+}

--- a/agents/backend-engineer/manifest.json
+++ b/agents/backend-engineer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "backend-engineer",
+  "name": "Backend Engineer",
+  "role": "backend-engineer",
+  "version": "0.1.0",
+  "capabilities": [
+    "service-impl",
+    "api-design",
+    "data-model"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.backend_engineer.v1",
+  "github_app_env_prefix": "GITHUB_APP_BACKEND",
+  "autonomy_level": "supervised",
+  "risk_class": "MEDIUM",
+  "module_path": ""
+}

--- a/agents/devops-engineer/manifest.json
+++ b/agents/devops-engineer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "devops-engineer",
+  "name": "DevOps Engineer",
+  "role": "devops-engineer",
+  "version": "0.1.0",
+  "capabilities": [
+    "ci-cd",
+    "infra-config",
+    "release-pipeline"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.devops_engineer.v1",
+  "github_app_env_prefix": "GITHUB_APP_DEVOPS",
+  "autonomy_level": "supervised",
+  "risk_class": "HIGH",
+  "module_path": ""
+}

--- a/agents/frontend-engineer/manifest.json
+++ b/agents/frontend-engineer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "frontend-engineer",
+  "name": "Frontend Engineer",
+  "role": "frontend-engineer",
+  "version": "0.1.0",
+  "capabilities": [
+    "ui-impl",
+    "component-design",
+    "state-management"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.frontend_engineer.v1",
+  "github_app_env_prefix": "GITHUB_APP_FRONTEND",
+  "autonomy_level": "supervised",
+  "risk_class": "MEDIUM",
+  "module_path": ""
+}

--- a/agents/product-designer/manifest.json
+++ b/agents/product-designer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "product-designer",
+  "name": "Product Designer",
+  "role": "product-designer",
+  "version": "0.1.0",
+  "capabilities": [
+    "ux-flow",
+    "wireframe",
+    "design-spec"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.product_designer.v1",
+  "github_app_env_prefix": "GITHUB_APP_DESIGNER",
+  "autonomy_level": "advisory",
+  "risk_class": "LOW",
+  "module_path": ""
+}

--- a/agents/qa-engineer/manifest.json
+++ b/agents/qa-engineer/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "qa-engineer",
+  "name": "QA Engineer",
+  "role": "qa-engineer",
+  "version": "0.1.0",
+  "capabilities": [
+    "test-design",
+    "regression-coverage",
+    "bug-triage"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.qa_engineer.v1",
+  "github_app_env_prefix": "GITHUB_APP_QA",
+  "autonomy_level": "supervised",
+  "risk_class": "MEDIUM",
+  "module_path": ""
+}

--- a/agents/tech-lead/manifest.json
+++ b/agents/tech-lead/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "tech-lead",
+  "name": "Tech Lead",
+  "role": "tech-lead",
+  "version": "0.1.0",
+  "capabilities": [
+    "task-decomposition",
+    "dependency-ordering",
+    "conflict-mediation"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "repo-map"
+  ],
+  "prompt_template_ref": "engineering.tech_lead.v1",
+  "github_app_env_prefix": "GITHUB_APP_TECH_LEAD",
+  "autonomy_level": "advisory",
+  "risk_class": "LOW",
+  "module_path": ""
+}

--- a/plugins/hookify/manifest.json
+++ b/plugins/hookify/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "hookify",
+  "name": "Hookify",
+  "version": "0.1.0",
+  "kind": "learning",
+  "hooks_provided": [
+    "PREFLIGHT",
+    "COMPLETION",
+    "POSTMORTEM"
+  ],
+  "hooks_consumed": [
+    "COMPLETION"
+  ],
+  "env_keys": [
+    "YULE_CACHE_DB_PATH"
+  ],
+  "autonomy_level": "advisory",
+  "paste_guard_required": true,
+  "risk_class": "MEDIUM",
+  "module_path": "yule_orchestrator.agents.learning.mistake_ledger"
+}

--- a/plugins/paste-guard/manifest.json
+++ b/plugins/paste-guard/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "paste-guard",
+  "name": "PasteGuard",
+  "version": "0.1.0",
+  "kind": "guard",
+  "hooks_provided": [
+    "OUTBOUND_LLM",
+    "OUTBOUND_DISCORD",
+    "OUTBOUND_GITHUB",
+    "OUTBOUND_VAULT"
+  ],
+  "hooks_consumed": [],
+  "env_keys": [],
+  "autonomy_level": "supervised",
+  "paste_guard_required": false,
+  "risk_class": "HIGH",
+  "module_path": "yule_orchestrator.agents.security.paste_guard"
+}

--- a/plugins/repo-map/manifest.json
+++ b/plugins/repo-map/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "repo-map",
+  "name": "RepoMap",
+  "version": "0.1.0",
+  "kind": "exploration",
+  "hooks_provided": [
+    "PREFLIGHT"
+  ],
+  "hooks_consumed": [],
+  "env_keys": [],
+  "autonomy_level": "advisory",
+  "paste_guard_required": true,
+  "risk_class": "LOW",
+  "module_path": "yule_orchestrator.agents.exploration.repo_map"
+}

--- a/src/yule_orchestrator/agents/extension/__init__.py
+++ b/src/yule_orchestrator/agents/extension/__init__.py
@@ -1,0 +1,63 @@
+"""Plugin + Agent extension architecture — manifest & registry layer (F11 / #102).
+
+This package provides the **manifest** and **registry** primitives that let
+plugins (F1/F2/F3 ...) and role-specific agents (tech-lead, backend-engineer,
+...) declare their identity, hooks, and risk surface without binding the
+runtime to specific implementations.
+
+MVP scope (issue #102 — manifest registry only):
+
+  * :class:`PluginManifest` / :class:`AgentManifest` — frozen dataclasses.
+  * :class:`HookEvent` — canonical enum of hook points plugins may
+    provide / consume.
+  * :func:`load_plugin_manifest_from_dict` / :func:`load_agent_manifest_from_dict`
+    — pure dict -> manifest factories. The caller is responsible for any
+    file I/O (JSON / YAML), keeping this module dependency-free.
+  * :func:`validate_plugin_manifest` / :func:`validate_agent_manifest` —
+    pure functions that raise :class:`ManifestValidationError` when a
+    manifest is malformed (unknown risk class, unknown hook name, bad
+    module path, ...).
+  * :class:`PluginRegistry` / :class:`AgentRegistry` — in-memory registries
+    used by the engineering-agent runtime to look up plugins by hook and
+    agents by role.
+
+Out of scope (follow-up PRs):
+
+  * HookChain invocation (manifests describe hooks; chain runtime is
+    deliberately not yet implemented).
+  * Manifest auto-discovery / loader from filesystem (caller registers
+    manually for now).
+  * F4 .. F10 manifests (kept out to avoid in-flight scope creep).
+"""
+
+from .manifest import (
+    AgentManifest,
+    HookEvent,
+    ManifestValidationError,
+    PluginManifest,
+    RISK_CLASSES,
+    AUTONOMY_LEVELS,
+    PLUGIN_KINDS,
+    load_agent_manifest_from_dict,
+    load_plugin_manifest_from_dict,
+    validate_agent_manifest,
+    validate_plugin_manifest,
+)
+from .plugin_registry import PluginRegistry
+from .agent_registry import AgentRegistry
+
+__all__ = [
+    "AgentManifest",
+    "AgentRegistry",
+    "AUTONOMY_LEVELS",
+    "HookEvent",
+    "ManifestValidationError",
+    "PLUGIN_KINDS",
+    "PluginManifest",
+    "PluginRegistry",
+    "RISK_CLASSES",
+    "load_agent_manifest_from_dict",
+    "load_plugin_manifest_from_dict",
+    "validate_agent_manifest",
+    "validate_plugin_manifest",
+]

--- a/src/yule_orchestrator/agents/extension/agent_registry.py
+++ b/src/yule_orchestrator/agents/extension/agent_registry.py
@@ -1,0 +1,66 @@
+"""In-memory agent registry (F11 / #102 MVP).
+
+An :class:`AgentRegistry` is the deterministic lookup the engineering
+runtime uses to resolve a role slug (``tech-lead``, ``backend-engineer``,
+...) into one or more :class:`~yule_orchestrator.agents.extension.manifest.AgentManifest`
+records.
+
+The registry is intentionally minimal:
+
+  * Manifests are registered explicitly (no auto-discovery).
+  * Each registered agent is keyed by ``manifest.id``; multiple agents
+    may share the same ``role`` (e.g. a "qa-engineer-v2" successor),
+    so :meth:`agents_for_role` returns a tuple.
+  * No plugin / module import happens here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+from .manifest import AgentManifest, validate_agent_manifest
+
+
+class AgentRegistry:
+    """Stores :class:`AgentManifest` records keyed by id."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, AgentManifest] = {}
+
+    def register(self, manifest: AgentManifest) -> None:
+        """Register an agent manifest. Re-registering the same id raises."""
+
+        validate_agent_manifest(manifest)
+        if manifest.id in self._agents:
+            raise ValueError(f"agent '{manifest.id}' is already registered")
+        self._agents[manifest.id] = manifest
+
+    def get(self, agent_id: str) -> AgentManifest:
+        """Return the manifest for ``agent_id`` or raise :class:`KeyError`."""
+
+        if agent_id not in self._agents:
+            raise KeyError(f"agent '{agent_id}' is not registered")
+        return self._agents[agent_id]
+
+    def agents_for_role(self, role: str) -> Tuple[AgentManifest, ...]:
+        """Return all manifests whose ``role`` matches, sorted by id."""
+
+        if not isinstance(role, str):
+            raise TypeError("role must be a string")
+        matching = [m for m in self._agents.values() if m.role == role]
+        matching.sort(key=lambda m: m.id)
+        return tuple(matching)
+
+    def all(self) -> Tuple[AgentManifest, ...]:
+        """Return every registered agent manifest, sorted by id."""
+
+        return tuple(sorted(self._agents.values(), key=lambda m: m.id))
+
+    def __contains__(self, agent_id: object) -> bool:
+        return isinstance(agent_id, str) and agent_id in self._agents
+
+    def __len__(self) -> int:
+        return len(self._agents)
+
+    def __iter__(self) -> Iterable[AgentManifest]:
+        return iter(self.all())

--- a/src/yule_orchestrator/agents/extension/manifest.py
+++ b/src/yule_orchestrator/agents/extension/manifest.py
@@ -1,0 +1,317 @@
+"""Plugin / Agent manifest dataclasses + validation (F11 / #102 MVP).
+
+A *manifest* describes the static surface of a plugin or a role-specific
+agent: identity, version, hook points, env keys, autonomy level, and risk
+class. The runtime never executes a plugin / agent without first parsing
+its manifest, so the rules here are intentionally strict.
+
+Hard rails (regression-tested):
+
+  * ``module_path`` must be a dotted Python identifier path — never a
+    filesystem path. The actual import happens elsewhere (lazily, only
+    after a registry lookup); this module *never* imports the target.
+  * ``risk_class`` must be one of :data:`RISK_CLASSES`.
+  * ``autonomy_level`` must be one of :data:`AUTONOMY_LEVELS`.
+  * ``kind`` (plugin) must be one of :data:`PLUGIN_KINDS`.
+  * ``hooks_provided`` / ``hooks_consumed`` entries must be valid
+    :class:`HookEvent` names.
+  * Manifests are :func:`dataclasses.dataclass(frozen=True)` — they are
+    pure data, never mutated post-load.
+
+The loaders accept a plain ``dict`` (typically produced by ``json.load``
+or a YAML library at the caller's discretion) so this module stays
+free of optional third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Tuple
+
+
+class ManifestValidationError(ValueError):
+    """Raised when a manifest payload is malformed or violates a hard rail."""
+
+
+class HookEvent(enum.Enum):
+    """Canonical hook points the engineering-agent runtime will fire.
+
+    The set is deliberately small and append-only — adding a new hook
+    is a governance-level change because plugins may bind to it and the
+    runtime must guarantee fire ordering.
+    """
+
+    PREFLIGHT = "preflight"
+    OUTBOUND_LLM = "outbound_llm"
+    OUTBOUND_DISCORD = "outbound_discord"
+    OUTBOUND_GITHUB = "outbound_github"
+    OUTBOUND_VAULT = "outbound_vault"
+    COMPLETION = "completion"
+    POSTMORTEM = "postmortem"
+
+
+#: Risk taxonomy a manifest must declare. ``HIGH`` is reserved for plugins
+#: that touch outbound payloads, secrets, or credentials.
+RISK_CLASSES: Tuple[str, ...] = ("LOW", "MEDIUM", "HIGH")
+
+#: Autonomy levels mirror the engineering-agent autonomy ladder.
+AUTONOMY_LEVELS: Tuple[str, ...] = (
+    "advisory",
+    "supervised",
+    "autonomous",
+)
+
+#: Plugin kinds — the runtime uses this to decide which surface the
+#: plugin attaches to. Append-only.
+PLUGIN_KINDS: Tuple[str, ...] = (
+    "guard",
+    "learning",
+    "exploration",
+    "observability",
+    "delivery",
+)
+
+
+_MODULE_PATH_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def _hook_names() -> Tuple[str, ...]:
+    return tuple(member.name for member in HookEvent)
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Static description of a plugin (F1 / F2 / F3 / ...).
+
+    Fields:
+      id: machine-stable identifier (kebab-case, ASCII).
+      name: human-readable display name.
+      version: semver-ish ``MAJOR.MINOR.PATCH[-pre|+build]``.
+      kind: one of :data:`PLUGIN_KINDS`.
+      hooks_provided: hook names this plugin implements.
+      hooks_consumed: hook names this plugin subscribes to (read-only).
+      env_keys: env var keys the plugin reads at runtime.
+      autonomy_level: minimum autonomy level required to run this plugin.
+      paste_guard_required: whether outbound payloads must pass through
+        PasteGuard before this plugin is invoked.
+      risk_class: one of :data:`RISK_CLASSES`.
+      module_path: dotted Python import path. **Never** loaded by this
+        module — recorded for later lazy import by the runtime.
+    """
+
+    id: str
+    name: str
+    version: str
+    kind: str
+    hooks_provided: Tuple[str, ...] = field(default_factory=tuple)
+    hooks_consumed: Tuple[str, ...] = field(default_factory=tuple)
+    env_keys: Tuple[str, ...] = field(default_factory=tuple)
+    autonomy_level: str = "advisory"
+    paste_guard_required: bool = True
+    risk_class: str = "LOW"
+    module_path: str = ""
+
+
+@dataclass(frozen=True)
+class AgentManifest:
+    """Static description of a role-specific agent.
+
+    Fields:
+      id: machine-stable identifier (kebab-case, ASCII).
+      name: human-readable display name.
+      role: canonical role slug (``tech-lead``, ``backend-engineer`` ...).
+      version: semver-ish version string.
+      capabilities: free-form tags the runtime uses to match a request
+        against an agent (informational; not part of routing today).
+      plugins_required: plugin ids that must be registered for this
+        agent to be usable.
+      prompt_template_ref: opaque identifier pointing at the prompt
+        template the agent expects (resolved elsewhere).
+      github_app_env_prefix: env var prefix for the role's GitHub App
+        credentials (multi-bot env keys land via #87 / .env.example).
+      autonomy_level: one of :data:`AUTONOMY_LEVELS`.
+      risk_class: one of :data:`RISK_CLASSES`.
+      module_path: dotted Python import path for the agent entrypoint.
+    """
+
+    id: str
+    name: str
+    role: str
+    version: str
+    capabilities: Tuple[str, ...] = field(default_factory=tuple)
+    plugins_required: Tuple[str, ...] = field(default_factory=tuple)
+    prompt_template_ref: str = ""
+    github_app_env_prefix: str = ""
+    autonomy_level: str = "advisory"
+    risk_class: str = "LOW"
+    module_path: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Dict -> manifest loaders
+# --------------------------------------------------------------------------- #
+
+
+def _require_mapping(payload: Any, what: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ManifestValidationError(f"{what} payload must be a mapping, got {type(payload).__name__}")
+    return payload
+
+
+def _str_tuple(value: Any, field_name: str) -> Tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str) or not hasattr(value, "__iter__"):
+        raise ManifestValidationError(f"{field_name} must be a list of strings")
+    out = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ManifestValidationError(f"{field_name} entries must be strings, got {type(item).__name__}")
+        out.append(item)
+    return tuple(out)
+
+
+def _required_str(payload: Mapping[str, Any], key: str, what: str) -> str:
+    if key not in payload:
+        raise ManifestValidationError(f"{what} missing required field '{key}'")
+    value = payload[key]
+    if not isinstance(value, str) or not value:
+        raise ManifestValidationError(f"{what} field '{key}' must be a non-empty string")
+    return value
+
+
+def load_plugin_manifest_from_dict(payload: Any) -> PluginManifest:
+    """Build a :class:`PluginManifest` from a dict-like payload.
+
+    The caller is responsible for any file I/O. Validation is performed
+    eagerly via :func:`validate_plugin_manifest` so a returned manifest
+    is always well-formed.
+    """
+
+    data = _require_mapping(payload, "plugin manifest")
+    manifest = PluginManifest(
+        id=_required_str(data, "id", "plugin manifest"),
+        name=_required_str(data, "name", "plugin manifest"),
+        version=_required_str(data, "version", "plugin manifest"),
+        kind=_required_str(data, "kind", "plugin manifest"),
+        hooks_provided=_str_tuple(data.get("hooks_provided"), "hooks_provided"),
+        hooks_consumed=_str_tuple(data.get("hooks_consumed"), "hooks_consumed"),
+        env_keys=_str_tuple(data.get("env_keys"), "env_keys"),
+        autonomy_level=data.get("autonomy_level", "advisory"),
+        paste_guard_required=bool(data.get("paste_guard_required", True)),
+        risk_class=data.get("risk_class", "LOW"),
+        module_path=data.get("module_path", ""),
+    )
+    validate_plugin_manifest(manifest)
+    return manifest
+
+
+def load_agent_manifest_from_dict(payload: Any) -> AgentManifest:
+    """Build an :class:`AgentManifest` from a dict-like payload."""
+
+    data = _require_mapping(payload, "agent manifest")
+    manifest = AgentManifest(
+        id=_required_str(data, "id", "agent manifest"),
+        name=_required_str(data, "name", "agent manifest"),
+        role=_required_str(data, "role", "agent manifest"),
+        version=_required_str(data, "version", "agent manifest"),
+        capabilities=_str_tuple(data.get("capabilities"), "capabilities"),
+        plugins_required=_str_tuple(data.get("plugins_required"), "plugins_required"),
+        prompt_template_ref=data.get("prompt_template_ref", ""),
+        github_app_env_prefix=data.get("github_app_env_prefix", ""),
+        autonomy_level=data.get("autonomy_level", "advisory"),
+        risk_class=data.get("risk_class", "LOW"),
+        module_path=data.get("module_path", ""),
+    )
+    validate_agent_manifest(manifest)
+    return manifest
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+def _validate_module_path(value: str, what: str) -> None:
+    # Empty module path is permitted for manifest-only registrations
+    # (the runtime fails later if it tries to import an empty path).
+    if value == "":
+        return
+    if not _MODULE_PATH_RE.match(value):
+        raise ManifestValidationError(
+            f"{what} module_path '{value}' must be a dotted Python identifier path"
+        )
+
+
+def _validate_id(value: str, what: str) -> None:
+    if not _ID_RE.match(value):
+        raise ManifestValidationError(
+            f"{what} id '{value}' must be kebab-case ASCII (^[a-z0-9][a-z0-9_-]{{0,63}}$)"
+        )
+
+
+def _validate_version(value: str, what: str) -> None:
+    if not _VERSION_RE.match(value):
+        raise ManifestValidationError(
+            f"{what} version '{value}' must be MAJOR.MINOR.PATCH[-pre|+build]"
+        )
+
+
+def _validate_hook_names(names: Tuple[str, ...], what: str, field_name: str) -> None:
+    valid = set(_hook_names())
+    for name in names:
+        if name not in valid:
+            raise ManifestValidationError(
+                f"{what} {field_name} contains unknown hook '{name}'. "
+                f"Valid hooks: {sorted(valid)}"
+            )
+
+
+def validate_plugin_manifest(manifest: PluginManifest) -> None:
+    """Raise :class:`ManifestValidationError` if the plugin manifest is invalid."""
+
+    if not isinstance(manifest, PluginManifest):
+        raise ManifestValidationError("validate_plugin_manifest expects a PluginManifest")
+    _validate_id(manifest.id, "plugin manifest")
+    _validate_version(manifest.version, "plugin manifest")
+    if manifest.kind not in PLUGIN_KINDS:
+        raise ManifestValidationError(
+            f"plugin manifest kind '{manifest.kind}' must be one of {PLUGIN_KINDS}"
+        )
+    if manifest.risk_class not in RISK_CLASSES:
+        raise ManifestValidationError(
+            f"plugin manifest risk_class '{manifest.risk_class}' must be one of {RISK_CLASSES}"
+        )
+    if manifest.autonomy_level not in AUTONOMY_LEVELS:
+        raise ManifestValidationError(
+            f"plugin manifest autonomy_level '{manifest.autonomy_level}' must be one of {AUTONOMY_LEVELS}"
+        )
+    _validate_hook_names(manifest.hooks_provided, "plugin manifest", "hooks_provided")
+    _validate_hook_names(manifest.hooks_consumed, "plugin manifest", "hooks_consumed")
+    _validate_module_path(manifest.module_path, "plugin manifest")
+
+
+def validate_agent_manifest(manifest: AgentManifest) -> None:
+    """Raise :class:`ManifestValidationError` if the agent manifest is invalid."""
+
+    if not isinstance(manifest, AgentManifest):
+        raise ManifestValidationError("validate_agent_manifest expects an AgentManifest")
+    _validate_id(manifest.id, "agent manifest")
+    _validate_version(manifest.version, "agent manifest")
+    if manifest.risk_class not in RISK_CLASSES:
+        raise ManifestValidationError(
+            f"agent manifest risk_class '{manifest.risk_class}' must be one of {RISK_CLASSES}"
+        )
+    if manifest.autonomy_level not in AUTONOMY_LEVELS:
+        raise ManifestValidationError(
+            f"agent manifest autonomy_level '{manifest.autonomy_level}' must be one of {AUTONOMY_LEVELS}"
+        )
+    if not manifest.role or not _ID_RE.match(manifest.role):
+        raise ManifestValidationError(
+            f"agent manifest role '{manifest.role}' must be kebab-case ASCII"
+        )
+    _validate_module_path(manifest.module_path, "agent manifest")

--- a/src/yule_orchestrator/agents/extension/plugin_registry.py
+++ b/src/yule_orchestrator/agents/extension/plugin_registry.py
@@ -1,0 +1,74 @@
+"""In-memory plugin registry (F11 / #102 MVP).
+
+A :class:`PluginRegistry` is a thin, deterministic lookup over a set of
+:class:`~yule_orchestrator.agents.extension.manifest.PluginManifest`
+records. It is the *only* surface the engineering-agent runtime should
+use to discover plugins by id or by hook event.
+
+Design rails:
+
+  * Registration is explicit — there is no filesystem auto-discovery
+    in this MVP. Callers register manifests after loading them from
+    JSON / YAML.
+  * The registry never imports the plugin's module. ``module_path``
+    is recorded for later lazy import by a HookChain runtime that is
+    out of scope here.
+  * Lookups are deterministic and return tuples (immutable snapshots),
+    so callers can iterate without risking mid-iteration mutation.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+from .manifest import HookEvent, PluginManifest, validate_plugin_manifest
+
+
+class PluginRegistry:
+    """Stores :class:`PluginManifest` records keyed by id."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, PluginManifest] = {}
+
+    def register(self, manifest: PluginManifest) -> None:
+        """Register a manifest. Re-registering the same id is an error."""
+
+        validate_plugin_manifest(manifest)
+        if manifest.id in self._plugins:
+            raise ValueError(f"plugin '{manifest.id}' is already registered")
+        self._plugins[manifest.id] = manifest
+
+    def get(self, plugin_id: str) -> PluginManifest:
+        """Return the manifest for ``plugin_id`` or raise :class:`KeyError`."""
+
+        if plugin_id not in self._plugins:
+            raise KeyError(f"plugin '{plugin_id}' is not registered")
+        return self._plugins[plugin_id]
+
+    def plugins_for_hook(self, hook: HookEvent) -> Tuple[PluginManifest, ...]:
+        """Return all manifests that *provide* ``hook``, sorted by id.
+
+        Hooks plugins merely *consume* are intentionally excluded — the
+        runtime needs the providers when it builds a chain.
+        """
+
+        if not isinstance(hook, HookEvent):
+            raise TypeError("plugins_for_hook expects a HookEvent enum member")
+        name = hook.name
+        matching = [m for m in self._plugins.values() if name in m.hooks_provided]
+        matching.sort(key=lambda m: m.id)
+        return tuple(matching)
+
+    def all(self) -> Tuple[PluginManifest, ...]:
+        """Return every registered manifest, sorted by id (test helper)."""
+
+        return tuple(sorted(self._plugins.values(), key=lambda m: m.id))
+
+    def __contains__(self, plugin_id: object) -> bool:
+        return isinstance(plugin_id, str) and plugin_id in self._plugins
+
+    def __len__(self) -> int:
+        return len(self._plugins)
+
+    def __iter__(self) -> Iterable[PluginManifest]:
+        return iter(self.all())

--- a/tests/agents/test_agent_registry.py
+++ b/tests/agents/test_agent_registry.py
@@ -1,0 +1,90 @@
+"""AgentRegistry tests (F11 / #102 MVP)."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.agent_registry import AgentRegistry
+from yule_orchestrator.agents.extension.manifest import AgentManifest
+
+
+def _make(agent_id: str, role: str | None = None) -> AgentManifest:
+    return AgentManifest(
+        id=agent_id,
+        name=agent_id.title(),
+        role=role or agent_id,
+        version="0.1.0",
+        capabilities=(),
+        plugins_required=(),
+        prompt_template_ref="",
+        github_app_env_prefix="",
+        autonomy_level="advisory",
+        risk_class="LOW",
+        module_path="",
+    )
+
+
+class AgentRegistryTests(unittest.TestCase):
+    def test_register_and_get_round_trip(self) -> None:
+        reg = AgentRegistry()
+        m = _make("tech-lead")
+        reg.register(m)
+        self.assertIs(reg.get("tech-lead"), m)
+        self.assertIn("tech-lead", reg)
+        self.assertEqual(len(reg), 1)
+
+    def test_get_missing_raises_key_error(self) -> None:
+        reg = AgentRegistry()
+        with self.assertRaises(KeyError):
+            reg.get("nope")
+
+    def test_duplicate_registration_raises(self) -> None:
+        reg = AgentRegistry()
+        reg.register(_make("tech-lead"))
+        with self.assertRaises(ValueError):
+            reg.register(_make("tech-lead"))
+
+    def test_agents_for_role_collects_multiple(self) -> None:
+        reg = AgentRegistry()
+        reg.register(_make("backend-engineer-v1", role="backend-engineer"))
+        reg.register(_make("backend-engineer-v2", role="backend-engineer"))
+        reg.register(_make("tech-lead"))
+        backend = reg.agents_for_role("backend-engineer")
+        self.assertEqual([m.id for m in backend], ["backend-engineer-v1", "backend-engineer-v2"])
+
+    def test_agents_for_role_returns_empty_tuple_for_unknown(self) -> None:
+        reg = AgentRegistry()
+        reg.register(_make("tech-lead"))
+        self.assertEqual(reg.agents_for_role("unknown-role"), ())
+
+    def test_agents_for_role_requires_string(self) -> None:
+        reg = AgentRegistry()
+        with self.assertRaises(TypeError):
+            reg.agents_for_role(42)  # type: ignore[arg-type]
+
+    def test_register_validates_manifest(self) -> None:
+        reg = AgentRegistry()
+        bogus = AgentManifest(
+            id="tech-lead",
+            name="x",
+            role="Not Kebab",
+            version="0.1.0",
+            module_path="",
+        )
+        with self.assertRaises(Exception):
+            reg.register(bogus)
+
+    def test_all_is_sorted_by_id(self) -> None:
+        reg = AgentRegistry()
+        reg.register(_make("zeta"))
+        reg.register(_make("alpha"))
+        self.assertEqual([m.id for m in reg.all()], ["alpha", "zeta"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_extension_manifest.py
+++ b/tests/agents/test_extension_manifest.py
@@ -1,0 +1,152 @@
+"""Manifest dataclass + validation tests (F11 / #102 MVP)."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.manifest import (
+    AUTONOMY_LEVELS,
+    AgentManifest,
+    HookEvent,
+    ManifestValidationError,
+    PLUGIN_KINDS,
+    PluginManifest,
+    RISK_CLASSES,
+    load_agent_manifest_from_dict,
+    load_plugin_manifest_from_dict,
+    validate_agent_manifest,
+    validate_plugin_manifest,
+)
+
+
+_VALID_PLUGIN_DICT = {
+    "id": "paste-guard",
+    "name": "PasteGuard",
+    "version": "0.1.0",
+    "kind": "guard",
+    "hooks_provided": ["OUTBOUND_LLM", "OUTBOUND_DISCORD"],
+    "hooks_consumed": [],
+    "env_keys": [],
+    "autonomy_level": "supervised",
+    "paste_guard_required": False,
+    "risk_class": "HIGH",
+    "module_path": "yule_orchestrator.agents.security.paste_guard",
+}
+
+_VALID_AGENT_DICT = {
+    "id": "tech-lead",
+    "name": "Tech Lead",
+    "role": "tech-lead",
+    "version": "0.1.0",
+    "capabilities": ["task-decomposition"],
+    "plugins_required": ["paste-guard"],
+    "prompt_template_ref": "engineering.tech_lead.v1",
+    "github_app_env_prefix": "GITHUB_APP_TECH_LEAD",
+    "autonomy_level": "advisory",
+    "risk_class": "LOW",
+    "module_path": "",
+}
+
+
+class HookEventTests(unittest.TestCase):
+    def test_canonical_hook_set(self) -> None:
+        expected = {
+            "PREFLIGHT",
+            "OUTBOUND_LLM",
+            "OUTBOUND_DISCORD",
+            "OUTBOUND_GITHUB",
+            "OUTBOUND_VAULT",
+            "COMPLETION",
+            "POSTMORTEM",
+        }
+        self.assertEqual({m.name for m in HookEvent}, expected)
+
+
+class PluginManifestLoaderTests(unittest.TestCase):
+    def test_load_from_dict_returns_frozen_dataclass(self) -> None:
+        manifest = load_plugin_manifest_from_dict(dict(_VALID_PLUGIN_DICT))
+        self.assertIsInstance(manifest, PluginManifest)
+        with self.assertRaises(Exception):
+            manifest.id = "mutated"  # type: ignore[misc]
+        self.assertEqual(manifest.hooks_provided, ("OUTBOUND_LLM", "OUTBOUND_DISCORD"))
+        self.assertEqual(manifest.risk_class, "HIGH")
+
+    def test_load_rejects_non_mapping(self) -> None:
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(["not", "a", "dict"])
+
+    def test_load_rejects_missing_required(self) -> None:
+        payload = dict(_VALID_PLUGIN_DICT)
+        del payload["kind"]
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(payload)
+
+    def test_load_rejects_unknown_hook(self) -> None:
+        payload = dict(_VALID_PLUGIN_DICT)
+        payload["hooks_provided"] = ["NOT_A_HOOK"]
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(payload)
+
+    def test_load_rejects_bad_module_path(self) -> None:
+        payload = dict(_VALID_PLUGIN_DICT)
+        payload["module_path"] = "path/with/slash.py"
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(payload)
+
+    def test_load_rejects_unknown_kind(self) -> None:
+        payload = dict(_VALID_PLUGIN_DICT)
+        payload["kind"] = "wizardry"
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(payload)
+
+    def test_load_rejects_unknown_risk_class(self) -> None:
+        payload = dict(_VALID_PLUGIN_DICT)
+        payload["risk_class"] = "CATASTROPHIC"
+        with self.assertRaises(ManifestValidationError):
+            load_plugin_manifest_from_dict(payload)
+
+
+class AgentManifestLoaderTests(unittest.TestCase):
+    def test_load_from_dict_returns_frozen_dataclass(self) -> None:
+        manifest = load_agent_manifest_from_dict(dict(_VALID_AGENT_DICT))
+        self.assertIsInstance(manifest, AgentManifest)
+        with self.assertRaises(Exception):
+            manifest.role = "renamed"  # type: ignore[misc]
+        self.assertEqual(manifest.plugins_required, ("paste-guard",))
+        self.assertEqual(manifest.role, "tech-lead")
+
+    def test_load_rejects_bad_role(self) -> None:
+        payload = dict(_VALID_AGENT_DICT)
+        payload["role"] = "Not Kebab"
+        with self.assertRaises(ManifestValidationError):
+            load_agent_manifest_from_dict(payload)
+
+    def test_load_rejects_bad_version(self) -> None:
+        payload = dict(_VALID_AGENT_DICT)
+        payload["version"] = "v1"
+        with self.assertRaises(ManifestValidationError):
+            load_agent_manifest_from_dict(payload)
+
+
+class ValidationDirectTests(unittest.TestCase):
+    def test_validate_plugin_rejects_wrong_type(self) -> None:
+        with self.assertRaises(ManifestValidationError):
+            validate_plugin_manifest("not-a-manifest")  # type: ignore[arg-type]
+
+    def test_validate_agent_rejects_wrong_type(self) -> None:
+        with self.assertRaises(ManifestValidationError):
+            validate_agent_manifest("not-a-manifest")  # type: ignore[arg-type]
+
+    def test_constants_are_exhaustive(self) -> None:
+        self.assertIn("HIGH", RISK_CLASSES)
+        self.assertIn("supervised", AUTONOMY_LEVELS)
+        self.assertIn("guard", PLUGIN_KINDS)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_plugin_registry.py
+++ b/tests/agents/test_plugin_registry.py
@@ -1,0 +1,93 @@
+"""PluginRegistry tests (F11 / #102 MVP)."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.manifest import HookEvent, PluginManifest
+from yule_orchestrator.agents.extension.plugin_registry import PluginRegistry
+
+
+def _make(plugin_id: str, hooks_provided=()) -> PluginManifest:
+    return PluginManifest(
+        id=plugin_id,
+        name=plugin_id.title(),
+        version="0.1.0",
+        kind="guard",
+        hooks_provided=tuple(hooks_provided),
+        hooks_consumed=(),
+        env_keys=(),
+        autonomy_level="advisory",
+        paste_guard_required=True,
+        risk_class="LOW",
+        module_path="",
+    )
+
+
+class PluginRegistryTests(unittest.TestCase):
+    def test_register_and_get_round_trip(self) -> None:
+        reg = PluginRegistry()
+        m = _make("paste-guard", ("OUTBOUND_LLM",))
+        reg.register(m)
+        self.assertIs(reg.get("paste-guard"), m)
+        self.assertIn("paste-guard", reg)
+        self.assertEqual(len(reg), 1)
+
+    def test_get_missing_raises_key_error(self) -> None:
+        reg = PluginRegistry()
+        with self.assertRaises(KeyError):
+            reg.get("nope")
+
+    def test_duplicate_registration_raises(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_make("paste-guard", ("OUTBOUND_LLM",)))
+        with self.assertRaises(ValueError):
+            reg.register(_make("paste-guard", ("OUTBOUND_LLM",)))
+
+    def test_plugins_for_hook_returns_providers_only(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_make("paste-guard", ("OUTBOUND_LLM", "OUTBOUND_DISCORD")))
+        reg.register(_make("hookify", ("PREFLIGHT",)))
+        reg.register(_make("repo-map", ("PREFLIGHT",)))
+        outbound = reg.plugins_for_hook(HookEvent.OUTBOUND_LLM)
+        self.assertEqual([m.id for m in outbound], ["paste-guard"])
+        preflight = reg.plugins_for_hook(HookEvent.PREFLIGHT)
+        self.assertEqual([m.id for m in preflight], ["hookify", "repo-map"])
+
+    def test_plugins_for_hook_requires_hook_event(self) -> None:
+        reg = PluginRegistry()
+        with self.assertRaises(TypeError):
+            reg.plugins_for_hook("PREFLIGHT")  # type: ignore[arg-type]
+
+    def test_register_validates_manifest(self) -> None:
+        reg = PluginRegistry()
+        bogus = PluginManifest(
+            id="BAD ID",
+            name="x",
+            version="0.1.0",
+            kind="guard",
+            module_path="",
+        )
+        with self.assertRaises(Exception):
+            reg.register(bogus)
+
+    def test_all_is_sorted_by_id(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_make("zeta"))
+        reg.register(_make("alpha"))
+        self.assertEqual([m.id for m in reg.all()], ["alpha", "zeta"])
+
+    def test_contains_handles_non_string(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_make("paste-guard"))
+        self.assertFalse(123 in reg)
+        self.assertTrue("paste-guard" in reg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_extension_governance.py
+++ b/tests/engineering/test_extension_governance.py
@@ -1,0 +1,114 @@
+"""Governance tests for F11 / #102 — plugin + agent manifest catalogue.
+
+These regression tests enforce two hard rails on the *shipped* manifest
+catalogue (the JSON files under ``plugins/`` and ``agents/``):
+
+  1. Every role in the 7-role engineering team has a manifest file and
+     the manifest's ``role`` matches its directory name.
+  2. Any plugin manifest whose ``risk_class`` is ``HIGH`` must declare
+     it explicitly (no silent default) — catching the case where a
+     reviewer accidentally drops the field on a sensitive plugin like
+     PasteGuard.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.manifest import (
+    load_agent_manifest_from_dict,
+    load_plugin_manifest_from_dict,
+)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PLUGINS_DIR = _REPO_ROOT / "plugins"
+_AGENTS_DIR = _REPO_ROOT / "agents"
+
+_EXPECTED_ROLES = (
+    "tech-lead",
+    "backend-engineer",
+    "frontend-engineer",
+    "qa-engineer",
+    "devops-engineer",
+    "ai-engineer",
+    "product-designer",
+)
+
+_HIGH_RISK_PLUGIN_IDS = ("paste-guard",)
+
+
+def _read_manifest_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+class ExtensionGovernanceTests(unittest.TestCase):
+    def test_seven_role_agent_manifests_exist(self) -> None:
+        for role in _EXPECTED_ROLES:
+            manifest_path = _AGENTS_DIR / role / "manifest.json"
+            self.assertTrue(
+                manifest_path.is_file(),
+                f"missing agent manifest for role '{role}' at {manifest_path}",
+            )
+
+    def test_agent_manifest_role_matches_directory(self) -> None:
+        for role in _EXPECTED_ROLES:
+            payload = _read_manifest_json(_AGENTS_DIR / role / "manifest.json")
+            manifest = load_agent_manifest_from_dict(payload)
+            self.assertEqual(
+                manifest.role,
+                role,
+                f"agents/{role}/manifest.json role mismatch: {manifest.role!r}",
+            )
+
+    def test_three_seed_plugin_manifests_load(self) -> None:
+        for plugin_id in ("paste-guard", "hookify", "repo-map"):
+            payload = _read_manifest_json(_PLUGINS_DIR / plugin_id / "manifest.json")
+            manifest = load_plugin_manifest_from_dict(payload)
+            self.assertEqual(manifest.id, plugin_id)
+
+    def test_high_risk_plugins_declare_risk_explicitly(self) -> None:
+        for plugin_id in _HIGH_RISK_PLUGIN_IDS:
+            raw = _read_manifest_json(_PLUGINS_DIR / plugin_id / "manifest.json")
+            self.assertEqual(
+                raw.get("risk_class"),
+                "HIGH",
+                f"plugin '{plugin_id}' must declare risk_class=HIGH explicitly",
+            )
+
+    def test_no_extra_role_directories_without_manifest(self) -> None:
+        for entry in sorted(_AGENTS_DIR.iterdir()):
+            if not entry.is_dir():
+                continue
+            if entry.name not in _EXPECTED_ROLES:
+                continue
+            self.assertTrue(
+                (entry / "manifest.json").is_file(),
+                f"role dir '{entry.name}' exists but has no manifest.json",
+            )
+
+    def test_paste_guard_provides_all_outbound_hooks(self) -> None:
+        payload = _read_manifest_json(_PLUGINS_DIR / "paste-guard" / "manifest.json")
+        manifest = load_plugin_manifest_from_dict(payload)
+        self.assertEqual(
+            set(manifest.hooks_provided),
+            {
+                "OUTBOUND_LLM",
+                "OUTBOUND_DISCORD",
+                "OUTBOUND_GITHUB",
+                "OUTBOUND_VAULT",
+            },
+            "PasteGuard must guard every outbound channel",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- F11 / #102 의 **MVP**: PluginManifest / AgentManifest frozen dataclass + HookEvent enum + 검증 + 두 in-memory Registry (`PluginRegistry`, `AgentRegistry`).
- F1 / F2 / F3 시드 plugin manifest 3종 + 7 역할 agent manifest 7종 (JSON, 외부 의존 회피).
- 회귀 게이트 4종 — manifest dict → dataclass 매트릭스, registry 동작, 거버넌스 (7 역할 manifest 존재 / PasteGuard HIGH risk 명시 강제).

## Scope
포함:
- `src/yule_orchestrator/agents/extension/{manifest,plugin_registry,agent_registry,__init__}.py`
- `plugins/{paste-guard,hookify,repo-map}/manifest.json`
- `agents/{tech-lead,backend-engineer,frontend-engineer,qa-engineer,devops-engineer,ai-engineer,product-designer}/manifest.json`
- `tests/agents/test_extension_manifest.py`, `tests/agents/test_plugin_registry.py`, `tests/agents/test_agent_registry.py`, `tests/engineering/test_extension_governance.py`

비포함 (후속 PR):
- HookChain invoke 실행 런타임
- manifest 자동 discovery / loader
- F4 ~ F10 plugin manifest
- `docs/policies/extension-architecture.md` 정책 문서
- example-marketing-agent 데모

## Hard rails
- 본 PR 은 manifest 만 land — 실제 hook 실행 안 함
- 외부 import lazy: `module_path` 는 기록만 하고 본 PR 코드는 plugin 모듈을 import 하지 않음
- YAML 의존 회피 — 표준 라이브러리 `json` 만 사용
- `paste-guard` plugin 의 `risk_class: HIGH` 는 거버넌스 테스트로 명시 강제
- branch / risk: **MEDIUM** (read-only manifest + registry)

## Test plan
- [x] `python3 -m unittest tests.agents.test_extension_manifest tests.agents.test_plugin_registry tests.agents.test_agent_registry tests.engineering.test_extension_governance` — 36/36 OK
- [x] `python3 -m unittest discover -s tests -t .` — 3761 OK (skipped=5), 회귀 깨짐 없음

## Follow-ups
- HookChain invoke 구현 (manifest → 런타임 chain)
- manifest 자동 discovery loader (`plugins/` / `agents/` 디렉터리 스캔)
- F4 ~ F10 plugin manifest 추가
- 정책 문서 (`docs/policies/extension-architecture.md`)

refs #102 (HookChain / loader / 정책 문서가 남아 본 PR 은 close 가 아닌 refs)