### PR TITLE
✨ [Feat] F11.1 HookChain invoke + manifest discovery loader

### DIFF
--- a/policies/runtime/agents/engineering-agent/extension-architecture.md
+++ b/policies/runtime/agents/engineering-agent/extension-architecture.md
@@ -1,0 +1,73 @@
+# engineering-agent — Extension Architecture (F11.1)
+
+`engineering-agent` 의 plugin / agent 확장 구조에 대한 1페이지 운영 정책. 본 문서가 단일 진실. 위반 시 mistake_ledger BLOCK.
+
+## 1. 구성요소
+
+| 계층 | 위치 | 역할 |
+| --- | --- | --- |
+| Manifest | `plugins/<id>/manifest.json`, `agents/<id>/manifest.json` | static 식별 / 훅 / 위험도 선언 |
+| Registry | `src/yule_orchestrator/agents/extension/plugin_registry.py`, `agent_registry.py` | in-memory lookup (id / hook / role) |
+| Loader | `src/yule_orchestrator/agents/extension/loader.py` | fs discovery + lazy `importlib` |
+| HookChain | `src/yule_orchestrator/agents/extension/hook_chain.py` | deterministic chain dispatch |
+
+## 2. 새 plugin 추가 절차
+
+1. `plugins/<plugin-id>/manifest.json` 작성. 필드 검증은 `manifest.py` 의 `_VALID_*` 규칙에 따른다 (id kebab-case, semver, dotted module_path).
+2. `module_path` 는 dotted Python path 만. 빈 문자열이면 `load_plugin_module` 이 ValueError 로 거부.
+3. 핸들러 노출 — 모듈에 둘 중 하나 제공:
+   - `HOOK_HANDLERS: Mapping[HookEvent, Callable]`
+   - 또는 `on_<lower-hook-name>(payload) -> HookResult`
+4. `risk_class` 결정:
+   - LOW / MEDIUM: 자동 활성
+   - HIGH: 자동 활성 **금지**. `invoke_hook(..., allow_high_risk=("plugin-id",))` 로 명시 허용 필요
+5. 회귀 추가 — `tests/agents/test_hook_chain.py` 또는 plugin 전용 테스트에 fake module fixture 케이스 1개 이상.
+6. discovery 검증 — `discover_manifests(plugins_dir=..., agents_dir=...)` 가 새 manifest 를 인식하는지 단위 테스트.
+
+## 3. 새 agent 추가 절차
+
+1. `agents/<agent-id>/manifest.json` 작성. `role` 은 kebab-case, `plugins_required` 는 등록 plugin id 만.
+2. `module_path` 비어있어도 manifest registration 자체는 허용 (entrypoint 미정 단계). 단 runtime 에서 호출 시점에 검증.
+3. `agent_registry.register(manifest)` — 동일 id 재등록은 거부. 동일 role 멀티 agent 허용 (v2 successor 등).
+4. `prompt_template_ref` 는 prompt 카탈로그의 안정 식별자. 폐기되면 deprecation note 동반 PR 필수.
+
+## 4. HookChain 동작
+
+```
+invoke_hook(event, payload, *, plugin_registry, module_loader=None, allow_high_risk=())
+```
+
+- Registry 가 `plugins_for_hook(event)` 로 제공자 목록을 id 오름차순 반환 → 결정적.
+- 각 plugin handler 는 직전 plugin 의 `modified_payload` 를 입력으로 받음 (chain 합성).
+- 반환 `HookResult.level`:
+  - `OK` / `WARN`: 다음 plugin 계속
+  - `SKIP`: 해당 plugin 건너뛰고 chain 계속
+  - `BLOCK`: 즉시 종료, 후속 plugin 미호출
+  - `ERROR`: 즉시 종료 + 후속 mistake_ledger 기록 대상
+- handler 가 raise → 자동으로 `ERROR` HookResult + signature `hook_chain.handler.exception`.
+- handler 반환값이 `Mapping` 이면 OK + `modified_payload` 로 흡수 (편의 어댑터).
+- handler 반환값이 `None` 이면 OK + payload 유지.
+
+## 5. Risk class 매트릭스
+
+| risk_class | 자동 활성 | 예시 plugin | 비고 |
+| --- | --- | --- | --- |
+| LOW | yes | docs / observability read-only | HookChain 통과 자유 |
+| MEDIUM | yes | hookify (mistake_ledger), repo-map | 회귀 필수 |
+| HIGH | **no** | paste-guard (outbound secret), credential rotation | `allow_high_risk` 명시 + 운영자 승인 |
+
+## 6. Hard rails
+
+- HIGH risk plugin 자동 활성 금지 — `allow_high_risk` 미포함 시 chain 에서 SKIP + `hook_chain.skip.high_risk_not_allowed` 로 기록.
+- 알 수 없는 hook 이벤트는 manifest 단에서 `ManifestValidationError`. runtime 단에서는 handler 부재 → `SKIP` + `hook_chain.handler.missing`.
+- `discover_manifests` 는 fail-fast — 단일 manifest validation 실패 시 `ManifestDiscoveryError` 로 중단. 등록 거부.
+- `load_plugin_module` 의 ImportError 는 `hook_chain.module.load_failed` 로 mistake_ledger 등록 대상.
+- destructive / force push / 보호 브랜치 직접 push 금지 (공통 안전 정책).
+
+## 7. 관련 코드 / 테스트
+
+- `src/yule_orchestrator/agents/extension/hook_chain.py`
+- `src/yule_orchestrator/agents/extension/loader.py`
+- `tests/agents/test_hook_chain.py`
+- `tests/agents/test_extension_loader.py`
+- 선행: PR #105 (F11 MVP — manifest + registry), issue #102 / #107.

--- a/src/yule_orchestrator/agents/extension/__init__.py
+++ b/src/yule_orchestrator/agents/extension/__init__.py
@@ -5,29 +5,26 @@ plugins (F1/F2/F3 ...) and role-specific agents (tech-lead, backend-engineer,
 ...) declare their identity, hooks, and risk surface without binding the
 runtime to specific implementations.
 
