### PR TITLE
✨ [Feat] F5 Role-based research live provider 확장 (RSS/Atom/release)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,3 +366,24 @@ DISCORD_GUILD_ID=
 #     (governance test 가 보호).
 # YULE_TOOL_GATE_ENABLED=true
 # YULE_TOOL_GATE_DEFAULT_AUTONOMY=L2_autonomous_record
+
+# =====================================================================
+# F5 / #92 — Role-based research live providers (RSS / Atom / release)
+#
+# `src/yule_orchestrator/agents/research/providers/live/` 는 backend /
+# frontend / qa / devops / tech-lead 역할별 외부 read-only source 를
+# 정규화된 `LiveEvidence` 로 ingest 한다. 기본 OFF — 운영자가 명시적
+# 으로 ON 했을 때만 외부 fetch 가 시도된다.
+#
+# 운영 정책:
+#   - default OFF (`false`). ON 으로 전환 시에도 카탈로그 외 host 는
+#     fetch 금지 (`governance test` 가 보호). robots.txt Disallow 위반
+#     source 는 자동 skip.
+#   - rate-limit 한도는 초당 1 호출. 0 이하 값은 default(1.0) 폴백.
+#   - PasteGuard 통합으로 raw secret / raw HTML 이 summary 로 새지
+#     않는다.
+# YULE_RESEARCH_LIVE_ENABLED=false
+# YULE_RESEARCH_LIVE_ALLOW_HOSTS=
+# YULE_RESEARCH_LIVE_DISABLE_HOSTS=
+# YULE_RESEARCH_LIVE_KINDS=rss,atom,github_release
+# YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC=1.0

--- a/src/yule_orchestrator/agents/research/providers/__init__.py
+++ b/src/yule_orchestrator/agents/research/providers/__init__.py
@@ -1,0 +1,8 @@
+"""Research providers — read-only source ingestion (F5 / #92).
+
+본 패키지는 외부 자료 (RSS/Atom feed, GitHub release, sitemap …) 를
+read-only 로 ingest 해 :class:`LiveEvidence` 로 정규화한다. 실제 모듈은
+:mod:`yule_orchestrator.agents.research.providers.live` 하위.
+"""
+
+__all__: tuple = ()

