### PR TITLE
✨ [Feat] F7 Auto-merge decider — risk class + 자율 머지 게이트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,3 +366,24 @@ DISCORD_GUILD_ID=
 #     (governance test 가 보호).
 # YULE_TOOL_GATE_ENABLED=true
 # YULE_TOOL_GATE_DEFAULT_AUTONOMY=L2_autonomous_record
+
+# =====================================================================
+# F7 / #98 — Auto-merge decider cycle authorization
+#
+# `src/yule_orchestrator/agents/release/auto_merge_decider.py` 는 PR 의
+# 8 자율 머지 조건(`policies/runtime/agents/engineering-agent/issue-pr-conventions.md`
+# §5.1) 을 평가해 tech-lead agent 자율 머지 가능 여부를 결정한다.
+#
+# 본 플래그는 conventions §5.3 의 "운영자 사이클 인가" 게이트다:
+#   - 비워두면 (default) 어떤 PR 도 자율 머지 자격을 얻지 못한다.
+#   - 사이클 이름(예: ``F1-F8``) 이나 ``true`` / ``yes`` / ``on`` / ``1``
+#     로 명시 셋업 시에만 그 사이클 동안 자율 머지가 활성화된다.
+#   - ``false`` / ``off`` / ``0`` / ``no`` / ``disabled`` 는 비활성화.
+#
+# 운영 정책 (Hard rails):
+#   1. HIGH / CRITICAL risk class PR 은 cycle 값과 무관하게 항상 BLOCK.
+#   2. 보호 브랜치(`main` / `master` / `develop` / `release/*` / `prod`)
+#      을 base 로 하는 PR 은 자동 머지 불가.
+#   3. 본 플래그는 `.env.example` 에는 절대 활성 사이클 이름으로
+#      적지 않는다. `.env.local` 에서만 운영자가 명시 셋업.
+# YULE_AUTOMERGE_CYCLE=

--- a/src/yule_orchestrator/agents/release/__init__.py
+++ b/src/yule_orchestrator/agents/release/__init__.py
@@ -1,0 +1,48 @@
+"""Release-time decision modules (F7 / #98).
+
+This package owns *post-implementation, pre-merge* decisions —
+specifically the auto-merge decider that classifies a PR's risk
+class and evaluates the 8 conventions §5 auto-merge conditions
+deterministically.
+
+The decider is intentionally a **pure data → verdict** module:
+no GitHub I/O, no clock reads, no env reads beyond the cycle
+authorization flag. Callers (gh-cli adapters, the tech-lead
+agent, ops review) build :class:`PrDiffSummary` /
+:class:`PrMetadata` from their own data sources and feed them
+into :func:`evaluate_auto_merge`. That keeps the policy
+auditable and unit-testable in isolation while live integration
+lives in a thin adapter layer that we will land in a follow-up
+PR.
+"""
+
+from __future__ import annotations
+
+from .auto_merge_decider import (
+    AutoMergeVerdict,
+    ENV_AUTOMERGE_CYCLE,
+    PROTECTED_BRANCHES,
+    PrDiffSummary,
+    PrMetadata,
+    RiskClass,
+    RiskSignal,
+    classify_risk,
+    evaluate_auto_merge,
+    is_cycle_authorized_from_env,
+    record_automerge_signature,
+)
+
+
+__all__ = (
+    "AutoMergeVerdict",
+    "ENV_AUTOMERGE_CYCLE",
+    "PROTECTED_BRANCHES",
+    "PrDiffSummary",
+    "PrMetadata",
+    "RiskClass",
+    "RiskSignal",
+    "classify_risk",
+    "evaluate_auto_merge",
+    "is_cycle_authorized_from_env",
+    "record_automerge_signature",
+)

