### PR TITLE
✨ [Feature] F12 Auto-mode risk classifier — pre-tool-call gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,3 +319,27 @@ DISCORD_GUILD_ID=
 # 그대로 재사용한다. 셋이 모두 채워지지 않으면 ProviderAvailability.MISSING_ENV
 # 로 떨어져 fake 로 폴백한다.
 # YULE_KNOWLEDGE_GITHUB_API_REPO_ACTIVITY_LIVE_ENABLED=false
+
+# =====================================================================
+# F12 / #103 — Tool-call risk gate (pre-tool-call 안전 가드)
+#
+# `src/yule_orchestrator/agents/safety/tool_call_gate.py` 는 모든 tool call
+# (subprocess / 외부 HTTP / file write / git operation) 직전에 risk class 를
+# 분류하고 autonomy × RiskClass 매트릭스에 따라 ALLOW / REQUIRE_APPROVAL /
+# BLOCK 을 결정한다. PasteGuard 와 layer 가 다르다 — PasteGuard 는
+# outbound payload 의 secret 제거를 담당하고, 본 gate 는 *실행 결정* 만
+# 담당한다.
+#
+# 운영 정책:
+#   - 본 가드는 *항상 ON* 이 default. 안전 우선이며 `.env.example` 에는
+#     플래그를 명시하지 않아도 동작한다.
+#   - `false` 로 끄면 회로가 transparent 하게 ALLOW 를 반환하지만,
+#     ``warnings.warn`` 으로 명시적 경고를 띄우며 governance test 가
+#     OFF 상태를 감지한다 — 운영자 책임 하에서만 사용.
+#   - autonomy 미지정 시 ``L2_autonomous_record`` 가 default.
+#     L0_manual_only / L1_advisory / L2_autonomous_record /
+#     L3_human_approval / L4_full_autonomous 5단계 중 하나로 셋업.
+#   - CRITICAL 등급은 어떤 autonomy 에서도 BLOCK — env 로 우회 불가
+#     (governance test 가 보호).
+# YULE_TOOL_GATE_ENABLED=true
+# YULE_TOOL_GATE_DEFAULT_AUTONOMY=L2_autonomous_record

--- a/src/yule_orchestrator/agents/safety/__init__.py
+++ b/src/yule_orchestrator/agents/safety/__init__.py
@@ -1,0 +1,58 @@
+"""Safety agent layer — pre-tool-call risk gate (F12 / #103).
+
+This package houses the *tool-call* axis of the safety stack. It is
+intentionally a different layer from
+:mod:`yule_orchestrator.agents.security.paste_guard`:
+
+  * :mod:`paste_guard` runs on *outbound payloads* (LLM prompts,
+    Discord posts, GitHub comments, Vault writes). It scrubs the
+    bytes before they leave the agent process.
+  * :mod:`risk_classifier` + :mod:`tool_call_gate` run on *tool
+    calls* (subprocess / external HTTP / file write / git
+    operation) before the tool actually fires. The gate decides
+    ``ALLOW`` / ``REQUIRE_APPROVAL`` / ``BLOCK`` based on the
+    autonomy level of the caller.
+
+Both gates can be active at the same time on the same operation
+(e.g. a git push touches the tool-call gate first, then any
+PR-body / discord-summary it produces still has to pass through
+PasteGuard). They do not share state — each enforces its own
+hard rails.
+
+Public API:
+
+  * :class:`RiskClass`, :class:`ToolCallContext`,
+    :class:`RiskSignal`, :func:`classify_tool_call`
+  * :class:`GateAction`, :class:`ToolGateVerdict`,
+    :func:`gate_tool_call`
+  * :data:`ENV_TOOL_GATE_ENABLED`,
+    :data:`ENV_TOOL_GATE_DEFAULT_AUTONOMY` — env knobs the gate
+    reads at call time.
+"""
+
+from .risk_classifier import (
+    RiskClass,
+    RiskSignal,
+    ToolCallContext,
+    classify_tool_call,
+)
+from .tool_call_gate import (
+    ENV_TOOL_GATE_DEFAULT_AUTONOMY,
+    ENV_TOOL_GATE_ENABLED,
+    GateAction,
+    ToolGateVerdict,
+    gate_tool_call,
+)
+
+
+__all__ = (
+    "ENV_TOOL_GATE_DEFAULT_AUTONOMY",
+    "ENV_TOOL_GATE_ENABLED",
+    "GateAction",
+    "RiskClass",
+    "RiskSignal",
+    "ToolCallContext",
+    "ToolGateVerdict",
+    "classify_tool_call",
+    "gate_tool_call",
+)

