### PR TITLE
✨ [Feat] F6 Discord 토의 UX — 결론/이유/리스크/다음액션 4-block 답변

### DIFF
--- a/src/yule_orchestrator/agents/conversation/__init__.py
+++ b/src/yule_orchestrator/agents/conversation/__init__.py
@@ -1,0 +1,64 @@
+"""Conversation surface — F6 4-block 토의 답변 빌더 (#93).
+
+Discord 토의가 단순 답변 봇이 아니라 *결론 / 이유 / 리스크 / 다음 액션*
+4-block 으로 정형화된 답변으로 끝나도록 묶어 주는 surface 모듈.
+
+본 패키지의 범위는 데이터 변환만이다 — 외부 I/O (LLM 호출 / Discord
+post / GitHub 등) 는 **호출자 책임**. F5 (live retrieval provider) /
+F10 (Claude memory provider) 는 후속 PR 에서 실 wiring 되며, 본 PR
+은 :class:`RetrievalProvider` / :class:`MemoryProvider` Protocol seam
++ deterministic fake 만 land 한다.
+
+엔트리 포인트:
+
+* :class:`DiscussionResponse` — frozen dataclass, 4 필드 + evidence /
+  memory ref + ``mode_hint``.
+* :func:`build_discussion_response` — :class:`ContextPack` +
+  :class:`DecisionRequest` 받아 deterministic 합성.
+* :func:`render_user_surface` / :func:`render_operator_surface` —
+  사용자 surface vs operator surface 분리. operator trace 가
+  사용자 surface 로 누출되지 않도록 가드.
+
+PasteGuard 호출은 본 모듈 책임이 아니다. caller (gateway / status
+poster) 가 outbound 전에 :func:`guard_outbound` 으로 한 번 더 감싼다.
+"""
+
+from .discussion_response import (
+    DiscussionResponse,
+    EvidenceRef,
+    MemoryProvider,
+    MemoryRef,
+    MODE_HINT_CLARIFICATION_NEEDED,
+    MODE_HINT_DISCUSSION,
+    MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    MODE_HINT_RESEARCH_ONLY,
+    MODE_HINTS,
+    RetrievalProvider,
+    EVIDENCE_SCORE_THRESHOLD,
+    NullMemoryProvider,
+    NullRetrievalProvider,
+    build_discussion_response,
+)
+from .response_format import (
+    render_operator_surface,
+    render_user_surface,
+)
+
+__all__ = (
+    "DiscussionResponse",
+    "EvidenceRef",
+    "MemoryProvider",
+    "MemoryRef",
+    "MODE_HINT_CLARIFICATION_NEEDED",
+    "MODE_HINT_DISCUSSION",
+    "MODE_HINT_IMPLEMENTATION_CANDIDATE",
+    "MODE_HINT_RESEARCH_ONLY",
+    "MODE_HINTS",
+    "RetrievalProvider",
+    "EVIDENCE_SCORE_THRESHOLD",
+    "NullMemoryProvider",
+    "NullRetrievalProvider",
+    "build_discussion_response",
+    "render_operator_surface",
+    "render_user_surface",
+)