--- a/src/yule_orchestrator/agents/release/auto_merge_decider.py
+++ b/src/yule_orchestrator/agents/release/auto_merge_decider.py
@@ -1,0 +1,709 @@
+"""Auto-merge decider — F7 / issue #98.
+
+The decider answers one question: *is this PR safe enough for
+the tech-lead agent to merge without operator approval?* It
+does so by:
+
+  1. Classifying the PR's :class:`RiskClass` from a static
+     :class:`PrDiffSummary` + :class:`PrMetadata` snapshot
+     (:func:`classify_risk`).
+  2. Evaluating the conventions §5 8 auto-merge conditions
+     deterministically and returning a :class:`AutoMergeVerdict`
+     (:func:`evaluate_auto_merge`).
+
+Vocabulary alignment with F12 (#103):
+
+  * Both modules expose a ``RiskClass`` enum with the same four
+    severity names (``LOW`` / ``MEDIUM`` / ``HIGH`` / ``CRITICAL``).
+    F12 also has a ``SAFE`` level for read-only tool calls — F7
+    deliberately starts at ``LOW`` because a PR by definition
+    introduces at least one change to a tracked file. Operators
+    reading either feed see one consistent ladder.
+
+Hard rails (regression-pinned in
+``tests/engineering/test_auto_merge_governance.py``):
+
+  * ``HIGH`` and ``CRITICAL`` PRs *never* land with
+    ``eligible=True`` — env, autonomy, or rule edits can't
+    bypass.
+  * ``cycle_authorized=False`` short-circuits every PR to
+    ``eligible=False`` regardless of risk class. The cycle gate
+    is the ops-side kill-switch.
+  * Protected branch bases (``main`` / ``master`` / ``develop`` /
+    ``release`` / ``prod`` / ``production``) escalate to at
+    least ``HIGH`` and block auto-merge. The convention treats
+    the base branch as the merge target — never the source.
+
+Mistake ledger signatures live under the ``automerge.*``
+namespace. ``record_automerge_signature`` is a thin helper that
+forwards into :class:`MistakeLedger.record_mistake` so the
+preflight hook can pick up repeat blocker hits.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Sequence, Tuple
+
+from ..learning.mistake_ledger import BlockerLevel, MistakeLedger
+
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+
+#: Environment variable that opt-ins the auto-merge cycle. Empty /
+#: unset means "no active cycle" and the decider refuses every
+#: PR. The value is interpreted leniently — see
+#: :func:`is_cycle_authorized_from_env`.
+ENV_AUTOMERGE_CYCLE: str = "YULE_AUTOMERGE_CYCLE"
+
+
+#: Protected branch names — direct auto-merge into these targets
+#: is forbidden by §5 condition 5. Names compared lowercased.
+PROTECTED_BRANCHES: frozenset[str] = frozenset(
+    {
+        "main",
+        "master",
+        "develop",
+        "release",
+        "prod",
+        "production",
+    }
+)
+
+
+_PROTECTED_BRANCH_PREFIXES: Tuple[str, ...] = ("release/", "hotfix/")
+
+
+_SECRET_KEYWORDS: Tuple[str, ...] = (
+    "secret",
+    "token",
+    "credential",
+    "api_key",
+    "apikey",
+    "private_key",
+    "password",
+    "passphrase",
+    ".pem",
+)
+
+
+# Modules whose changes mean a PR touches *security / outbound /
+# secret handling*. A diff that lands here climbs at least to
+# HIGH per §5.2.
+_HIGH_RISK_MODULE_PREFIXES: Tuple[str, ...] = (
+    "src/yule_orchestrator/agents/security/",
+    "src/yule_orchestrator/agents/safety/",
+    "policies/runtime/agents/engineering-agent/issue-pr-conventions",
+)
+
+
+_LIVE_LLM_MODULE_PREFIXES: Tuple[str, ...] = (
+    "src/yule_orchestrator/agents/job_queue/coding_executor_live",
+    "src/yule_orchestrator/agents/job_queue/claude_subprocess_adapter",
+)
+
+
+_LARGE_DIFF_LINES_THRESHOLD: int = 600
+_MEDIUM_DIFF_LINES_THRESHOLD: int = 150
+_LARGE_FILES_THRESHOLD: int = 20
+_MEDIUM_FILES_THRESHOLD: int = 6
+
+
+# ---------------------------------------------------------------------------
+# RiskClass
+# ---------------------------------------------------------------------------
+
+
+class RiskClass(str, enum.Enum):
+    """PR-level severity ladder for auto-merge (F7 / #98).
+
+    Vocabulary intentionally identical to the F12 (#103)
+    tool-call ``RiskClass`` enum modulo the missing ``SAFE``
+    level — a PR by definition changes at least one file so the
+    floor here is ``LOW``.
+    """
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+_CLASS_ORDER: Mapping[RiskClass, int] = {
+    RiskClass.LOW: 0,
+    RiskClass.MEDIUM: 1,
+    RiskClass.HIGH: 2,
+    RiskClass.CRITICAL: 3,
+}
+
+
+def _max_class(a: RiskClass, b: RiskClass) -> RiskClass:
+    return a if _CLASS_ORDER[a] >= _CLASS_ORDER[b] else b
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrDiffSummary:
+    """Static snapshot of a PR's diff shape.
+
+    ``modules_touched`` is the (relative) set of top-level paths
+    the diff touches — caller may pass file paths or coarser
+    module names; the classifier just looks for prefix matches.
+
+    ``has_secret_keywords`` is True when *anything* in the PR
+    body / commit messages / diff hunks tripped a secret keyword
+    scan (PasteGuard layer feeds this — the decider doesn't
+    re-scan). ``touches_protected_branch_policy`` is True when
+    the diff edits files under
+    ``policies/.../protected-branch*`` or the conventions doc
+    itself.
+    """
+
+    files_changed: int = 0
+    lines_added: int = 0
+    lines_removed: int = 0
+    modules_touched: Tuple[str, ...] = ()
+    has_secret_keywords: bool = False
+    touches_protected_branch_policy: bool = False
+
+    def total_lines(self) -> int:
+        return max(0, int(self.lines_added)) + max(0, int(self.lines_removed))
+
+
+@dataclass(frozen=True)
+class PrMetadata:
+    """GitHub-side metadata snapshot.
+
+    Fields mirror the subset the §5 8 conditions actually care
+    about. ``status_check_state`` is the rolled-up CI / required
+    check status — one of ``SUCCESS`` / ``PENDING`` / ``FAILURE``
+    / ``ERROR`` (case-insensitive). ``mergeable`` and
+    ``merge_state`` follow GitHub's REST shape
+    (``MERGEABLE`` / ``CLEAN`` etc.).
+    """
+
+    pr_number: int = 0
+    base_branch: str = ""
+    head_branch: str = ""
+    is_draft: bool = False
+    mergeable: str = ""
+    merge_state: str = ""
+    status_check_state: str = ""
+    author_role: str = ""
+    labels: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RiskSignal:
+    """One piece of evidence behind a risk classification.
+
+    ``weight`` is the :class:`RiskClass` this signal pushes the
+    overall verdict toward. Signals are *additive but escalation-
+    only* — they can only raise the verdict, never lower it.
+    """
+
+    name: str
+    weight: RiskClass
+    evidence: str
+
+
+@dataclass(frozen=True)
+class AutoMergeVerdict:
+    """Final auto-merge decision for a PR.
+
+    * ``eligible`` — True iff every condition listed in
+      :data:`satisfied_conditions` is met AND no blocker remains.
+    * ``risk_class`` — verdict from :func:`classify_risk`.
+    * ``reason`` — short, single-line summary suitable for a PR
+      comment or audit log.
+    * ``blocker_signatures`` — mistake-ledger signatures keyed
+      under the ``automerge.*`` namespace. Empty when eligible.
+    * ``satisfied_conditions`` — names of the §5 conditions that
+      passed. Always present (helpful even on failure).
+    * ``failed_conditions`` — names of the §5 conditions that
+      failed. Empty when eligible.
+    """
+
+    eligible: bool
+    risk_class: RiskClass
+    reason: str
+    blocker_signatures: Tuple[str, ...]
+    satisfied_conditions: Tuple[str, ...]
+    failed_conditions: Tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Risk classification
+# ---------------------------------------------------------------------------
+
+
+def classify_risk(
+    diff: PrDiffSummary,
+    meta: PrMetadata,
+) -> Tuple[RiskClass, Tuple[RiskSignal, ...]]:
+    """Return ``(RiskClass, signals)`` for the given PR snapshot.
+
+    Pure function: no I/O, no clock, no env reads. The signal
+    list is deterministic and ordered by the order rules fire.
+    Multiple matching signals only raise the class, never lower
+    it.
+    """
+
+    signals: list[RiskSignal] = []
+    verdict = RiskClass.LOW
+
+    # Baseline: every PR starts at LOW. Emit an explicit baseline
+    # signal so the evidence trail always has at least one entry.
+    signals.append(
+        RiskSignal(
+            name="baseline.pr",
+            weight=RiskClass.LOW,
+            evidence=f"pr=#{meta.pr_number or 0}",
+        )
+    )
+
+    # Rule: protected base branch — always HIGH minimum.
+    base_lower = (meta.base_branch or "").strip().lower()
+    if _is_protected_branch(base_lower):
+        signals.append(
+            RiskSignal(
+                name="rule.protected_branch.base",
+                weight=RiskClass.HIGH,
+                evidence=f"base_branch={meta.base_branch}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+
+    # Rule: secret keywords detected in PR (PasteGuard upstream)
+    # → HIGH minimum. The decider does not re-scan; it trusts
+    # the caller's hint and treats it as a hard escalation.
+    if diff.has_secret_keywords:
+        signals.append(
+            RiskSignal(
+                name="rule.secret.keyword",
+                weight=RiskClass.HIGH,
+                evidence="diff.has_secret_keywords=True",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+
+    # Rule: protected branch policy edits → CRITICAL. Editing
+    # the branch guard itself is the most sensitive surface.
+    if diff.touches_protected_branch_policy:
+        signals.append(
+            RiskSignal(
+                name="rule.protected_branch.policy_edit",
+                weight=RiskClass.CRITICAL,
+                evidence="diff.touches_protected_branch_policy=True",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.CRITICAL)
+
+    # Rule: modules under security/safety / live LLM live wiring
+    # are HIGH at minimum.
+    modules = tuple(str(m or "").strip() for m in diff.modules_touched or ())
+    for prefix in _HIGH_RISK_MODULE_PREFIXES:
+        if any(_module_matches(prefix, m) for m in modules):
+            signals.append(
+                RiskSignal(
+                    name="rule.module.security_or_safety",
+                    weight=RiskClass.HIGH,
+                    evidence=f"module_prefix={prefix}",
+                )
+            )
+            verdict = _max_class(verdict, RiskClass.HIGH)
+            break
+
+    for prefix in _LIVE_LLM_MODULE_PREFIXES:
+        if any(_module_matches(prefix, m) for m in modules):
+            signals.append(
+                RiskSignal(
+                    name="rule.module.live_llm",
+                    weight=RiskClass.HIGH,
+                    evidence=f"module_prefix={prefix}",
+                )
+            )
+            verdict = _max_class(verdict, RiskClass.HIGH)
+            break
+
+    # Rule: diff size — large diffs are MEDIUM at minimum.
+    total_lines = diff.total_lines()
+    files_changed = max(0, int(diff.files_changed))
+    if (
+        total_lines >= _LARGE_DIFF_LINES_THRESHOLD
+        or files_changed >= _LARGE_FILES_THRESHOLD
+    ):
+        signals.append(
+            RiskSignal(
+                name="rule.diff.large",
+                weight=RiskClass.MEDIUM,
+                evidence=f"files={files_changed}, lines={total_lines}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.MEDIUM)
+    elif (
+        total_lines >= _MEDIUM_DIFF_LINES_THRESHOLD
+        or files_changed >= _MEDIUM_FILES_THRESHOLD
+    ):
+        signals.append(
+            RiskSignal(
+                name="rule.diff.medium",
+                weight=RiskClass.MEDIUM,
+                evidence=f"files={files_changed}, lines={total_lines}",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.MEDIUM)
+
+    # Rule: PR labels — explicit governance labels push higher.
+    label_set = frozenset(
+        _normalise_label(label) for label in (meta.labels or ()) if label
+    )
+    if "security" in label_set or "secret" in label_set:
+        signals.append(
+            RiskSignal(
+                name="rule.label.security",
+                weight=RiskClass.HIGH,
+                evidence="labels contain security/secret",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.HIGH)
+    if "deploy" in label_set or "production" in label_set:
+        signals.append(
+            RiskSignal(
+                name="rule.label.deploy",
+                weight=RiskClass.CRITICAL,
+                evidence="labels contain deploy/production",
+            )
+        )
+        verdict = _max_class(verdict, RiskClass.CRITICAL)
+
+    return verdict, tuple(signals)
+
+
+# ---------------------------------------------------------------------------
+# 8-condition evaluation
+# ---------------------------------------------------------------------------
+
+
+# Names match conventions §5.1 ordering so audit readers can
+# cross-reference the doc and the verdict.
+_CONDITION_NAMES: Tuple[str, ...] = (
+    "ci_regression_ok",
+    "governance_regression_ok",
+    "mergeable_and_clean",
+    "risk_class_low",
+    "no_protected_branch_direct_push",
+    "no_force_or_no_verify",
+    "paste_guard_clean",
+    "acceptance_criteria_reported",
+)
+
+
+def evaluate_auto_merge(
+    diff: PrDiffSummary,
+    meta: PrMetadata,
+    *,
+    cycle_authorized: bool,
+    ci_ok: Optional[bool] = None,
+    governance_ok: Optional[bool] = None,
+    paste_guard_clean: Optional[bool] = None,
+    acceptance_criteria_reported: Optional[bool] = None,
+    force_push_detected: bool = False,
+    no_verify_detected: bool = False,
+    protected_branch_direct_push: bool = False,
+) -> AutoMergeVerdict:
+    """Return :class:`AutoMergeVerdict` for the supplied PR snapshot.
+
+    The 8 §5.1 conditions are evaluated in order; the result
+    accumulates pass/fail names and blocker signatures. The
+    function never raises on missing optional inputs — it
+    treats them as "unknown" and **fails closed** (the condition
+    counts as failing). This keeps the decider safe to call
+    early in the pipeline before every input is gathered.
+
+    Hard rails:
+
+      * ``cycle_authorized=False`` → ``eligible=False`` with
+        a single signature ``automerge.cycle.not_authorized``.
+      * Any ``risk_class`` >= ``HIGH`` → ``eligible=False`` with
+        signature ``automerge.risk-class.high-without-approval``
+        (matches the §7 ledger row).
+      * Protected branch base → reported under
+        ``no_protected_branch_direct_push`` failing and the
+        signature ``automerge.protected_branch.base``.
+    """
+
+    risk_class, _ = classify_risk(diff, meta)
+
+    satisfied: list[str] = []
+    failed: list[str] = []
+    blockers: list[str] = []
+
+    def _record(name: str, ok: bool, *signatures: str) -> None:
+        if ok:
+            satisfied.append(name)
+        else:
+            failed.append(name)
+            for signature in signatures:
+                if signature and signature not in blockers:
+                    blockers.append(signature)
+
+    # ------------------------------------------------------------
+    # Hard rail 1: cycle authorization is the kill-switch.
+    # ------------------------------------------------------------
+    if not cycle_authorized:
+        # Mark every condition as failed for transparency, but
+        # the dominant reason is the cycle gate.
+        for name in _CONDITION_NAMES:
+            failed.append(name)
+        return AutoMergeVerdict(
+            eligible=False,
+            risk_class=risk_class,
+            reason="cycle not authorized — YULE_AUTOMERGE_CYCLE empty/false",
+            blocker_signatures=("automerge.cycle.not_authorized",),
+            satisfied_conditions=(),
+            failed_conditions=tuple(failed),
+        )
+
+    # ------------------------------------------------------------
+    # Condition 1: CI / regression test OK.
+    # ------------------------------------------------------------
+    state = (meta.status_check_state or "").strip().lower()
+    if ci_ok is None:
+        ci_ok_value = state == "success"
+    else:
+        ci_ok_value = bool(ci_ok) and state in {"", "success"}
+    _record("ci_regression_ok", ci_ok_value, "automerge.ci.regression_failed")
+
+    # ------------------------------------------------------------
+    # Condition 2: governance regression test OK.
+    # ------------------------------------------------------------
+    _record(
+        "governance_regression_ok",
+        bool(governance_ok) if governance_ok is not None else False,
+        "automerge.governance.regression_failed",
+    )
+
+    # ------------------------------------------------------------
+    # Condition 3: mergeable=MERGEABLE + mergeStateStatus=CLEAN.
+    # ------------------------------------------------------------
+    mergeable_ok = (meta.mergeable or "").strip().upper() == "MERGEABLE"
+    state_clean = (meta.merge_state or "").strip().upper() == "CLEAN"
+    not_draft = not bool(meta.is_draft)
+    _record(
+        "mergeable_and_clean",
+        mergeable_ok and state_clean and not_draft,
+        "automerge.merge_state.not_clean",
+    )
+
+    # ------------------------------------------------------------
+    # Condition 4: risk class is LOW.
+    # ------------------------------------------------------------
+    low_only = risk_class is RiskClass.LOW
+    if risk_class in (RiskClass.HIGH, RiskClass.CRITICAL):
+        _record(
+            "risk_class_low",
+            False,
+            "automerge.risk-class.high-without-approval",
+        )
+    else:
+        _record(
+            "risk_class_low",
+            low_only,
+            "automerge.risk-class.not_low",
+        )
+
+    # ------------------------------------------------------------
+    # Condition 5: no protected branch direct push.
+    # ------------------------------------------------------------
+    base_protected = _is_protected_branch((meta.base_branch or "").strip().lower())
+    _record(
+        "no_protected_branch_direct_push",
+        not protected_branch_direct_push and not base_protected,
+        "automerge.protected_branch.base"
+        if base_protected
+        else "automerge.protected_branch.direct_push",
+    )
+
+    # ------------------------------------------------------------
+    # Condition 6: no force push, no --no-verify.
+    # ------------------------------------------------------------
+    _record(
+        "no_force_or_no_verify",
+        not force_push_detected and not no_verify_detected,
+        "automerge.force_push.detected"
+        if force_push_detected
+        else "automerge.no_verify.detected",
+    )
+
+    # ------------------------------------------------------------
+    # Condition 7: PasteGuard clean (no surviving secret findings).
+    # ------------------------------------------------------------
+    _record(
+        "paste_guard_clean",
+        bool(paste_guard_clean) if paste_guard_clean is not None else False,
+        "automerge.paste_guard.secret_detected",
+    )
+
+    # ------------------------------------------------------------
+    # Condition 8: acceptance criteria self-report present.
+    # ------------------------------------------------------------
+    _record(
+        "acceptance_criteria_reported",
+        bool(acceptance_criteria_reported)
+        if acceptance_criteria_reported is not None
+        else False,
+        "automerge.acceptance.missing_report",
+    )
+
+    eligible = not failed and risk_class is RiskClass.LOW
+
+    reason = _build_reason(
+        eligible=eligible,
+        risk_class=risk_class,
+        failed=failed,
+    )
+
+    return AutoMergeVerdict(
+        eligible=eligible,
+        risk_class=risk_class,
+        reason=reason,
+        blocker_signatures=tuple(blockers),
+        satisfied_conditions=tuple(satisfied),
+        failed_conditions=tuple(failed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mistake ledger integration
+# ---------------------------------------------------------------------------
+
+
+def record_automerge_signature(
+    ledger: MistakeLedger,
+    *,
+    role: str,
+    signature: str,
+    pr_number: int,
+    blocker_level: BlockerLevel = BlockerLevel.WARNING,
+    postmortem_ref: Optional[str] = None,
+) -> None:
+    """Persist an ``automerge.*`` signature into the mistake ledger.
+
+    Convenience wrapper so callers (the tech-lead agent's
+    pre-merge hook, the GitHub adapter, governance tests) don't
+    have to remember the ``pattern="automerge"`` convention.
+
+    Signatures starting with ``automerge.risk-class.high`` are
+    forced to :class:`BlockerLevel.BLOCK` regardless of the
+    caller's input — that matches conventions §7 row for the
+    HIGH-without-approval rail.
+    """
+
+    sig = str(signature or "").strip()
+    if not sig:
+        return
+    if not sig.startswith("automerge."):
+        sig = f"automerge.{sig}"
+    level = blocker_level
+    if sig.startswith("automerge.risk-class.high") or sig.startswith(
+        "automerge.cycle"
+    ):
+        level = BlockerLevel.BLOCK
+    ledger.record_mistake(
+        role=role or "engineering-agent/tech-lead",
+        pattern="automerge",
+        signature=f"{sig} pr=#{pr_number or 0}",
+        postmortem_ref=postmortem_ref,
+        blocker_level=level,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+def is_cycle_authorized_from_env(
+    env: Optional[Mapping[str, str]] = None,
+) -> bool:
+    """True iff ``YULE_AUTOMERGE_CYCLE`` is set to an active value.
+
+    Accepted truthy values (case-insensitive): non-empty cycle
+    name (e.g. ``"F1-F8"``), ``"true"``, ``"yes"``, ``"on"``,
+    ``"1"``. Empty / unset / ``"false"`` / ``"off"`` / ``"0"`` /
+    ``"no"`` all mean "no active cycle".
+    """
+
+    raw = (env if env is not None else os.environ).get(ENV_AUTOMERGE_CYCLE, "")
+    text = str(raw or "").strip()
+    if not text:
+        return False
+    lowered = text.lower()
+    if lowered in {"false", "off", "0", "no", "disabled"}:
+        return False
+    # Any other non-empty value (cycle name, "true", "yes", ...) is
+    # treated as "operator has explicitly named a cycle".
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _is_protected_branch(name: str) -> bool:
+    if not name:
+        return False
+    candidate = name.strip().lower()
+    if candidate in PROTECTED_BRANCHES:
+        return True
+    if candidate.startswith("refs/heads/"):
+        candidate = candidate.rsplit("/", 1)[-1]
+        if candidate in PROTECTED_BRANCHES:
+            return True
+    for prefix in _PROTECTED_BRANCH_PREFIXES:
+        if candidate.startswith(prefix):
+            return True
+    return False
+
+
+def _module_matches(prefix: str, module: str) -> bool:
+    normalised = (module or "").strip().lstrip("./")
+    return normalised.startswith(prefix)
+
+
+_LABEL_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalise_label(label: str) -> str:
+    text = str(label or "").strip().lower()
+    tokens = _LABEL_TOKEN_RE.findall(text)
+    return tokens[-1] if tokens else text
+
+
+def _build_reason(
+    *,
+    eligible: bool,
+    risk_class: RiskClass,
+    failed: Sequence[str],
+) -> str:
+    if eligible:
+        return f"all 8 conditions satisfied; risk_class={risk_class.value}"
+    if risk_class in (RiskClass.HIGH, RiskClass.CRITICAL):
+        return (
+            f"blocked — risk_class={risk_class.value} requires operator approval"
+        )
+    if failed:
+        return f"blocked — failed_conditions={','.join(failed)}"
+    return f"blocked — risk_class={risk_class.value}"

--- a/tests/agents/test_auto_merge_decider.py
+++ b/tests/agents/test_auto_merge_decider.py
@@ -1,0 +1,380 @@
+"""Unit tests for the F7 / #98 auto-merge decider.
+
+Covers the 4 RiskClass levels × representative diff/meta
+combinations, the 8-condition evaluator's pass/fail wiring, the
+env helper, and the mistake-ledger signature helper.
+
+Pure-function tests — no GitHub I/O, no clock reads. The
+``cycle_authorized`` flag is fed directly to keep the suite
+self-contained.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.release.auto_merge_decider import (
+    ENV_AUTOMERGE_CYCLE,
+    AutoMergeVerdict,
+    PrDiffSummary,
+    PrMetadata,
+    RiskClass,
+    classify_risk,
+    evaluate_auto_merge,
+    is_cycle_authorized_from_env,
+    record_automerge_signature,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _low_diff(**overrides) -> PrDiffSummary:
+    defaults = dict(
+        files_changed=2,
+        lines_added=30,
+        lines_removed=5,
+        modules_touched=("docs/operations.md", "tests/agents/test_foo.py"),
+        has_secret_keywords=False,
+        touches_protected_branch_policy=False,
+    )
+    defaults.update(overrides)
+    return PrDiffSummary(**defaults)
+
+
+def _clean_meta(**overrides) -> PrMetadata:
+    defaults = dict(
+        pr_number=123,
+        base_branch="feature/integration",
+        head_branch="feature/auto-merge-decider-issue-98-v2",
+        is_draft=False,
+        mergeable="MERGEABLE",
+        merge_state="CLEAN",
+        status_check_state="SUCCESS",
+        author_role="engineering-agent/devops-engineer",
+        labels=("✨ Feature", "🤖 Agent-runtime"),
+    )
+    defaults.update(overrides)
+    return PrMetadata(**defaults)
+
+
+def _full_pass_kwargs(**overrides):
+    defaults = dict(
+        cycle_authorized=True,
+        ci_ok=True,
+        governance_ok=True,
+        paste_guard_clean=True,
+        acceptance_criteria_reported=True,
+        force_push_detected=False,
+        no_verify_detected=False,
+        protected_branch_direct_push=False,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# RiskClass — 4 levels × representative inputs
+# ---------------------------------------------------------------------------
+
+
+class ClassifyRiskTests(unittest.TestCase):
+    """Static classification covers the four RiskClass levels."""
+
+    def test_low_docs_only_pr_is_low(self) -> None:
+        diff = _low_diff(
+            modules_touched=("docs/runbook.md",),
+            files_changed=1,
+            lines_added=10,
+            lines_removed=2,
+        )
+        risk, signals = classify_risk(diff, _clean_meta())
+        self.assertEqual(risk, RiskClass.LOW)
+        self.assertTrue(any(s.weight is RiskClass.LOW for s in signals))
+
+    def test_medium_large_diff_is_medium(self) -> None:
+        diff = _low_diff(
+            files_changed=10,
+            lines_added=400,
+            lines_removed=120,
+        )
+        risk, signals = classify_risk(diff, _clean_meta())
+        self.assertEqual(risk, RiskClass.MEDIUM)
+        self.assertTrue(
+            any(s.name.startswith("rule.diff") for s in signals),
+            "diff-size rule should fire",
+        )
+
+    def test_high_protected_base_branch_is_high(self) -> None:
+        risk, signals = classify_risk(_low_diff(), _clean_meta(base_branch="main"))
+        self.assertEqual(risk, RiskClass.HIGH)
+        self.assertTrue(
+            any(s.name == "rule.protected_branch.base" for s in signals)
+        )
+
+    def test_high_secret_keywords_is_high(self) -> None:
+        diff = _low_diff(has_secret_keywords=True)
+        risk, _ = classify_risk(diff, _clean_meta())
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_high_security_module_is_high(self) -> None:
+        diff = _low_diff(
+            modules_touched=(
+                "src/yule_orchestrator/agents/security/paste_guard.py",
+            ),
+        )
+        risk, _ = classify_risk(diff, _clean_meta())
+        self.assertEqual(risk, RiskClass.HIGH)
+
+    def test_critical_protected_branch_policy_edit_is_critical(self) -> None:
+        diff = _low_diff(touches_protected_branch_policy=True)
+        risk, signals = classify_risk(diff, _clean_meta())
+        self.assertEqual(risk, RiskClass.CRITICAL)
+        self.assertTrue(
+            any(
+                s.name == "rule.protected_branch.policy_edit" for s in signals
+            )
+        )
+
+    def test_critical_deploy_label_is_critical(self) -> None:
+        meta = _clean_meta(labels=("🌏 Deploy", "✨ Feature"))
+        risk, _ = classify_risk(_low_diff(), meta)
+        self.assertEqual(risk, RiskClass.CRITICAL)
+
+
+# ---------------------------------------------------------------------------
+# 8-condition evaluator
+# ---------------------------------------------------------------------------
+
+
+class EvaluateAutoMergeTests(unittest.TestCase):
+    """Full 8-condition pass/fail wiring."""
+
+    def test_full_pass_returns_eligible(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(),
+        )
+        self.assertIsInstance(verdict, AutoMergeVerdict)
+        self.assertTrue(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.LOW)
+        self.assertEqual(len(verdict.satisfied_conditions), 8)
+        self.assertEqual(verdict.failed_conditions, ())
+        self.assertEqual(verdict.blocker_signatures, ())
+
+    def test_cycle_unauthorized_blocks_everything(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(cycle_authorized=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn(
+            "automerge.cycle.not_authorized", verdict.blocker_signatures
+        )
+        self.assertEqual(verdict.satisfied_conditions, ())
+
+    def test_ci_failure_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(status_check_state="FAILURE"),
+            **_full_pass_kwargs(ci_ok=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn("ci_regression_ok", verdict.failed_conditions)
+        self.assertIn(
+            "automerge.ci.regression_failed", verdict.blocker_signatures
+        )
+
+    def test_governance_failure_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(governance_ok=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn("governance_regression_ok", verdict.failed_conditions)
+
+    def test_dirty_merge_state_or_draft_blocks(self) -> None:
+        for meta in (
+            _clean_meta(is_draft=True),
+            _clean_meta(mergeable="CONFLICTING", merge_state="DIRTY"),
+        ):
+            with self.subTest(meta=meta):
+                verdict = evaluate_auto_merge(
+                    _low_diff(), meta, **_full_pass_kwargs()
+                )
+                self.assertFalse(verdict.eligible)
+                self.assertIn(
+                    "mergeable_and_clean", verdict.failed_conditions
+                )
+
+    def test_force_push_or_no_verify_blocks(self) -> None:
+        for kwargs in (
+            _full_pass_kwargs(force_push_detected=True),
+            _full_pass_kwargs(no_verify_detected=True),
+        ):
+            with self.subTest(kwargs=kwargs):
+                verdict = evaluate_auto_merge(
+                    _low_diff(), _clean_meta(), **kwargs
+                )
+                self.assertFalse(verdict.eligible)
+                self.assertIn(
+                    "no_force_or_no_verify", verdict.failed_conditions
+                )
+
+    def test_paste_guard_failure_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(paste_guard_clean=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn("paste_guard_clean", verdict.failed_conditions)
+
+    def test_acceptance_report_missing_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(acceptance_criteria_reported=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn(
+            "acceptance_criteria_reported", verdict.failed_conditions
+        )
+
+    def test_medium_risk_class_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(files_changed=10, lines_added=500, lines_removed=200),
+            _clean_meta(),
+            **_full_pass_kwargs(),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.MEDIUM)
+        self.assertIn("risk_class_low", verdict.failed_conditions)
+
+    def test_protected_branch_bases_block(self) -> None:
+        for base in ("main", "release/2026-05"):
+            with self.subTest(base=base):
+                verdict = evaluate_auto_merge(
+                    _low_diff(),
+                    _clean_meta(base_branch=base),
+                    **_full_pass_kwargs(),
+                )
+                self.assertFalse(verdict.eligible)
+                self.assertIn(
+                    "no_protected_branch_direct_push",
+                    verdict.failed_conditions,
+                )
+
+    def test_missing_optional_inputs_fail_closed(self) -> None:
+        # ci_ok / governance_ok / paste_guard_clean / acceptance left None
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            cycle_authorized=True,
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn("governance_regression_ok", verdict.failed_conditions)
+        self.assertIn("paste_guard_clean", verdict.failed_conditions)
+        self.assertIn(
+            "acceptance_criteria_reported", verdict.failed_conditions
+        )
+
+    def test_reason_payload_carries_block_context(self) -> None:
+        # HIGH-class block surfaces the risk class in the reason; a
+        # LOW-class block surfaces the failed condition names.
+        high = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(base_branch="main"),
+            **_full_pass_kwargs(),
+        )
+        self.assertIn("HIGH", high.reason)
+        low_block = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(ci_ok=False, governance_ok=False),
+        )
+        self.assertIn("ci_regression_ok", low_block.reason)
+
+
+# ---------------------------------------------------------------------------
+# Env helper + ledger integration
+# ---------------------------------------------------------------------------
+
+
+class CycleEnvHelperTests(unittest.TestCase):
+    """``YULE_AUTOMERGE_CYCLE`` interpretation."""
+
+    def test_empty_env_returns_false(self) -> None:
+        self.assertFalse(is_cycle_authorized_from_env({}))
+
+    def test_explicit_cycle_name_returns_true(self) -> None:
+        self.assertTrue(
+            is_cycle_authorized_from_env({ENV_AUTOMERGE_CYCLE: "F1-F8"})
+        )
+
+    def test_falsy_strings_return_false(self) -> None:
+        for value in ("false", "0", "off", "no", "disabled", "FALSE"):
+            with self.subTest(value=value):
+                self.assertFalse(
+                    is_cycle_authorized_from_env(
+                        {ENV_AUTOMERGE_CYCLE: value}
+                    )
+                )
+
+    def test_truthy_strings_return_true(self) -> None:
+        for value in ("true", "yes", "on", "1"):
+            with self.subTest(value=value):
+                self.assertTrue(
+                    is_cycle_authorized_from_env(
+                        {ENV_AUTOMERGE_CYCLE: value}
+                    )
+                )
+
+
+class LedgerIntegrationTests(unittest.TestCase):
+    """``record_automerge_signature`` round-trip."""
+
+    def setUp(self) -> None:
+        self.ledger = MistakeLedger(database_path=":memory:")
+        self.addCleanup(self.ledger.close)
+
+    def test_signature_namespaced_automerge(self) -> None:
+        record_automerge_signature(
+            self.ledger,
+            role="engineering-agent/tech-lead",
+            signature="ci.regression_failed",
+            pr_number=42,
+        )
+        records = self.ledger.all_records()
+        self.assertEqual(len(records), 1)
+        self.assertTrue(records[0].signature.startswith("automerge."))
+        self.assertEqual(records[0].pattern, "automerge")
+
+    def test_high_signature_escalates_to_block(self) -> None:
+        record_automerge_signature(
+            self.ledger,
+            role="engineering-agent/tech-lead",
+            signature="automerge.risk-class.high-without-approval",
+            pr_number=98,
+            blocker_level=BlockerLevel.ADVISORY,
+        )
+        records = self.ledger.all_records()
+        self.assertEqual(records[0].blocker_level, BlockerLevel.BLOCK)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_auto_merge_governance.py
+++ b/tests/engineering/test_auto_merge_governance.py
@@ -1,0 +1,191 @@
+"""Governance regression for the F7 / #98 auto-merge decider.
+
+Pins the conventions §5 hard rails into one suite so a single
+rule edit cannot silently regress them:
+
+  1. HIGH and CRITICAL risk class PRs are *never* eligible —
+     even when the 8 conditions otherwise look pristine and
+     ``cycle_authorized=True``.
+  2. ``cycle_authorized=False`` short-circuits every PR to
+     ``eligible=False``, even a LOW-class PR with every
+     condition satisfied.
+  3. Protected branch bases (``main`` / ``master`` / ``develop``
+     / ``release/*`` / ``prod``) always escalate to at least
+     ``HIGH`` and block.
+  4. PasteGuard layer is independent — the decider trusts the
+     ``paste_guard_clean`` signal and exposes a single
+     ``automerge.paste_guard.secret_detected`` signature for the
+     mistake ledger.
+  5. The §7 signature ``automerge.risk-class.high-without-approval``
+     is the exact string the decider emits for HIGH/CRITICAL
+     blocks — the ledger row in the doc and the code must agree.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.release.auto_merge_decider import (
+    AutoMergeVerdict,
+    PrDiffSummary,
+    PrMetadata,
+    RiskClass,
+    classify_risk,
+    evaluate_auto_merge,
+    record_automerge_signature,
+)
+
+
+def _clean_meta(**overrides) -> PrMetadata:
+    defaults = dict(
+        pr_number=98,
+        base_branch="feature/integration",
+        head_branch="feature/auto-merge-decider-issue-98-v2",
+        is_draft=False,
+        mergeable="MERGEABLE",
+        merge_state="CLEAN",
+        status_check_state="SUCCESS",
+        author_role="engineering-agent/devops-engineer",
+        labels=("✨ Feature",),
+    )
+    defaults.update(overrides)
+    return PrMetadata(**defaults)
+
+
+def _low_diff(**overrides) -> PrDiffSummary:
+    defaults = dict(
+        files_changed=2,
+        lines_added=30,
+        lines_removed=5,
+        modules_touched=("docs/operations.md",),
+        has_secret_keywords=False,
+        touches_protected_branch_policy=False,
+    )
+    defaults.update(overrides)
+    return PrDiffSummary(**defaults)
+
+
+def _full_pass_kwargs(**overrides):
+    defaults = dict(
+        cycle_authorized=True,
+        ci_ok=True,
+        governance_ok=True,
+        paste_guard_clean=True,
+        acceptance_criteria_reported=True,
+        force_push_detected=False,
+        no_verify_detected=False,
+        protected_branch_direct_push=False,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+class HighCriticalNeverEligibleTests(unittest.TestCase):
+    """Hard rail #1 — HIGH / CRITICAL never eligible=True."""
+
+    def test_high_risk_secret_keyword_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(has_secret_keywords=True),
+            _clean_meta(),
+            **_full_pass_kwargs(),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.HIGH)
+        self.assertIn(
+            "automerge.risk-class.high-without-approval",
+            verdict.blocker_signatures,
+        )
+
+    def test_critical_protected_branch_policy_edit_blocks(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(touches_protected_branch_policy=True),
+            _clean_meta(),
+            **_full_pass_kwargs(),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.CRITICAL)
+        self.assertIn(
+            "automerge.risk-class.high-without-approval",
+            verdict.blocker_signatures,
+        )
+
+    def test_high_security_module_with_all_conditions_pass_still_blocks(
+        self,
+    ) -> None:
+        diff = _low_diff(
+            modules_touched=(
+                "src/yule_orchestrator/agents/security/paste_guard.py",
+            ),
+        )
+        verdict = evaluate_auto_merge(
+            diff, _clean_meta(), **_full_pass_kwargs()
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.HIGH)
+
+
+class CycleAuthorizationKillSwitchTests(unittest.TestCase):
+    """Hard rail #2 — cycle_authorized=False blocks everything."""
+
+    def test_cycle_off_blocks_otherwise_perfect_low_pr(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(),
+            **_full_pass_kwargs(cycle_authorized=False),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertIn(
+            "automerge.cycle.not_authorized", verdict.blocker_signatures
+        )
+        # cycle gate short-circuits → no satisfied conditions reported.
+        self.assertEqual(verdict.satisfied_conditions, ())
+
+
+class ProtectedBranchBaseTests(unittest.TestCase):
+    """Hard rail #3 — protected branch base always blocks."""
+
+    def test_main_base_escalates_to_high(self) -> None:
+        verdict = evaluate_auto_merge(
+            _low_diff(),
+            _clean_meta(base_branch="main"),
+            **_full_pass_kwargs(),
+        )
+        self.assertFalse(verdict.eligible)
+        self.assertEqual(verdict.risk_class, RiskClass.HIGH)
+        self.assertIn(
+            "automerge.protected_branch.base", verdict.blocker_signatures
+        )
+
+
+class LedgerSignatureContractTests(unittest.TestCase):
+    """Hard rail #5 — §7 signature exact-string match + BLOCK level."""
+
+    def test_high_signature_records_block_level(self) -> None:
+        ledger = MistakeLedger(database_path=":memory:")
+        try:
+            record_automerge_signature(
+                ledger,
+                role="engineering-agent/tech-lead",
+                signature="automerge.risk-class.high-without-approval",
+                pr_number=98,
+                blocker_level=BlockerLevel.ADVISORY,  # caller asks lower
+            )
+            records = ledger.all_records()
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0].blocker_level, BlockerLevel.BLOCK)
+            self.assertTrue(records[0].signature.startswith("automerge."))
+        finally:
+            ledger.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #98
- parent #81
- 의존 PR #94 (PasteGuard) / #96 (mistake_ledger) / #97 (conventions §5)

## 🎯 목적
PR 의 risk class 를 정적 분석으로 결정하고 conventions §5 의 8 자율 머지 조건을 deterministic 하게 평가하는 read-only decider 모듈을 신설한다. 운영자가 매번 머지 버튼을 누르지 않아도 LOW 클래스의 안전한 PR 은 tech-lead agent 가 자율 머지하도록 가드한다.

## 📐 범위
- `src/yule_orchestrator/agents/release/__init__.py` + `auto_merge_decider.py` 신설
- `RiskClass` enum: LOW / MEDIUM / HIGH / CRITICAL (F12 #103 RiskClass 와 vocabulary 정합)
- `PrDiffSummary(files_changed, lines_added, lines_removed, modules_touched, has_secret_keywords, touches_protected_branch_policy)`
- `PrMetadata(pr_number, base_branch, head_branch, is_draft, mergeable, merge_state, status_check_state, author_role, labels)`
- `classify_risk(diff, meta) -> (RiskClass, signals)` — 정적 규칙
- `evaluate_auto_merge(diff, meta, *, cycle_authorized) -> AutoMergeVerdict` — 8 조건 평가
- `record_automerge_signature` mistake_ledger 통합 (`automerge.*` namespace)
- `is_cycle_authorized_from_env` env 헬퍼
- `.env.example` `YULE_AUTOMERGE_CYCLE=` 추가 (default 비활성)

**비범위 (후속 PR):**
- gh-cli 실 PR 데이터 fetch 어댑터 (`fetch_pr_summary`)
- tech-lead agent 의 pre-merge 호출 와이어링
- preflight hook 등록

## ✅ Acceptance Criteria
1. 4 RiskClass 정적 분류 — PASS (`ClassifyRiskTests`)
2. HIGH / CRITICAL 절대 eligible=True 반환 안 됨 — PASS (`HighCriticalNeverEligibleTests`)
3. `cycle_authorized=False` → 모든 PR eligible=False — PASS (`CycleAuthorizationKillSwitchTests`)
4. 보호 브랜치 base PR 절대 자동 머지 안 됨 — PASS (`ProtectedBranchBaseTests`)
5. PasteGuard 통합 (paste_guard_clean 입력 신호 + 전용 signature)

## 🔒 Hard rails
- HIGH/CRITICAL 자동 머지 차단 (`automerge.risk-class.high-without-approval` BLOCK)
- 보호 브랜치(`main` / `master` / `develop` / `release/*` / `prod` / `production`) base 항상 escalate → HIGH 이상
- `cycle_authorized=False` 킬스위치 — env 미설정 / `false` 류 값은 모든 PR 차단
- `YULE_AUTOMERGE_CYCLE` 은 `.env.example` 에 활성 사이클 이름 명시 금지

## 🔗 의존성
- 선행: PR #94 (PasteGuard) / #96 (mistake_ledger) / #97 (conventions §5) — 머지됨

## 🧰 Harness
- `tests/agents/test_auto_merge_decider.py` — 25 케이스 (4 RiskClass × 시나리오 + 8조건 wiring + env 헬퍼 + ledger 통합)
- `tests/engineering/test_auto_merge_governance.py` — 6 케이스 (HIGH/CRITICAL 항상 차단 / cycle 킬스위치 / 보호 브랜치 base / §7 signature contract)
- 신규 31 테스트 PASS / full regression 3911 tests — 사전 존재 1건 (`tests.agents.test_discussion_response` pytest 미설치) 외 신규 회귀 없음

## 🤖 Agent
- role: engineering-agent/devops-engineer
- autonomy: L2_AUTONOMOUS_RECORD
- risk_class: LOW (read-only decider 모듈 추가)
- v2 retry — 이전 attempt 의 token harness 가이드 적용 (신규 test only first → full regression 1회)