-MVP scope (issue #102 — manifest registry only):
+F11 MVP (issue #102) landed manifest + registry; F11.1 (issue #107)
+adds the HookChain dispatch + filesystem manifest discovery loader.
+
+Surfaces exposed:
 
   * :class:`PluginManifest` / :class:`AgentManifest` — frozen dataclasses.
   * :class:`HookEvent` — canonical enum of hook points plugins may
     provide / consume.
   * :func:`load_plugin_manifest_from_dict` / :func:`load_agent_manifest_from_dict`
-    — pure dict -> manifest factories. The caller is responsible for any
-    file I/O (JSON / YAML), keeping this module dependency-free.
+    — pure dict -> manifest factories.
   * :func:`validate_plugin_manifest` / :func:`validate_agent_manifest` —
-    pure functions that raise :class:`ManifestValidationError` when a
-    manifest is malformed (unknown risk class, unknown hook name, bad
-    module path, ...).
-  * :class:`PluginRegistry` / :class:`AgentRegistry` — in-memory registries
-    used by the engineering-agent runtime to look up plugins by hook and
-    agents by role.
+    pure validators that raise :class:`ManifestValidationError`.
+  * :class:`PluginRegistry` / :class:`AgentRegistry` — in-memory registries.
+  * :func:`invoke_hook` / :class:`HookResult` / :class:`HookLevel` —
+    deterministic chain dispatch over a registry.
+  * :func:`discover_manifests` / :func:`load_plugin_module` — filesystem
+    discovery + lazy importlib loader.
 
-Out of scope (follow-up PRs):
-
-  * HookChain invocation (manifests describe hooks; chain runtime is
-    deliberately not yet implemented).
-  * Manifest auto-discovery / loader from filesystem (caller registers
-    manually for now).
-  * F4 .. F10 manifests (kept out to avoid in-flight scope creep).
+Out of scope (follow-up PRs): F4..F10 manifests; the wider routing
+runtime that maps a role request onto an :class:`AgentManifest`.
 """
 
 from .manifest import (
@@ -45,19 +42,43 @@ from .manifest import (
 )
 from .plugin_registry import PluginRegistry
 from .agent_registry import AgentRegistry
+from .hook_chain import (
+    HookHandler,
+    HookLevel,
+    HookResult,
+    ModuleLoader,
+    invoke_hook,
+)
+from .loader import (
+    DiscoveryReport,
+    ManifestDiscoveryError,
+    discover_manifests,
+    discover_manifests_with_report,
+    load_plugin_module,
+)
 
 __all__ = [
     "AgentManifest",
     "AgentRegistry",
     "AUTONOMY_LEVELS",
+    "DiscoveryReport",
     "HookEvent",
+    "HookHandler",
+    "HookLevel",
+    "HookResult",
+    "ManifestDiscoveryError",
     "ManifestValidationError",
+    "ModuleLoader",
     "PLUGIN_KINDS",
     "PluginManifest",
     "PluginRegistry",
     "RISK_CLASSES",
+    "discover_manifests",
+    "discover_manifests_with_report",
+    "invoke_hook",
     "load_agent_manifest_from_dict",
     "load_plugin_manifest_from_dict",
+    "load_plugin_module",
     "validate_agent_manifest",
     "validate_plugin_manifest",
 ]

--- a/src/yule_orchestrator/agents/extension/hook_chain.py
+++ b/src/yule_orchestrator/agents/extension/hook_chain.py
@@ -1,0 +1,309 @@
+"""HookChain invocation runtime (F11.1 / #107).
+
+The :class:`PluginRegistry` only stores manifests. This module turns
+that static description into an actual *dispatch*: given a
+:class:`~yule_orchestrator.agents.extension.manifest.HookEvent` and a
+payload, walk every plugin that *provides* the hook in deterministic
+order and let each transform / approve / block the payload.
+
+Design rails (regression-tested):
+
+  * The chain is deterministic — providers are visited in the order the
+    :class:`PluginRegistry` exposes them (id ascending). The runtime
+    must not depend on registration order.
+  * Each plugin handler receives the *most recent* payload — the
+    output of the previous plugin's ``modified_payload`` (when present)
+    is the input of the next plugin. This makes the chain composable
+    without any plugin needing to know about its peers.
+  * ``BLOCK`` short-circuits the chain: once any plugin emits a
+    :class:`HookResult` with level ``BLOCK``, no subsequent plugin is
+    called and that result is returned verbatim.
+  * Handlers may raise. Exceptions are converted into a synthetic
+    ``ERROR`` :class:`HookResult` so the caller surfaces a structured
+    failure (and the mistake ledger can pick it up) instead of seeing a
+    bare traceback. The chain stops on ``ERROR`` as well — a misbehaving
+    plugin must not silently let later plugins observe a half-mutated
+    payload.
+  * Plugin modules are *never* imported by this module directly. The
+    caller supplies a ``module_loader`` (defaulting to
+    :func:`~yule_orchestrator.agents.extension.loader.load_plugin_module`)
+    so tests can fully isolate the chain from filesystem state.
+
+Hard rails:
+
+  * HIGH risk plugins are *not* auto-activated. If a registered manifest
+    has ``risk_class == "HIGH"`` and the caller did not pass it in
+    ``allow_high_risk`` (kwarg), the chain skips it and records an
+    advisory entry in the returned trail.
+  * Unknown / non-callable handler attributes are skipped with a warning
+    via :mod:`logging`; they do not break the chain.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Optional, Tuple
+
+from .manifest import HookEvent, PluginManifest
+from .plugin_registry import PluginRegistry
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HookLevel(enum.Enum):
+    """Severity / continuation signal returned by a plugin handler."""
+
+    OK = "ok"          # plugin ran cleanly, chain continues
+    WARN = "warn"      # plugin flagged something but chain continues
+    BLOCK = "block"    # plugin refused; chain stops immediately
+    SKIP = "skip"      # plugin opted out (e.g. autonomy mismatch)
+    ERROR = "error"    # plugin raised; chain stops, surfaces failure
+
+
+@dataclass(frozen=True)
+class HookResult:
+    """Outcome of a single plugin invocation in the chain.
+
+    Fields:
+      level: :class:`HookLevel` continuation signal.
+      modified_payload: payload to forward to the next plugin. ``None``
+        means "no modification" — the previous payload propagates as-is.
+      blocker_reason: human-readable reason when ``level`` is ``BLOCK``
+        or ``ERROR``; empty string otherwise.
+      plugin_id: id of the plugin that produced the result. The synthetic
+        terminal result emitted when the chain has no providers carries
+        the sentinel ``""``.
+      signature: mistake-ledger-style signature (e.g.
+        ``"paste_guard.secret_detected"``). Empty for OK/SKIP results.
+    """
+
+    level: HookLevel
+    modified_payload: Optional[Mapping[str, Any]] = None
+    blocker_reason: str = ""
+    plugin_id: str = ""
+    signature: str = ""
+
+
+#: Signature of a plugin's hook handler. Handlers receive the current
+#: payload and return a :class:`HookResult`. They must not mutate the
+#: input mapping.
+HookHandler = Callable[[Mapping[str, Any]], HookResult]
+
+
+#: Signature of a module loader (matches
+#: :func:`yule_orchestrator.agents.extension.loader.load_plugin_module`).
+ModuleLoader = Callable[[PluginManifest], Any]
+
+
+def _resolve_handler(
+    module: Any,
+    hook: HookEvent,
+) -> Optional[HookHandler]:
+    """Pick the hook handler off a loaded plugin module.
+
+    A plugin module may expose either:
+
+      * ``HOOK_HANDLERS`` mapping ``HookEvent`` -> callable, or
+      * a callable attribute named ``on_<lower-hook-name>`` (e.g.
+        ``on_outbound_llm``).
+
+    Returns ``None`` if no matching handler is found; the caller treats
+    that as a skip.
+    """
+
+    handlers = getattr(module, "HOOK_HANDLERS", None)
+    if isinstance(handlers, Mapping):
+        candidate = handlers.get(hook) or handlers.get(hook.name)
+        if callable(candidate):
+            return candidate
+
+    attr_name = f"on_{hook.name.lower()}"
+    candidate = getattr(module, attr_name, None)
+    if callable(candidate):
+        return candidate
+    return None
+
+
+def _coerce_result(
+    raw: Any,
+    *,
+    plugin_id: str,
+    fallback_payload: Mapping[str, Any],
+) -> HookResult:
+    """Normalise a handler's return value into a :class:`HookResult`."""
+
+    if isinstance(raw, HookResult):
+        # Always stamp the plugin id even if the handler omitted it; the
+        # chain is the source of truth for that field.
+        if raw.plugin_id == plugin_id:
+            return raw
+        return HookResult(
+            level=raw.level,
+            modified_payload=raw.modified_payload,
+            blocker_reason=raw.blocker_reason,
+            plugin_id=plugin_id,
+            signature=raw.signature,
+        )
+    if raw is None:
+        return HookResult(level=HookLevel.OK, plugin_id=plugin_id)
+    if isinstance(raw, Mapping):
+        # Convenience: treat a plain dict return as an OK with a
+        # modified payload (tests often go this route).
+        return HookResult(
+            level=HookLevel.OK,
+            modified_payload=raw,
+            plugin_id=plugin_id,
+        )
+    # Anything else is a contract violation; surface as ERROR rather than
+    # silently dropping it.
+    return HookResult(
+        level=HookLevel.ERROR,
+        modified_payload=fallback_payload,
+        blocker_reason=f"plugin '{plugin_id}' returned unsupported handler value: {type(raw).__name__}",
+        plugin_id=plugin_id,
+        signature="hook_chain.handler.bad_return",
+    )
+
+
+def invoke_hook(
+    event: HookEvent,
+    payload: Mapping[str, Any],
+    *,
+    plugin_registry: PluginRegistry,
+    module_loader: Optional[ModuleLoader] = None,
+    allow_high_risk: Iterable[str] = (),
+) -> HookResult:
+    """Run every registered provider for ``event`` in deterministic order.
+
+    Args:
+      event: the :class:`HookEvent` to dispatch.
+      payload: initial payload. Treated as immutable; plugins receive
+        each successive ``modified_payload`` instead of mutating in place.
+      plugin_registry: registry to consult for providers.
+      module_loader: callable that returns a plugin's module given its
+        manifest. Defaults to
+        :func:`yule_orchestrator.agents.extension.loader.load_plugin_module`.
+        Tests pass a fake so no real import is performed.
+      allow_high_risk: iterable of plugin ids the caller has explicitly
+        authorised to run despite ``risk_class == "HIGH"``. HIGH-risk
+        plugins outside this allow-list are skipped (hard rail).
+
+    Returns:
+      The terminal :class:`HookResult`. When no plugin provides the
+      event, returns an ``OK`` result with the original payload and an
+      empty ``plugin_id`` so callers can detect the no-op case.
+    """
+
+    if not isinstance(event, HookEvent):
+        raise TypeError("invoke_hook expects a HookEvent enum member")
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping")
+
+    allow_list = frozenset(allow_high_risk)
+    providers = plugin_registry.plugins_for_hook(event)
+
+    if not providers:
+        _LOGGER.debug("hook %s has no providers; returning no-op result", event.name)
+        return HookResult(level=HookLevel.OK, modified_payload=payload)
+
+    if module_loader is None:
+        # Local import keeps the module dependency-free at import time
+        # and lets tests that don't touch the filesystem stay cheap.
+        from .loader import load_plugin_module as _default_loader
+
+        module_loader = _default_loader
+
+    current_payload: Mapping[str, Any] = payload
+    last_result: HookResult = HookResult(level=HookLevel.OK, modified_payload=payload)
+
+    for manifest in providers:
+        if manifest.risk_class == "HIGH" and manifest.id not in allow_list:
+            _LOGGER.warning(
+                "skipping HIGH risk plugin '%s' for hook %s (not in allow_high_risk)",
+                manifest.id,
+                event.name,
+            )
+            last_result = HookResult(
+                level=HookLevel.SKIP,
+                modified_payload=current_payload,
+                blocker_reason=f"plugin '{manifest.id}' is HIGH risk and was not explicitly allowed",
+                plugin_id=manifest.id,
+                signature="hook_chain.skip.high_risk_not_allowed",
+            )
+            continue
+
+        try:
+            module = module_loader(manifest)
+        except Exception as exc:  # noqa: BLE001 — any import / load failure halts the chain
+            _LOGGER.exception("module_loader failed for plugin '%s'", manifest.id)
+            return HookResult(
+                level=HookLevel.ERROR,
+                modified_payload=current_payload,
+                blocker_reason=f"plugin '{manifest.id}' module load failed: {exc}",
+                plugin_id=manifest.id,
+                signature="hook_chain.module.load_failed",
+            )
+
+        handler = _resolve_handler(module, event)
+        if handler is None:
+            _LOGGER.warning(
+                "plugin '%s' declares hook %s but exposes no matching handler; skipping",
+                manifest.id,
+                event.name,
+            )
+            last_result = HookResult(
+                level=HookLevel.SKIP,
+                modified_payload=current_payload,
+                blocker_reason=f"plugin '{manifest.id}' has no handler for {event.name}",
+                plugin_id=manifest.id,
+                signature="hook_chain.handler.missing",
+            )
+            continue
+
+        try:
+            raw = handler(current_payload)
+        except Exception as exc:  # noqa: BLE001 — surface handler failure as ERROR
+            _LOGGER.exception("handler for plugin '%s' raised", manifest.id)
+            return HookResult(
+                level=HookLevel.ERROR,
+                modified_payload=current_payload,
+                blocker_reason=f"plugin '{manifest.id}' handler raised: {exc}",
+                plugin_id=manifest.id,
+                signature="hook_chain.handler.exception",
+            )
+
+        result = _coerce_result(raw, plugin_id=manifest.id, fallback_payload=current_payload)
+        last_result = result
+
+        if result.modified_payload is not None:
+            current_payload = result.modified_payload
+
+        if result.level is HookLevel.BLOCK:
+            return result
+        if result.level is HookLevel.ERROR:
+            return result
+
+    # Normalise the terminal payload so callers always see a payload on
+    # the final result even when the last plugin returned modifications
+    # via earlier link.
+    if last_result.modified_payload is None:
+        last_result = HookResult(
+            level=last_result.level,
+            modified_payload=current_payload,
+            blocker_reason=last_result.blocker_reason,
+            plugin_id=last_result.plugin_id,
+            signature=last_result.signature,
+        )
+    return last_result
+
+
+__all__ = [
+    "HookHandler",
+    "HookLevel",
+    "HookResult",
+    "ModuleLoader",
+    "invoke_hook",
+]

--- a/src/yule_orchestrator/agents/extension/loader.py
+++ b/src/yule_orchestrator/agents/extension/loader.py
@@ -1,0 +1,234 @@
+"""Manifest discovery + lazy module loader (F11.1 / #107).
+
+The F11 MVP forced callers to register every plugin / agent manifest by
+hand. This module gives the runtime a tiny filesystem discovery surface
+(``plugins/<id>/manifest.json`` + ``agents/<id>/manifest.json``) plus a
+lazy importer (:func:`load_plugin_module`) that defers
+:mod:`importlib` calls until a hook is actually dispatched.
+
+Design rails:
+
+  * The loader does *not* register manifests into a registry on its own
+    — it just returns parsed, validated dataclass tuples. The caller
+    decides which to register (so e.g. a HIGH-risk plugin can be left
+    out until a human enables it).
+  * JSON is the only on-disk format supported today; YAML would add a
+    third-party dependency we don't yet need.
+  * Manifests that fail validation are *not* silently dropped. The
+    loader raises :class:`ManifestDiscoveryError` so the surrounding
+    workflow can record the failure (mistake ledger) and operators can
+    spot the regression.
+  * Discovery is deterministic — entries are returned sorted by
+    ``manifest.id`` so test fixtures don't depend on filesystem order.
+
+Hard rails (regression-tested):
+
+  * Unknown / extra files inside a plugin directory are ignored — only
+    ``manifest.json`` is read.
+  * A symlinked / non-mapping JSON body raises
+    :class:`ManifestDiscoveryError` immediately.
+  * :func:`load_plugin_module` refuses an empty ``module_path`` to avoid
+    importing the engineering-agent's top-level package by accident.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Tuple
+
+from .manifest import (
+    AgentManifest,
+    ManifestValidationError,
+    PluginManifest,
+    load_agent_manifest_from_dict,
+    load_plugin_manifest_from_dict,
+)
+
+
+_LOGGER = logging.getLogger(__name__)
+
+_MANIFEST_FILENAME = "manifest.json"
+
+
+class ManifestDiscoveryError(RuntimeError):
+    """Raised when a manifest file is malformed or cannot be parsed.
+
+    The error carries the offending path so the caller can include it in
+    operator-facing telemetry without re-walking the directory tree.
+    """
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(f"{path}: {reason}")
+        self.path = path
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class DiscoveryReport:
+    """Outcome of a discovery sweep — useful for surface telemetry.
+
+    Tests typically read :attr:`plugins` / :attr:`agents` directly; the
+    ``skipped`` field records directories that contained no
+    ``manifest.json`` (i.e. work-in-progress folders) so the runtime can
+    warn instead of silently ignoring them.
+    """
+
+    plugins: Tuple[PluginManifest, ...]
+    agents: Tuple[AgentManifest, ...]
+    skipped: Tuple[Path, ...] = ()
+
+
+def _read_manifest_json(path: Path) -> Any:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestDiscoveryError(path, f"unable to read manifest: {exc}") from exc
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ManifestDiscoveryError(path, f"invalid JSON: {exc.msg}") from exc
+
+
+def _iter_manifest_dirs(root: Path) -> Tuple[Path, ...]:
+    if not root.exists():
+        return ()
+    if not root.is_dir():
+        raise ManifestDiscoveryError(root, "expected a directory")
+    entries = [p for p in root.iterdir() if p.is_dir() and not p.name.startswith(".")]
+    entries.sort(key=lambda p: p.name)
+    return tuple(entries)
+
+
+def discover_manifests(
+    *,
+    plugins_dir: Path,
+    agents_dir: Path,
+) -> Tuple[Tuple[PluginManifest, ...], Tuple[AgentManifest, ...]]:
+    """Scan ``plugins_dir`` and ``agents_dir`` for ``manifest.json`` files.
+
+    Args:
+      plugins_dir: root directory containing ``<plugin_id>/manifest.json``
+        subdirs. May be absent; an empty tuple is returned in that case.
+      agents_dir: same structure as ``plugins_dir`` but for agent
+        manifests.
+
+    Returns:
+      ``(plugin_manifests, agent_manifests)`` — tuples of validated,
+      frozen dataclasses sorted by ``id``.
+
+    Raises:
+      ManifestDiscoveryError: on malformed JSON, non-mapping payloads,
+        or validation failures (re-wrapped from
+        :class:`ManifestValidationError`). Discovery is fail-fast: a
+        single bad manifest aborts the sweep so operators can fix it
+        before any plugin runs.
+    """
+
+    plugins = _load_plugin_manifests(plugins_dir)
+    agents = _load_agent_manifests(agents_dir)
+    return plugins, agents
+
+
+def discover_manifests_with_report(
+    *,
+    plugins_dir: Path,
+    agents_dir: Path,
+) -> DiscoveryReport:
+    """Same as :func:`discover_manifests` but returns a :class:`DiscoveryReport`.
+
+    The report includes ``skipped`` directories that had no
+    ``manifest.json`` — useful for warning operators about a stale
+    plugin scaffold.
+    """
+
+    skipped: list[Path] = []
+    plugins = _load_plugin_manifests(plugins_dir, skipped_sink=skipped)
+    agents = _load_agent_manifests(agents_dir, skipped_sink=skipped)
+    return DiscoveryReport(
+        plugins=plugins,
+        agents=agents,
+        skipped=tuple(sorted(skipped, key=lambda p: str(p))),
+    )
+
+
+def _load_plugin_manifests(
+    root: Path,
+    *,
+    skipped_sink: list[Path] | None = None,
+) -> Tuple[PluginManifest, ...]:
+    out: list[PluginManifest] = []
+    for entry in _iter_manifest_dirs(root):
+        manifest_path = entry / _MANIFEST_FILENAME
+        if not manifest_path.is_file():
+            _LOGGER.warning("plugin directory %s missing %s; skipping", entry, _MANIFEST_FILENAME)
+            if skipped_sink is not None:
+                skipped_sink.append(entry)
+            continue
+        payload = _read_manifest_json(manifest_path)
+        if not isinstance(payload, dict):
+            raise ManifestDiscoveryError(manifest_path, "manifest payload must be a JSON object")
+        try:
+            out.append(load_plugin_manifest_from_dict(payload))
+        except ManifestValidationError as exc:
+            raise ManifestDiscoveryError(manifest_path, str(exc)) from exc
+    out.sort(key=lambda m: m.id)
+    return tuple(out)
+
+
+def _load_agent_manifests(
+    root: Path,
+    *,
+    skipped_sink: list[Path] | None = None,
+) -> Tuple[AgentManifest, ...]:
+    out: list[AgentManifest] = []
+    for entry in _iter_manifest_dirs(root):
+        manifest_path = entry / _MANIFEST_FILENAME
+        if not manifest_path.is_file():
+            _LOGGER.warning("agent directory %s missing %s; skipping", entry, _MANIFEST_FILENAME)
+            if skipped_sink is not None:
+                skipped_sink.append(entry)
+            continue
+        payload = _read_manifest_json(manifest_path)
+        if not isinstance(payload, dict):
+            raise ManifestDiscoveryError(manifest_path, "manifest payload must be a JSON object")
+        try:
+            out.append(load_agent_manifest_from_dict(payload))
+        except ManifestValidationError as exc:
+            raise ManifestDiscoveryError(manifest_path, str(exc)) from exc
+    out.sort(key=lambda m: m.id)
+    return tuple(out)
+
+
+def load_plugin_module(manifest: PluginManifest) -> Any:
+    """Lazy-import the plugin's ``module_path`` via :mod:`importlib`.
+
+    The import happens *only* when this function is called, never at
+    manifest registration time. Failures raise the original
+    :class:`ImportError` (or its subclass) so the caller — typically
+    :func:`yule_orchestrator.agents.extension.hook_chain.invoke_hook`
+    — can record it in the mistake ledger as a manifest rejection.
+
+    Refuses an empty ``module_path`` with :class:`ValueError` to keep a
+    blank manifest from accidentally pulling the top-level package in.
+    """
+
+    if not isinstance(manifest, PluginManifest):
+        raise TypeError("load_plugin_module expects a PluginManifest")
+    if not manifest.module_path:
+        raise ValueError(
+            f"plugin '{manifest.id}' has an empty module_path; refusing to import"
+        )
+    return importlib.import_module(manifest.module_path)
+
+
+__all__ = [
+    "DiscoveryReport",
+    "ManifestDiscoveryError",
+    "discover_manifests",
+    "discover_manifests_with_report",
+    "load_plugin_module",
+]

--- a/tests/agents/test_extension_loader.py
+++ b/tests/agents/test_extension_loader.py
@@ -1,0 +1,188 @@
+"""Manifest discovery + lazy module loader tests (F11.1 / #107)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.loader import (
+    ManifestDiscoveryError,
+    discover_manifests,
+    discover_manifests_with_report,
+    load_plugin_module,
+)
+from yule_orchestrator.agents.extension.manifest import PluginManifest
+
+
+_PLUGIN_VALID = {
+    "id": "paste-guard",
+    "name": "PasteGuard",
+    "version": "0.1.0",
+    "kind": "guard",
+    "hooks_provided": ["OUTBOUND_LLM"],
+    "hooks_consumed": [],
+    "env_keys": [],
+    "autonomy_level": "supervised",
+    "paste_guard_required": False,
+    "risk_class": "HIGH",
+    "module_path": "yule_orchestrator.agents.security.paste_guard",
+}
+
+_AGENT_VALID = {
+    "id": "tech-lead",
+    "name": "Tech Lead",
+    "role": "tech-lead",
+    "version": "0.1.0",
+    "capabilities": ["task-decomposition"],
+    "plugins_required": ["paste-guard"],
+    "prompt_template_ref": "engineering.tech_lead.v1",
+    "github_app_env_prefix": "GITHUB_APP_TECH_LEAD",
+    "autonomy_level": "advisory",
+    "risk_class": "LOW",
+    "module_path": "",
+}
+
+
+def _write_manifest(root: Path, sub: str, payload: dict) -> None:
+    entry = root / sub
+    entry.mkdir(parents=True, exist_ok=True)
+    (entry / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class DiscoverManifestsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.plugins_dir = self.root / "plugins"
+        self.agents_dir = self.root / "agents"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_returns_empty_tuples_when_dirs_missing(self) -> None:
+        plugins, agents = discover_manifests(
+            plugins_dir=self.root / "missing-plugins",
+            agents_dir=self.root / "missing-agents",
+        )
+        self.assertEqual(plugins, ())
+        self.assertEqual(agents, ())
+
+    def test_discovers_plugin_and_agent_manifests(self) -> None:
+        _write_manifest(self.plugins_dir, "paste-guard", _PLUGIN_VALID)
+        hookify = dict(_PLUGIN_VALID)
+        hookify.update(
+            {
+                "id": "hookify",
+                "name": "Hookify",
+                "kind": "learning",
+                "risk_class": "MEDIUM",
+                "hooks_provided": ["PREFLIGHT", "COMPLETION"],
+                "paste_guard_required": True,
+                "autonomy_level": "advisory",
+                "module_path": "yule_orchestrator.agents.learning.mistake_ledger",
+            }
+        )
+        _write_manifest(self.plugins_dir, "hookify", hookify)
+        _write_manifest(self.agents_dir, "tech-lead", _AGENT_VALID)
+
+        plugins, agents = discover_manifests(
+            plugins_dir=self.plugins_dir,
+            agents_dir=self.agents_dir,
+        )
+
+        self.assertEqual([m.id for m in plugins], ["hookify", "paste-guard"])  # sorted
+        self.assertEqual([m.id for m in agents], ["tech-lead"])
+        self.assertEqual(plugins[1].risk_class, "HIGH")
+
+    def test_invalid_json_raises_discovery_error(self) -> None:
+        entry = self.plugins_dir / "broken"
+        entry.mkdir(parents=True)
+        (entry / "manifest.json").write_text("{not json", encoding="utf-8")
+
+        with self.assertRaises(ManifestDiscoveryError) as ctx:
+            discover_manifests(plugins_dir=self.plugins_dir, agents_dir=self.agents_dir)
+        self.assertIn("invalid JSON", str(ctx.exception))
+
+    def test_non_object_payload_raises(self) -> None:
+        entry = self.plugins_dir / "arrayish"
+        entry.mkdir(parents=True)
+        (entry / "manifest.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        with self.assertRaises(ManifestDiscoveryError):
+            discover_manifests(plugins_dir=self.plugins_dir, agents_dir=self.agents_dir)
+
+    def test_validation_failure_is_wrapped_as_discovery_error(self) -> None:
+        bad = dict(_PLUGIN_VALID)
+        bad["risk_class"] = "ULTRA"  # not a valid RISK_CLASSES entry
+        _write_manifest(self.plugins_dir, "paste-guard", bad)
+
+        with self.assertRaises(ManifestDiscoveryError) as ctx:
+            discover_manifests(plugins_dir=self.plugins_dir, agents_dir=self.agents_dir)
+        self.assertIn("risk_class", str(ctx.exception))
+
+    def test_directory_without_manifest_is_recorded_as_skipped(self) -> None:
+        (self.plugins_dir / "wip-plugin").mkdir(parents=True)
+        _write_manifest(self.agents_dir, "tech-lead", _AGENT_VALID)
+
+        report = discover_manifests_with_report(
+            plugins_dir=self.plugins_dir,
+            agents_dir=self.agents_dir,
+        )
+
+        self.assertEqual(report.plugins, ())
+        self.assertEqual([m.id for m in report.agents], ["tech-lead"])
+        self.assertTrue(any("wip-plugin" in str(p) for p in report.skipped))
+
+
+class LoadPluginModuleTests(unittest.TestCase):
+    def _manifest(self, *, module_path: str) -> PluginManifest:
+        return PluginManifest(
+            id="fake",
+            name="Fake",
+            version="0.1.0",
+            kind="guard",
+            hooks_provided=(),
+            hooks_consumed=(),
+            env_keys=(),
+            autonomy_level="advisory",
+            paste_guard_required=True,
+            risk_class="LOW",
+            module_path=module_path,
+        )
+
+    def test_empty_module_path_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            load_plugin_module(self._manifest(module_path=""))
+
+    def test_lazy_import_resolves_registered_module(self) -> None:
+        mod_name = "tests_fake_loader_module_for_hook_chain"
+        fake = types.ModuleType(mod_name)
+        fake.MARKER = "hello"
+        sys.modules[mod_name] = fake
+        try:
+            module = load_plugin_module(self._manifest(module_path=mod_name))
+            self.assertIs(module, fake)
+            self.assertEqual(module.MARKER, "hello")
+        finally:
+            sys.modules.pop(mod_name, None)
+
+    def test_import_failure_propagates(self) -> None:
+        with self.assertRaises(ImportError):
+            load_plugin_module(self._manifest(module_path="definitely.not.a.real.module.x9z"))
+
+    def test_non_manifest_input_rejected(self) -> None:
+        with self.assertRaises(TypeError):
+            load_plugin_module({"module_path": "os"})  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    unittest.main()

--- a/tests/agents/test_hook_chain.py
+++ b/tests/agents/test_hook_chain.py
@@ -1,0 +1,352 @@
+"""HookChain dispatch tests (F11.1 / #107)."""
+
+from __future__ import annotations
+
+import types
+import unittest
+from typing import Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.extension.hook_chain import (
+    HookLevel,
+    HookResult,
+    invoke_hook,
+)
+from yule_orchestrator.agents.extension.manifest import HookEvent, PluginManifest
+from yule_orchestrator.agents.extension.plugin_registry import PluginRegistry
+
+
+def _manifest(
+    plugin_id: str,
+    *,
+    hooks=("OUTBOUND_LLM",),
+    risk_class: str = "LOW",
+    module_path: str = "tests.fake.module",
+) -> PluginManifest:
+    return PluginManifest(
+        id=plugin_id,
+        name=plugin_id.title(),
+        version="0.1.0",
+        kind="guard",
+        hooks_provided=tuple(hooks),
+        hooks_consumed=(),
+        env_keys=(),
+        autonomy_level="advisory",
+        paste_guard_required=False,
+        risk_class=risk_class,
+        module_path=module_path,
+    )
+
+
+def _module_with(**attrs) -> types.SimpleNamespace:
+    return types.SimpleNamespace(**attrs)
+
+
+def _loader_for(modules: dict) -> "callable":
+    """Build a deterministic module_loader from plugin_id -> module."""
+
+    def loader(manifest: PluginManifest):
+        if manifest.id not in modules:
+            raise ImportError(f"no fake module for {manifest.id}")
+        return modules[manifest.id]
+
+    return loader
+
+
+class HookChainTests(unittest.TestCase):
+    def test_no_providers_returns_ok_with_original_payload(self) -> None:
+        reg = PluginRegistry()
+        payload = {"prompt": "hello"}
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            payload,
+            plugin_registry=reg,
+            module_loader=_loader_for({}),
+        )
+
+        self.assertIs(result.level, HookLevel.OK)
+        self.assertEqual(result.modified_payload, payload)
+        self.assertEqual(result.plugin_id, "")
+
+    def test_chain_runs_providers_in_deterministic_order(self) -> None:
+        reg = PluginRegistry()
+        # Register in reverse id order to prove sort happens.
+        reg.register(_manifest("zeta"))
+        reg.register(_manifest("alpha"))
+
+        order: list[str] = []
+
+        def make_handler(plugin_id: str):
+            def handler(payload: Mapping):
+                order.append(plugin_id)
+                return HookResult(level=HookLevel.OK, plugin_id=plugin_id)
+
+            return handler
+
+        modules = {
+            "alpha": _module_with(on_outbound_llm=make_handler("alpha")),
+            "zeta": _module_with(on_outbound_llm=make_handler("zeta")),
+        }
+
+        invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertEqual(order, ["alpha", "zeta"])
+
+    def test_payload_propagates_through_chain(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("a"))
+        reg.register(_manifest("b"))
+
+        def handler_a(payload: Mapping):
+            return HookResult(
+                level=HookLevel.OK,
+                modified_payload={**payload, "via_a": True},
+            )
+
+        def handler_b(payload: Mapping):
+            # b must see the modification a produced.
+            assert payload.get("via_a") is True
+            return HookResult(
+                level=HookLevel.OK,
+                modified_payload={**payload, "via_b": True},
+            )
+
+        modules = {
+            "a": _module_with(on_outbound_llm=handler_a),
+            "b": _module_with(on_outbound_llm=handler_b),
+        }
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"start": True},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertIs(result.level, HookLevel.OK)
+        self.assertEqual(
+            result.modified_payload,
+            {"start": True, "via_a": True, "via_b": True},
+        )
+
+    def test_block_short_circuits_chain(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("blocker"))
+        reg.register(_manifest("never-runs"))
+
+        call_log: list[str] = []
+
+        def blocker(payload: Mapping):
+            call_log.append("blocker")
+            return HookResult(
+                level=HookLevel.BLOCK,
+                modified_payload=payload,
+                blocker_reason="secret detected",
+                signature="paste_guard.secret_detected",
+            )
+
+        def never_runs(payload: Mapping):
+            call_log.append("never-runs")
+            return HookResult(level=HookLevel.OK)
+
+        modules = {
+            "blocker": _module_with(on_outbound_llm=blocker),
+            "never-runs": _module_with(on_outbound_llm=never_runs),
+        }
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"prompt": "x"},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertEqual(call_log, ["blocker"])
+        self.assertIs(result.level, HookLevel.BLOCK)
+        self.assertEqual(result.plugin_id, "blocker")
+        self.assertEqual(result.signature, "paste_guard.secret_detected")
+
+    def test_handler_exception_becomes_error_result(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("broken"))
+        reg.register(_manifest("never-runs"))
+
+        def broken(payload: Mapping):
+            raise RuntimeError("kaboom")
+
+        def never_runs(payload: Mapping):
+            self.fail("chain must stop after ERROR")
+
+        modules = {
+            "broken": _module_with(on_outbound_llm=broken),
+            "never-runs": _module_with(on_outbound_llm=never_runs),
+        }
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertIs(result.level, HookLevel.ERROR)
+        self.assertEqual(result.plugin_id, "broken")
+        self.assertIn("kaboom", result.blocker_reason)
+        self.assertEqual(result.signature, "hook_chain.handler.exception")
+
+    def test_high_risk_plugin_skipped_without_allow_list(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("paste-guard", risk_class="HIGH"))
+
+        called: list[str] = []
+
+        def handler(payload: Mapping):
+            called.append("paste-guard")
+            return HookResult(level=HookLevel.OK)
+
+        modules = {"paste-guard": _module_with(on_outbound_llm=handler)}
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertEqual(called, [])
+        self.assertIs(result.level, HookLevel.SKIP)
+        self.assertEqual(result.plugin_id, "paste-guard")
+        self.assertEqual(result.signature, "hook_chain.skip.high_risk_not_allowed")
+
+    def test_high_risk_runs_when_explicitly_allowed(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("paste-guard", risk_class="HIGH"))
+
+        called: list[str] = []
+
+        def handler(payload: Mapping):
+            called.append("paste-guard")
+            return HookResult(level=HookLevel.OK, modified_payload={"sanitised": True})
+
+        modules = {"paste-guard": _module_with(on_outbound_llm=handler)}
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+            allow_high_risk=("paste-guard",),
+        )
+
+        self.assertEqual(called, ["paste-guard"])
+        self.assertIs(result.level, HookLevel.OK)
+        self.assertEqual(result.modified_payload, {"sanitised": True})
+
+    def test_handler_returning_mapping_is_treated_as_modified_payload(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("rewriter"))
+
+        def handler(payload: Mapping):
+            return {**payload, "augmented": True}
+
+        modules = {"rewriter": _module_with(on_outbound_llm=handler)}
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertIs(result.level, HookLevel.OK)
+        self.assertEqual(result.modified_payload, {"x": 1, "augmented": True})
+
+    def test_missing_handler_results_in_skip(self) -> None:
+        # Order: id-sorted -> "alpha-real" before "zeta-missing", so the
+        # working plugin runs first and the misconfigured one becomes the
+        # terminal SKIP result. The hook chain must surface that SKIP so
+        # operators see the broken plugin instead of an apparent OK.
+        reg = PluginRegistry()
+        reg.register(_manifest("alpha-real"))
+        reg.register(_manifest("zeta-missing"))
+
+        called: list[str] = []
+
+        def real_handler(payload: Mapping):
+            called.append("alpha-real")
+            return HookResult(level=HookLevel.OK)
+
+        modules = {
+            "alpha-real": _module_with(on_outbound_llm=real_handler),
+            "zeta-missing": _module_with(),  # no handler attrs at all
+        }
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        # Both plugins were visited (alpha-real ran, zeta-missing skipped).
+        self.assertEqual(called, ["alpha-real"])
+        self.assertIs(result.level, HookLevel.SKIP)
+        self.assertEqual(result.plugin_id, "zeta-missing")
+        self.assertEqual(result.signature, "hook_chain.handler.missing")
+
+    def test_module_loader_import_failure_returns_error(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("missing"))
+
+        def loader(manifest: PluginManifest):
+            raise ImportError("nope")
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=loader,
+        )
+
+        self.assertIs(result.level, HookLevel.ERROR)
+        self.assertEqual(result.plugin_id, "missing")
+        self.assertEqual(result.signature, "hook_chain.module.load_failed")
+
+    def test_hook_handlers_mapping_is_supported(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_manifest("mapper"))
+
+        def handler(payload: Mapping):
+            return HookResult(level=HookLevel.OK, modified_payload={"via_mapping": True})
+
+        modules = {
+            "mapper": _module_with(HOOK_HANDLERS={HookEvent.OUTBOUND_LLM: handler}),
+        }
+
+        result = invoke_hook(
+            HookEvent.OUTBOUND_LLM,
+            {"x": 1},
+            plugin_registry=reg,
+            module_loader=_loader_for(modules),
+        )
+
+        self.assertEqual(result.modified_payload, {"via_mapping": True})
+
+    def test_invoke_hook_rejects_non_enum_event(self) -> None:
+        reg = PluginRegistry()
+        with self.assertRaises(TypeError):
+            invoke_hook("OUTBOUND_LLM", {}, plugin_registry=reg)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #107
- parent #81
- follow-up of #102 (PR #105 — F11 MVP)