--- a/src/yule_orchestrator/agents/conversation/discussion_response.py
+++ b/src/yule_orchestrator/agents/conversation/discussion_response.py
@@ -1,0 +1,597 @@
+"""4-block 토의 답변 빌더 — F6 / #93.
+
+본 모듈은 Discord 토의 turn 의 결과를 *결론 (conclusion) / 이유
+(reasoning) / 리스크 (risks) / 다음 액션 (next_actions)* 네 가지로
+정형화한 :class:`DiscussionResponse` 를 만든다.
+
+설계 원칙:
+
+1. **순수 데이터 변환.** I/O 는 호출자 책임. retrieval / memory 입력
+   은 :class:`RetrievalProvider` / :class:`MemoryProvider` Protocol
+   로 주입한다. 본 PR 은 fake provider 만 land 한다 — F5 (#92) /
+   F10 후속 PR 에서 실 wiring.
+2. **mode_hint 전환 가시화.** 입력 mode 가 단정적이지 않으면 답변
+   말미에 mode 전환 제안 (`clarification_needed` /
+   `research_only` / `implementation_candidate`) 을 첨부.
+3. **Hard rails.**
+
+   * evidence ``score < EVIDENCE_SCORE_THRESHOLD`` 이면 evidence
+     를 채택하지 않고 risks 에 "근거 부족" 명시.
+   * 어떤 필드도 빈 문자열로 두지 않는다 — 최소한 한 문장을 작성.
+   * 본 모듈은 plain 출력. PasteGuard 호출은 caller 책임.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+)
+
+from ..decision.context_pack import ContextPack
+from ..decision.router import (
+    DecisionRequest,
+    MODE_CLARIFICATION_NEEDED,
+    MODE_DISCUSSION,
+    MODE_IMPLEMENTATION_CANDIDATE,
+    MODE_RESEARCH_ONLY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mode hint vocabulary
+# ---------------------------------------------------------------------------
+
+
+MODE_HINT_DISCUSSION: str = MODE_DISCUSSION
+MODE_HINT_RESEARCH_ONLY: str = MODE_RESEARCH_ONLY
+MODE_HINT_IMPLEMENTATION_CANDIDATE: str = MODE_IMPLEMENTATION_CANDIDATE
+MODE_HINT_CLARIFICATION_NEEDED: str = MODE_CLARIFICATION_NEEDED
+
+MODE_HINTS: Tuple[str, ...] = (
+    MODE_HINT_DISCUSSION,
+    MODE_HINT_RESEARCH_ONLY,
+    MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    MODE_HINT_CLARIFICATION_NEEDED,
+)
+
+
+# Evidence / memory score threshold — 그 아래는 채택 안 함.
+EVIDENCE_SCORE_THRESHOLD: float = 0.3
+
+
+# ---------------------------------------------------------------------------
+# Refs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """retrieval provider 가 만들어 주는 evidence 한 건.
+
+    * ``kind`` — ``"note"`` / ``"issue"`` / ``"pr"`` / ``"commit"`` 등 자유
+      문자열. 본 모듈은 검증하지 않는다.
+    * ``title`` — 사람이 읽는 짧은 제목.
+    * ``url_or_path`` — 클릭/접근 가능한 위치. 비어 있을 수 있다.
+    * ``snippet`` — 1~2 문장 요약. None 허용.
+    * ``score`` — 0.0 ~ 1.0. ``EVIDENCE_SCORE_THRESHOLD`` 미만이면
+      :func:`build_discussion_response` 가 채택하지 않는다.
+    """
+
+    kind: str
+    title: str
+    url_or_path: str
+    snippet: Optional[str] = None
+    score: float = 0.0
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "kind": self.kind,
+            "title": self.title,
+            "url_or_path": self.url_or_path,
+            "snippet": self.snippet,
+            "score": self.score,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryRef:
+    """memory provider 가 만들어 주는 shard 한 건.
+
+    Claude memory / Obsidian shard 등 *recall* 류 자료. 본 모듈은
+    의미 검증을 하지 않는다 — provider 가 score 까지 채워서 넘긴다.
+    """
+
+    kind: str
+    title: str
+    summary: str
+    source: str
+    score: float = 0.0
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "kind": self.kind,
+            "title": self.title,
+            "summary": self.summary,
+            "source": self.source,
+            "score": self.score,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Provider protocols (F5 / F10 후속 PR 에서 실 wiring)
+# ---------------------------------------------------------------------------
+
+
+class RetrievalProvider(Protocol):
+    """F5 후속 PR 에서 실 ranking 결과를 채울 seam.
+
+    * ``role`` — tech-lead / backend-engineer / ... role 키.
+    * ``keywords`` — DecisionRequest 에서 뽑아 낸 키워드.
+    * ``limit`` — 최대 반환 개수.
+    """
+
+    def for_request(
+        self,
+        *,
+        role: Optional[str],
+        keywords: Sequence[str],
+        limit: int,
+    ) -> Tuple[EvidenceRef, ...]:  # pragma: no cover - Protocol
+        ...
+
+
+class MemoryProvider(Protocol):
+    """F10 후속 PR 에서 실 Claude memory recall 을 채울 seam."""
+
+    def recent_shards(
+        self,
+        *,
+        role: Optional[str],
+        topic: str,
+        limit: int,
+    ) -> Tuple[MemoryRef, ...]:  # pragma: no cover - Protocol
+        ...
+
+
+class NullRetrievalProvider:
+    """본 PR 의 default — 빈 evidence 반환 fake."""
+
+    def for_request(
+        self,
+        *,
+        role: Optional[str],
+        keywords: Sequence[str],
+        limit: int,
+    ) -> Tuple[EvidenceRef, ...]:
+        return ()
+
+
+class NullMemoryProvider:
+    """본 PR 의 default — 빈 memory 반환 fake."""
+
+    def recent_shards(
+        self,
+        *,
+        role: Optional[str],
+        topic: str,
+        limit: int,
+    ) -> Tuple[MemoryRef, ...]:
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# Response model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiscussionResponse:
+    """4-block 답변 컨테이너 — 결론 / 이유 / 리스크 / 다음 액션.
+
+    * ``conclusion`` — 단정형 1~2 줄. 빈 문자열 금지.
+    * ``reasoning`` — 결론에 도달한 이유 (>=1 항).
+    * ``risks`` — 위험 / 미확정 (>=1 항). 위험이 정말 없으면 ``"낮음"``.
+    * ``next_actions`` — 다음 단계 1~3 항.
+    * ``evidence_refs`` — 채택된 :class:`EvidenceRef` (score >= threshold).
+    * ``memory_refs`` — 채택된 :class:`MemoryRef`.
+    * ``mode_hint`` — 다음 turn 에 제안할 mode (None 이면 mode 전환 없음).
+    """
+
+    conclusion: str
+    reasoning: Tuple[str, ...]
+    risks: Tuple[str, ...]
+    next_actions: Tuple[str, ...]
+    evidence_refs: Tuple[EvidenceRef, ...] = ()
+    memory_refs: Tuple[MemoryRef, ...] = ()
+    mode_hint: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not (self.conclusion or "").strip():
+            raise ValueError("DiscussionResponse.conclusion must not be empty")
+        if not self.reasoning:
+            raise ValueError("DiscussionResponse.reasoning must have ≥1 item")
+        if not self.risks:
+            raise ValueError("DiscussionResponse.risks must have ≥1 item")
+        if not self.next_actions:
+            raise ValueError("DiscussionResponse.next_actions must have ≥1 item")
+        if self.mode_hint is not None and self.mode_hint not in MODE_HINTS:
+            raise ValueError(
+                f"DiscussionResponse.mode_hint must be one of {MODE_HINTS}, "
+                f"got {self.mode_hint!r}"
+            )
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "conclusion": self.conclusion,
+            "reasoning": list(self.reasoning),
+            "risks": list(self.risks),
+            "next_actions": list(self.next_actions),
+            "evidence_refs": [ref.to_dict() for ref in self.evidence_refs],
+            "memory_refs": [ref.to_dict() for ref in self.memory_refs],
+            "mode_hint": self.mode_hint,
+            "metadata": dict(self.metadata),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def build_discussion_response(
+    *,
+    request: DecisionRequest,
+    context_pack: ContextPack,
+    retrieval: Optional[RetrievalProvider] = None,
+    memory: Optional[MemoryProvider] = None,
+    role_perspective: Optional[str] = None,
+    mode_hint: Optional[str] = None,
+    evidence_limit: int = 3,
+    memory_limit: int = 3,
+) -> DiscussionResponse:
+    """``request`` + ``context_pack`` 으로 4-block 답변 합성.
+
+    * ``mode_hint`` 가 명시되면 그대로 채택 — 단, 알 수 없는 값이면
+      ``ValueError`` (Response __post_init__ 가드).
+    * ``mode_hint`` 가 ``None`` 이면 deterministic 추정:
+      pack 비어 있으면 ``clarification_needed``, research_only 키워드
+      가 prompt 에 있으면 ``research_only``, 구현 키워드면
+      ``implementation_candidate``, 그 외에는 mode_hint 없음.
+    * evidence / memory 는 ``score >= EVIDENCE_SCORE_THRESHOLD`` 인
+      항목만 채택. 채택 결과 0 건이면 ``risks`` 에 "근거 부족" 명시.
+    * Reasoning 은 context pack 의 related notes / issues / PRs /
+      code hints 를 사람 읽기용 한국어 한 줄씩 변환.
+    """
+
+    retrieval_provider: RetrievalProvider = retrieval or NullRetrievalProvider()
+    memory_provider: MemoryProvider = memory or NullMemoryProvider()
+
+    prompt = (request.prompt or "").strip()
+    keywords = _extract_keywords(prompt)
+    topic = _short_topic(prompt)
+
+    raw_evidence = retrieval_provider.for_request(
+        role=role_perspective, keywords=keywords, limit=evidence_limit
+    )
+    raw_memory = memory_provider.recent_shards(
+        role=role_perspective, topic=topic, limit=memory_limit
+    )
+
+    evidence = tuple(
+        ref for ref in raw_evidence if ref.score >= EVIDENCE_SCORE_THRESHOLD
+    )
+    memory_refs = tuple(
+        ref for ref in raw_memory if ref.score >= EVIDENCE_SCORE_THRESHOLD
+    )
+
+    derived_mode = mode_hint if mode_hint is not None else _derive_mode_hint(
+        prompt=prompt, context_pack=context_pack
+    )
+
+    conclusion = _build_conclusion(
+        topic=topic,
+        mode_hint=derived_mode,
+        role_perspective=role_perspective,
+        context_pack=context_pack,
+        evidence=evidence,
+    )
+    reasoning = _build_reasoning(
+        context_pack=context_pack,
+        evidence=evidence,
+        memory=memory_refs,
+        role_perspective=role_perspective,
+    )
+    risks = _build_risks(
+        context_pack=context_pack,
+        evidence=evidence,
+        raw_evidence=raw_evidence,
+        mode_hint=derived_mode,
+    )
+    next_actions = _build_next_actions(
+        mode_hint=derived_mode,
+        context_pack=context_pack,
+        role_perspective=role_perspective,
+    )
+
+    return DiscussionResponse(
+        conclusion=conclusion,
+        reasoning=reasoning,
+        risks=risks,
+        next_actions=next_actions,
+        evidence_refs=evidence,
+        memory_refs=memory_refs,
+        mode_hint=derived_mode,
+        metadata={
+            "context_pack_id": context_pack.id,
+            "role_perspective": role_perspective,
+            "evidence_threshold": EVIDENCE_SCORE_THRESHOLD,
+            "evidence_total": len(raw_evidence),
+            "evidence_accepted": len(evidence),
+            "memory_total": len(raw_memory),
+            "memory_accepted": len(memory_refs),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder internals
+# ---------------------------------------------------------------------------
+
+
+_RESEARCH_HINTS: Tuple[str, ...] = (
+    "research",
+    "조사",
+    "리서치",
+    "참고 자료",
+    "자료 수집",
+    "정리만",
+)
+
+_IMPLEMENTATION_HINTS: Tuple[str, ...] = (
+    "구현",
+    "implement",
+    "수정해",
+    "버그 고",
+    "버그 수정",
+    "open a pr",
+    "draft pr",
+    "pr 만들",
+    "pr 올려",
+)
+
+_AMBIGUOUS_HINTS: Tuple[str, ...] = (
+    "??",
+    "모르겠",
+    "헷갈",
+    "not sure",
+    "maybe",
+)
+
+
+def _derive_mode_hint(
+    *, prompt: str, context_pack: ContextPack
+) -> Optional[str]:
+    if not prompt:
+        return MODE_HINT_CLARIFICATION_NEEDED
+
+    lowered = prompt.lower()
+
+    if any(hint in lowered for hint in _AMBIGUOUS_HINTS) and context_pack.is_empty:
+        return MODE_HINT_CLARIFICATION_NEEDED
+
+    has_research = any(hint in lowered for hint in _RESEARCH_HINTS)
+    has_impl = any(hint in lowered for hint in _IMPLEMENTATION_HINTS)
+
+    if has_research and not has_impl:
+        return MODE_HINT_RESEARCH_ONLY
+    if has_impl and not has_research:
+        return MODE_HINT_IMPLEMENTATION_CANDIDATE
+
+    if context_pack.is_empty:
+        return MODE_HINT_CLARIFICATION_NEEDED
+    return None
+
+
+def _short_topic(text: str, max_chars: int = 60) -> str:
+    if not text:
+        return "(요청 본문 없음)"
+    head = text.strip().splitlines()[0].strip()
+    if not head:
+        return "(요청 본문 없음)"
+    if len(head) <= max_chars:
+        return head
+    return head[: max_chars - 1].rstrip() + "…"
+
+
+def _extract_keywords(text: str, *, limit: int = 6) -> Tuple[str, ...]:
+    if not text:
+        return ()
+    cleaned: list = []
+    for token in text.replace("\n", " ").split():
+        stripped = token.strip(".,!?;:()[]{}\"'`").lower()
+        if len(stripped) < 2:
+            continue
+        if stripped in cleaned:
+            continue
+        cleaned.append(stripped)
+        if len(cleaned) >= limit:
+            break
+    return tuple(cleaned)
+
+
+def _build_conclusion(
+    *,
+    topic: str,
+    mode_hint: Optional[str],
+    role_perspective: Optional[str],
+    context_pack: ContextPack,
+    evidence: Tuple[EvidenceRef, ...],
+) -> str:
+    role_label = (role_perspective or "tech-lead").split("/")[-1]
+    if mode_hint == MODE_HINT_CLARIFICATION_NEEDED:
+        return (
+            f"\"{topic}\" 는 지금 정보만으로 결론을 내기엔 부족합니다 — "
+            "추가 정보를 받은 뒤 합의로 이어 가는 게 안전합니다."
+        )
+    if mode_hint == MODE_HINT_RESEARCH_ONLY:
+        return (
+            f"\"{topic}\" 는 코드 변경 전에 자료부터 모으는 단계로 진행합니다."
+        )
+    if mode_hint == MODE_HINT_IMPLEMENTATION_CANDIDATE:
+        return (
+            f"\"{topic}\" 는 구현 후보로 보입니다 — 권한 제안을 먼저 만들어 검토합니다."
+        )
+    # discussion 또는 mode_hint 없음
+    if evidence:
+        return (
+            f"\"{topic}\" 는 모은 근거 {len(evidence)} 건을 기준으로 "
+            f"{role_label} 관점에서 토의를 이어 가겠습니다."
+        )
+    return (
+        f"\"{topic}\" 는 {role_label} 관점에서 다음 단계를 함께 정해 보겠습니다."
+    )
+
+
+def _build_reasoning(
+    *,
+    context_pack: ContextPack,
+    evidence: Tuple[EvidenceRef, ...],
+    memory: Tuple[MemoryRef, ...],
+    role_perspective: Optional[str],
+) -> Tuple[str, ...]:
+    out: list = []
+
+    if context_pack.related_notes:
+        out.append(
+            f"Obsidian 관련 노트 {len(context_pack.related_notes)} 건 "
+            f"(예: {context_pack.related_notes[0]})"
+        )
+    if context_pack.related_issues:
+        issue_list = ", ".join(f"#{n}" for n in context_pack.related_issues[:3])
+        out.append(f"관련 이슈 — {issue_list}")
+    if context_pack.related_prs:
+        pr_list = ", ".join(f"#{n}" for n in context_pack.related_prs[:3])
+        out.append(f"관련 PR — {pr_list}")
+    if context_pack.code_hints:
+        hints = ", ".join(context_pack.code_hints[:3])
+        out.append(f"코드 힌트 — {hints}")
+
+    for ref in evidence:
+        prefix = ref.kind or "evidence"
+        title = ref.title or "(제목 없음)"
+        out.append(f"근거({prefix}): {title}")
+
+    for ref in memory:
+        out.append(f"기억({ref.kind}): {ref.title}")
+
+    if role_perspective:
+        out.append(
+            f"역할 관점 — {role_perspective.split('/')[-1]} 시선으로 1차 검토"
+        )
+
+    if not out:
+        out.append(
+            "현재 context pack 이 비어 있어, 추가 정보가 확보된 이후 재평가합니다."
+        )
+    return tuple(out)
+
+
+def _build_risks(
+    *,
+    context_pack: ContextPack,
+    evidence: Tuple[EvidenceRef, ...],
+    raw_evidence: Tuple[EvidenceRef, ...],
+    mode_hint: Optional[str],
+) -> Tuple[str, ...]:
+    risks: list = []
+
+    if not evidence:
+        if raw_evidence:
+            risks.append(
+                "근거 부족 — retrieval 결과가 신뢰 임계값 미달이라 채택하지 않았습니다."
+            )
+        else:
+            risks.append(
+                "근거 부족 — retrieval 가 빈 결과를 반환했습니다."
+            )
+
+    if context_pack.is_empty:
+        risks.append("Context pack 이 비어 있어 잘못된 가정이 들어갈 위험.")
+
+    if mode_hint == MODE_HINT_IMPLEMENTATION_CANDIDATE:
+        risks.append(
+            "구현 단계는 권한 제안 + 사용자 승인 phrase 가 선행되지 않으면 코드 변경 금지."
+        )
+    if mode_hint == MODE_HINT_CLARIFICATION_NEEDED:
+        risks.append(
+            "추가 정보를 받기 전 진행하면 잘못된 방향으로 작업이 분기할 위험."
+        )
+
+    if not risks:
+        risks.append("낮음 — 결정적 차단 요인 없음. 합의 즉시 다음 단계로 진행 가능.")
+    return tuple(risks)
+
+
+def _build_next_actions(
+    *,
+    mode_hint: Optional[str],
+    context_pack: ContextPack,
+    role_perspective: Optional[str],
+) -> Tuple[str, ...]:
+    if mode_hint == MODE_HINT_CLARIFICATION_NEEDED:
+        return (
+            "막혀 있는 지점 / 원하는 결과를 한 줄로 알려 주세요.",
+            "참고 가능한 링크 · PR · 스크린샷이 있으면 함께 주세요.",
+            "정보가 정리되면 토의 / 조사 / 구현 중 어느 흐름으로 갈지 정합니다.",
+        )
+    if mode_hint == MODE_HINT_RESEARCH_ONLY:
+        return (
+            "research collector 호출로 1차 자료 수집.",
+            "정리 결과를 Obsidian research note + thread 에 게시.",
+            "구현 필요 여부는 별도 요청 (`수정 권한 제안`) 으로 분기.",
+        )
+    if mode_hint == MODE_HINT_IMPLEMENTATION_CANDIDATE:
+        return (
+            "tech-lead 가 추천 executor 역할을 1차 제안.",
+            "권한 제안 (CodingAuthorizationProposal) 을 사용자에게 표시.",
+            "사용자 승인 phrase 전까지는 어떤 파일도 수정하지 않음.",
+        )
+    # discussion / 기본
+    actions: list = [
+        "결정이 필요한 항목을 한 번에 하나씩 합의.",
+    ]
+    if role_perspective:
+        actions.append(
+            f"{role_perspective.split('/')[-1]} 관점 체크 포인트 1차 답변 받기."
+        )
+    else:
+        actions.append("관련 역할 관점 (backend / frontend / devops / qa) 보강 필요.")
+    actions.append(
+        "방향이 정해지면 `수정 권한 제안` 으로 답해 권한 제안 흐름으로 이동."
+    )
+    return tuple(actions)
+
+
+__all__ = (
+    "DiscussionResponse",
+    "EvidenceRef",
+    "MemoryProvider",
+    "MemoryRef",
+    "MODE_HINT_CLARIFICATION_NEEDED",
+    "MODE_HINT_DISCUSSION",
+    "MODE_HINT_IMPLEMENTATION_CANDIDATE",
+    "MODE_HINT_RESEARCH_ONLY",
+    "MODE_HINTS",
+    "RetrievalProvider",
+    "EVIDENCE_SCORE_THRESHOLD",
+    "NullMemoryProvider",
+    "NullRetrievalProvider",
+    "build_discussion_response",
+)

--- a/src/yule_orchestrator/agents/conversation/response_format.py
+++ b/src/yule_orchestrator/agents/conversation/response_format.py
@@ -1,0 +1,195 @@
+"""DiscussionResponse 렌더러 — user surface vs operator surface 분리.
+
+* :func:`render_user_surface` — Discord 에 노출되는 4-block 본문만.
+  retrieval trace / classifier verdict / context pack id 등 운영자
+  전용 정보는 절대 포함하지 않는다.
+* :func:`render_operator_surface` — ``#봇-상태`` 등 운영자 surface 용.
+  user surface 본문 + classifier verdict / retrieval trace / pack
+  metadata 를 함께 노출.
+
+PasteGuard 호출은 본 모듈 책임이 아니다. caller (status poster /
+gateway) 가 outbound 전에 :func:`guard_outbound` 으로 한 번 더 감싼다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from .discussion_response import (
+    DiscussionResponse,
+    EVIDENCE_SCORE_THRESHOLD,
+    EvidenceRef,
+    MemoryRef,
+    MODE_HINT_CLARIFICATION_NEEDED,
+    MODE_HINT_DISCUSSION,
+    MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    MODE_HINT_RESEARCH_ONLY,
+)
+
+
+# ---------------------------------------------------------------------------
+# User surface
+# ---------------------------------------------------------------------------
+
+
+_MODE_HINT_LABEL: Mapping[str, str] = {
+    MODE_HINT_DISCUSSION: "토의 (discussion)",
+    MODE_HINT_RESEARCH_ONLY: "조사 (research_only)",
+    MODE_HINT_IMPLEMENTATION_CANDIDATE: "구현 후보 (implementation_candidate)",
+    MODE_HINT_CLARIFICATION_NEEDED: "추가 질문 필요 (clarification_needed)",
+}
+
+
+def render_user_surface(resp: DiscussionResponse) -> str:
+    """4-block 사용자 surface 문자열.
+
+    구성:
+
+    ```
+    **결론**
+    <conclusion>
+
+    **이유**
+    - ...
+
+    **리스크**
+    - ...
+
+    **다음 액션**
+    - ...
+
+    > 모드 전환 제안: <mode label> (선택)
+    ```
+
+    * retrieval_trace / classifier verdict / context_pack_id 등 운영자
+      전용 정보는 절대 포함하지 않는다.
+    * mode_hint 가 ``None`` 이면 모드 전환 한 줄을 생략한다.
+    """
+
+    if not isinstance(resp, DiscussionResponse):
+        raise TypeError(
+            f"render_user_surface expects DiscussionResponse, got {type(resp).__name__}"
+        )
+
+    lines: list = ["**결론**", resp.conclusion.strip(), ""]
+
+    lines.append("**이유**")
+    lines.extend(f"- {item}" for item in resp.reasoning)
+    lines.append("")
+
+    lines.append("**리스크**")
+    lines.extend(f"- {item}" for item in resp.risks)
+    lines.append("")
+
+    lines.append("**다음 액션**")
+    lines.extend(f"- {item}" for item in resp.next_actions)
+
+    if resp.mode_hint and resp.mode_hint in _MODE_HINT_LABEL:
+        label = _MODE_HINT_LABEL[resp.mode_hint]
+        lines.append("")
+        lines.append(f"> 모드 전환 제안: **{label}** 로 이어 갈까요?")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Operator surface
+# ---------------------------------------------------------------------------
+
+
+def render_operator_surface(
+    resp: DiscussionResponse,
+    *,
+    classifier_verdict: Optional[Mapping[str, Any]] = None,
+    retrieval_trace: Optional[Sequence[Mapping[str, Any]]] = None,
+) -> str:
+    """``#봇-상태`` operator surface 문자열.
+
+    user surface 본문 + 다음을 추가:
+
+    * `Classifier verdict` — :class:`DecisionResult.to_payload()` 형 dict.
+    * `Retrieval trace` — provider 가 만든 trace entries.
+    * `Pack metadata` — :class:`DiscussionResponse.metadata` (pack id, 임계값
+      등).
+    * `Evidence / Memory refs` — 채택된 ref 목록 (점수 포함).
+
+    user surface 만 추출하려면 :func:`render_user_surface` 를 직접 호출.
+    """
+
+    if not isinstance(resp, DiscussionResponse):
+        raise TypeError(
+            f"render_operator_surface expects DiscussionResponse, got {type(resp).__name__}"
+        )
+
+    parts: list = [render_user_surface(resp), "---", "**Operator trace**", ""]
+
+    if classifier_verdict:
+        parts.append("Classifier verdict:")
+        parts.extend(_render_kv(classifier_verdict))
+        parts.append("")
+
+    if retrieval_trace:
+        parts.append("Retrieval trace:")
+        for entry in retrieval_trace:
+            parts.append(f"- {_compact_kv(entry)}")
+        parts.append("")
+
+    if resp.evidence_refs:
+        parts.append(f"Evidence refs (threshold {EVIDENCE_SCORE_THRESHOLD}):")
+        for ref in resp.evidence_refs:
+            parts.append(f"- {_render_evidence(ref)}")
+        parts.append("")
+
+    if resp.memory_refs:
+        parts.append("Memory refs:")
+        for ref in resp.memory_refs:
+            parts.append(f"- {_render_memory(ref)}")
+        parts.append("")
+
+    if resp.metadata:
+        parts.append("Pack metadata:")
+        parts.extend(_render_kv(resp.metadata))
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _render_kv(mapping: Mapping[str, Any]) -> list:
+    out: list = []
+    for key, value in mapping.items():
+        out.append(f"- {key}: {_format_value(value)}")
+    return out
+
+
+def _compact_kv(entry: Mapping[str, Any]) -> str:
+    return ", ".join(f"{k}={_format_value(v)}" for k, v in entry.items())
+
+
+def _format_value(value: Any) -> str:
+    if is_dataclass(value):
+        return repr(asdict(value))
+    return repr(value)
+
+
+def _render_evidence(ref: EvidenceRef) -> str:
+    location = ref.url_or_path or "(no-url)"
+    return (
+        f"{ref.kind}: {ref.title} · {location} · score={ref.score}"
+    )
+
+
+def _render_memory(ref: MemoryRef) -> str:
+    return (
+        f"{ref.kind}: {ref.title} · source={ref.source} · score={ref.score}"
+    )
+
+
+__all__ = (
+    "render_operator_surface",
+    "render_user_surface",
+)