--- a/src/yule_orchestrator/agents/safety/risk_classifier.py
+++ b/src/yule_orchestrator/agents/safety/risk_classifier.py
@@ -1,0 +1,398 @@
+"""Static risk classifier for individual tool calls (F12 / #103).
+
+Tool calls are *atomic actions the agent can perform on the world*:
+reading a file, running a unit test, opening an external HTTP
+connection, committing to git, force-pushing to a protected
+branch, etc. The classifier inspects a :class:`ToolCallContext`
+and returns one of five :class:`RiskClass` levels plus the
+:class:`RiskSignal` evidence list that drove the decision.
+
+Design contract:
+
+  * **Deterministic and pure** — same ``ToolCallContext`` →
+    same ``(RiskClass, signals)``. No I/O, no clock, no env
+    reads. This is what lets the gate layer (``tool_call_gate``)
+    sit on top of it without re-running side-effecty logic.
+  * **Static rule catalogue** — the ≥15 rule patterns are
+    enumerated below. New rules append to :data:`_RULES` so the
+    catalogue stays auditable in a single place.
+  * **Vocabulary aligned with F7** — same five names as the F7
+    auto-merge risk class so an operator reading either feed
+    sees one consistent severity ladder
+    (SAFE → LOW → MEDIUM → HIGH → CRITICAL).
+  * **Escalation wins** — multiple matching signals only raise
+    the class, never lower it. CRITICAL signals are absolute.
+
+Hard rails:
+
+  * Protected branch (``main`` / ``master`` / ``develop`` /
+    ``prod``) push always lands at CRITICAL — covered by both
+    ``protected_branch_push`` rule and explicit
+    ``_protected_branch_target`` evidence.
+  * ``rm -rf`` / ``--no-verify`` / ``force push`` /
+    ``git reset --hard`` / sandbox-disable shapes all land at
+    CRITICAL even when other signals look benign.
+  * Unknown tool ids default to MEDIUM (not SAFE) — an unknown
+    surface should be treated as if it can touch real state until
+    the catalogue learns it.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Callable, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# RiskClass
+# ---------------------------------------------------------------------------
+
+
+class RiskClass(str, enum.Enum):
+    """Severity ladder for tool calls.
+
+    Same names as the F7 (#98) auto-merge :class:`RiskClass` —
+    the alignment is intentional so operator-facing surfaces show
+    one vocabulary across both axes (PR-level vs. tool-call-level).
+    """
+
+    SAFE = "SAFE"
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+_CLASS_ORDER = {
+    RiskClass.SAFE: 0,
+    RiskClass.LOW: 1,
+    RiskClass.MEDIUM: 2,
+    RiskClass.HIGH: 3,
+    RiskClass.CRITICAL: 4,
+}
+
+
+def _max_class(a: RiskClass, b: RiskClass) -> RiskClass:
+    return a if _CLASS_ORDER[a] >= _CLASS_ORDER[b] else b
+
+
+# ---------------------------------------------------------------------------
+# Context + signal dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolCallContext:
+    """Snapshot of one tool call before it fires.
+
+    ``tool_id`` is the canonical short identifier (``git_push``,
+    ``read_file``, ``external_http_fetch``, ...). ``target`` is
+    the primary subject of the call — a file path, a branch
+    name, a URL, depending on the tool. ``args`` carries
+    additional positional arguments as a tuple of strings so the
+    classifier can pattern-match on them (e.g. ``rm`` with
+    ``-rf`` flag → CRITICAL).
+    """
+
+    tool_id: str
+    target: str = ""
+    args: Tuple[str, ...] = ()
+    role: str = ""
+    session_id: str = ""
+    autonomy_level: str = ""
+
+    def normalised_tool_id(self) -> str:
+        return (self.tool_id or "").strip().lower()
+
+    def normalised_target(self) -> str:
+        return (self.target or "").strip()
+
+    def normalised_args(self) -> Tuple[str, ...]:
+        return tuple(str(arg or "") for arg in self.args or ())
+
+
+@dataclass(frozen=True)
+class RiskSignal:
+    """One piece of evidence that contributed to the verdict.
+
+    ``weight`` is the :class:`RiskClass` this signal pushes the
+    overall verdict toward. ``evidence`` is a short, redaction-
+    safe string suitable for audit logs (it must never echo
+    secrets — callers already pass non-sensitive identifiers).
+    """
+
+    name: str
+    weight: RiskClass
+    evidence: str
+
+
+# ---------------------------------------------------------------------------
+# Rule catalogue
+# ---------------------------------------------------------------------------
+
+
+# Protected branches that must never accept a direct push.
+_PROTECTED_BRANCHES: frozenset[str] = frozenset(
+    {"main", "master", "develop", "release", "prod", "production"}
+)
+
+
+# Tool ids grouped by their baseline risk class. The classifier
+# consults these tables first; downstream rules may *escalate*
+# (e.g. ``edit_file`` is LOW by default but if the target is
+# ``.env.local`` it climbs to HIGH).
+_SAFE_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "read_file",
+        "glob",
+        "grep",
+        "git_status",
+        "git_log",
+        "git_diff",
+        "ls",
+    }
+)
+
+_LOW_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "edit_file",
+        "git_add",
+        "unittest",
+        "pytest",
+    }
+)
+
+_MEDIUM_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "git_commit",
+        "git_branch_create",
+        "new_module_add",
+        "subprocess_within_repo",
+    }
+)
+
+_HIGH_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "git_push",
+        "external_http_fetch",
+        "subprocess_outside_repo",
+        "live_llm_call",
+        "env_local_modify",
+        "secret_decode_attempt",
+    }
+)
+
+_CRITICAL_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "git_reset_hard",
+        "rm_rf",
+        "force_push",
+        "secret_rotation",
+        "protected_branch_push",
+        "dangerouslyDisableSandbox".lower(),
+        "git_no_verify",
+    }
+)
+
+
+def _baseline_for_tool(tool_id: str) -> Tuple[RiskClass, str]:
+    """Map a normalised tool id to its baseline risk class."""
+
+    if tool_id in _SAFE_TOOL_IDS:
+        return RiskClass.SAFE, "tool_id.catalogue.safe"
+    if tool_id in _LOW_TOOL_IDS:
+        return RiskClass.LOW, "tool_id.catalogue.low"
+    if tool_id in _MEDIUM_TOOL_IDS:
+        return RiskClass.MEDIUM, "tool_id.catalogue.medium"
+    if tool_id in _HIGH_TOOL_IDS:
+        return RiskClass.HIGH, "tool_id.catalogue.high"
+    if tool_id in _CRITICAL_TOOL_IDS:
+        return RiskClass.CRITICAL, "tool_id.catalogue.critical"
+    # Unknown surface — default to MEDIUM so the gate at least
+    # asks for approval at L1 / L3 rather than silently allowing.
+    return RiskClass.MEDIUM, "tool_id.unknown.default_medium"
+
+
+# ---------------------------------------------------------------------------
+# Escalation rules
+# ---------------------------------------------------------------------------
+
+
+_DANGEROUS_ARG_FLAGS: Tuple[Tuple[str, RiskClass, str], ...] = (
+    ("--force", RiskClass.CRITICAL, "args.flag.force"),
+    ("-f", RiskClass.HIGH, "args.flag.short_force"),
+    ("--no-verify", RiskClass.CRITICAL, "args.flag.no_verify"),
+    ("--hard", RiskClass.CRITICAL, "args.flag.hard_reset"),
+    ("-rf", RiskClass.CRITICAL, "args.flag.rm_rf"),
+    ("dangerouslydisablesandbox", RiskClass.CRITICAL, "args.flag.sandbox_disable"),
+)
+
+
+_SECRET_KEYWORDS: Tuple[str, ...] = (
+    "secret",
+    "token",
+    "credential",
+    "api_key",
+    "apikey",
+    "private_key",
+)
+
+
+def _matches_protected_branch(target: str) -> bool:
+    if not target:
+        return False
+    candidate = target.strip().lower()
+    if candidate in _PROTECTED_BRANCHES:
+        return True
+    # Allow ``refs/heads/main`` style targets.
+    if candidate.startswith("refs/heads/"):
+        return candidate.rsplit("/", 1)[-1] in _PROTECTED_BRANCHES
+    if candidate.startswith("origin/"):
+        return candidate.split("/", 1)[1] in _PROTECTED_BRANCHES
+    return False
+
+
+def _matches_env_local(target: str) -> bool:
+    if not target:
+        return False
+    lowered = target.strip().lower()
+    return lowered.endswith(".env.local") or lowered.endswith("/.env") or lowered == ".env.local"
+
+
+def _contains_secret_keyword(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(keyword in lowered for keyword in _SECRET_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_tool_call(
+    ctx: ToolCallContext,
+) -> Tuple[RiskClass, Tuple[RiskSignal, ...]]:
+    """Return ``(RiskClass, signals)`` for *ctx*.
+
+    The function is pure: no I/O, no env reads, no clock. The
+    signal list is deterministic and ordered by the order rules
+    fire — first the catalogue baseline, then escalation rules
+    (protected branch / dangerous args / secret keywords).
+    """
+
+    tool_id = ctx.normalised_tool_id()
+    target = ctx.normalised_target()
+    args = ctx.normalised_args()
+
+    signals: list[RiskSignal] = []
+
+    baseline_class, baseline_name = _baseline_for_tool(tool_id)
+    signals.append(
+        RiskSignal(
+            name=baseline_name,
+            weight=baseline_class,
+            evidence=f"tool_id={tool_id or '<empty>'}",
+        )
+    )
+    verdict = baseline_class
+
+    # Rule: protected branch push always climbs to CRITICAL.
+    if tool_id in {"git_push", "force_push", "protected_branch_push"} and (
+        _matches_protected_branch(target)
+        or any(_matches_protected_branch(arg) for arg in args)
+    ):
+        signals.append(
+            RiskSignal(
+                name="rule.protected_branch.push",
+                weight=RiskClass.CRITICAL,
+                evidence=f"target={target or '<args>'}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.CRITICAL)
+
+    # Rule: env.local / .env modifications are HIGH even via the
+    # generic edit_file shape.
+    if tool_id in {"edit_file", "env_local_modify", "write_file"} and _matches_env_local(
+        target
+    ):
+        signals.append(
+            RiskSignal(
+                name="rule.env_local.modify",
+                weight=RiskClass.HIGH,
+                evidence=f"target={target}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+
+    # Rule: dangerous flag combinations regardless of tool id.
+    lowered_args = tuple(arg.lower() for arg in args)
+    for flag, weight, name in _DANGEROUS_ARG_FLAGS:
+        if flag in lowered_args:
+            signals.append(
+                RiskSignal(
+                    name=f"rule.dangerous_flag.{name.rsplit('.', 1)[-1]}",
+                    weight=weight,
+                    evidence=f"flag={flag}",
+                )
+            )
+            verdict = _max_class(verdict, weight)
+
+    # Rule: secret-related keywords in target or args nudge up to
+    # HIGH (or stay CRITICAL if already there).
+    if tool_id == "secret_decode_attempt":
+        # already HIGH via catalogue; still emit explicit signal.
+        signals.append(
+            RiskSignal(
+                name="rule.secret.decode_attempt",
+                weight=RiskClass.HIGH,
+                evidence="tool_id=secret_decode_attempt",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+    elif _contains_secret_keyword(target) or any(
+        _contains_secret_keyword(arg) for arg in args
+    ):
+        signals.append(
+            RiskSignal(
+                name="rule.secret.keyword",
+                weight=RiskClass.HIGH,
+                evidence=f"target_or_args_contains_secret_keyword",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+
+    # Rule: subprocess pointing outside the repo escalates to
+    # HIGH even if the catalogue had it as MEDIUM (e.g. when a
+    # caller mislabels).
+    if tool_id == "subprocess_outside_repo":
+        signals.append(
+            RiskSignal(
+                name="rule.subprocess.outside_repo",
+                weight=RiskClass.HIGH,
+                evidence=f"target={target}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+
+    # Rule: secret rotation — even if caller normalised tool_id
+    # differently, args mentioning rotation are CRITICAL.
+    if tool_id == "secret_rotation" or "secret_rotation" in lowered_args:
+        signals.append(
+            RiskSignal(
+                name="rule.secret.rotation",
+                weight=RiskClass.CRITICAL,
+                evidence="secret_rotation",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.CRITICAL)
+
+    return verdict, tuple(signals)
+
+
+__all__ = (
+    "RiskClass",
+    "RiskSignal",
+    "ToolCallContext",
+    "classify_tool_call",
+)

--- a/src/yule_orchestrator/agents/safety/tool_call_gate.py
+++ b/src/yule_orchestrator/agents/safety/tool_call_gate.py
@@ -1,0 +1,379 @@
+"""Pre-tool-call gate that turns a risk class into an action verdict
+(F12 / #103).
+
+Where :mod:`risk_classifier` answers *"how dangerous is this tool
+call?"*, this module answers *"given the caller's autonomy level,
+should we ALLOW it, REQUIRE_APPROVAL, or BLOCK it?"*. The decision
+is the cross of:
+
+  * :class:`yule_orchestrator.agents.safety.risk_classifier.RiskClass`
+    (SAFE / LOW / MEDIUM / HIGH / CRITICAL)
+  * the autonomy level string carried on
+    :class:`~yule_orchestrator.agents.safety.risk_classifier.ToolCallContext`
+    (L0_manual_only / L1_advisory / L2_autonomous_record /
+    L3_human_approval / L4_full_autonomous)
+
+Hard rails (regression-tested in
+``tests/engineering/test_tool_gate_governance.py``):
+
+  * CRITICAL is ``BLOCK`` for *every* autonomy level. No flag, no
+    env var, no caller-supplied autonomy short-circuits this.
+  * Env switch ``YULE_TOOL_GATE_ENABLED=false`` makes the gate
+    *transparent* (always ALLOW) but emits an explicit
+    :mod:`warnings` warning so a governance test can detect that
+    the safety circuit is bypassed.
+  * Protected branch pushes climb to CRITICAL in the classifier;
+    the gate then blocks them.
+  * BLOCK verdicts register a stable signature
+    (``tool_gate.<risk_class>.blocked``) on the mistake ledger if
+    one was injected, so repeated attempts accumulate the same
+    audit row.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Optional, Tuple
+
+from .risk_classifier import (
+    RiskClass,
+    RiskSignal,
+    ToolCallContext,
+    classify_tool_call,
+)
+
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+
+
+ENV_TOOL_GATE_ENABLED: str = "YULE_TOOL_GATE_ENABLED"
+ENV_TOOL_GATE_DEFAULT_AUTONOMY: str = "YULE_TOOL_GATE_DEFAULT_AUTONOMY"
+
+
+_DEFAULT_AUTONOMY_FALLBACK: str = "L2_autonomous_record"
+
+
+def _env_truthy(value: Optional[str]) -> bool:
+    """Permissive truthy decode (``true`` / ``1`` / ``yes`` / ``on``)."""
+
+    if value is None:
+        return False
+    return value.strip().lower() in {"true", "1", "yes", "on"}
+
+
+def _gate_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """Return whether the gate circuit is active.
+
+    Default is **ON** (safety-first). The gate is considered
+    disabled only when the operator sets
+    ``YULE_TOOL_GATE_ENABLED`` to an explicit falsey value
+    (``false`` / ``0`` / ``no`` / ``off``).
+    """
+
+    src = env if env is not None else os.environ
+    raw = src.get(ENV_TOOL_GATE_ENABLED)
+    if raw is None:
+        return True
+    text = raw.strip().lower()
+    if not text:
+        return True
+    return text in {"true", "1", "yes", "on"}
+
+
+def _resolve_autonomy(
+    ctx_autonomy: str,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Pick the autonomy level for *ctx*.
+
+    Context's own ``autonomy_level`` always wins; falling back to
+    ``YULE_TOOL_GATE_DEFAULT_AUTONOMY`` and finally to
+    ``L2_autonomous_record``.
+    """
+
+    explicit = (ctx_autonomy or "").strip()
+    if explicit:
+        return explicit
+    src = env if env is not None else os.environ
+    configured = (src.get(ENV_TOOL_GATE_DEFAULT_AUTONOMY) or "").strip()
+    if configured:
+        return configured
+    return _DEFAULT_AUTONOMY_FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# Action + verdict dataclasses
+# ---------------------------------------------------------------------------
+
+
+class GateAction(str, enum.Enum):
+    """Decision the gate emits for a single tool call."""
+
+    ALLOW = "ALLOW"
+    REQUIRE_APPROVAL = "REQUIRE_APPROVAL"
+    BLOCK = "BLOCK"
+
+
+@dataclass(frozen=True)
+class ToolGateVerdict:
+    """Outcome of a :func:`gate_tool_call` call.
+
+    ``signatures`` lists the mistake-ledger signatures that
+    *would* be registered for the verdict (the gate only writes
+    them when ``ledger`` is injected — see :func:`gate_tool_call`).
+    """
+
+    risk_class: RiskClass
+    action: GateAction
+    reason: str
+    signatures: Tuple[str, ...] = ()
+    evaluated_at: str = ""
+
+    def is_blocked(self) -> bool:
+        return self.action is GateAction.BLOCK
+
+    def requires_approval(self) -> bool:
+        return self.action is GateAction.REQUIRE_APPROVAL
+
+    def is_allowed(self) -> bool:
+        return self.action is GateAction.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# autonomy × RiskClass matrix
+# ---------------------------------------------------------------------------
+
+
+_R = RiskClass
+_A = GateAction
+
+
+# Each row maps a normalised autonomy key → mapping of RiskClass
+# → GateAction. Normalisation: lowercase, strip whitespace.
+_GATE_MATRIX: Mapping[str, Mapping[RiskClass, GateAction]] = {
+    "l0_manual_only": {
+        _R.SAFE: _A.REQUIRE_APPROVAL,
+        _R.LOW: _A.REQUIRE_APPROVAL,
+        _R.MEDIUM: _A.REQUIRE_APPROVAL,
+        _R.HIGH: _A.REQUIRE_APPROVAL,
+        _R.CRITICAL: _A.BLOCK,
+    },
+    "l1_advisory": {
+        _R.SAFE: _A.ALLOW,
+        _R.LOW: _A.ALLOW,
+        _R.MEDIUM: _A.REQUIRE_APPROVAL,
+        _R.HIGH: _A.REQUIRE_APPROVAL,
+        _R.CRITICAL: _A.BLOCK,
+    },
+    "l2_autonomous_record": {
+        _R.SAFE: _A.ALLOW,
+        _R.LOW: _A.ALLOW,
+        _R.MEDIUM: _A.ALLOW,
+        _R.HIGH: _A.REQUIRE_APPROVAL,
+        _R.CRITICAL: _A.BLOCK,
+    },
+    "l3_human_approval": {
+        _R.SAFE: _A.ALLOW,
+        _R.LOW: _A.REQUIRE_APPROVAL,
+        _R.MEDIUM: _A.REQUIRE_APPROVAL,
+        _R.HIGH: _A.REQUIRE_APPROVAL,
+        _R.CRITICAL: _A.BLOCK,
+    },
+    "l4_full_autonomous": {
+        _R.SAFE: _A.ALLOW,
+        _R.LOW: _A.ALLOW,
+        _R.MEDIUM: _A.ALLOW,
+        _R.HIGH: _A.ALLOW,
+        _R.CRITICAL: _A.BLOCK,
+    },
+}
+
+
+# Short alias map so callers can pass either "L2_autonomous_record"
+# or the bare "L2" — both resolve to the same row. Hard rail: even
+# bare "L4" cannot escape CRITICAL → BLOCK because the matrix row
+# itself carries that mapping.
+_AUTONOMY_ALIASES: Mapping[str, str] = {
+    "l0": "l0_manual_only",
+    "l1": "l1_advisory",
+    "l2": "l2_autonomous_record",
+    "l3": "l3_human_approval",
+    "l4": "l4_full_autonomous",
+}
+
+
+def _normalise_autonomy_key(value: str) -> str:
+    text = (value or "").strip().lower()
+    if not text:
+        return "l2_autonomous_record"
+    if text in _GATE_MATRIX:
+        return text
+    if text in _AUTONOMY_ALIASES:
+        return _AUTONOMY_ALIASES[text]
+    return text  # let the lookup below fall back
+
+
+def _resolve_action(autonomy_key: str, risk: RiskClass) -> Tuple[GateAction, str]:
+    """Resolve a matrix cell, hard-railing CRITICAL → BLOCK."""
+
+    # Hard rail: CRITICAL is BLOCK regardless of autonomy. This
+    # is the single most important invariant of F12 — we encode
+    # it once here so a future matrix edit cannot accidentally
+    # weaken it.
+    if risk is RiskClass.CRITICAL:
+        return GateAction.BLOCK, "hard_rail.critical_always_blocked"
+
+    row = _GATE_MATRIX.get(autonomy_key)
+    if row is None:
+        # Unknown autonomy level — fall back to the strictest sane
+        # default (L0_manual_only) so the gate never accidentally
+        # ALLOWs an action from an unrecognised caller.
+        return (
+            GateAction.REQUIRE_APPROVAL,
+            f"autonomy.unknown.fallback_l0:{autonomy_key}",
+        )
+
+    action = row.get(risk)
+    if action is None:  # pragma: no cover - defensive
+        return (
+            GateAction.REQUIRE_APPROVAL,
+            f"matrix.missing_cell:{autonomy_key}:{risk.value}",
+        )
+    return action, f"matrix.{autonomy_key}.{risk.value}"
+
+
+# ---------------------------------------------------------------------------
+# Gate entry point
+# ---------------------------------------------------------------------------
+
+
+_GATE_DISABLED_WARNING_FORMAT: str = (
+    "YULE tool-call gate is disabled via env "
+    f"{ENV_TOOL_GATE_ENABLED}=false — tool calls are not being "
+    "checked. This is a regression guard surface; expect "
+    "test_tool_gate_governance to flag it."
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _ledger_signature(risk: RiskClass) -> str:
+    return f"tool_gate.{risk.value.lower()}.blocked"
+
+
+def _register_block_signature(
+    *,
+    ledger: Any,
+    risk: RiskClass,
+    ctx: ToolCallContext,
+) -> str:
+    """Best-effort: record a BLOCK on the injected mistake ledger.
+
+    The ledger object must expose ``record_mistake(role=,
+    pattern=, signature=, blocker_level=)`` — that's the
+    public surface of
+    :class:`yule_orchestrator.agents.learning.mistake_ledger.MistakeLedger`.
+    Any other shape (or any exception) is swallowed so a failing
+    ledger never silently leaks into the gate verdict.
+    """
+
+    signature = _ledger_signature(risk)
+    if ledger is None:
+        return signature
+
+    try:
+        # Late import keeps the safety package independent of
+        # learning at import time — the gate only needs the
+        # ``record_mistake`` duck-typed call site.
+        from ..learning.mistake_ledger import BlockerLevel  # noqa: WPS433
+
+        role = (ctx.role or "engineering-agent").strip() or "engineering-agent"
+        pattern = f"tool_call_gate.{risk.value.lower()}"
+        ledger.record_mistake(
+            role=role,
+            pattern=pattern,
+            signature=signature,
+            blocker_level=BlockerLevel.BLOCK,
+        )
+    except Exception:  # noqa: BLE001 - never let the audit leg crash the gate
+        pass
+    return signature
+
+
+def gate_tool_call(
+    ctx: ToolCallContext,
+    *,
+    classifier: Callable[
+        [ToolCallContext], Tuple[RiskClass, Tuple[RiskSignal, ...]]
+    ] = classify_tool_call,
+    ledger: Any = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> ToolGateVerdict:
+    """Run the gate for one tool call.
+
+    Wiring:
+
+      1. If ``YULE_TOOL_GATE_ENABLED`` decodes to false → emit a
+         warning and return a transparent ``(SAFE, ALLOW)``
+         verdict. The reason field cites ``gate disabled`` so
+         downstream audit can tell apart "legitimately SAFE" from
+         "safety circuit bypassed".
+      2. Otherwise classify the call via *classifier*, look up the
+         action in the autonomy × RiskClass matrix, and return a
+         :class:`ToolGateVerdict`.
+      3. If the verdict is BLOCK *and* ``ledger`` is supplied,
+         register the canonical ``tool_gate.<risk_class>.blocked``
+         signature so repeat attempts accumulate.
+    """
+
+    if not _gate_enabled(env=env):
+        warnings.warn(
+            _GATE_DISABLED_WARNING_FORMAT,
+            stacklevel=2,
+        )
+        return ToolGateVerdict(
+            risk_class=RiskClass.SAFE,
+            action=GateAction.ALLOW,
+            reason="gate disabled",
+            signatures=(),
+            evaluated_at=_now_iso(),
+        )
+
+    risk_class, _signals = classifier(ctx)
+    autonomy = _resolve_autonomy(ctx.autonomy_level, env=env)
+    key = _normalise_autonomy_key(autonomy)
+    action, reason = _resolve_action(key, risk_class)
+
+    signatures: Tuple[str, ...] = ()
+    if action is GateAction.BLOCK:
+        sig = _register_block_signature(
+            ledger=ledger,
+            risk=risk_class,
+            ctx=ctx,
+        )
+        signatures = (sig,)
+
+    return ToolGateVerdict(
+        risk_class=risk_class,
+        action=action,
+        reason=reason,
+        signatures=signatures,
+        evaluated_at=_now_iso(),
+    )
+
+
+__all__ = (
+    "ENV_TOOL_GATE_DEFAULT_AUTONOMY",
+    "ENV_TOOL_GATE_ENABLED",
+    "GateAction",
+    "ToolGateVerdict",
+    "gate_tool_call",
+)

--- a/tests/agents/test_risk_classifier.py
+++ b/tests/agents/test_risk_classifier.py
@@ -1,0 +1,240 @@
+"""Unit tests for the F12 / #103 static risk classifier.
+
+Covers the 5 RiskClass levels × catalogue surfaces, the protected
+branch escalation, the dangerous-flag rules, and the secret keyword
+nudge. Pure-function tests — no env reads, no I/O.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.safety.risk_classifier import (
+    RiskClass,
+    RiskSignal,
+    ToolCallContext,
+    classify_tool_call,
+)
+
+
+def _ctx(
+    tool_id: str,
+    *,
+    target: str = "",
+    args=(),
+    role: str = "engineering-agent/devops-engineer",
+) -> ToolCallContext:
+    return ToolCallContext(
+        tool_id=tool_id,
+        target=target,
+        args=tuple(args),
+        role=role,
+        session_id="session-test",
+        autonomy_level="L2_autonomous_record",
+    )
+
+
+class SafeToolMatrixTests(unittest.TestCase):
+    """SAFE-class tool ids — read-only surfaces."""
+
+    def test_read_file_is_safe(self) -> None:
+        risk, signals = classify_tool_call(_ctx("read_file", target="README.md"))
+        self.assertEqual(risk, RiskClass.SAFE)
+        self.assertTrue(any(s.weight is RiskClass.SAFE for s in signals))
+
+    def test_git_status_is_safe(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_status"))
+        self.assertEqual(risk, RiskClass.SAFE)
+
+    def test_git_log_is_safe(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_log"))
+        self.assertEqual(risk, RiskClass.SAFE)
+
+    def test_grep_is_safe(self) -> None:
+        risk, _ = classify_tool_call(_ctx("grep", target="hello"))
+        self.assertEqual(risk, RiskClass.SAFE)
+
+
+class LowToolMatrixTests(unittest.TestCase):
+    """LOW-class tool ids — single edits and tests."""
+
+    def test_edit_file_single_is_low(self) -> None:
+        risk, _ = classify_tool_call(_ctx("edit_file", target="src/foo.py"))
+        self.assertEqual(risk, RiskClass.LOW)
+
+    def test_unittest_runs_low(self) -> None:
+        risk, _ = classify_tool_call(_ctx("unittest"))
+        self.assertEqual(risk, RiskClass.LOW)
+
+    def test_pytest_runs_low(self) -> None:
+        risk, _ = classify_tool_call(_ctx("pytest"))
+        self.assertEqual(risk, RiskClass.LOW)
+
+    def test_git_add_is_low(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_add"))
+        self.assertEqual(risk, RiskClass.LOW)
+
+
+class MediumToolMatrixTests(unittest.TestCase):
+    """MEDIUM-class tool ids — repo-local mutations."""
+
+    def test_git_commit_is_medium(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_commit"))
+        self.assertEqual(risk, RiskClass.MEDIUM)
+
+    def test_git_branch_create_is_medium(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_branch_create", target="feature/x"))
+        self.assertEqual(risk, RiskClass.MEDIUM)
+
+    def test_new_module_add_is_medium(self) -> None:
+        risk, _ = classify_tool_call(_ctx("new_module_add"))
+        self.assertEqual(risk, RiskClass.MEDIUM)
+
+    def test_subprocess_within_repo_is_medium(self) -> None:
+        risk, _ = classify_tool_call(_ctx("subprocess_within_repo"))
+        self.assertEqual(risk, RiskClass.MEDIUM)
+
+    def test_unknown_tool_defaults_to_medium(self) -> None:
+        risk, signals = classify_tool_call(_ctx("totally_new_surface"))
+        self.assertEqual(risk, RiskClass.MEDIUM)
+        self.assertTrue(any("unknown" in s.name for s in signals))
+
+
+class HighToolMatrixTests(unittest.TestCase):
+    """HIGH-class tool ids — external surface / live state."""
+
+    def test_git_push_feature_branch_is_high(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_push", target="feature/foo"))
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_external_http_fetch_is_high(self) -> None:
+        risk, _ = classify_tool_call(
+            _ctx("external_http_fetch", target="https://api.example.com")
+        )
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_live_llm_call_is_high(self) -> None:
+        risk, _ = classify_tool_call(_ctx("live_llm_call"))
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_env_local_modify_via_tool_id_is_high(self) -> None:
+        risk, _ = classify_tool_call(_ctx("env_local_modify"))
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_edit_file_targeting_env_local_escalates_to_high(self) -> None:
+        risk, signals = classify_tool_call(
+            _ctx("edit_file", target=".env.local")
+        )
+        self.assertEqual(risk, RiskClass.HIGH)
+        self.assertTrue(any("env_local" in s.name for s in signals))
+
+    def test_subprocess_outside_repo_is_high(self) -> None:
+        risk, _ = classify_tool_call(_ctx("subprocess_outside_repo"))
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_secret_decode_attempt_is_high(self) -> None:
+        risk, _ = classify_tool_call(_ctx("secret_decode_attempt"))
+        self.assertEqual(risk, RiskClass.HIGH)
+
+
+class CriticalToolMatrixTests(unittest.TestCase):
+    """CRITICAL-class tool ids — destructive / irreversible."""
+
+    def test_git_reset_hard_is_critical(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_reset_hard"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_rm_rf_is_critical(self) -> None:
+        risk, _ = classify_tool_call(_ctx("rm_rf", target="/"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_force_push_is_critical(self) -> None:
+        risk, _ = classify_tool_call(_ctx("force_push", target="feature/foo"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_secret_rotation_is_critical(self) -> None:
+        risk, _ = classify_tool_call(_ctx("secret_rotation"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_no_verify_flag_escalates_to_critical(self) -> None:
+        risk, signals = classify_tool_call(
+            _ctx("git_commit", args=("--no-verify",))
+        )
+        self.assertEqual(risk, RiskClass.CRITICAL)
+        self.assertTrue(any("no_verify" in s.name for s in signals))
+
+    def test_dangerously_disable_sandbox_is_critical(self) -> None:
+        risk, _ = classify_tool_call(_ctx("dangerouslydisablesandbox"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+
+class ProtectedBranchTests(unittest.TestCase):
+    """Hard rail: pushing to a protected branch is always CRITICAL."""
+
+    def test_git_push_main_escalates_to_critical(self) -> None:
+        risk, signals = classify_tool_call(_ctx("git_push", target="main"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+        self.assertTrue(any("protected_branch" in s.name for s in signals))
+
+    def test_git_push_origin_master_escalates(self) -> None:
+        risk, _ = classify_tool_call(_ctx("git_push", target="origin/master"))
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_git_push_refs_heads_develop_escalates(self) -> None:
+        risk, _ = classify_tool_call(
+            _ctx("git_push", target="refs/heads/develop")
+        )
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+    def test_protected_branch_target_via_args(self) -> None:
+        risk, _ = classify_tool_call(
+            _ctx("git_push", target="", args=("origin", "main"))
+        )
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+
+class SecretKeywordTests(unittest.TestCase):
+    """target or args containing secret-like keywords nudges to HIGH."""
+
+    def test_edit_file_with_secret_keyword_target_escalates(self) -> None:
+        risk, signals = classify_tool_call(
+            _ctx("edit_file", target="configs/my_secret.yml")
+        )
+        # Baseline LOW + secret keyword nudge → HIGH.
+        self.assertEqual(risk, RiskClass.HIGH)
+        self.assertTrue(any("secret.keyword" in s.name for s in signals))
+
+    def test_args_with_api_key_escalates(self) -> None:
+        risk, _ = classify_tool_call(
+            _ctx("subprocess_within_repo", args=("dump_api_key",))
+        )
+        self.assertEqual(risk, RiskClass.HIGH)
+
+
+class SignalShapeTests(unittest.TestCase):
+    """Smoke tests on the signal contract itself."""
+
+    def test_signal_dataclass_is_frozen(self) -> None:
+        signal = RiskSignal(name="x", weight=RiskClass.SAFE, evidence="e")
+        with self.assertRaises(Exception):
+            signal.name = "y"  # type: ignore[misc]
+
+    def test_classify_is_pure_deterministic(self) -> None:
+        ctx = _ctx("git_push", target="main")
+        a = classify_tool_call(ctx)
+        b = classify_tool_call(ctx)
+        self.assertEqual(a, b)
+
+    def test_context_dataclass_is_frozen(self) -> None:
+        ctx = _ctx("read_file")
+        with self.assertRaises(Exception):
+            ctx.tool_id = "git_push"  # type: ignore[misc]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_tool_call_gate.py
+++ b/tests/agents/test_tool_call_gate.py
@@ -1,0 +1,395 @@
+"""Unit tests for the F12 / #103 pre-tool-call gate.
+
+The matrix is autonomy × RiskClass → action. The matrix is the
+contract, so we sweep every cell. We also assert:
+
+  * env OFF makes the gate transparent + emits a warning,
+  * BLOCK verdicts register the canonical signature on an
+    injected mistake ledger,
+  * the classifier callback is honoured (so callers can plug a
+    deterministic fake during tests / re-orchestration).
+"""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.safety.risk_classifier import (
+    RiskClass,
+    RiskSignal,
+    ToolCallContext,
+)
+from yule_orchestrator.agents.safety.tool_call_gate import (
+    ENV_TOOL_GATE_DEFAULT_AUTONOMY,
+    ENV_TOOL_GATE_ENABLED,
+    GateAction,
+    ToolGateVerdict,
+    gate_tool_call,
+)
+
+
+def _ctx(autonomy: str, tool_id: str = "read_file", **kwargs) -> ToolCallContext:
+    return ToolCallContext(
+        tool_id=tool_id,
+        target=kwargs.get("target", ""),
+        args=tuple(kwargs.get("args", ())),
+        role=kwargs.get("role", "engineering-agent/devops-engineer"),
+        session_id=kwargs.get("session_id", "session-test"),
+        autonomy_level=autonomy,
+    )
+
+
+def _fake_classifier(risk: RiskClass):
+    """Return a classifier callable that always emits *risk*."""
+
+    def _cls(ctx):
+        return risk, (RiskSignal(name="fake", weight=risk, evidence="fake"),)
+
+    return _cls
+
+
+_ENV_ON = {ENV_TOOL_GATE_ENABLED: "true"}
+
+
+class L0MatrixTests(unittest.TestCase):
+    """L0_manual_only — every non-CRITICAL is REQUIRE_APPROVAL."""
+
+    def test_l0_safe_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L0_manual_only"),
+            classifier=_fake_classifier(RiskClass.SAFE),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l0_low_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L0_manual_only"),
+            classifier=_fake_classifier(RiskClass.LOW),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l0_medium_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L0_manual_only"),
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l0_high_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L0_manual_only"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l0_critical_is_blocked(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L0_manual_only"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class L1MatrixTests(unittest.TestCase):
+    """L1_advisory — SAFE/LOW ALLOW, others gate."""
+
+    def test_l1_safe_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.SAFE),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l1_low_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.LOW),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l1_medium_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l1_high_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l1_critical_is_blocked(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class L2MatrixTests(unittest.TestCase):
+    """L2_autonomous_record — SAFE/LOW/MEDIUM ALLOW, HIGH approve, CRIT block."""
+
+    def test_l2_safe_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.SAFE),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l2_medium_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l2_high_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l2_critical_is_blocked(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class L3MatrixTests(unittest.TestCase):
+    """L3_human_approval — SAFE ALLOW, everything else requires approval."""
+
+    def test_l3_safe_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L3_human_approval"),
+            classifier=_fake_classifier(RiskClass.SAFE),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l3_low_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L3_human_approval"),
+            classifier=_fake_classifier(RiskClass.LOW),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l3_high_requires_approval(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L3_human_approval"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_l3_critical_is_blocked(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L3_human_approval"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class L4MatrixTests(unittest.TestCase):
+    """L4_full_autonomous — non-CRITICAL ALLOW, CRITICAL still BLOCK."""
+
+    def test_l4_high_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L4_full_autonomous"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l4_medium_allows(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L4_full_autonomous"),
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_l4_critical_is_blocked(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L4_full_autonomous"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class EnvSwitchTests(unittest.TestCase):
+    """env OFF makes the gate transparent + warns."""
+
+    def test_env_off_returns_safe_allow(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            verdict = gate_tool_call(
+                _ctx("L0_manual_only"),
+                classifier=_fake_classifier(RiskClass.CRITICAL),
+                env={ENV_TOOL_GATE_ENABLED: "false"},
+            )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+        self.assertEqual(verdict.risk_class, RiskClass.SAFE)
+        self.assertIn("gate disabled", verdict.reason)
+        self.assertTrue(
+            any("disabled" in str(w.message) for w in caught),
+            "env OFF must emit a warning",
+        )
+
+    def test_env_default_is_on(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            env={},  # nothing configured
+        )
+        # ON default → HIGH at L2 → REQUIRE_APPROVAL
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+    def test_env_default_autonomy_used_when_ctx_missing(self) -> None:
+        verdict = gate_tool_call(
+            _ctx(""),  # no autonomy on ctx
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            env={
+                ENV_TOOL_GATE_ENABLED: "true",
+                ENV_TOOL_GATE_DEFAULT_AUTONOMY: "L1_advisory",
+            },
+        )
+        # L1 + MEDIUM → REQUIRE_APPROVAL
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+
+class MistakeLedgerIntegrationTests(unittest.TestCase):
+    """BLOCK verdicts register the canonical signature on a ledger."""
+
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+
+    def tearDown(self) -> None:
+        self.ledger.close()
+
+    def test_block_records_signature(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            ledger=self.ledger,
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+        self.assertEqual(
+            verdict.signatures,
+            ("tool_gate.critical.blocked",),
+        )
+        records = self.ledger.all_records()
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record.signature, "tool_gate.critical.blocked")
+        self.assertEqual(record.blocker_level, BlockerLevel.BLOCK)
+
+    def test_repeated_block_bumps_occurrences(self) -> None:
+        for _ in range(3):
+            gate_tool_call(
+                _ctx("L2_autonomous_record"),
+                classifier=_fake_classifier(RiskClass.CRITICAL),
+                ledger=self.ledger,
+                env=_ENV_ON,
+            )
+        records = self.ledger.all_records()
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].occurrences, 3)
+
+    def test_allow_does_not_touch_ledger(self) -> None:
+        gate_tool_call(
+            _ctx("L4_full_autonomous"),
+            classifier=_fake_classifier(RiskClass.HIGH),
+            ledger=self.ledger,
+            env=_ENV_ON,
+        )
+        self.assertEqual(self.ledger.all_records(), ())
+
+    def test_require_approval_does_not_touch_ledger(self) -> None:
+        gate_tool_call(
+            _ctx("L1_advisory"),
+            classifier=_fake_classifier(RiskClass.MEDIUM),
+            ledger=self.ledger,
+            env=_ENV_ON,
+        )
+        self.assertEqual(self.ledger.all_records(), ())
+
+    def test_block_without_ledger_still_returns_signature(self) -> None:
+        verdict = gate_tool_call(
+            _ctx("L2_autonomous_record"),
+            classifier=_fake_classifier(RiskClass.CRITICAL),
+            ledger=None,
+            env=_ENV_ON,
+        )
+        # Verdict still carries the signature for downstream audit.
+        self.assertEqual(
+            verdict.signatures,
+            ("tool_gate.critical.blocked",),
+        )
+
+
+class IntegrationSmokeTests(unittest.TestCase):
+    """End-to-end smoke against the real classifier."""
+
+    def test_real_classifier_git_push_main_is_blocked_at_l4(self) -> None:
+        ctx = ToolCallContext(
+            tool_id="git_push",
+            target="main",
+            args=("origin", "main"),
+            role="engineering-agent/devops-engineer",
+            session_id="s1",
+            autonomy_level="L4_full_autonomous",
+        )
+        verdict = gate_tool_call(ctx, env=_ENV_ON)
+        self.assertEqual(verdict.risk_class, RiskClass.CRITICAL)
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+    def test_real_classifier_read_file_is_allowed_at_l1(self) -> None:
+        ctx = ToolCallContext(
+            tool_id="read_file",
+            target="README.md",
+            args=(),
+            role="engineering-agent/devops-engineer",
+            session_id="s1",
+            autonomy_level="L1_advisory",
+        )
+        verdict = gate_tool_call(ctx, env=_ENV_ON)
+        self.assertEqual(verdict.risk_class, RiskClass.SAFE)
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_tool_gate_governance.py
+++ b/tests/engineering/test_tool_gate_governance.py
@@ -1,0 +1,259 @@
+"""Governance regression for the F12 / #103 tool-call gate.
+
+Pins the hard rails into one suite so a single rename / matrix
+edit cannot silently regress them:
+
+  1. CRITICAL is BLOCK for *every* autonomy level — even
+     L4_full_autonomous, even when the matrix row is edited.
+  2. env OFF makes the circuit transparent but emits an explicit
+     warning so an audit reader can see the safety surface is
+     bypassed.
+  3. PasteGuard (outbound secret guard) keeps its own contract —
+     the two layers do not share state and a gate verdict cannot
+     short-circuit a PasteGuard finding.
+  4. Protected branch pushes never ALLOW — at any autonomy level,
+     the real classifier escalates to CRITICAL and the gate
+     blocks.
+  5. BLOCK verdicts produce a stable signature that the mistake
+     ledger can ingest (matches
+     ``tool_gate.<risk_class>.blocked``).
+  6. The gate's default autonomy fallback (``L2_autonomous_record``)
+     plus default env (ON) is documented and exercised.
+"""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.safety.risk_classifier import (
+    RiskClass,
+    RiskSignal,
+    ToolCallContext,
+    classify_tool_call,
+)
+from yule_orchestrator.agents.safety.tool_call_gate import (
+    ENV_TOOL_GATE_DEFAULT_AUTONOMY,
+    ENV_TOOL_GATE_ENABLED,
+    GateAction,
+    ToolGateVerdict,
+    gate_tool_call,
+)
+from yule_orchestrator.agents.security.paste_guard import (
+    OutboundChannel,
+    guard_outbound,
+)
+
+
+_ALL_AUTONOMY_LEVELS = (
+    "L0_manual_only",
+    "L1_advisory",
+    "L2_autonomous_record",
+    "L3_human_approval",
+    "L4_full_autonomous",
+)
+
+
+def _critical_classifier(ctx):
+    return RiskClass.CRITICAL, (
+        RiskSignal(name="fake", weight=RiskClass.CRITICAL, evidence="fake"),
+    )
+
+
+def _make_ctx(autonomy: str, tool_id: str = "git_reset_hard", **kw) -> ToolCallContext:
+    return ToolCallContext(
+        tool_id=tool_id,
+        target=kw.get("target", ""),
+        args=tuple(kw.get("args", ())),
+        role="engineering-agent/devops-engineer",
+        session_id="session-gov",
+        autonomy_level=autonomy,
+    )
+
+
+_ENV_ON = {ENV_TOOL_GATE_ENABLED: "true"}
+
+
+class CriticalAlwaysBlocksTests(unittest.TestCase):
+    """Hard rail #1 — CRITICAL is BLOCK at every autonomy level."""
+
+    def test_critical_blocked_for_every_autonomy(self) -> None:
+        for autonomy in _ALL_AUTONOMY_LEVELS:
+            with self.subTest(autonomy=autonomy):
+                verdict = gate_tool_call(
+                    _make_ctx(autonomy),
+                    classifier=_critical_classifier,
+                    env=_ENV_ON,
+                )
+                self.assertEqual(verdict.action, GateAction.BLOCK)
+                self.assertEqual(verdict.risk_class, RiskClass.CRITICAL)
+
+    def test_critical_blocked_even_with_unknown_autonomy(self) -> None:
+        verdict = gate_tool_call(
+            _make_ctx("L99_yolo_mode"),
+            classifier=_critical_classifier,
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class EnvOffWarningTests(unittest.TestCase):
+    """Hard rail #2 — env OFF transparent but explicitly warned."""
+
+    def test_env_off_emits_warning_and_allows(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            verdict = gate_tool_call(
+                _make_ctx("L0_manual_only"),
+                classifier=_critical_classifier,
+                env={ENV_TOOL_GATE_ENABLED: "false"},
+            )
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+        self.assertEqual(verdict.risk_class, RiskClass.SAFE)
+        self.assertIn("gate disabled", verdict.reason)
+        self.assertTrue(
+            any("disabled" in str(w.message) for w in caught),
+            "env OFF must emit an explicit warning so a governance "
+            "test can detect the bypass",
+        )
+
+    def test_env_off_with_zero_value_also_warns(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gate_tool_call(
+                _make_ctx("L4_full_autonomous"),
+                classifier=_critical_classifier,
+                env={ENV_TOOL_GATE_ENABLED: "0"},
+            )
+        self.assertTrue(any("disabled" in str(w.message) for w in caught))
+
+
+class PasteGuardLayerSeparationTests(unittest.TestCase):
+    """Hard rail #3 — gate and PasteGuard do not share state.
+
+    They operate on different axes: the gate decides whether a
+    tool fires, PasteGuard decides what bytes leave the process.
+    A gate ALLOW does not authorise PasteGuard to leak a secret,
+    and a PasteGuard miss does not weaken the gate.
+    """
+
+    def test_gate_allow_does_not_affect_paste_guard_finding(self) -> None:
+        gate_verdict = gate_tool_call(
+            _make_ctx("L4_full_autonomous", tool_id="read_file"),
+            env=_ENV_ON,
+        )
+        self.assertEqual(gate_verdict.action, GateAction.ALLOW)
+
+        # PasteGuard still detects a secret in an outbound payload.
+        leak = "ghp_" + "A" * 40
+        guard_verdict = guard_outbound(
+            channel=OutboundChannel.GITHUB,
+            payload=f"prefix {leak} suffix",
+        )
+        self.assertGreaterEqual(len(guard_verdict.findings), 1)
+        self.assertNotIn(leak, guard_verdict.redacted)
+
+    def test_gate_block_independent_of_paste_guard_inputs(self) -> None:
+        # CRITICAL gate verdict is independent of any payload that
+        # might also be flagged by PasteGuard.
+        verdict = gate_tool_call(
+            _make_ctx("L2_autonomous_record", tool_id="git_reset_hard"),
+            env=_ENV_ON,
+        )
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class ProtectedBranchNeverAllowedTests(unittest.TestCase):
+    """Hard rail #4 — protected branch push never ALLOW."""
+
+    def test_protected_branch_push_blocked_at_every_autonomy(self) -> None:
+        for autonomy in _ALL_AUTONOMY_LEVELS:
+            with self.subTest(autonomy=autonomy):
+                ctx = ToolCallContext(
+                    tool_id="git_push",
+                    target="main",
+                    args=("origin", "main"),
+                    role="engineering-agent/devops-engineer",
+                    session_id="gov",
+                    autonomy_level=autonomy,
+                )
+                verdict = gate_tool_call(ctx, env=_ENV_ON)
+                self.assertEqual(verdict.risk_class, RiskClass.CRITICAL)
+                self.assertEqual(verdict.action, GateAction.BLOCK)
+
+    def test_protected_branch_force_push_blocked(self) -> None:
+        ctx = ToolCallContext(
+            tool_id="force_push",
+            target="develop",
+            args=(),
+            role="engineering-agent/devops-engineer",
+            session_id="gov",
+            autonomy_level="L4_full_autonomous",
+        )
+        verdict = gate_tool_call(ctx, env=_ENV_ON)
+        self.assertEqual(verdict.action, GateAction.BLOCK)
+
+
+class LedgerSignatureContractTests(unittest.TestCase):
+    """Hard rail #5 — BLOCK signatures match the canonical shape."""
+
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+
+    def tearDown(self) -> None:
+        self.ledger.close()
+
+    def test_block_signature_canonical_shape(self) -> None:
+        verdict = gate_tool_call(
+            _make_ctx("L0_manual_only"),
+            classifier=_critical_classifier,
+            ledger=self.ledger,
+            env=_ENV_ON,
+        )
+        self.assertEqual(
+            verdict.signatures,
+            ("tool_gate.critical.blocked",),
+        )
+        records = self.ledger.all_records()
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record.blocker_level, BlockerLevel.BLOCK)
+        self.assertTrue(record.signature.startswith("tool_gate."))
+
+
+class DefaultAutonomyDocumentedTests(unittest.TestCase):
+    """Hard rail #6 — default autonomy fallback is documented + active."""
+
+    def test_default_autonomy_is_l2_autonomous_record(self) -> None:
+        # Empty ctx autonomy + empty env → L2_autonomous_record.
+        # MEDIUM at L2 → ALLOW.
+        verdict = gate_tool_call(
+            _make_ctx("", tool_id="git_commit"),
+            env={ENV_TOOL_GATE_ENABLED: "true"},
+        )
+        self.assertEqual(verdict.risk_class, RiskClass.MEDIUM)
+        self.assertEqual(verdict.action, GateAction.ALLOW)
+
+    def test_env_default_autonomy_override_applied(self) -> None:
+        verdict = gate_tool_call(
+            _make_ctx("", tool_id="git_commit"),
+            env={
+                ENV_TOOL_GATE_ENABLED: "true",
+                ENV_TOOL_GATE_DEFAULT_AUTONOMY: "L0_manual_only",
+            },
+        )
+        # L0 + MEDIUM → REQUIRE_APPROVAL.
+        self.assertEqual(verdict.action, GateAction.REQUIRE_APPROVAL)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #103
- parent #81
- 관련 #98 (F7 auto-merge decider — 같은 risk class 어휘 재사용)
- 관련 #88 (PasteGuard — outbound 가드 와 짝)

## 🎯 목적
각 tool call (subprocess / 외부 API / file write / git operation) 직전에 **risk class 분류기** 를 거치게 해서, 안전한 작업은 자동 진행 / 위험한 작업은 차단 / 중간은 approval. F7 의 PR 단위 risk class 어휘를 *tool call 단위* 로 내린 버전.

## 📐 범위
- 신규 모듈
  - `src/yule_orchestrator/agents/safety/__init__.py`
  - `src/yule_orchestrator/agents/safety/risk_classifier.py`
  - `src/yule_orchestrator/agents/safety/tool_call_gate.py`
- 신규 테스트
  - `tests/agents/test_risk_classifier.py` (35 case)
  - `tests/agents/test_tool_call_gate.py` (27 case — 5 autonomy × 5 RiskClass 매트릭스 + env OFF + mistake_ledger 통합 + real classifier smoke)
  - `tests/engineering/test_tool_gate_governance.py` (15 case)
- env: `.env.example` 에 `YULE_TOOL_GATE_ENABLED`, `YULE_TOOL_GATE_DEFAULT_AUTONOMY` 2종 추가 + 정책 주석.

## ✅ Acceptance Criteria
1. RiskClass 5단계 정적 분류 (≥15 패턴) — SAFE / LOW / MEDIUM / HIGH / CRITICAL.
2. autonomy_level × RiskClass 매트릭스 (L0_manual_only / L1_advisory / L2_autonomous_record / L3_human_approval / L4_full_autonomous).
3. allow / require_approval / block 3-action 매트릭스.
4. BLOCK 시 `tool_gate.<risk_class>.blocked` signature 를 (주입된) mistake_ledger 에 등록.
5. 회귀 25+ case + governance 6+ case. 본 PR 은 총 77 case 신규 추가.

## 🔒 Hard rails
- CRITICAL 은 어떤 autonomy 에서도 BLOCK (governance test 가 보호).
- env OFF 시 transparent ALLOW 지만 `warnings.warn` 명시 경고 — governance test 가 OFF 회귀 감지.
- PasteGuard 와 layer 분리 — 다른 축 (PasteGuard 는 outbound payload, gate 는 tool 실행 결정).
- 보호 브랜치 (main / master / develop / release / prod) push 절대 ALLOW 안 됨 (classifier 가 CRITICAL 로 escalate).
- force push / `--no-verify` / `--hard` / `-rf` / sandbox-disable 등 위험 flag CRITICAL 강제.

## 🔗 의존성
- 선행: F1 PasteGuard (#88) — 머지됨
- 선행: F2 Hookify (#89) — 머지됨 (mistake_ledger 통합 의존)
- 관련: F7 auto-merge (#98) — 같은 RiskClass 어휘
- 관련: F4 live editor (#91) — gate 호출 통합 후속 PR

## 🧰 Harness
- `tests/agents/test_risk_classifier.py` — 5 RiskClass × catalogue + 보호 브랜치 + 보안 키워드 + dataclass frozen + 결정성.
- `tests/agents/test_tool_call_gate.py` — 5 autonomy × 5 RiskClass 매트릭스 sweep + env OFF + ledger 통합 + real classifier smoke.
- `tests/engineering/test_tool_gate_governance.py` — CRITICAL 절대 BLOCK / env OFF warning / PasteGuard 충돌 없음 / 보호 브랜치 never ALLOW / signature canonical shape / default autonomy.

## 무엇을 변경했는지
| commit | 목적 |
| --- | --- |
| `f3cf5a2` | F12 risk classifier + tool-call gate + 테스트 3종 + env 문서화 |

## 🤖 Agent WorkOS Audit
- audit_id: `f12-issue-103-tool-call-gate-2026-05-11`
- branch: `feature/tool-call-gate-issue-103` (from `main`)
- role: `engineering-agent/devops-engineer`
- autonomy_level: `L2_AUTONOMOUS_RECORD`
- mode: spawned-worktree
- risk_class: `MEDIUM` (보안 critical 분류기, env ON default)

## 자체 회귀 결과
- 새 77 케이스 전부 통과.
- 전체 회귀 3801/3802 통과.
- 단 1건 실패 (`tests/runtime/test_gateway_shutdown.test_login_failure_translates_to_value_error`) 는 main 에서도 동일하게 재현되는 `sys.modules['discord']` 오염 이슈로, 격리 실행 시 정상 통과. F12 변경과 무관.