--- a/src/yule_orchestrator/agents/research/providers/live/__init__.py
+++ b/src/yule_orchestrator/agents/research/providers/live/__init__.py
@@ -1,0 +1,151 @@
+"""Live research providers — F5 / #92.
+
+본 모듈은 외부 read-only source 를 정규화된 :class:`LiveEvidence` 로
+ingest 하기 위한 **공용 dataclass** 와 ``LiveProvider`` 프로토콜을
+정의한다. 실제 fetch 로직(:mod:`rss_atom`, :mod:`github_release`) 은
+서브모듈이 담당한다.
+
+설계 원칙:
+- I/O 호출은 **항상** ``YULE_RESEARCH_LIVE_ENABLED=true`` + allow-list
+  ``host`` + ``robots_compliant=True`` 3 가지가 동시에 충족돼야 한다.
+- ``YULE_RESEARCH_LIVE_ENABLED`` default 는 ``false`` — 운영자가 명시적
+  으로 켜기 전까지 모든 provider 는 mock fallback (빈 결과 또는 fake
+  evidence) 으로 동작한다.
+- 본 패키지의 어떤 함수도 PasteGuard 를 통과하지 않은 raw HTML 본문을
+  외부 채널로 내보내지 않는다. ingest 결과는 항상 정규화된 메타데이터
+  + redacted summary 만 노출.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Mapping, Optional, Protocol, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Source kind 상수
+# ---------------------------------------------------------------------------
+
+KIND_RSS: str = "rss"
+KIND_ATOM: str = "atom"
+KIND_GITHUB_RELEASE: str = "github_release"
+KIND_SITEMAP: str = "sitemap"
+
+ALL_KINDS: Tuple[str, ...] = (
+    KIND_RSS,
+    KIND_ATOM,
+    KIND_GITHUB_RELEASE,
+    KIND_SITEMAP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveSource:
+    """외부 source 메타데이터.
+
+    * ``host`` — 정규화된 hostname (소문자, no scheme/port). allow-list
+      매칭 키. 예: ``"docs.github.com"``.
+    * ``kind`` — :data:`ALL_KINDS` 중 하나.
+    * ``allow_listed`` — 운영자가 명시 등록한 host 인지. False 면 fetch
+      금지 + trust 페널티 (-3).
+    * ``robots_compliant`` — robots.txt Disallow 와 충돌하지 않는지.
+      False 면 fetch 금지 + trust 페널티 (-5).
+    * ``rate_limit_per_sec`` — provider 가 자체 제한할 초당 호출 한도.
+      governance 가드의 하한선이며 1 이하 값을 권장 (Hard rail).
+    """
+
+    host: str
+    kind: str
+    allow_listed: bool = True
+    robots_compliant: bool = True
+    rate_limit_per_sec: float = 1.0
+    url: str = ""
+
+    def __post_init__(self) -> None:
+        if self.kind not in ALL_KINDS:
+            raise ValueError(
+                f"LiveSource.kind invalid: {self.kind!r} not in {ALL_KINDS}"
+            )
+        if self.rate_limit_per_sec <= 0:
+            raise ValueError(
+                "LiveSource.rate_limit_per_sec must be > 0 "
+                f"(got {self.rate_limit_per_sec!r})"
+            )
+
+
+@dataclass(frozen=True)
+class LiveEvidence:
+    """정규화된 외부 자료 단위 (한 entry / release).
+
+    * ``source`` — 출처 :class:`LiveSource`.
+    * ``title`` — entry 제목 (이미 PasteGuard 통과 가정).
+    * ``url`` — 자료 URL.
+    * ``summary`` — 짧은 요약. raw HTML 금지 — plain text + redacted.
+    * ``published_at`` — entry 발행 시각 (없으면 None).
+    * ``tags`` — entry 태그/카테고리.
+    * ``extra`` — provider 별 부가 메타 (release version, feed lang …).
+    """
+
+    source: LiveSource
+    title: str
+    url: str
+    summary: str = ""
+    published_at: Optional[datetime] = None
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+    extra: Mapping[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Provider protocol
+# ---------------------------------------------------------------------------
+
+
+class LiveProvider(Protocol):
+    """Live ingest provider 공용 인터페이스.
+
+    구현체는 :meth:`ingest` 가 호출 시점의 source 목록에서 evidence 를
+    수집해 반환해야 한다. env OFF / allow-list 위반 / robots 위반 시에는
+    빈 튜플을 반환 (예외 X) — 호출자는 mock fallback 으로 자연스럽게
+    이행된다.
+    """
+
+    name: str
+
+    def ingest(self) -> Tuple[LiveEvidence, ...]:  # pragma: no cover - protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Re-export
+# ---------------------------------------------------------------------------
+
+from .registry import (  # noqa: E402 - 순환 회피용 후행 import
+    build_live_provider_registry_from_env,
+    LiveProviderRegistry,
+    default_role_source_catalog,
+)
+from .rss_atom import RssAtomProvider  # noqa: E402
+from .github_release import GithubReleaseProvider  # noqa: E402
+
+
+__all__ = (
+    "ALL_KINDS",
+    "KIND_ATOM",
+    "KIND_GITHUB_RELEASE",
+    "KIND_RSS",
+    "KIND_SITEMAP",
+    "GithubReleaseProvider",
+    "LiveEvidence",
+    "LiveProvider",
+    "LiveProviderRegistry",
+    "LiveSource",
+    "RssAtomProvider",
+    "build_live_provider_registry_from_env",
+    "default_role_source_catalog",
+)

--- a/src/yule_orchestrator/agents/research/providers/live/github_release.py
+++ b/src/yule_orchestrator/agents/research/providers/live/github_release.py
@@ -1,0 +1,134 @@
+"""GitHub release live provider (F5 / #92).
+
+GitHub repo 의 release 메타데이터를 read-only 로 수집해 :class:`LiveEvidence`
+로 정규화한다. 본 provider 는 GitHub REST API (또는 Atom feed) 양쪽 모두
+지원할 수 있도록 ``release_fetch`` 콜러블에만 의존한다 — 실제 transport
+선택은 caller 책임이다.
+
+Hard rails:
+  * env ``YULE_RESEARCH_LIVE_ENABLED`` 가 ``true`` 가 아니면 fetch skip.
+  * source ``allow_listed=False`` / ``robots_compliant=False`` 면 skip.
+  * release body 는 raw markdown 그대로 노출하지 않고 PasteGuard
+    redacted summary 로 변환.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from ...security_compat import guard_text
+from . import KIND_GITHUB_RELEASE, LiveEvidence, LiveSource
+
+
+# release_fetch(repo: str) → 정규화된 dict 시퀀스.
+# 각 dict 는 다음 키를 가진다:
+#   - "tag_name": str (e.g. "v1.2.3")
+#   - "name": str (release title, optional)
+#   - "html_url": str
+#   - "published_at": str (ISO8601, optional)
+#   - "body": str (release notes markdown, optional)
+ReleaseFetcher = Callable[[str], Sequence[Mapping[str, str]]]
+
+
+@dataclass(frozen=True)
+class GithubReleaseProvider:
+    """GitHub release ingest provider.
+
+    * ``sources`` — :data:`LiveSource.kind == "github_release"` 만 다룸.
+      ``source.url`` 에는 ``"owner/repo"`` 형태의 repo slug 를 담는다
+      (예: ``"fastapi/fastapi"``).
+    * ``release_fetch`` — repo slug → release dict 시퀀스.
+    * ``env_enabled`` — ``YULE_RESEARCH_LIVE_ENABLED`` bool.
+    * ``max_releases_per_repo`` — repo 당 최대 release 수 (default 5).
+    """
+
+    sources: Tuple[LiveSource, ...]
+    release_fetch: Optional[ReleaseFetcher] = None
+    env_enabled: bool = False
+    max_releases_per_repo: int = 5
+
+    name: str = "github_release"
+
+    def ingest(self) -> Tuple[LiveEvidence, ...]:
+        if not self.env_enabled or self.release_fetch is None:
+            return ()
+
+        out: list[LiveEvidence] = []
+        for src in self.sources:
+            if src.kind != KIND_GITHUB_RELEASE:
+                continue
+            if not src.allow_listed or not src.robots_compliant:
+                continue
+            repo_slug = (src.url or "").strip()
+            if not repo_slug or "/" not in repo_slug:
+                continue
+            try:
+                releases = self.release_fetch(repo_slug)
+            except Exception:  # noqa: BLE001 - 외부 fetch 격리
+                continue
+            for raw in list(releases)[: self.max_releases_per_repo]:
+                ev = _to_evidence(src, raw, repo_slug)
+                if ev is not None:
+                    out.append(ev)
+        return tuple(out)
+
+
+def _to_evidence(
+    src: LiveSource,
+    raw: Mapping[str, str],
+    repo_slug: str,
+) -> Optional[LiveEvidence]:
+    """release dict → :class:`LiveEvidence`. PasteGuard 통과."""
+
+    tag = (raw.get("tag_name") or "").strip()
+    name = (raw.get("name") or "").strip() or tag
+    if not tag and not name:
+        return None
+    title = guard_text(f"{repo_slug} {name or tag}".strip())
+    url = (raw.get("html_url") or "").strip() or (
+        f"https://github.com/{repo_slug}/releases/tag/{tag}" if tag else ""
+    )
+    body = (raw.get("body") or "").strip()
+    summary = guard_text(_shorten(body, limit=400))
+    published_at = _parse_iso(raw.get("published_at"))
+    return LiveEvidence(
+        source=src,
+        title=title,
+        url=url,
+        summary=summary,
+        published_at=published_at,
+        tags=(tag,) if tag else (),
+        extra={"repo": repo_slug, "tag": tag},
+    )
+
+
+def _shorten(text: str, *, limit: int) -> str:
+    if not text:
+        return ""
+    flat = " ".join(text.split())
+    if len(flat) <= limit:
+        return flat
+    return flat[: limit - 1].rstrip() + "…"
+
+
+def _parse_iso(raw: Optional[str]) -> Optional[datetime]:
+    if not raw:
+        return None
+    raw = raw.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+__all__ = (
+    "GithubReleaseProvider",
+    "ReleaseFetcher",
+)

--- a/src/yule_orchestrator/agents/research/providers/live/registry.py
+++ b/src/yule_orchestrator/agents/research/providers/live/registry.py
@@ -1,0 +1,281 @@
+"""Live provider registry + env factory (F5 / #92).
+
+본 모듈은 5 역할 (backend / frontend / qa / devops / tech-lead) 의 기본
+:class:`LiveSource` 카탈로그를 정의하고, ``build_live_provider_registry_from_env``
+팩토리로 env 기반 활성/비활성 + allow-list 확장을 처리한다.
+
+env 키:
+  * ``YULE_RESEARCH_LIVE_ENABLED`` — default ``false``. ``true`` 일 때만
+    provider 가 실제 fetch 호출.
+  * ``YULE_RESEARCH_LIVE_ALLOW_HOSTS`` — comma-separated host list.
+    카탈로그 기본값 외 추가 host 를 allow-list 에 편입. 비어 있으면 카탈
+    로그 default 만 활성.
+  * ``YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC`` — provider rate-limit 한도.
+    default 1.0. 0 이하 값은 무시 (default 적용).
+  * ``YULE_RESEARCH_LIVE_DISABLE_HOSTS`` — comma-separated host list.
+    카탈로그 기본 host 중 사용 안 할 것 명시. 운영자가 특정 source 만 끌
+    수 있게 함.
+  * ``YULE_RESEARCH_LIVE_KINDS`` — comma-separated kind list. 활성 kind
+    제한. 비어있으면 모두 활성 (``rss,atom,github_release``).
+
+env OFF 또는 카탈로그가 비면 :func:`LiveProviderRegistry.ingest_all` 은
+빈 튜플을 반환 (mock fallback 으로 호출자 자연스럽게 이행).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from . import (
+    KIND_ATOM,
+    KIND_GITHUB_RELEASE,
+    KIND_RSS,
+    LiveEvidence,
+    LiveProvider,
+    LiveSource,
+)
+from .github_release import GithubReleaseProvider, ReleaseFetcher
+from .rss_atom import HttpFetcher, RssAtomProvider
+
+
+# ---------------------------------------------------------------------------
+# Default role-source catalog
+# ---------------------------------------------------------------------------
+
+# (role, host, kind, url) 튜플 시퀀스. url 은 RSS/Atom 의 경우 feed url,
+# github_release 의 경우 ``"owner/repo"`` slug.
+_DEFAULT_CATALOG: Tuple[Tuple[str, str, str, str], ...] = (
+    # backend
+    ("backend-engineer", "fastapi.tiangolo.com", KIND_GITHUB_RELEASE, "tiangolo/fastapi"),
+    ("backend-engineer", "docs.sqlalchemy.org", KIND_GITHUB_RELEASE, "sqlalchemy/sqlalchemy"),
+    ("backend-engineer", "python.org", KIND_ATOM, "https://www.python.org/dev/peps/peps.rss/"),
+    ("backend-engineer", "owasp.org", KIND_RSS, "https://owasp.org/news/feed.xml"),
+    # frontend
+    ("frontend-engineer", "developer.mozilla.org", KIND_ATOM, "https://developer.mozilla.org/en-US/blog/rss.xml"),
+    ("frontend-engineer", "react.dev", KIND_GITHUB_RELEASE, "facebook/react"),
+    ("frontend-engineer", "vuejs.org", KIND_GITHUB_RELEASE, "vuejs/core"),
+    ("frontend-engineer", "typescriptlang.org", KIND_GITHUB_RELEASE, "microsoft/TypeScript"),
+    # qa
+    ("qa-engineer", "playwright.dev", KIND_GITHUB_RELEASE, "microsoft/playwright"),
+    ("qa-engineer", "docs.cypress.io", KIND_GITHUB_RELEASE, "cypress-io/cypress"),
+    ("qa-engineer", "vitest.dev", KIND_GITHUB_RELEASE, "vitest-dev/vitest"),
+    # devops
+    ("devops-engineer", "docs.github.com", KIND_ATOM, "https://github.blog/feed/"),
+    ("devops-engineer", "kubernetes.io", KIND_GITHUB_RELEASE, "kubernetes/kubernetes"),
+    ("devops-engineer", "prometheus.io", KIND_GITHUB_RELEASE, "prometheus/prometheus"),
+    # tech-lead
+    ("tech-lead", "github.blog", KIND_RSS, "https://github.blog/feed/"),
+    ("tech-lead", "cncf.io", KIND_RSS, "https://www.cncf.io/feed/"),
+)
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    role: str
+    source: LiveSource
+
+
+def default_role_source_catalog(
+    *,
+    extra_allow_hosts: Sequence[str] = (),
+    disable_hosts: Sequence[str] = (),
+    allowed_kinds: Sequence[str] = (),
+    rate_limit_per_sec: float = 1.0,
+) -> Tuple[CatalogEntry, ...]:
+    """기본 카탈로그 → :class:`CatalogEntry` 튜플.
+
+    * ``extra_allow_hosts`` — 카탈로그 외 host 도 allow-list 에 편입 (현재
+      구현은 단순 통과만; 운영자가 같은 호스트로 카탈로그를 직접 등록할
+      때 ``allow_listed=True`` 로 표시할 때만 의미가 있다).
+    * ``disable_hosts`` — 매칭 host 는 catalog 에서 제거.
+    * ``allowed_kinds`` — 빈 시퀀스면 전부, 아니면 매칭 kind 만 남김.
+    * ``rate_limit_per_sec`` — 카탈로그 entry 전체에 적용할 rate-limit.
+    """
+
+    disable_set = {h.lower().strip() for h in disable_hosts if h}
+    allow_extra = {h.lower().strip() for h in extra_allow_hosts if h}
+    kind_set = {k.lower().strip() for k in allowed_kinds if k}
+
+    out: list[CatalogEntry] = []
+    for role, host, kind, url in _DEFAULT_CATALOG:
+        h = host.lower()
+        if h in disable_set:
+            continue
+        if kind_set and kind not in kind_set:
+            continue
+        out.append(
+            CatalogEntry(
+                role=role,
+                source=LiveSource(
+                    host=h,
+                    kind=kind,
+                    allow_listed=True,
+                    robots_compliant=True,
+                    rate_limit_per_sec=rate_limit_per_sec,
+                    url=url,
+                ),
+            )
+        )
+    # extra_allow_hosts 는 현재 catalog 외 host 메타 등록만 노출.
+    # 실제 fetch 는 caller 가 별도 LiveSource 를 만들어 추가해야 한다.
+    for h in sorted(allow_extra):
+        if any(e.source.host == h for e in out):
+            continue
+        # 카탈로그에 등록 안 된 extra host 는 default kind=rss + allow_listed
+        # 로 등록만 해 두고, url 은 비워둔다. caller 가 url 을 세팅해야 fetch
+        # 가 가능.
+        out.append(
+            CatalogEntry(
+                role="tech-lead",
+                source=LiveSource(
+                    host=h,
+                    kind=KIND_RSS,
+                    allow_listed=True,
+                    robots_compliant=True,
+                    rate_limit_per_sec=rate_limit_per_sec,
+                    url="",
+                ),
+            )
+        )
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveProviderRegistry:
+    """Live provider 묶음. ``ingest_all`` 은 모든 provider 의 결과를 합친다.
+
+    env OFF / provider 비활성 시 빈 튜플 반환 — caller (research loop /
+    workflow) 는 mock fallback 으로 자연스럽게 이행한다.
+    """
+
+    providers: Tuple[LiveProvider, ...]
+    env_enabled: bool
+    rate_limit_per_sec: float
+
+    def ingest_all(self) -> Tuple[LiveEvidence, ...]:
+        if not self.env_enabled:
+            return ()
+        out: list[LiveEvidence] = []
+        for p in self.providers:
+            try:
+                out.extend(p.ingest())
+            except Exception:  # noqa: BLE001 - provider 격리
+                continue
+        return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Env factory
+# ---------------------------------------------------------------------------
+
+
+def build_live_provider_registry_from_env(
+    env: Mapping[str, str],
+    *,
+    http_fetch: Optional[HttpFetcher] = None,
+    release_fetch: Optional[ReleaseFetcher] = None,
+) -> LiveProviderRegistry:
+    """env mapping 으로부터 :class:`LiveProviderRegistry` 를 구성.
+
+    env OFF (default) 시 ``providers`` 는 빈 튜플로 만들어 mock fallback
+    경로가 자연스럽게 활성화되도록 한다.
+
+    ``http_fetch`` / ``release_fetch`` 는 외부 transport. 둘 다 None 이면
+    env 가 ON 이어도 실제 fetch 는 일어나지 않는다 — caller 가 명시적
+    으로 주입했을 때만 외부 호출 가능.
+    """
+
+    enabled = _bool_env(env.get("YULE_RESEARCH_LIVE_ENABLED"), default=False)
+    rate_limit = _float_env(
+        env.get("YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC"),
+        default=1.0,
+    )
+    if rate_limit <= 0:
+        rate_limit = 1.0
+
+    extra = _csv(env.get("YULE_RESEARCH_LIVE_ALLOW_HOSTS"))
+    disable = _csv(env.get("YULE_RESEARCH_LIVE_DISABLE_HOSTS"))
+    kinds = _csv(env.get("YULE_RESEARCH_LIVE_KINDS"))
+
+    catalog = default_role_source_catalog(
+        extra_allow_hosts=extra,
+        disable_hosts=disable,
+        allowed_kinds=kinds,
+        rate_limit_per_sec=rate_limit,
+    )
+
+    rss_sources = tuple(
+        e.source for e in catalog if e.source.kind in (KIND_RSS, KIND_ATOM)
+    )
+    release_sources = tuple(
+        e.source for e in catalog if e.source.kind == KIND_GITHUB_RELEASE
+    )
+
+    providers: list[LiveProvider] = []
+    if rss_sources:
+        providers.append(
+            RssAtomProvider(
+                sources=rss_sources,
+                http_fetch=http_fetch,
+                env_enabled=enabled,
+            )
+        )
+    if release_sources:
+        providers.append(
+            GithubReleaseProvider(
+                sources=release_sources,
+                release_fetch=release_fetch,
+                env_enabled=enabled,
+            )
+        )
+
+    return LiveProviderRegistry(
+        providers=tuple(providers),
+        env_enabled=enabled,
+        rate_limit_per_sec=rate_limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bool_env(value: Optional[str], *, default: bool) -> bool:
+    if value is None:
+        return default
+    v = value.strip().lower()
+    if v in ("1", "true", "yes", "on"):
+        return True
+    if v in ("0", "false", "no", "off", ""):
+        return False
+    return default
+
+
+def _float_env(value: Optional[str], *, default: float) -> float:
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value.strip())
+    except ValueError:
+        return default
+
+
+def _csv(value: Optional[str]) -> Tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(s.strip() for s in value.split(",") if s.strip())
+
+
+__all__ = (
+    "CatalogEntry",
+    "LiveProviderRegistry",
+    "build_live_provider_registry_from_env",
+    "default_role_source_catalog",
+)

--- a/src/yule_orchestrator/agents/research/providers/live/rss_atom.py
+++ b/src/yule_orchestrator/agents/research/providers/live/rss_atom.py
@@ -1,0 +1,248 @@
+"""RSS / Atom feed live provider (F5 / #92).
+
+XML 파싱은 stdlib ``xml.etree.ElementTree`` 만 사용 — 외부 의존 X.
+실제 HTTP fetch 는 호출자가 주입한 ``http_fetch`` 콜러블이 담당하고,
+본 provider 는 (1) 정책 가드 → (2) fetch → (3) 파싱 → (4) PasteGuard
+정규화 → (5) :class:`LiveEvidence` 변환 까지를 책임진다.
+
+Hard rails:
+  * env ``YULE_RESEARCH_LIVE_ENABLED`` 가 ``true`` 가 아니면 fetch 호출
+    자체를 skip 하고 빈 튜플 반환.
+  * source ``allow_listed=False`` 또는 ``robots_compliant=False`` 면
+    fetch skip.
+  * fetch 결과 본문은 항상 :func:`guard_outbound` (channel=LLM) 으로
+    redact 한 후 summary 로 노출 (raw HTML 절대 노출 금지).
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from ...security_compat import guard_text  # noqa: E402  (see module note)
+from . import KIND_ATOM, KIND_RSS, LiveEvidence, LiveSource
+
+
+HttpFetcher = Callable[[str], str]
+"""url → body(str). Provider 는 본 콜러블에만 의존 — 실제 transport 는
+주입측 책임. 테스트 / mock 은 in-memory dict 로 대체."""
+
+
+@dataclass(frozen=True)
+class RssAtomProvider:
+    """RSS 2.0 / Atom 1.0 feed ingest provider.
+
+    * ``sources`` — 이번 ingest 라운드의 :class:`LiveSource` 시퀀스.
+    * ``http_fetch`` — url → body 콜러블. 비활성 시 None 가능.
+    * ``env_enabled`` — ``YULE_RESEARCH_LIVE_ENABLED`` 결과 bool.
+      False 면 어떤 source 도 fetch 하지 않는다.
+    * ``max_entries_per_feed`` — 단일 feed 당 최대 항목 수 (default 10).
+    """
+
+    sources: Tuple[LiveSource, ...]
+    http_fetch: Optional[HttpFetcher] = None
+    env_enabled: bool = False
+    max_entries_per_feed: int = 10
+
+    name: str = "rss_atom"
+
+    def ingest(self) -> Tuple[LiveEvidence, ...]:
+        """정책 가드 후 모든 source 에서 evidence 를 수집해 반환.
+
+        env OFF / allow-list 위반 / robots 위반 source 는 skip.
+        fetch 실패 (예외) 한 source 도 skip — caller 로 예외 전파 X.
+        """
+
+        if not self.env_enabled or self.http_fetch is None:
+            return ()
+
+        out: list[LiveEvidence] = []
+        for src in self.sources:
+            if src.kind not in (KIND_RSS, KIND_ATOM):
+                continue
+            if not src.allow_listed or not src.robots_compliant:
+                continue
+            try:
+                body = self.http_fetch(src.url or _url_for(src))
+            except Exception:  # noqa: BLE001 - 외부 fetch 격리
+                continue
+            if not body:
+                continue
+            try:
+                entries = parse_feed(body, kind=src.kind)
+            except Exception:  # noqa: BLE001 - 파싱 실패 격리
+                continue
+            for entry in entries[: self.max_entries_per_feed]:
+                out.append(_to_evidence(src, entry))
+        return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeedEntry:
+    """원시 feed entry — provider 내부 표현."""
+
+    title: str
+    url: str
+    summary: str
+    published_at: Optional[datetime]
+    tags: Tuple[str, ...]
+
+
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+
+
+def parse_feed(body: str, *, kind: str) -> Tuple[FeedEntry, ...]:
+    """RSS 2.0 / Atom 1.0 body 를 :class:`FeedEntry` 튜플로 파싱.
+
+    잘못된 XML 은 :class:`ET.ParseError` 를 던지며, 호출자가 격리한다.
+    """
+
+    if kind not in (KIND_RSS, KIND_ATOM):
+        raise ValueError(f"unsupported feed kind: {kind!r}")
+
+    root = ET.fromstring(body)
+
+    if kind == KIND_RSS:
+        return _parse_rss(root)
+    return _parse_atom(root)
+
+
+def _parse_rss(root: ET.Element) -> Tuple[FeedEntry, ...]:
+    channel = root.find("channel")
+    if channel is None:
+        return ()
+    out: list[FeedEntry] = []
+    for item in channel.findall("item"):
+        title = (item.findtext("title") or "").strip()
+        url = (item.findtext("link") or "").strip()
+        description = (item.findtext("description") or "").strip()
+        pub_raw = item.findtext("pubDate")
+        published_at = _parse_rss_date(pub_raw) if pub_raw else None
+        tags = tuple(
+            (c.text or "").strip()
+            for c in item.findall("category")
+            if c.text
+        )
+        out.append(
+            FeedEntry(
+                title=title,
+                url=url,
+                summary=description,
+                published_at=published_at,
+                tags=tags,
+            )
+        )
+    return tuple(out)
+
+
+def _parse_atom(root: ET.Element) -> Tuple[FeedEntry, ...]:
+    out: list[FeedEntry] = []
+    for entry in root.findall(f"{_ATOM_NS}entry"):
+        title = (entry.findtext(f"{_ATOM_NS}title") or "").strip()
+
+        link_url = ""
+        link_el = entry.find(f"{_ATOM_NS}link")
+        if link_el is not None:
+            link_url = (link_el.attrib.get("href") or "").strip()
+
+        summary = (entry.findtext(f"{_ATOM_NS}summary") or "").strip()
+        if not summary:
+            summary = (entry.findtext(f"{_ATOM_NS}content") or "").strip()
+
+        updated_raw = entry.findtext(f"{_ATOM_NS}updated") or entry.findtext(
+            f"{_ATOM_NS}published"
+        )
+        published_at = _parse_atom_date(updated_raw) if updated_raw else None
+
+        tags = tuple(
+            (c.attrib.get("term") or "").strip()
+            for c in entry.findall(f"{_ATOM_NS}category")
+            if c.attrib.get("term")
+        )
+
+        out.append(
+            FeedEntry(
+                title=title,
+                url=link_url,
+                summary=summary,
+                published_at=published_at,
+                tags=tags,
+            )
+        )
+    return tuple(out)
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str) -> str:
+    """tag 제거 + 연속 공백 정리. raw HTML 노출 방지용."""
+
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", _TAG_RE.sub(" ", text)).strip()
+
+
+def _to_evidence(src: LiveSource, entry: FeedEntry) -> LiveEvidence:
+    """:class:`FeedEntry` → :class:`LiveEvidence`. PasteGuard 통과."""
+
+    safe_title = guard_text(entry.title)
+    safe_summary = guard_text(_strip_html(entry.summary))
+    return LiveEvidence(
+        source=src,
+        title=safe_title,
+        url=entry.url,
+        summary=safe_summary,
+        published_at=entry.published_at,
+        tags=entry.tags,
+        extra={"kind": src.kind},
+    )
+
+
+def _parse_rss_date(raw: str) -> Optional[datetime]:
+    try:
+        dt = parsedate_to_datetime(raw)
+    except (TypeError, ValueError, IndexError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_atom_date(raw: str) -> Optional[datetime]:
+    raw = raw.strip()
+    if not raw:
+        return None
+    # Python 3.9 의 fromisoformat 은 'Z' 를 못 읽으므로 보정.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _url_for(src: LiveSource) -> str:
+    if src.url:
+        return src.url
+    # 기본은 https://host (구체적 path 는 caller 가 url 로 명시 주입).
+    return f"https://{src.host}"
+
+
+__all__ = (
+    "FeedEntry",
+    "HttpFetcher",
+    "RssAtomProvider",
+    "parse_feed",
+)

--- a/src/yule_orchestrator/agents/research/scoring.py
+++ b/src/yule_orchestrator/agents/research/scoring.py
@@ -1,0 +1,330 @@
+"""Trust / Freshness / Priority scoring + request-time ranking (F5 / #92).
+
+본 모듈은 외부 live source 에서 ingest 된 :class:`LiveEvidence` 들에
+대해 신뢰도(TrustScore) / 신선도(FreshnessScore) 를 부여하고, 요청
+시점(``now``)과 역할(``role``)/태스크(``task_type``)에 따라 우선순위
+ranking 을 산출한다.
+
+설계 원칙:
+- I/O 없음. 순수 dataclass + 산술 + frozenset 룩업.
+- 점수는 0~10 정수 또는 0~10 float 척도 (직관/디버깅).
+- ``rank_for_request`` 는 deterministic: 동일 입력 → 동일 ranking.
+- 외부 fetch / 캐시 / robots 검증 책임은 본 모듈 영역 밖.
+
+본 모듈은 :mod:`yule_orchestrator.agents.research.providers.live` 의
+:class:`LiveEvidence` / :class:`LiveSource` 와 협업하며, 그 dataclass
+정의는 ``providers/live/__init__.py`` 에 있다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .providers.live import LiveEvidence, LiveSource
+
+
+# ---------------------------------------------------------------------------
+# Trust 기준
+# ---------------------------------------------------------------------------
+
+# host → 기준 trust 점수(0~10). 운영자가 검증한 vendor / standards-body /
+# 공식 docs 만 9~10 으로 박는다. 그 외 host 는 기본 5.
+_TRUST_BASELINE: Mapping[str, int] = {
+    # backend / language
+    "python.org": 10,
+    "fastapi.tiangolo.com": 9,
+    "docs.sqlalchemy.org": 9,
+    "owasp.org": 10,
+    # frontend
+    "developer.mozilla.org": 10,
+    "react.dev": 9,
+    "vuejs.org": 9,
+    "typescriptlang.org": 9,
+    # qa
+    "playwright.dev": 9,
+    "docs.cypress.io": 9,
+    "vitest.dev": 9,
+    # devops
+    "docs.github.com": 10,
+    "kubernetes.io": 10,
+    "prometheus.io": 9,
+    # tech-lead / industry signal
+    "github.blog": 8,
+    "cncf.io": 9,
+    # github release source
+    "github.com": 7,
+}
+
+# allow_listed 가 False 면 -3, robots_compliant 가 False 면 -5.
+_TRUST_PENALTY_NOT_ALLOWLISTED: int = 3
+_TRUST_PENALTY_ROBOTS_VIOLATION: int = 5
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrustScore:
+    """Host / 정책 기반 신뢰도 점수.
+
+    ``baseline`` 은 host 카탈로그에서 가져온 기준점 (없으면 5).
+    ``penalties`` 는 (사유, 감점) 튜플 시퀀스. ``value`` 는 둘을 합산해
+    0~10 으로 clip 된 최종 점수.
+    """
+
+    host: str
+    baseline: int
+    penalties: Tuple[Tuple[str, int], ...]
+    value: int
+
+
+@dataclass(frozen=True)
+class FreshnessScore:
+    """published_at vs now 기반 신선도 점수 (0~10).
+
+    하루 미만 = 10, 7일 미만 = 8, 30일 미만 = 6, 180일 미만 = 4,
+    365일 미만 = 2, 그 외 = 1. published_at 이 None 이면 3 (unknown).
+    미래 시점은 0 (clock skew / 조작 의심).
+    """
+
+    age_seconds: int  # 음수 = 미래, -1 = unknown
+    value: int
+
+
+@dataclass(frozen=True)
+class RankedEvidence:
+    """:class:`LiveEvidence` + 점수 + 우선순위 결정 메타.
+
+    ``priority`` 는 (trust + freshness + role_boost) / 3 의 round.
+    동일 priority 일 때 (trust desc → freshness desc → published_at desc
+    → host asc → title asc) 로 deterministic tie-break.
+    """
+
+    evidence: "LiveEvidence"
+    trust: TrustScore
+    freshness: FreshnessScore
+    role_boost: int
+    priority: int
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Trust scoring
+# ---------------------------------------------------------------------------
+
+
+def trust_score_for_source(source: "LiveSource") -> TrustScore:
+    """:class:`LiveSource` 에 대한 :class:`TrustScore` 산출.
+
+    baseline 은 :data:`_TRUST_BASELINE` 룩업 (없으면 5).
+    penalties:
+      * ``allow_listed`` 가 False → ``-3`` (allow-list 외 host)
+      * ``robots_compliant`` 가 False → ``-5`` (robots Disallow 위반)
+
+    최종 ``value`` 는 0~10 으로 clip.
+    """
+
+    host = (source.host or "").lower().strip()
+    baseline = _TRUST_BASELINE.get(host, 5)
+
+    penalties: list[Tuple[str, int]] = []
+    if not source.allow_listed:
+        penalties.append(("not_allowlisted", _TRUST_PENALTY_NOT_ALLOWLISTED))
+    if not source.robots_compliant:
+        penalties.append(("robots_violation", _TRUST_PENALTY_ROBOTS_VIOLATION))
+
+    raw = baseline - sum(p for _, p in penalties)
+    value = max(0, min(10, raw))
+    return TrustScore(
+        host=host,
+        baseline=baseline,
+        penalties=tuple(penalties),
+        value=value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Freshness scoring
+# ---------------------------------------------------------------------------
+
+
+def freshness_score(
+    published_at: datetime | None,
+    *,
+    now: datetime,
+) -> FreshnessScore:
+    """published_at vs now 기반 :class:`FreshnessScore`.
+
+    ``published_at`` 이 None 이면 unknown(-1, 3 점).
+    naive datetime 은 UTC 로 간주.
+    """
+
+    if published_at is None:
+        return FreshnessScore(age_seconds=-1, value=3)
+
+    pub = _as_utc(published_at)
+    nw = _as_utc(now)
+    age_seconds = int((nw - pub).total_seconds())
+
+    if age_seconds < 0:
+        # 미래 시점 — clock skew / 조작 의심. 점수 0.
+        return FreshnessScore(age_seconds=age_seconds, value=0)
+
+    day = 86400
+    if age_seconds < day:
+        value = 10
+    elif age_seconds < 7 * day:
+        value = 8
+    elif age_seconds < 30 * day:
+        value = 6
+    elif age_seconds < 180 * day:
+        value = 4
+    elif age_seconds < 365 * day:
+        value = 2
+    else:
+        value = 1
+    return FreshnessScore(age_seconds=age_seconds, value=value)
+
+
+# ---------------------------------------------------------------------------
+# Role boost — 역할별 source kind 가산점
+# ---------------------------------------------------------------------------
+
+# kind 는 :class:`LiveSource.kind` 와 동일 ("rss", "atom", "github_release",
+# "sitemap"). 역할에 잘 맞는 kind 일수록 +1~+2 boost.
+_ROLE_KIND_BOOST: Mapping[str, Mapping[str, int]] = {
+    "backend-engineer": {
+        "rss": 1,
+        "atom": 1,
+        "github_release": 2,
+    },
+    "frontend-engineer": {
+        "rss": 1,
+        "atom": 2,
+        "github_release": 1,
+    },
+    "qa-engineer": {
+        "github_release": 2,
+        "rss": 1,
+    },
+    "devops-engineer": {
+        "github_release": 2,
+        "rss": 1,
+        "atom": 1,
+    },
+    "tech-lead": {
+        "rss": 1,
+        "atom": 1,
+        "github_release": 1,
+    },
+    "ai-engineer": {
+        "rss": 1,
+        "github_release": 2,
+    },
+    "product-designer": {
+        "rss": 1,
+        "atom": 1,
+    },
+}
+
+
+def role_boost_for(role: str, kind: str) -> int:
+    """역할/kind 조합의 boost 점수 (0~2)."""
+
+    return _ROLE_KIND_BOOST.get(role, {}).get(kind, 0)
+
+
+# ---------------------------------------------------------------------------
+# Request-time ranking
+# ---------------------------------------------------------------------------
+
+
+def rank_for_request(
+    evidences: Sequence["LiveEvidence"],
+    *,
+    role: str,
+    task_type: str,
+    now: datetime,
+    limit: int | None = None,
+) -> Tuple[RankedEvidence, ...]:
+    """요청 시점 ranking 산출.
+
+    각 evidence 에 대해 (trust, freshness, role_boost) → priority 를 계산
+    하고, deterministic tie-break 으로 정렬한다.
+
+    ``task_type`` 은 현재 ranking 계산에서는 직접 쓰이지 않고 ``notes``
+    에 기록되어 디버깅/observability 용도로 노출된다. (역할별 task heavy
+    매핑은 :mod:`profiles` 가 별도로 담당.)
+    """
+
+    ranked: list[RankedEvidence] = []
+    for ev in evidences:
+        trust = trust_score_for_source(ev.source)
+        fresh = freshness_score(ev.published_at, now=now)
+        boost = role_boost_for(role, ev.source.kind)
+        priority = round((trust.value + fresh.value + boost) / 3)
+        notes = (
+            f"role={role}",
+            f"task={task_type}",
+            f"kind={ev.source.kind}",
+        )
+        ranked.append(
+            RankedEvidence(
+                evidence=ev,
+                trust=trust,
+                freshness=fresh,
+                role_boost=boost,
+                priority=priority,
+                notes=notes,
+            )
+        )
+
+    ranked.sort(key=_ranking_key, reverse=False)
+    if limit is not None and limit >= 0:
+        ranked = ranked[:limit]
+    return tuple(ranked)
+
+
+def _ranking_key(r: RankedEvidence) -> Tuple[int, int, int, float, str, str]:
+    """Deterministic tie-break.
+
+    sort 는 ascending 이므로 desc 가 필요한 필드는 음수화한다.
+    """
+
+    pub_ts = -_published_ts(r.evidence)
+    return (
+        -r.priority,
+        -r.trust.value,
+        -r.freshness.value,
+        pub_ts,
+        (r.evidence.source.host or "").lower(),
+        (r.evidence.title or "").lower(),
+    )
+
+
+def _published_ts(ev: "LiveEvidence") -> float:
+    if ev.published_at is None:
+        return 0.0
+    return _as_utc(ev.published_at).timestamp()
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+__all__ = (
+    "FreshnessScore",
+    "RankedEvidence",
+    "TrustScore",
+    "freshness_score",
+    "rank_for_request",
+    "role_boost_for",
+    "trust_score_for_source",
+)

--- a/src/yule_orchestrator/agents/research/security_compat.py
+++ b/src/yule_orchestrator/agents/research/security_compat.py
@@ -1,0 +1,33 @@
+"""PasteGuard integration shim for research live providers (F5 / #92).
+
+본 모듈은 :mod:`yule_orchestrator.agents.security.paste_guard` 의
+:func:`guard_outbound` 를 live provider 내부에서 부르기 쉽게 감싼다.
+
+* :func:`guard_text` — text 한 줄 (title / summary / tag) 에 대한 PasteGuard
+  pass-through. 결과는 redacted plain text. block 된 경우 빈 문자열을
+  반환해 caller 가 자연스럽게 skip 하도록 한다.
+* 본 모듈은 PasteGuard 외부 의존을 추가하지 않는다 — provider 측 import
+  surface 를 최소화하기 위해 별도 파일로 분리만 한 것.
+"""
+
+from __future__ import annotations
+
+from ..security.paste_guard import OutboundChannel, guard_outbound
+
+
+def guard_text(value: str) -> str:
+    """PasteGuard 로 ``value`` 를 정규화해 반환.
+
+    내부적으로 channel=LLM 으로 검증하고, block 시 빈 문자열, 아니면
+    redacted 문자열을 반환한다. 입력이 비어 있으면 그대로 빈 문자열.
+    """
+
+    if not value:
+        return ""
+    verdict = guard_outbound(channel=OutboundChannel.LLM, payload=value)
+    if verdict.blocked:
+        return ""
+    return verdict.redacted
+
+
+__all__ = ("guard_text",)

--- a/tests/agents/test_live_providers_github_release.py
+++ b/tests/agents/test_live_providers_github_release.py
@@ -1,0 +1,134 @@
+"""Tests for :mod:`yule_orchestrator.agents.research.providers.live.github_release`.
+
+F5 / issue #92. GithubReleaseProvider 회귀.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from yule_orchestrator.agents.research.providers.live import (
+    KIND_GITHUB_RELEASE,
+    GithubReleaseProvider,
+    LiveSource,
+)
+
+
+def _src(repo: str = "tiangolo/fastapi", **kw) -> LiveSource:
+    return LiveSource(
+        host=kw.get("host", "github.com"),
+        kind=KIND_GITHUB_RELEASE,
+        allow_listed=kw.get("allow_listed", True),
+        robots_compliant=kw.get("robots_compliant", True),
+        rate_limit_per_sec=1.0,
+        url=repo,
+    )
+
+
+_RELEASES_FASTAPI = [
+    {
+        "tag_name": "v0.110.0",
+        "name": "0.110.0 — feat",
+        "html_url": "https://github.com/tiangolo/fastapi/releases/tag/v0.110.0",
+        "published_at": "2026-04-15T09:00:00Z",
+        "body": "## Features\n- Added support for X.\n- Bumped deps.",
+    },
+    {
+        "tag_name": "v0.109.0",
+        "name": "0.109.0",
+        "html_url": "https://github.com/tiangolo/fastapi/releases/tag/v0.109.0",
+        "published_at": "2026-03-01T00:00:00Z",
+        "body": "bugfix",
+    },
+]
+
+
+def test_release_provider_disabled_when_env_off() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(),),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=False,
+    )
+    assert p.ingest() == ()
+
+
+def test_release_provider_skips_non_allowlisted_source() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(allow_listed=False),),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=True,
+    )
+    assert p.ingest() == ()
+
+
+def test_release_provider_skips_robots_violation_source() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(robots_compliant=False),),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=True,
+    )
+    assert p.ingest() == ()
+
+
+def test_release_provider_ingests_releases_into_evidence() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(),),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=True,
+    )
+    out = p.ingest()
+    assert len(out) == 2
+    first = out[0]
+    assert "fastapi" in first.title.lower()
+    assert first.url.endswith("v0.110.0")
+    assert first.published_at == datetime(2026, 4, 15, 9, 0, 0, tzinfo=timezone.utc)
+    assert first.tags == ("v0.110.0",)
+    assert first.extra["repo"] == "tiangolo/fastapi"
+    assert first.extra["tag"] == "v0.110.0"
+
+
+def test_release_provider_truncates_to_max_releases() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(),),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=True,
+        max_releases_per_repo=1,
+    )
+    out = p.ingest()
+    assert len(out) == 1
+    assert out[0].tags == ("v0.110.0",)
+
+
+def test_release_provider_isolates_fetch_exceptions() -> None:
+    def boom(_r):
+        raise RuntimeError("api 503")
+
+    p = GithubReleaseProvider(
+        sources=(_src(),),
+        release_fetch=boom,
+        env_enabled=True,
+    )
+    assert p.ingest() == ()
+
+
+def test_release_provider_skips_invalid_repo_slug() -> None:
+    bad = LiveSource(
+        host="github.com",
+        kind=KIND_GITHUB_RELEASE,
+        url="not-a-slug",  # no slash
+    )
+    p = GithubReleaseProvider(
+        sources=(bad,),
+        release_fetch=lambda _r: _RELEASES_FASTAPI,
+        env_enabled=True,
+    )
+    assert p.ingest() == ()
+
+
+def test_release_provider_skips_release_without_tag_or_name() -> None:
+    p = GithubReleaseProvider(
+        sources=(_src(),),
+        release_fetch=lambda _r: [{"body": "orphan"}],
+        env_enabled=True,
+    )
+    assert p.ingest() == ()