--- a/tests/agents/test_discussion_response.py
+++ b/tests/agents/test_discussion_response.py
@@ -1,0 +1,385 @@
+"""DiscussionResponse builder 회귀 (#93).
+
+4 mode x fake retrieval/memory provider 매트릭스 ≤18 case. F5 / F10
+live wiring 은 후속 PR — 본 테스트는 deterministic fake 만 사용한다.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple
+
+import pytest
+
+from yule_orchestrator.agents.conversation.discussion_response import (
+    DiscussionResponse,
+    EVIDENCE_SCORE_THRESHOLD,
+    EvidenceRef,
+    MODE_HINT_CLARIFICATION_NEEDED,
+    MODE_HINT_DISCUSSION,
+    MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    MODE_HINT_RESEARCH_ONLY,
+    MODE_HINTS,
+    MemoryRef,
+    NullMemoryProvider,
+    NullRetrievalProvider,
+    build_discussion_response,
+)
+from yule_orchestrator.agents.decision.context_pack import ContextPack
+from yule_orchestrator.agents.decision.router import DecisionRequest
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeRetrievalProvider:
+    """Deterministic fake — 호출 인자를 record + 미리 셋된 evidence 반환."""
+
+    def __init__(self, evidence: Tuple[EvidenceRef, ...]) -> None:
+        self._evidence = evidence
+        self.calls: list = []
+
+    def for_request(
+        self,
+        *,
+        role: Optional[str],
+        keywords: Sequence[str],
+        limit: int,
+    ) -> Tuple[EvidenceRef, ...]:
+        self.calls.append({"role": role, "keywords": tuple(keywords), "limit": limit})
+        return self._evidence[:limit]
+
+
+class FakeMemoryProvider:
+    """Deterministic fake — recent_shards 호출 record."""
+
+    def __init__(self, shards: Tuple[MemoryRef, ...]) -> None:
+        self._shards = shards
+        self.calls: list = []
+
+    def recent_shards(
+        self,
+        *,
+        role: Optional[str],
+        topic: str,
+        limit: int,
+    ) -> Tuple[MemoryRef, ...]:
+        self.calls.append({"role": role, "topic": topic, "limit": limit})
+        return self._shards[:limit]
+
+
+def _pack(
+    *,
+    notes=(),
+    issues=(),
+    prs=(),
+    hints=(),
+    threads=(),
+) -> ContextPack:
+    return ContextPack(
+        id="ctx-test-001",
+        related_notes=tuple(notes),
+        recent_threads=tuple(threads),
+        related_issues=tuple(issues),
+        related_prs=tuple(prs),
+        code_hints=tuple(hints),
+        created_at="2026-05-11T00:00:00+00:00",
+        metadata={},
+    )
+
+
+def _request(prompt: str) -> DecisionRequest:
+    return DecisionRequest(prompt=prompt, session_id="sess-1", channel="dm")
+
+
+# ---------------------------------------------------------------------------
+# 1. Acceptance — DiscussionResponse 가 4 필드 명시
+# ---------------------------------------------------------------------------
+
+
+def test_discussion_response_has_four_blocks() -> None:
+    resp = DiscussionResponse(
+        conclusion="결론 1줄.",
+        reasoning=("이유",),
+        risks=("리스크",),
+        next_actions=("다음 액션",),
+    )
+    assert resp.conclusion
+    assert resp.reasoning
+    assert resp.risks
+    assert resp.next_actions
+
+
+def test_discussion_response_rejects_empty_fields() -> None:
+    with pytest.raises(ValueError):
+        DiscussionResponse(
+            conclusion="",
+            reasoning=("이유",),
+            risks=("리스크",),
+            next_actions=("다음",),
+        )
+    with pytest.raises(ValueError):
+        DiscussionResponse(
+            conclusion="결론",
+            reasoning=(),
+            risks=("리스크",),
+            next_actions=("다음",),
+        )
+    with pytest.raises(ValueError):
+        DiscussionResponse(
+            conclusion="결론",
+            reasoning=("이유",),
+            risks=(),
+            next_actions=("다음",),
+        )
+    with pytest.raises(ValueError):
+        DiscussionResponse(
+            conclusion="결론",
+            reasoning=("이유",),
+            risks=("리스크",),
+            next_actions=(),
+        )
+
+
+def test_discussion_response_rejects_unknown_mode_hint() -> None:
+    with pytest.raises(ValueError):
+        DiscussionResponse(
+            conclusion="결론",
+            reasoning=("이유",),
+            risks=("리스크",),
+            next_actions=("다음",),
+            mode_hint="bogus_mode",
+        )
+
+
+def test_mode_hints_exposed_constants_match() -> None:
+    assert set(MODE_HINTS) == {
+        MODE_HINT_DISCUSSION,
+        MODE_HINT_RESEARCH_ONLY,
+        MODE_HINT_IMPLEMENTATION_CANDIDATE,
+        MODE_HINT_CLARIFICATION_NEEDED,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. 4 mode x fake provider 매트릭스
+# ---------------------------------------------------------------------------
+
+
+def test_build_discussion_mode_with_evidence_accepted() -> None:
+    evidence = (
+        EvidenceRef(
+            kind="note",
+            title="aggregator-spec",
+            url_or_path="notes/agg.md",
+            snippet="aggregator spec",
+            score=0.9,
+        ),
+    )
+    retrieval = FakeRetrievalProvider(evidence)
+    memory = FakeMemoryProvider(())
+    resp = build_discussion_response(
+        request=_request("다음 스프린트 방향 토의해줘"),
+        context_pack=_pack(notes=("notes/agg.md",)),
+        retrieval=retrieval,
+        memory=memory,
+        role_perspective="engineering-agent/tech-lead",
+    )
+    assert resp.mode_hint is None  # 명확한 discussion — 전환 제안 없음
+    assert len(resp.evidence_refs) == 1
+    assert any("근거(note)" in r for r in resp.reasoning)
+    assert any("낮음" in r for r in resp.risks)
+    assert retrieval.calls and retrieval.calls[0]["role"] == "engineering-agent/tech-lead"
+
+
+def test_build_clarification_when_prompt_empty_and_pack_empty() -> None:
+    resp = build_discussion_response(
+        request=_request(""),
+        context_pack=_pack(),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    assert resp.mode_hint == MODE_HINT_CLARIFICATION_NEEDED
+    assert any("근거 부족" in r for r in resp.risks)
+    assert "정보만으로" in resp.conclusion
+
+
+def test_build_research_only_via_keyword() -> None:
+    resp = build_discussion_response(
+        request=_request("이 부분은 코드 변경 전에 조사부터 부탁해"),
+        context_pack=_pack(notes=("notes/foo.md",)),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    assert resp.mode_hint == MODE_HINT_RESEARCH_ONLY
+    assert "자료부터" in resp.conclusion
+    assert any("research collector" in a for a in resp.next_actions)
+
+
+def test_build_implementation_candidate_via_keyword() -> None:
+    resp = build_discussion_response(
+        request=_request("이 버그 수정해줘 — PR 만들어 줘"),
+        context_pack=_pack(issues=(91, 93)),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    assert resp.mode_hint == MODE_HINT_IMPLEMENTATION_CANDIDATE
+    assert "구현 후보" in resp.conclusion
+    assert any("권한 제안" in a for a in resp.next_actions)
+    assert any("권한 제안" in r for r in resp.risks)
+
+
+def test_build_explicit_mode_hint_overrides_derivation() -> None:
+    resp = build_discussion_response(
+        request=_request("그냥 잡담 같은 메시지"),
+        context_pack=_pack(),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+        mode_hint=MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    )
+    assert resp.mode_hint == MODE_HINT_IMPLEMENTATION_CANDIDATE
+
+
+# ---------------------------------------------------------------------------
+# 3. Hard rails — evidence score threshold + memory threshold
+# ---------------------------------------------------------------------------
+
+
+def test_low_score_evidence_dropped_and_risk_noted() -> None:
+    low = (
+        EvidenceRef(
+            kind="note",
+            title="low-quality",
+            url_or_path="notes/low.md",
+            snippet=None,
+            score=EVIDENCE_SCORE_THRESHOLD - 0.01,
+        ),
+    )
+    resp = build_discussion_response(
+        request=_request("토의 이어 가자"),
+        context_pack=_pack(),
+        retrieval=FakeRetrievalProvider(low),
+        memory=NullMemoryProvider(),
+    )
+    assert resp.evidence_refs == ()
+    assert resp.metadata["evidence_total"] == 1
+    assert resp.metadata["evidence_accepted"] == 0
+    assert any("근거 부족" in r for r in resp.risks)
+
+
+def test_mixed_score_evidence_only_accepts_passing() -> None:
+    refs = (
+        EvidenceRef("note", "high", "n/h.md", "h", 0.8),
+        EvidenceRef("note", "low", "n/l.md", "l", 0.1),
+    )
+    resp = build_discussion_response(
+        request=_request("토의"),
+        context_pack=_pack(),
+        retrieval=FakeRetrievalProvider(refs),
+        memory=NullMemoryProvider(),
+    )
+    titles = [ref.title for ref in resp.evidence_refs]
+    assert titles == ["high"]
+    assert resp.metadata["evidence_accepted"] == 1
+
+
+def test_memory_refs_threshold_applied() -> None:
+    shards = (
+        MemoryRef("shard", "ok", "summary", "memory", 0.7),
+        MemoryRef("shard", "drop", "summary", "memory", 0.05),
+    )
+    resp = build_discussion_response(
+        request=_request("토의"),
+        context_pack=_pack(),
+        retrieval=NullRetrievalProvider(),
+        memory=FakeMemoryProvider(shards),
+    )
+    assert [ref.title for ref in resp.memory_refs] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider seam — keyword extraction + topic passing
+# ---------------------------------------------------------------------------
+
+
+def test_keywords_passed_to_retrieval_provider() -> None:
+    retrieval = FakeRetrievalProvider(())
+    memory = FakeMemoryProvider(())
+    build_discussion_response(
+        request=_request("아키텍처 회의 일정 잡자 — 다음 주 화요일 어떨까?"),
+        context_pack=_pack(),
+        retrieval=retrieval,
+        memory=memory,
+        role_perspective="engineering-agent/backend-engineer",
+    )
+    assert retrieval.calls
+    kw = retrieval.calls[0]["keywords"]
+    assert "아키텍처" in kw
+    assert retrieval.calls[0]["role"] == "engineering-agent/backend-engineer"
+    assert memory.calls
+    assert memory.calls[0]["topic"]
+
+
+def test_pack_with_only_code_hints_yields_reasoning() -> None:
+    resp = build_discussion_response(
+        request=_request("이 모듈 만져 보자"),
+        context_pack=_pack(hints=("src/foo.py", "src/bar.py")),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    assert any("코드 힌트" in r for r in resp.reasoning)
+
+
+def test_pack_issues_and_prs_in_reasoning() -> None:
+    resp = build_discussion_response(
+        request=_request("이슈 91 관련"),
+        context_pack=_pack(issues=(91,), prs=(105,)),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    joined = "\n".join(resp.reasoning)
+    assert "#91" in joined
+    assert "#105" in joined
+
+
+def test_to_dict_round_trip_does_not_lose_fields() -> None:
+    resp = build_discussion_response(
+        request=_request("토의"),
+        context_pack=_pack(notes=("n.md",)),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    payload = resp.to_dict()
+    assert payload["conclusion"] == resp.conclusion
+    assert payload["reasoning"] == list(resp.reasoning)
+    assert payload["risks"] == list(resp.risks)
+    assert payload["next_actions"] == list(resp.next_actions)
+    assert payload["mode_hint"] == resp.mode_hint
+    assert payload["metadata"]["context_pack_id"] == "ctx-test-001"
+
+
+# ---------------------------------------------------------------------------
+# 5. mode 전환 가시화 — clarification 만 빈 prompt 에서 발동
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_prompt_with_empty_pack_yields_clarification() -> None:
+    resp = build_discussion_response(
+        request=_request("음... 모르겠다 — 어떻게 갈까?"),
+        context_pack=_pack(),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    assert resp.mode_hint == MODE_HINT_CLARIFICATION_NEEDED
+
+
+def test_ambiguous_prompt_with_pack_does_not_clarify() -> None:
+    resp = build_discussion_response(
+        request=_request("음... 모르겠다 — 어떻게 갈까?"),
+        context_pack=_pack(notes=("notes/x.md",), issues=(10,)),
+        retrieval=NullRetrievalProvider(),
+        memory=NullMemoryProvider(),
+    )
+    # pack 이 채워져 있으면 clarification 으로 강제되지 않음.
+    assert resp.mode_hint != MODE_HINT_CLARIFICATION_NEEDED

--- a/tests/agents/test_response_format.py
+++ b/tests/agents/test_response_format.py
@@ -1,0 +1,131 @@
+"""DiscussionResponse 렌더러 회귀 (#93).
+
+* user surface 4-block 보장
+* operator surface trace 가 user surface 에 누출되지 않음
+* 어떤 surface 도 추가 secret 을 만들어 내지 않음 (PasteGuard 호출은
+  caller 책임이며 본 모듈은 plain 출력)
+"""
+
+from __future__ import annotations
+
+from yule_orchestrator.agents.conversation.discussion_response import (
+    DiscussionResponse,
+    EvidenceRef,
+    MODE_HINT_IMPLEMENTATION_CANDIDATE,
+    MODE_HINT_RESEARCH_ONLY,
+    MemoryRef,
+)
+from yule_orchestrator.agents.conversation.response_format import (
+    render_operator_surface,
+    render_user_surface,
+)
+
+
+def _sample(mode_hint=None, evidence=(), memory=()) -> DiscussionResponse:
+    return DiscussionResponse(
+        conclusion="결론 한 줄 — 이대로 진행.",
+        reasoning=("관련 이슈 #91", "역할 관점 — backend"),
+        risks=("낮음 — 결정적 차단 요인 없음.",),
+        next_actions=("결정 항목 하나씩 합의.", "권한 제안 단계로 이동."),
+        evidence_refs=tuple(evidence),
+        memory_refs=tuple(memory),
+        mode_hint=mode_hint,
+        metadata={
+            "context_pack_id": "ctx-secret-001",
+            "evidence_threshold": 0.3,
+            "evidence_total": len(evidence),
+            "evidence_accepted": len(evidence),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. user surface — 4-block 만, trace 미포함
+# ---------------------------------------------------------------------------
+
+
+def test_user_surface_contains_four_blocks() -> None:
+    text = render_user_surface(_sample())
+    assert "**결론**" in text
+    assert "**이유**" in text
+    assert "**리스크**" in text
+    assert "**다음 액션**" in text
+
+
+def test_user_surface_omits_operator_trace_metadata() -> None:
+    evidence = (
+        EvidenceRef("note", "agg", "notes/agg.md", "snippet", 0.7),
+    )
+    text = render_user_surface(_sample(evidence=evidence))
+    # operator-only 정보가 user surface 에 절대 노출 금지
+    assert "ctx-secret-001" not in text
+    assert "Operator trace" not in text
+    assert "Classifier verdict" not in text
+    assert "Retrieval trace" not in text
+    assert "score=" not in text  # evidence score 도 user surface 노출 금지
+    assert "Pack metadata" not in text
+
+
+def test_user_surface_renders_mode_hint_when_present() -> None:
+    text = render_user_surface(_sample(mode_hint=MODE_HINT_IMPLEMENTATION_CANDIDATE))
+    assert "모드 전환 제안" in text
+    assert "구현 후보" in text
+
+
+def test_user_surface_omits_mode_hint_block_when_none() -> None:
+    text = render_user_surface(_sample(mode_hint=None))
+    assert "모드 전환 제안" not in text
+
+
+# ---------------------------------------------------------------------------
+# 2. operator surface — trace + classifier verdict 노출
+# ---------------------------------------------------------------------------
+
+
+def test_operator_surface_contains_user_surface_then_trace() -> None:
+    evidence = (
+        EvidenceRef("note", "agg", "notes/agg.md", "snippet", 0.7),
+    )
+    memory = (MemoryRef("shard", "recall", "ok", "claude-mem", 0.6),)
+    text = render_operator_surface(
+        _sample(
+            mode_hint=MODE_HINT_RESEARCH_ONLY,
+            evidence=evidence,
+            memory=memory,
+        ),
+        classifier_verdict={
+            "mode": "research_only",
+            "confidence": 0.91,
+            "source": "fast_path",
+        },
+        retrieval_trace=[
+            {"provider": "fake-live", "hits": 3, "kept": 1},
+            {"provider": "fake-live", "hits": 0, "kept": 0},
+        ],
+    )
+    # 본문에 user surface 4-block 포함
+    assert "**결론**" in text
+    assert "**이유**" in text
+    # operator trace 포함
+    assert "Classifier verdict" in text
+    assert "research_only" in text
+    assert "Retrieval trace" in text
+    assert "provider=" in text
+    assert "Pack metadata" in text
+    assert "ctx-secret-001" in text  # operator surface 에는 노출 OK
+    assert "Evidence refs" in text
+    assert "Memory refs" in text
+
+
+# ---------------------------------------------------------------------------
+# 3. 입력 가드 — 잘못된 타입은 TypeError
+# ---------------------------------------------------------------------------
+
+
+def test_render_helpers_reject_non_response_inputs() -> None:
+    import pytest
+
+    with pytest.raises(TypeError):
+        render_user_surface({"conclusion": "x"})  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        render_operator_surface({"conclusion": "x"})  # type: ignore[arg-type]


### PR DESCRIPTION
## 📌 관련 이슈
- close #93
- parent #81
- 후속 — F5 live RetrievalProvider 실 wiring (#92), F10 MemoryProvider 실 wiring

## ✨ 과제 내용

### 변경 사항

| commit | 목적 |
| --- | --- |
| `c4a667a` | F6 4-block 답변 빌더 (`agents/conversation/discussion_response.py`) + surface 분리 (`response_format.py`) + 회귀 24 case (18 + 6) |

* `DiscussionResponse` frozen dataclass — `conclusion / reasoning / risks / next_actions` 4 필드 + `evidence_refs` / `memory_refs` / `mode_hint` / `metadata`. `__post_init__` 에서 빈 필드 + 알 수 없는 mode_hint 거부.
* `RetrievalProvider` / `MemoryProvider` Protocol + `NullRetrievalProvider` / `NullMemoryProvider` deterministic fake. F5 (#92) / F10 후속 PR 에서 실 wiring.
* `build_discussion_response()` — keyword 기반 mode_hint 추정 (`research_only` / `implementation_candidate` / `clarification_needed`), evidence score < `EVIDENCE_SCORE_THRESHOLD` (0.3) 인 항목은 거부 + 리스크에 "근거 부족" 명시.
* `render_user_surface()` — 사용자에게 보일 4-block 본문만. retrieval trace / classifier verdict / context_pack_id / score 어느 것도 포함하지 않음.
* `render_operator_surface()` — user surface 본문 + `Classifier verdict` / `Retrieval trace` / `Evidence refs` / `Memory refs` / `Pack metadata`.

### Acceptance 검증

1. `DiscussionResponse` 가 4 필드 (결론/이유/리스크/다음액션) 명시 — `test_discussion_response_has_four_blocks` 외 3 case.
2. operator surface 의 retrieval_trace 가 user surface 에 절대 노출되지 않음 — `test_user_surface_omits_operator_trace_metadata`.
3. mode_hint 가 `clarification_needed` / `research_only` / `implementation_candidate` 전환 제안 포함 — `test_build_clarification_when_prompt_empty_and_pack_empty`, `test_build_research_only_via_keyword`, `test_build_implementation_candidate_via_keyword`.
4. fake `RetrievalProvider` + `MemoryProvider` 로 회귀 가능 — `FakeRetrievalProvider` / `FakeMemoryProvider` (`tests/agents/test_discussion_response.py`).
5. PasteGuard 통합은 caller 책임 — 본 모듈은 plain 출력. `governance test` (operator trace 미노출) 는 `tests/agents/test_response_format.py` 에서 가드.

회귀: `pytest tests` → **3880 passed / 1 skipped** (skip 은 `tests/github_app/test_auth.py` cryptography 의존성 conditional, 사전 존재).

### 무엇을 아직 하지 않았는지

* F5 live RetrievalProvider 실 wiring — 후속 PR (#92 dependency).
* F10 MemoryProvider 실 wiring (Claude memory shard recall) — 후속 PR.
* PasteGuard 통합 호출 — caller (gateway / status poster) 에서 outbound 직전 `guard_outbound` 으로 한 번 더 감싸도록 후속 정리.
* 영어 토글 (한국어/영어 동시 출력) — Acceptance #3 (4-block 출력 템플릿 토글) 은 별도 wiring 단계로 분리.

### 🤖 Agent WorkOS Audit

- audit_id: `worktree-agent-a99fc769`
- branch: `feature/discussion-response-issue-93`
- role: `engineering-agent/tech-lead` (+ frontend-engineer 사용자 facing 표현 보조)
- autonomy_level: `L2_AUTONOMOUS_RECORD`
- mode: `implementation_candidate`
- risk_class: `LOW` (read-only 신규 모듈 추가 + 신규 회귀 테스트만)

## :camera_with_flash: 스크린샷(선택)

_(N/A — 코드만)_

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 신규 모듈 인덱스
  - `src/yule_orchestrator/agents/conversation/__init__.py`
  - `src/yule_orchestrator/agents/conversation/discussion_response.py`
  - `src/yule_orchestrator/agents/conversation/response_format.py`
- 신규 회귀
  - `tests/agents/test_discussion_response.py` (18 case)
  - `tests/agents/test_response_format.py` (6 case)
- 정책
  - `policies/runtime/agents/engineering-agent/issue-pr-conventions.md` (§1.0 / §2.2 — 4-section PR body 절대 준수)
- 후속 과제: F5 RetrievalProvider 실 wiring (#92), F10 MemoryProvider 실 wiring, gateway 에서 `render_user_surface` 결과 PasteGuard 통과 후 Discord 게시.
- 새로 알게 된 점: F5 / F10 가 in-flight 인 동안 Protocol seam + Null fake 만 land 하면 회귀 가능 상태에서 단계적으로 dependency 를 흡수할 수 있다. evidence score threshold 를 `EVIDENCE_SCORE_THRESHOLD = 0.3` 상수로 노출하면 후속 PR 에서 튜닝 진입점이 한 곳으로 모인다.