## ✨ 과제 내용
F11 MVP (PR #105) 가 PluginManifest / AgentManifest / Registry 까지만 land 한 상태. 본 PR 에서 plugin 실제 dispatch + `plugins/` / `agents/` 자동 discovery + extension-architecture 정책 1페이지를 land 한다.

- `src/yule_orchestrator/agents/extension/hook_chain.py`
  - `HookLevel(OK/WARN/SKIP/BLOCK/ERROR)`, `HookResult(level, modified_payload, blocker_reason, plugin_id, signature)`
  - `invoke_hook(event, payload, *, plugin_registry, module_loader=None, allow_high_risk=())` — id 오름차순 결정적 chain, 직전 plugin 의 `modified_payload` 가 다음 plugin 의 입력
  - `BLOCK` / `ERROR` 즉시 short-circuit, handler 예외는 `hook_chain.handler.exception` ERROR 로 변환, module load 실패는 `hook_chain.module.load_failed` ERROR 로 변환
  - HIGH risk plugin 은 `allow_high_risk` 미지정 시 SKIP + `hook_chain.skip.high_risk_not_allowed` (하드 레일)
  - handler 해석: `HOOK_HANDLERS` mapping 또는 `on_<lower_hook_name>` 콜러블, 부재 시 SKIP + `hook_chain.handler.missing`
- `src/yule_orchestrator/agents/extension/loader.py`
  - `discover_manifests(plugins_dir, agents_dir)` — `<id>/manifest.json` scan, id 오름차순 반환, validation 실패 시 `ManifestDiscoveryError` fail-fast
  - `discover_manifests_with_report` — 누락된 `manifest.json` 디렉터리를 `skipped` 로 surface
  - `load_plugin_module(manifest)` — `importlib.import_module` lazy import, 빈 `module_path` 거부 (하드 레일)
- `policies/runtime/agents/engineering-agent/extension-architecture.md`
  - plugin / agent 추가 절차, hook chain 동작, risk_class 매트릭스, hard rails 1페이지
- `src/yule_orchestrator/agents/extension/__init__.py` — 신규 surface re-export
- `tests/agents/test_hook_chain.py` 12 case + `tests/agents/test_extension_loader.py` 10 case

### Acceptance Criteria 자체 검증
1. invoke_hook 이 등록된 paste-guard / hookify / repo-map 류 plugin 의 hooks_provided 매칭 chain 호출 — `test_chain_runs_providers_in_deterministic_order`, `test_payload_propagates_through_chain`, `test_hook_handlers_mapping_is_supported`
2. BLOCK level 시 즉시 stop + 이후 plugin 미호출 — `test_block_short_circuits_chain`
3. discover_manifests 가 `plugins/` 와 `agents/` 의 `manifest.json` 모두 인식 — `test_discovers_plugin_and_agent_manifests`
4. load_plugin_module 이 manifest.module_path 를 importlib 로 lazy import — `test_lazy_import_resolves_registered_module`
5. extension-architecture.md 1페이지 — 위 정책 문서

### 회귀
- 신규 단위 22 PASS (`tests/agents/test_hook_chain.py` 12 + `tests/agents/test_extension_loader.py` 10)
- `tests/agents` 전체 470 PASS (+22)
- full `python3 -m unittest discover -s tests` 3879 중 1 fail (`runtime.test_gateway_shutdown.test_login_failure_translates_to_value_error`) — base branch 에서도 동일하게 실패하는 사전 회귀로 본 PR 변경과 무관 (`discord.LoginFailure` 미존재 환경 이슈)

## :camera_with_flash: 스크린샷(선택)
- 해당 없음 (CLI / 정책 변경).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 새로 알게 된 내용
  - `unittest.discover` 가 동일 베이스 이름의 테스트 파일을 sub-package 사이에서 충돌로 무시할 수 있음 → `__init__.py` 존재 확인 후 명시 sub-path 로 fallback 시 정확히 잡힘
  - plugin handler 의 반환값을 `HookResult` / `Mapping` / `None` 세 가지로 어댑팅하면 fake plugin fixture 가 매우 간결해져 회귀 케이스 작성 비용이 낮아진다
- 후속 / 궁금
  - F11.2 에서 HookChain 을 paste_guard / mistake_ledger / repo_map 의 실제 entrypoint 에 wiring 할 때 `allow_high_risk` 화이트리스트를 어디서 주입할지 (router level vs settings.json) 결정 필요
  - `runtime.test_gateway_shutdown` 의 사전 회귀는 `discord.py` 버전 핀 변경 또는 패치 자체 회복력 강화로 별도 이슈 묶음에서 처리