--- a/tests/agents/test_live_providers_rss.py
+++ b/tests/agents/test_live_providers_rss.py
@@ -1,0 +1,205 @@
+"""Tests for :mod:`yule_orchestrator.agents.research.providers.live.rss_atom`.
+
+F5 / issue #92. RssAtomProvider + parse_feed 의 행위 회귀.
+
+Hard rails (governance test 는 별도):
+  * env OFF / non-allowlisted / non-robots-compliant 시 fetch skip.
+  * raw HTML tag 가 summary 로 그대로 노출되지 않는다.
+  * 파싱 실패 (잘못된 XML) 는 caller 로 예외 전파 X.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from yule_orchestrator.agents.research.providers.live import (
+    KIND_ATOM,
+    KIND_RSS,
+    LiveSource,
+    RssAtomProvider,
+)
+from yule_orchestrator.agents.research.providers.live.rss_atom import parse_feed
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (소형 in-memory feed)
+# ---------------------------------------------------------------------------
+
+
+_RSS_BODY = """<?xml version="1.0"?>
+<rss version="2.0"><channel>
+  <title>Demo Feed</title>
+  <item>
+    <title>New Release v1.2</title>
+    <link>https://example.com/r/v1.2</link>
+    <description>&lt;p&gt;Fixes &lt;b&gt;bug&lt;/b&gt;.&lt;/p&gt;</description>
+    <pubDate>Wed, 01 May 2026 12:00:00 +0000</pubDate>
+    <category>release</category>
+    <category>fix</category>
+  </item>
+  <item>
+    <title>Note</title>
+    <link>https://example.com/r/note</link>
+    <description>Plain text.</description>
+  </item>
+</channel></rss>
+"""
+
+_ATOM_BODY = """<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Demo Atom</title>
+  <entry>
+    <title>Alpha</title>
+    <link href="https://example.com/a/alpha"/>
+    <summary>summary alpha</summary>
+    <updated>2026-04-30T01:02:03Z</updated>
+    <category term="meta"/>
+  </entry>
+  <entry>
+    <title>Beta</title>
+    <link href="https://example.com/a/beta"/>
+    <content>content beta</content>
+    <published>2026-04-29T00:00:00+00:00</published>
+  </entry>
+</feed>
+"""
+
+
+def _make_source(host="example.com", kind=KIND_RSS, **kw) -> LiveSource:
+    return LiveSource(
+        host=host,
+        kind=kind,
+        allow_listed=kw.get("allow_listed", True),
+        robots_compliant=kw.get("robots_compliant", True),
+        rate_limit_per_sec=kw.get("rate_limit_per_sec", 1.0),
+        url=kw.get("url", "https://example.com/feed.xml"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_feed
+# ---------------------------------------------------------------------------
+
+
+def test_parse_feed_rss_extracts_entries_with_metadata() -> None:
+    entries = parse_feed(_RSS_BODY, kind=KIND_RSS)
+    assert len(entries) == 2
+    first = entries[0]
+    assert first.title == "New Release v1.2"
+    assert first.url == "https://example.com/r/v1.2"
+    assert first.tags == ("release", "fix")
+    assert first.published_at is not None
+    assert first.published_at.tzinfo is not None
+
+
+def test_parse_feed_atom_uses_summary_or_content_fallback() -> None:
+    entries = parse_feed(_ATOM_BODY, kind=KIND_ATOM)
+    assert len(entries) == 2
+    titles = [e.title for e in entries]
+    assert titles == ["Alpha", "Beta"]
+    # Beta has no <summary>, falls back to <content>.
+    beta = entries[1]
+    assert beta.summary == "content beta"
+    assert beta.url == "https://example.com/a/beta"
+
+
+def test_parse_feed_atom_parses_dates_including_z_suffix() -> None:
+    entries = parse_feed(_ATOM_BODY, kind=KIND_ATOM)
+    alpha = entries[0]
+    assert alpha.published_at == datetime(2026, 4, 30, 1, 2, 3, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# RssAtomProvider — env / allow-list / robots gates
+# ---------------------------------------------------------------------------
+
+
+def test_provider_returns_empty_when_env_disabled() -> None:
+    src = _make_source()
+    provider = RssAtomProvider(
+        sources=(src,),
+        http_fetch=lambda _u: _RSS_BODY,
+        env_enabled=False,
+    )
+    assert provider.ingest() == ()
+
+
+def test_provider_skips_when_fetcher_is_none_even_if_enabled() -> None:
+    provider = RssAtomProvider(
+        sources=(_make_source(),),
+        http_fetch=None,
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+
+
+def test_provider_skips_non_allowlisted_source() -> None:
+    bad = _make_source(allow_listed=False)
+    provider = RssAtomProvider(
+        sources=(bad,),
+        http_fetch=lambda _u: _RSS_BODY,
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+
+
+def test_provider_skips_robots_violation_source() -> None:
+    bad = _make_source(robots_compliant=False)
+    provider = RssAtomProvider(
+        sources=(bad,),
+        http_fetch=lambda _u: _RSS_BODY,
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+
+
+def test_provider_ingests_and_redacts_html_in_summary() -> None:
+    src = _make_source()
+    provider = RssAtomProvider(
+        sources=(src,),
+        http_fetch=lambda _u: _RSS_BODY,
+        env_enabled=True,
+    )
+    out = provider.ingest()
+    assert len(out) == 2
+    # HTML tags 가 raw 로 노출되지 않는다 (strip + PasteGuard).
+    first = out[0]
+    assert "<p>" not in first.summary
+    assert "<b>" not in first.summary
+    assert "bug" in first.summary
+    assert first.tags == ("release", "fix")
+
+
+def test_provider_isolates_fetch_exceptions() -> None:
+    def boom(_url):
+        raise RuntimeError("network down")
+
+    provider = RssAtomProvider(
+        sources=(_make_source(),),
+        http_fetch=boom,
+        env_enabled=True,
+    )
+    # 예외가 caller 로 전파되지 않고 빈 튜플 반환.
+    assert provider.ingest() == ()
+
+
+def test_provider_isolates_parse_errors() -> None:
+    provider = RssAtomProvider(
+        sources=(_make_source(),),
+        http_fetch=lambda _u: "<not-xml",
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+
+
+def test_provider_truncates_entries_to_max() -> None:
+    src = _make_source()
+    provider = RssAtomProvider(
+        sources=(src,),
+        http_fetch=lambda _u: _RSS_BODY,
+        env_enabled=True,
+        max_entries_per_feed=1,
+    )
+    out = provider.ingest()
+    assert len(out) == 1
+    assert out[0].title == "New Release v1.2"

--- a/tests/agents/test_research_scoring.py
+++ b/tests/agents/test_research_scoring.py
@@ -1,0 +1,161 @@
+"""Tests for :mod:`yule_orchestrator.agents.research.scoring`.
+
+F5 / issue #92. TrustScore / FreshnessScore / rank_for_request 회귀.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from yule_orchestrator.agents.research.providers.live import (
+    KIND_ATOM,
+    KIND_GITHUB_RELEASE,
+    KIND_RSS,
+    LiveEvidence,
+    LiveSource,
+)
+from yule_orchestrator.agents.research.scoring import (
+    FreshnessScore,
+    TrustScore,
+    freshness_score,
+    rank_for_request,
+    role_boost_for,
+    trust_score_for_source,
+)
+
+
+def _src(host: str, kind: str = KIND_RSS, **kw) -> LiveSource:
+    return LiveSource(
+        host=host,
+        kind=kind,
+        allow_listed=kw.get("allow_listed", True),
+        robots_compliant=kw.get("robots_compliant", True),
+        rate_limit_per_sec=1.0,
+        url=kw.get("url", f"https://{host}/feed"),
+    )
+
+
+def _ev(host: str, *, kind=KIND_RSS, title="t", age_days: float | None = 0) -> LiveEvidence:
+    if age_days is None:
+        published = None
+    else:
+        published = datetime(2026, 5, 11, 0, 0, 0, tzinfo=timezone.utc) - timedelta(
+            days=age_days
+        )
+    return LiveEvidence(
+        source=_src(host, kind=kind),
+        title=title,
+        url=f"https://{host}/{title}",
+        summary="",
+        published_at=published,
+    )
+
+
+# ---------------------------------------------------------------------------
+# trust_score_for_source
+# ---------------------------------------------------------------------------
+
+
+def test_trust_score_uses_baseline_for_known_host() -> None:
+    score = trust_score_for_source(_src("python.org"))
+    assert isinstance(score, TrustScore)
+    assert score.baseline == 10
+    assert score.penalties == ()
+    assert score.value == 10
+
+
+def test_trust_score_penalises_non_allowlisted_and_robots_violation() -> None:
+    src = _src("python.org", allow_listed=False, robots_compliant=False)
+    score = trust_score_for_source(src)
+    assert score.baseline == 10
+    pen_kinds = {name for name, _ in score.penalties}
+    assert pen_kinds == {"not_allowlisted", "robots_violation"}
+    # 10 - 3 - 5 = 2
+    assert score.value == 2
+
+
+def test_trust_score_defaults_unknown_host_to_five() -> None:
+    score = trust_score_for_source(_src("random.example.com"))
+    assert score.baseline == 5
+    assert score.value == 5
+
+
+def test_trust_score_clips_to_zero() -> None:
+    src = _src("random.example.com", allow_listed=False, robots_compliant=False)
+    # 5 - 3 - 5 = -3 → clip 0
+    score = trust_score_for_source(src)
+    assert score.value == 0
+
+
+# ---------------------------------------------------------------------------
+# freshness_score
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_unknown_when_published_at_none() -> None:
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    fs = freshness_score(None, now=now)
+    assert fs.age_seconds == -1
+    assert fs.value == 3
+
+
+def test_freshness_buckets_match_thresholds() -> None:
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    assert freshness_score(now - timedelta(hours=1), now=now).value == 10
+    assert freshness_score(now - timedelta(days=3), now=now).value == 8
+    assert freshness_score(now - timedelta(days=15), now=now).value == 6
+    assert freshness_score(now - timedelta(days=90), now=now).value == 4
+    assert freshness_score(now - timedelta(days=300), now=now).value == 2
+    assert freshness_score(now - timedelta(days=800), now=now).value == 1
+
+
+def test_freshness_future_published_at_scored_zero() -> None:
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    fs = freshness_score(now + timedelta(hours=1), now=now)
+    assert fs.value == 0
+    assert fs.age_seconds < 0
+
+
+# ---------------------------------------------------------------------------
+# role_boost_for
+# ---------------------------------------------------------------------------
+
+
+def test_role_boost_known_pair_and_unknown_role_default_zero() -> None:
+    assert role_boost_for("backend-engineer", KIND_GITHUB_RELEASE) == 2
+    assert role_boost_for("frontend-engineer", KIND_ATOM) == 2
+    assert role_boost_for("nobody", KIND_RSS) == 0
+
+
+# ---------------------------------------------------------------------------
+# rank_for_request
+# ---------------------------------------------------------------------------
+
+
+def test_rank_for_request_orders_by_priority_desc_with_deterministic_tiebreak() -> None:
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    high = _ev("python.org", kind=KIND_RSS, title="A", age_days=0)
+    mid = _ev("github.blog", kind=KIND_RSS, title="B", age_days=10)
+    low = _ev("random.example.com", kind=KIND_RSS, title="C", age_days=400)
+    out = rank_for_request(
+        [low, mid, high],
+        role="backend-engineer",
+        task_type="backend-feature",
+        now=now,
+    )
+    assert [r.evidence.title for r in out] == ["A", "B", "C"]
+    # priority 가 정렬 키 — 첫 결과가 가장 높아야 한다.
+    assert out[0].priority >= out[-1].priority
+
+
+def test_rank_for_request_limit_truncates_results() -> None:
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    evs = [_ev("python.org", title=f"t{i}", age_days=i) for i in range(5)]
+    out = rank_for_request(
+        evs,
+        role="backend-engineer",
+        task_type="backend-feature",
+        now=now,
+        limit=2,
+    )
+    assert len(out) == 2

--- a/tests/engineering/test_research_live_governance.py
+++ b/tests/engineering/test_research_live_governance.py
@@ -1,0 +1,147 @@
+"""Governance regression for live research providers (F5 / #92).
+
+본 테스트는 acceptance criteria 의 hard rails 를 직접 가드한다:
+
+1. ``YULE_RESEARCH_LIVE_ENABLED`` default 는 ``false`` — env 없는 호출은
+   외부 transport 를 절대 부르면 안 된다.
+2. allow-list 외 host 를 강제로 등록한 source 도 ingest 되지 않아야 한다.
+3. robots.txt 위반(``robots_compliant=False``) source 는 fetch skip.
+4. provider 결과는 PasteGuard 를 통과하여 raw secret / raw HTML tag 가
+   외부로 새지 않는다.
+5. rate-limit env 가 0 이하일 때 default(=1.0) 로 폴백한다.
+6. 카탈로그 default host 는 모두 :data:`_TRUST_BASELINE` 와 정합하여
+   trust score >= 5 를 받는다 (운영자 검증 host 만 등재).
+"""
+
+from __future__ import annotations
+
+from yule_orchestrator.agents.research.providers.live import (
+    KIND_GITHUB_RELEASE,
+    KIND_RSS,
+    LiveSource,
+    RssAtomProvider,
+    build_live_provider_registry_from_env,
+    default_role_source_catalog,
+)
+from yule_orchestrator.agents.research.scoring import trust_score_for_source
+
+
+def test_env_default_off_means_no_fetch_no_evidence() -> None:
+    """env 없는 호출은 외부 transport 를 절대 부르지 않는다."""
+
+    called = {"http": 0, "release": 0}
+
+    def http(_u):  # pragma: no cover - 호출되면 안 됨
+        called["http"] += 1
+        return "<rss/>"
+
+    def release(_r):  # pragma: no cover - 호출되면 안 됨
+        called["release"] += 1
+        return []
+
+    reg = build_live_provider_registry_from_env(
+        {},
+        http_fetch=http,
+        release_fetch=release,
+    )
+    assert reg.env_enabled is False
+    assert reg.ingest_all() == ()
+    assert called == {"http": 0, "release": 0}
+
+
+def test_non_allowlisted_source_blocks_ingest_even_when_env_on() -> None:
+    bad = LiveSource(
+        host="evil.example.com",
+        kind=KIND_RSS,
+        allow_listed=False,
+        robots_compliant=True,
+        rate_limit_per_sec=1.0,
+        url="https://evil.example.com/feed",
+    )
+    called = {"http": 0}
+
+    def http(_u):  # pragma: no cover - 호출되면 안 됨
+        called["http"] += 1
+        return "<rss><channel><item><title>x</title></item></channel></rss>"
+
+    provider = RssAtomProvider(
+        sources=(bad,),
+        http_fetch=http,
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+    assert called["http"] == 0
+
+
+def test_robots_violation_blocks_ingest_even_when_env_on() -> None:
+    bad = LiveSource(
+        host="blocked.example.com",
+        kind=KIND_RSS,
+        allow_listed=True,
+        robots_compliant=False,
+        rate_limit_per_sec=1.0,
+        url="https://blocked.example.com/feed",
+    )
+    called = {"http": 0}
+
+    def http(_u):  # pragma: no cover - 호출되면 안 됨
+        called["http"] += 1
+        return "<rss/>"
+
+    provider = RssAtomProvider(
+        sources=(bad,),
+        http_fetch=http,
+        env_enabled=True,
+    )
+    assert provider.ingest() == ()
+    assert called["http"] == 0
+
+
+def test_paste_guard_redacts_secret_leaking_summary() -> None:
+    """raw secret (sk-ant-…) 이 summary 로 새어 나가면 안 된다."""
+
+    body = (
+        "<rss version='2.0'><channel><item>"
+        "<title>leak</title>"
+        "<link>https://example.com/leak</link>"
+        "<description>token=sk-ant-abcdefghijklmnopqrstuvwxyz</description>"
+        "</item></channel></rss>"
+    )
+    src = LiveSource(
+        host="example.com",
+        kind=KIND_RSS,
+        allow_listed=True,
+        robots_compliant=True,
+        rate_limit_per_sec=1.0,
+        url="https://example.com/feed",
+    )
+    provider = RssAtomProvider(
+        sources=(src,),
+        http_fetch=lambda _u: body,
+        env_enabled=True,
+    )
+    out = provider.ingest()
+    assert len(out) == 1
+    summary = out[0].summary
+    # PasteGuard 가 raw 키를 마스킹해야 한다 — 원문이 그대로 노출되면 BLOCK.
+    assert "sk-ant-abcdefghijklmnopqrstuvwxyz" not in summary
+
+
+def test_rate_limit_env_zero_falls_back_to_default() -> None:
+    reg = build_live_provider_registry_from_env(
+        {"YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC": "0"},
+    )
+    assert reg.rate_limit_per_sec == 1.0
+
+
+def test_default_catalog_hosts_all_pass_min_trust_threshold() -> None:
+    """카탈로그의 default host 는 운영자가 검증한 source 만 들어 있다."""
+
+    catalog = default_role_source_catalog()
+    assert catalog, "catalog must not be empty"
+    for entry in catalog:
+        score = trust_score_for_source(entry.source)
+        assert score.value >= 5, (
+            f"default catalog host {entry.source.host!r} fell below trust "
+            f"baseline (got {score.value}); update _TRUST_BASELINE or remove."
+        )


### PR DESCRIPTION
## 📌 관련 이슈

- close #92 (parent #81)
- 의존: 없음 (Tier 2 독립)

## 🎯 과제 내용

backend / frontend / qa / devops / tech-lead 5 역할이 외부 read-only source 에서 신선한 자료를 ingest 해 **TrustScore / FreshnessScore** 기반으로 요청 시점 ranking 까지 끌어올린다. issue #92 v1 stall 후 재시도 — 슬림 scope (RSS/Atom + GitHub release + scoring + governance) 만 land, sitemap 은 후속.

### 신설 모듈

- `src/yule_orchestrator/agents/research/providers/live/`
  - `__init__.py` — `LiveSource(host, kind, allow_listed, robots_compliant, rate_limit_per_sec, url)` / `LiveEvidence(...)` / `LiveProvider` protocol
  - `rss_atom.py` — RSS 2.0 / Atom 1.0 ingest (stdlib `xml.etree.ElementTree` 만)
  - `github_release.py` — release dict → `LiveEvidence` 정규화
  - `registry.py` — 5 역할 기본 catalog (16 host) + `build_live_provider_registry_from_env`
- `src/yule_orchestrator/agents/research/scoring.py` — `TrustScore` / `FreshnessScore` / `RankedEvidence` / `rank_for_request` (deterministic tie-break)
- `security_compat.guard_text` — PasteGuard 통합 shim (raw secret / raw HTML 차단)

### env (default OFF)

- `YULE_RESEARCH_LIVE_ENABLED=false`
- `YULE_RESEARCH_LIVE_ALLOW_HOSTS=` (카탈로그 외 확장)
- `YULE_RESEARCH_LIVE_DISABLE_HOSTS=`
- `YULE_RESEARCH_LIVE_KINDS=rss,atom,github_release`
- `YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC=1.0`

### Hard rails (governance test 가 보호)

1. env OFF default → 외부 transport 호출 0회
2. allow-list 외 host fetch 금지
3. robots.txt Disallow source fetch 금지
4. PasteGuard 가 summary 의 raw secret / raw HTML 차단
5. rate-limit 0 이하 → default(1.0) 폴백
6. 카탈로그 default host 는 trust baseline >= 5 만 등재

### 회귀

- 신규 테스트 36 PASS
  - `tests/agents/test_live_providers_rss.py` (10)
  - `tests/agents/test_live_providers_github_release.py` (8)
  - `tests/agents/test_research_scoring.py` (12)
  - `tests/engineering/test_research_live_governance.py` (6)
- 전체 pytest: **3938 passed / 1 skipped / 0 failed** (10.89s)

## 🖼 스크린샷

(N/A — 백엔드 모듈 + dataclass 추가. 회귀 결과는 위 섹션 참조.)

## 🔗 레퍼런스

- issue #92 / parent #81
- `policies/runtime/agents/engineering-agent/issue-pr-conventions.md` §1.0 §2.2 §5
- `src/yule_orchestrator/agents/security/paste_guard.py` — outbound 검증
- 후속 단계: sitemap provider + ETag/If-Modified-Since 캐시 + (F6) Discord UX retrieval 소비

## 🤖 Agent WorkOS Audit

- branch: `feature/live-research-provider-issue-92-v2` (from `main`)
- role: engineering-agent/ai-engineer
- autonomy_level: L2_AUTONOMOUS_RECORD
- risk_class: MEDIUM (외부 fetch — env 가드 + allow-list + PasteGuard 로 완화)
- mode: Draft → 자체 회귀 OK 확인 후 ready