### PR TITLE
✨ [Feat] F10 Claude Mem unifier — cross-session 장기 메모리 정형화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,3 +366,23 @@ DISCORD_GUILD_ID=
 #     (governance test 가 보호).
 # YULE_TOOL_GATE_ENABLED=true
 # YULE_TOOL_GATE_DEFAULT_AUTONOMY=L2_autonomous_record
+
+# =====================================================================
+# F10 / #101 — Claude Mem unifier (cross-session 장기 메모리)
+#
+# `src/yule_orchestrator/agents/memory/` 의 LongTermMemory 는 Obsidian
+# vault / session.extra / mistake_ledger / decision audit / 일반 audit
+# 5개 source 를 단일 MemoryPack 으로 묶어 ContextPack 에 실어 보낸다.
+# 다음 작업 시작 시 이전 세션의 결정/실수가 자동 surface 되는 게 목적.
+#
+# 운영 정책:
+#   - default OFF. 운영자가 vault path / mistake_ledger / audit log 가
+#     모두 준비된 환경에서만 true 로 켠다. OFF 면 build_memory_pack 이
+#     즉시 빈 MemoryPack 을 반환 (회로 단절 안전).
+#   - freshness 윈도우는 RelevanceSelector 의 recency 점수가 0 으로
+#     떨어지는 경계일 수. 기본 30일.
+#   - max_shards_per_query 는 source 당 fanout 캡 — adapter 가 한 번에
+#     반환할 shard 최대 수. RelevanceSelector 가 최종 limit 적용.
+# YULE_LONG_TERM_MEMORY_ENABLED=false
+# YULE_MEMORY_FRESHNESS_DAYS=30
+# YULE_MEMORY_MAX_SHARDS_PER_QUERY=10

--- a/src/yule_orchestrator/agents/decision/context_pack.py
+++ b/src/yule_orchestrator/agents/decision/context_pack.py
@@ -31,6 +31,8 @@ from typing import (
     Tuple,
 )
 
+from ..memory import MemoryPack
+
 
 # ---------------------------------------------------------------------------
 # Models
@@ -39,7 +41,14 @@ from typing import (
 
 @dataclass(frozen=True)
 class ContextPack:
-    """Bundle of related context the classifier reads."""
+    """Bundle of related context the classifier reads.
+
+    F10 (issue #101) extends this with an optional ``memory_pack``
+    field carrying the cross-session :class:`MemoryPack` produced by
+    the long-term memory unifier. Older callers that don't wire the
+    unifier keep getting ``memory_pack=None`` so the field is fully
+    backwards compatible.
+    """
 
     id: str
     related_notes: Tuple[str, ...]
@@ -49,9 +58,10 @@ class ContextPack:
     code_hints: Tuple[str, ...]
     created_at: str
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    memory_pack: Optional[MemoryPack] = None
 
     def to_payload(self) -> Mapping[str, Any]:
-        return {
+        payload: dict = {
             "id": self.id,
             "related_notes": list(self.related_notes),
             "recent_threads": list(self.recent_threads),
@@ -61,15 +71,24 @@ class ContextPack:
             "created_at": self.created_at,
             "metadata": dict(self.metadata),
         }
+        if self.memory_pack is not None:
+            payload["memory_pack"] = self.memory_pack.to_payload()
+        else:
+            payload["memory_pack"] = None
+        return payload
 
     @property
     def is_empty(self) -> bool:
+        has_memory = bool(
+            self.memory_pack is not None and self.memory_pack.shards
+        )
         return not (
             self.related_notes
             or self.recent_threads
             or self.related_issues
             or self.related_prs
             or self.code_hints
+            or has_memory
         )
 
 
@@ -131,6 +150,7 @@ def build_context_pack(
     pr_limit: int = 3,
     code_limit: int = 5,
     metadata: Optional[Mapping[str, Any]] = None,
+    memory_pack: Optional[MemoryPack] = None,
 ) -> ContextPack:
     """Compose a :class:`ContextPack` from the available providers.
 
@@ -187,6 +207,7 @@ def build_context_pack(
         code_hints=hints,
         created_at=datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat(),
         metadata=dict(metadata or {}),
+        memory_pack=memory_pack,
     )
 
 

--- a/src/yule_orchestrator/agents/memory/__init__.py
+++ b/src/yule_orchestrator/agents/memory/__init__.py
@@ -1,0 +1,377 @@
+"""Claude Mem unifier — F10 / issue #101.
+
+Cross-session 장기 메모리 정형화 계층. 다음 5개 source 를 단일
+``MemorySource`` Protocol 뒤에 묶어 "이전 세션 / 결정 / 실수 / 회의록"
+이 다음 작업 시작 시점에 자동 surface 되게 한다:
+
+  * **Obsidian vault-mirror** — ``notes/vault-mirror/`` 의 노트
+  * **session.extra** — round-1 short-term ledger
+  * **mistake_ledger** — F2 의 cross-session 영구 mistake DB
+  * **decision** — agent_ops_audit 의 ``DECISION`` action
+  * **audit** — agent_ops_audit 의 일반 운영 이벤트
+
+각 source 는 :class:`MemoryShard` 시퀀스를 read-only 로 노출하며,
+:class:`LongTermMemory` 가 query (topic / role / issue) 단위로 fanout
+한 다음 :class:`RelevanceSelector` 가 deterministic ranking 한다.
+
+Hard rails (governance regression-tested):
+
+  * 모든 source 는 read-only — :meth:`MemorySource.query` 는 결과를
+    반환만 하고 원본 데이터를 mutate 하지 않는다.
+  * env ``YULE_LONG_TERM_MEMORY_ENABLED=false`` → 회로 단절. 빈
+    :class:`MemoryPack` 을 즉시 반환해 caller 흐름을 깨지 않는다.
+  * mistake BLOCK shard 는 항상 ``MemoryPack.shards[0]`` 에 surface.
+    relevance score 와 무관하게 검열하지 않는다 (검열은 caller 의
+    PasteGuard wrapping 책임).
+  * PasteGuard 통합은 fail-closed — shard ``content`` 의 outbound
+    masking 은 caller 가 :func:`guard_outbound` 로 감싸야 한다.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    Iterable,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+)
+
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+
+
+ENV_LONG_TERM_MEMORY_ENABLED: str = "YULE_LONG_TERM_MEMORY_ENABLED"
+ENV_MEMORY_FRESHNESS_DAYS: str = "YULE_MEMORY_FRESHNESS_DAYS"
+ENV_MEMORY_MAX_SHARDS_PER_QUERY: str = "YULE_MEMORY_MAX_SHARDS_PER_QUERY"
+
+DEFAULT_FRESHNESS_DAYS: int = 30
+DEFAULT_MAX_SHARDS_PER_QUERY: int = 10
+
+
+def long_term_memory_enabled() -> bool:
+    """Return whether the unified long-term memory layer is on.
+
+    Defaults to **False** so the layer is opt-in. Operator flips the
+    env to ``true`` (case-insensitive) to wire it into the runtime.
+    """
+
+    value = os.environ.get(ENV_LONG_TERM_MEMORY_ENABLED, "false")
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def freshness_days() -> int:
+    """Return the recency window (days) used by :class:`RelevanceSelector`."""
+
+    raw = os.environ.get(ENV_MEMORY_FRESHNESS_DAYS, "")
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_FRESHNESS_DAYS
+    if value <= 0:
+        return DEFAULT_FRESHNESS_DAYS
+    return value
+
+
+def max_shards_per_query() -> int:
+    """Return the per-source fanout cap."""
+
+    raw = os.environ.get(ENV_MEMORY_MAX_SHARDS_PER_QUERY, "")
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_SHARDS_PER_QUERY
+    if value <= 0:
+        return DEFAULT_MAX_SHARDS_PER_QUERY
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Shard kinds + source trust
+# ---------------------------------------------------------------------------
+
+
+class ShardKind(str, enum.Enum):
+    """Enumerated kinds of memory shards.
+
+    Stored as a string enum so payloads can quote the literal kind
+    value without leaking implementation detail. Source-trust scores
+    in :class:`RelevanceSelector` are indexed by this enum.
+    """
+
+    OBSIDIAN_NOTE = "obsidian_note"
+    SESSION_EXTRA = "session_extra"
+    MISTAKE = "mistake"
+    DECISION = "decision"
+    AUDIT = "audit"
+
+
+# Source trust weight (0..1) used as one of the 4 RelevanceSelector
+# components. BLOCK mistake shards are special-cased to 1.0 by
+# :meth:`RelevanceSelector.score` so the preflight signal always wins.
+SOURCE_TRUST: Mapping[ShardKind, float] = {
+    ShardKind.DECISION: 0.9,
+    ShardKind.MISTAKE: 0.85,
+    ShardKind.AUDIT: 0.8,
+    ShardKind.OBSIDIAN_NOTE: 0.7,
+    ShardKind.SESSION_EXTRA: 0.5,
+}
+
+
+def _coerce_kind(value: Any) -> ShardKind:
+    """Coerce *value* into a :class:`ShardKind` (defaults to AUDIT)."""
+
+    if isinstance(value, ShardKind):
+        return value
+    text = str(value or "").strip().lower()
+    for member in ShardKind:
+        if member.value == text:
+            return member
+    return ShardKind.AUDIT
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MemoryShard:
+    """A single addressable unit of long-term memory.
+
+    The shape is intentionally narrow so heterogeneous sources can
+    project into one common surface. ``content`` is plain-text only —
+    binary or structured blobs must be summarised by the adapter
+    before being lifted into a shard.
+
+    Hard rails:
+
+      * ``hash`` is a sha256 over (kind, source, content) — caller can
+        de-dupe two shards from different sources but with identical
+        content. The hash also lets audit trails reference a shard
+        without re-shipping the content.
+      * ``created_at`` is ISO8601 with explicit timezone (UTC by
+        default). :meth:`RelevanceSelector._recency_score` parses it.
+      * ``topic_tags`` is a tuple of lower-case tokens; the TopicIndex
+        builds an inverse map from these.
+      * ``related_issue`` / ``related_pr`` are optional ints; when set
+        :meth:`LongTermMemory.for_issue` filters by them.
+    """
+
+    kind: ShardKind
+    source: str
+    content: str
+    created_at: str
+    topic_tags: Tuple[str, ...] = ()
+    related_issue: Optional[int] = None
+    related_pr: Optional[int] = None
+    hash: str = ""
+    blocker_level: Optional[str] = None  # set by MistakeLedgerSource
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, ShardKind):
+            object.__setattr__(self, "kind", _coerce_kind(self.kind))
+        if not self.hash:
+            object.__setattr__(self, "hash", _shard_hash(
+                kind=self.kind, source=self.source, content=self.content
+            ))
+        if self.topic_tags and not isinstance(self.topic_tags, tuple):
+            object.__setattr__(self, "topic_tags", tuple(self.topic_tags))
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "source": self.source,
+            "content": self.content,
+            "created_at": self.created_at,
+            "topic_tags": list(self.topic_tags),
+            "related_issue": self.related_issue,
+            "related_pr": self.related_pr,
+            "hash": self.hash,
+            "blocker_level": self.blocker_level,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryFilter:
+    """Query filter forwarded to :class:`MemorySource` adapters.
+
+    Adapters use whichever fields make sense — e.g. ObsidianVault
+    matches on ``topic_tags`` / ``role``, MistakeLedger on ``role``,
+    Decision/Audit on ``issue``. Unknown filter fields are ignored.
+    """
+
+    role: Optional[str] = None
+    topic_tags: Tuple[str, ...] = ()
+    issue: Optional[int] = None
+    pr: Optional[int] = None
+    since: Optional[str] = None  # ISO8601 lower bound
+    limit: int = DEFAULT_MAX_SHARDS_PER_QUERY
+
+
+@dataclass(frozen=True)
+class MemoryPack:
+    """Ranked, deduplicated bundle of shards returned to callers.
+
+    Empty (``shards=()``) when the long-term memory layer is disabled
+    or no source produced a relevant shard. ``query_signature`` is a
+    stable token of the originating request — two identical requests
+    yield equal signatures so audit logs can correlate.
+    """
+
+    shards: Tuple[MemoryShard, ...]
+    generated_at: str
+    query_signature: str
+
+    def to_payload(self) -> Mapping[str, Any]:
+        return {
+            "shards": [s.to_payload() for s in self.shards],
+            "generated_at": self.generated_at,
+            "query_signature": self.query_signature,
+        }
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.shards
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Lightweight context bundle the relevance selector consumes.
+
+    Pure data — no I/O. Caller hydrates it from whatever the worker
+    already knows (active role, request topic tags, optional issue
+    number). Unknown fields default to empty so older callers do not
+    break when new signals are added.
+    """
+
+    role: Optional[str] = None
+    topic_tags: Tuple[str, ...] = ()
+    issue: Optional[int] = None
+    pr: Optional[int] = None
+    now: Optional[datetime] = None
+
+    def normalised_tags(self) -> frozenset[str]:
+        return frozenset(_normalise_token(t) for t in self.topic_tags if t)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class MemorySource(Protocol):
+    """Read-only adapter that yields shards for a filter.
+
+    Implementations **must not** mutate their backing store. The
+    governance regression test introspects each adapter for ``write``
+    / ``insert`` / ``delete`` methods and fails closed if found.
+    """
+
+    kind: ShardKind
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:  # pragma: no cover - Protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalise_token(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    return text
+
+
+def tokenize(value: str) -> frozenset[str]:
+    """Lower-case ASCII tokenisation used by topic / role matching."""
+
+    text = str(value or "").strip().lower()
+    if not text:
+        return frozenset()
+    return frozenset(_TOKEN_RE.findall(text))
+
+
+def _shard_hash(*, kind: ShardKind, source: str, content: str) -> str:
+    digest = hashlib.sha256(
+        f"{kind.value}|{source}|{content}".encode("utf-8", errors="replace")
+    ).hexdigest()
+    return f"sha256:{digest[:24]}"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _query_signature(*, request_context: RequestContext, limit: int) -> str:
+    parts = [
+        request_context.role or "",
+        ",".join(sorted(_normalise_token(t) for t in request_context.topic_tags)),
+        str(request_context.issue or ""),
+        str(request_context.pr or ""),
+        str(limit),
+    ]
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"q-{digest[:16]}"
+
+
+# Re-export adapter modules at package level so callers do
+# `from yule_orchestrator.agents.memory import LongTermMemory` etc.
+from .long_term_memory import (  # noqa: E402
+    LongTermMemory,
+    build_memory_pack,
+)
+from .relevance_selector import RelevanceSelector  # noqa: E402
+from .topic_index import TopicIndex  # noqa: E402
+from .sources import (  # noqa: E402
+    AuditSource,
+    DecisionSource,
+    MistakeLedgerSource,
+    ObsidianVaultSource,
+    SessionExtraSource,
+)
+
+
+__all__ = (
+    "AuditSource",
+    "DEFAULT_FRESHNESS_DAYS",
+    "DEFAULT_MAX_SHARDS_PER_QUERY",
+    "DecisionSource",
+    "ENV_LONG_TERM_MEMORY_ENABLED",
+    "ENV_MEMORY_FRESHNESS_DAYS",
+    "ENV_MEMORY_MAX_SHARDS_PER_QUERY",
+    "LongTermMemory",
+    "MemoryFilter",
+    "MemoryPack",
+    "MemoryShard",
+    "MemorySource",
+    "MistakeLedgerSource",
+    "ObsidianVaultSource",
+    "RelevanceSelector",
+    "RequestContext",
+    "SOURCE_TRUST",
+    "SessionExtraSource",
+    "ShardKind",
+    "TopicIndex",
+    "build_memory_pack",
+    "freshness_days",
+    "long_term_memory_enabled",
+    "max_shards_per_query",
+    "tokenize",
+)

--- a/src/yule_orchestrator/agents/memory/long_term_memory.py
+++ b/src/yule_orchestrator/agents/memory/long_term_memory.py
@@ -1,0 +1,248 @@
+"""LongTermMemory facade + build_memory_pack (F10 / #101).
+
+Single entrypoint a worker uses to retrieve a deduplicated, ranked
+:class:`MemoryPack` for a given request. Composes:
+
+  * Fanout: ``LongTermMemory.for_topic / for_role / for_issue /
+    recent_decisions`` query every registered :class:`MemorySource`.
+  * Rank: :class:`RelevanceSelector` scores each shard. BLOCK
+    mistake shards are pinned at the top regardless of score.
+  * Dedupe: shards with identical ``hash`` are merged — the highest-
+    scoring instance wins.
+
+Hard rails:
+
+  * ``env YULE_LONG_TERM_MEMORY_ENABLED=false`` → :func:`build_memory_pack`
+    returns an empty pack immediately (no source query, no scoring).
+    This is the "회로 단절 안전" rail from issue #101.
+  * No source is invoked twice for the same filter — each method
+    builds a filter once and dispatches once per source.
+  * Source ``query`` exceptions are isolated: a misbehaving adapter
+    cannot block other adapters' shards from surfacing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from . import (
+    DEFAULT_MAX_SHARDS_PER_QUERY,
+    MemoryFilter,
+    MemoryPack,
+    MemoryShard,
+    MemorySource,
+    RequestContext,
+    ShardKind,
+    _query_signature,
+    _utc_now_iso,
+    long_term_memory_enabled,
+    max_shards_per_query,
+)
+from .relevance_selector import RelevanceSelector
+
+
+# ---------------------------------------------------------------------------
+# Facade
+# ---------------------------------------------------------------------------
+
+
+class LongTermMemory:
+    """Facade over an ordered list of :class:`MemorySource` adapters.
+
+    Construct with whichever subset of sources is wired in the
+    operator's runtime. Methods are read-only — each call dispatches
+    fresh queries; no result caching happens here so adapters control
+    their own freshness story.
+    """
+
+    def __init__(self, sources: Sequence[MemorySource]) -> None:
+        self._sources: Tuple[MemorySource, ...] = tuple(sources)
+
+    @property
+    def sources(self) -> Tuple[MemorySource, ...]:
+        return self._sources
+
+    # ------------------------------------------------------------------
+    # Convenience fanout methods
+    # ------------------------------------------------------------------
+
+    def for_topic(
+        self,
+        topic_tags: Sequence[str],
+        *,
+        limit: int = DEFAULT_MAX_SHARDS_PER_QUERY,
+    ) -> Tuple[MemoryShard, ...]:
+        return self._fanout(
+            MemoryFilter(topic_tags=tuple(topic_tags), limit=limit)
+        )
+
+    def for_role(
+        self,
+        role: str,
+        *,
+        limit: int = DEFAULT_MAX_SHARDS_PER_QUERY,
+    ) -> Tuple[MemoryShard, ...]:
+        return self._fanout(MemoryFilter(role=role, limit=limit))
+
+    def for_issue(
+        self,
+        issue: int,
+        *,
+        limit: int = DEFAULT_MAX_SHARDS_PER_QUERY,
+    ) -> Tuple[MemoryShard, ...]:
+        return self._fanout(MemoryFilter(issue=issue, limit=limit))
+
+    def recent_decisions(
+        self,
+        *,
+        limit: int = DEFAULT_MAX_SHARDS_PER_QUERY,
+        since: Optional[str] = None,
+    ) -> Tuple[MemoryShard, ...]:
+        """Return shards from DECISION-kind sources only.
+
+        Other kinds are filtered out so a caller looking for "what
+        did we already decide?" sees the audit trail without noise
+        from notes / mistakes.
+        """
+
+        filter_ = MemoryFilter(limit=limit, since=since)
+        out: List[MemoryShard] = []
+        for source in self._sources:
+            if getattr(source, "kind", None) != ShardKind.DECISION:
+                continue
+            for shard in _safe_query(source, filter_):
+                out.append(shard)
+        return tuple(out)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fanout(self, filter: MemoryFilter) -> Tuple[MemoryShard, ...]:
+        out: List[MemoryShard] = []
+        seen_hashes: set = set()
+        for source in self._sources:
+            for shard in _safe_query(source, filter):
+                if shard.hash in seen_hashes:
+                    continue
+                seen_hashes.add(shard.hash)
+                out.append(shard)
+        return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# build_memory_pack
+# ---------------------------------------------------------------------------
+
+
+def build_memory_pack(
+    *,
+    long_term_memory: Optional[LongTermMemory],
+    request_context: RequestContext,
+    limit: int = DEFAULT_MAX_SHARDS_PER_QUERY,
+    selector: Optional[RelevanceSelector] = None,
+) -> MemoryPack:
+    """Compose a ranked, deduplicated :class:`MemoryPack`.
+
+    Returns an empty pack when:
+
+      * ``long_term_memory`` is None (no adapter wired), OR
+      * ``YULE_LONG_TERM_MEMORY_ENABLED`` is false / unset.
+
+    Otherwise queries the union of (role + topic + issue) filters,
+    deduplicates by ``hash`` (best score wins), pins BLOCK mistakes
+    to the top, then returns the top *limit* shards.
+    """
+
+    signature = _query_signature(
+        request_context=request_context,
+        limit=limit,
+    )
+    if long_term_memory is None or not long_term_memory_enabled():
+        return MemoryPack(
+            shards=(),
+            generated_at=_utc_now_iso(),
+            query_signature=signature,
+        )
+
+    effective_selector = selector or RelevanceSelector()
+    per_source_cap = max_shards_per_query()
+
+    # Build a union filter — request context tells us all three axes
+    # at once.
+    filter_ = MemoryFilter(
+        role=request_context.role,
+        topic_tags=tuple(request_context.topic_tags),
+        issue=request_context.issue,
+        pr=request_context.pr,
+        limit=per_source_cap,
+    )
+
+    scored_by_hash: Dict[str, Tuple[float, MemoryShard]] = {}
+    for source in long_term_memory.sources:
+        for shard in _safe_query(source, filter_):
+            score = effective_selector.score(
+                shard, request_context=request_context
+            )
+            existing = scored_by_hash.get(shard.hash)
+            if existing is None or score > existing[0]:
+                scored_by_hash[shard.hash] = (score, shard)
+
+    # Sort: BLOCK mistakes first, then by score desc, then by
+    # created_at desc, then by hash for total determinism.
+    def _sort_key(entry: Tuple[float, MemoryShard]) -> Tuple[int, float, str, str]:
+        score, shard = entry
+        block_priority = 0
+        if (
+            shard.kind == ShardKind.MISTAKE
+            and (shard.blocker_level or "").upper() == "BLOCK"
+        ):
+            block_priority = -1  # smaller = earlier
+        # Negate score so larger ends up first.
+        return (block_priority, -score, _invert(shard.created_at), shard.hash)
+
+    sorted_entries = sorted(scored_by_hash.values(), key=_sort_key)
+    bounded = sorted_entries[: max(0, int(limit))]
+    shards = tuple(shard for _, shard in bounded)
+
+    return MemoryPack(
+        shards=shards,
+        generated_at=_utc_now_iso(),
+        query_signature=signature,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_query(source: MemorySource, filter: MemoryFilter) -> Iterable[MemoryShard]:
+    try:
+        return tuple(source.query(filter))
+    except Exception:  # noqa: BLE001 - isolate adapter faults
+        return ()
+
+
+def _invert(value: str) -> str:
+    """Return a sort key such that newer ISO timestamps sort earlier.
+
+    Python sorts ASCII descending naturally with reverse=True, but
+    we want a single composite key. Inverting via a max-character
+    placeholder yields the same effect within tuple-sort ordering.
+    """
+
+    if not value:
+        return "\uffff"
+    # Use a "complementary" string: pad with a high codepoint so
+    # later (lexicographically larger) ISO timestamps end up earlier
+    # when sorted ascending.
+    return "".join(chr(0x10FFFF - min(ord(c), 0x10FFFF)) for c in value)
+
+
+__all__ = (
+    "LongTermMemory",
+    "build_memory_pack",
+)

--- a/src/yule_orchestrator/agents/memory/relevance_selector.py
+++ b/src/yule_orchestrator/agents/memory/relevance_selector.py
@@ -1,0 +1,205 @@
+"""Relevance scoring for memory shards (F10 / #101).
+
+Deterministic, dependency-free ranker. Four components combine via
+weighted average into a single 0..1 score:
+
+  1. **recency** — exponential decay against the env-configured
+     freshness window (default 30 days). Shards with malformed or
+     missing ``created_at`` get 0.0 so a poorly-shaped source can
+     never dominate.
+  2. **topic_overlap** — Jaccard similarity between the shard's
+     ``topic_tags`` and the request's ``topic_tags``. Returns 0.0
+     when either set is empty.
+  3. **role_match** — 1.0 when the shard's source string contains
+     the request role (lower-case substring match), else 0.0. Most
+     sources prefix the source identifier with a role name so the
+     match is high-precision.
+  4. **source_trust** — the static table in :data:`SOURCE_TRUST`,
+     with one override: mistake shards at ``BLOCK`` blocker level
+     surface at 1.0 so the preflight signal cannot be drowned out.
+
+Default weights (sum to 1.0):
+
+  ``recency=0.25, topic_overlap=0.35, role_match=0.15, source_trust=0.25``
+
+Callers can pass custom weights for experimentation but
+:meth:`RelevanceSelector.score` always clamps the final value into
+[0.0, 1.0] so downstream callers can compare shards confidently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+
+from . import (
+    MemoryShard,
+    RequestContext,
+    ShardKind,
+    SOURCE_TRUST,
+    freshness_days,
+    tokenize,
+)
+
+
+# ---------------------------------------------------------------------------
+# Default weights
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_WEIGHTS: Mapping[str, float] = {
+    "recency": 0.25,
+    "topic_overlap": 0.35,
+    "role_match": 0.15,
+    "source_trust": 0.25,
+}
+
+
+# ---------------------------------------------------------------------------
+# Selector
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RelevanceSelector:
+    """Deterministic 4-component relevance scorer.
+
+    Construct with default weights (:data:`DEFAULT_WEIGHTS`) unless
+    an experiment is in flight. The class is frozen so callers can
+    share one instance across threads without surprise mutation.
+    """
+
+    weights: Mapping[str, float] = None  # type: ignore[assignment]
+    horizon_days: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.weights is None:
+            object.__setattr__(self, "weights", dict(DEFAULT_WEIGHTS))
+        if self.horizon_days is None:
+            object.__setattr__(self, "horizon_days", freshness_days())
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def score(
+        self,
+        shard: MemoryShard,
+        *,
+        request_context: RequestContext,
+    ) -> float:
+        """Return the [0.0, 1.0] relevance score for *shard*.
+
+        Special case: a mistake shard with ``blocker_level=='BLOCK'``
+        always returns 1.0. This implements the issue #101 "BLOCK
+        shard 항상 top surface" hard rail — relevance cannot dim a
+        critical preflight signal.
+        """
+
+        if (
+            shard.kind == ShardKind.MISTAKE
+            and (shard.blocker_level or "").upper() == "BLOCK"
+        ):
+            return 1.0
+
+        components = {
+            "recency": self._recency_score(shard, request_context),
+            "topic_overlap": self._topic_overlap_score(shard, request_context),
+            "role_match": self._role_match_score(shard, request_context),
+            "source_trust": self._source_trust_score(shard),
+        }
+        total = 0.0
+        for key, weight in self.weights.items():
+            total += float(weight) * float(components.get(key, 0.0))
+        return max(0.0, min(1.0, total))
+
+    # ------------------------------------------------------------------
+    # Component scores (exposed for tests + harness debugging)
+    # ------------------------------------------------------------------
+
+    def _recency_score(
+        self,
+        shard: MemoryShard,
+        request_context: RequestContext,
+    ) -> float:
+        created = _parse_iso(shard.created_at)
+        if created is None:
+            return 0.0
+        now = request_context.now or datetime.now(tz=timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        age_days = (now - created).total_seconds() / 86_400.0
+        if age_days <= 0:
+            return 1.0
+        horizon = max(1, int(self.horizon_days or 1))
+        if age_days >= horizon:
+            return 0.0
+        return max(0.0, 1.0 - (age_days / horizon))
+
+    def _topic_overlap_score(
+        self,
+        shard: MemoryShard,
+        request_context: RequestContext,
+    ) -> float:
+        request_tags = request_context.normalised_tags()
+        if not request_tags:
+            return 0.0
+        shard_tags = frozenset(t.strip().lower() for t in shard.topic_tags if t)
+        if not shard_tags:
+            return 0.0
+        intersection = shard_tags & request_tags
+        union = shard_tags | request_tags
+        if not union:
+            return 0.0
+        return len(intersection) / len(union)
+
+    def _role_match_score(
+        self,
+        shard: MemoryShard,
+        request_context: RequestContext,
+    ) -> float:
+        role = (request_context.role or "").strip().lower()
+        if not role:
+            return 0.0
+        source = (shard.source or "").lower()
+        if not source:
+            return 0.0
+        # Role names are typically slashed (e.g. "engineering-agent/ai-engineer").
+        # Match against either the full string or the trailing segment.
+        if role in source:
+            return 1.0
+        last_segment = role.rsplit("/", 1)[-1]
+        if last_segment and last_segment in source:
+            return 1.0
+        return 0.0
+
+    def _source_trust_score(self, shard: MemoryShard) -> float:
+        return float(SOURCE_TRUST.get(shard.kind, 0.0))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    # Accept trailing "Z" as UTC
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+__all__ = (
+    "DEFAULT_WEIGHTS",
+    "RelevanceSelector",
+)

--- a/src/yule_orchestrator/agents/memory/sources.py
+++ b/src/yule_orchestrator/agents/memory/sources.py
@@ -1,0 +1,578 @@
+"""Five memory source adapters (F10 / #101).
+
+Each adapter implements the :class:`MemorySource` protocol — a single
+``query(filter)`` method returning an iterable of :class:`MemoryShard`.
+Adapters are intentionally narrow:
+
+  * **ObsidianVaultSource** — pure file-system reader over a vault
+    directory. No vault writes; never traverses outside the root.
+  * **SessionExtraSource** — projects the round-1 session.extra
+    ledger into shards. Pure in-memory; caller injects the snapshot.
+  * **MistakeLedgerSource** — reads from F2 SQLite ``MistakeLedger``
+    via its public read methods (``list_for_role`` / ``find_similar``).
+    Never calls a mutating method.
+  * **DecisionSource** — projects an injected sequence of audit-style
+    decisions into shards. Caller owns the audit fetch.
+  * **AuditSource** — projects an injected sequence of general audit
+    events into shards. Same shape as DecisionSource but lower trust.
+
+Hard rails:
+
+  * Every adapter exposes ONLY ``query``. No ``write`` / ``insert`` /
+    ``delete`` / ``upsert`` method. The governance regression test
+    introspects each instance to enforce this.
+  * Inputs to in-memory adapters (Session/Decision/Audit) are deep-
+    copied at construction so a caller mutating the original list
+    does not leak into shard output.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from . import (
+    MemoryFilter,
+    MemoryShard,
+    ShardKind,
+    _utc_now_iso,
+    tokenize,
+)
+
+
+# ---------------------------------------------------------------------------
+# Obsidian vault source
+# ---------------------------------------------------------------------------
+
+
+class ObsidianVaultSource:
+    """Read-only adapter over an Obsidian vault directory.
+
+    The adapter walks ``*.md`` files under ``vault_root`` and projects
+    each into a single :class:`MemoryShard`. ``topic_tags`` come from
+    YAML frontmatter ``tags:`` (best-effort parse) plus any literal
+    ``#tag`` hits in the body. ``related_issue`` is parsed from
+    frontmatter ``issue:`` or a trailing ``-issue-<n>.md`` filename
+    suffix per the F8 obsidian convention.
+
+    The adapter never writes to the vault. ``query`` re-reads on each
+    call so vault edits surface without restart — this is fine for
+    MVP scale (≤ low hundreds of notes).
+    """
+
+    kind = ShardKind.OBSIDIAN_NOTE
+
+    def __init__(
+        self,
+        vault_root: str | Path,
+        *,
+        max_files: int = 200,
+        source_label: Optional[str] = None,
+    ) -> None:
+        self._vault_root = Path(vault_root).expanduser().resolve()
+        self._max_files = max(1, int(max_files))
+        self._source_label = source_label or "obsidian-vault"
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        if not self._vault_root.exists() or not self._vault_root.is_dir():
+            return ()
+        out: List[MemoryShard] = []
+        for path in sorted(self._vault_root.rglob("*.md"))[: self._max_files]:
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            shard = self._project(path, text)
+            if shard is None:
+                continue
+            if not _filter_matches(shard, filter):
+                continue
+            out.append(shard)
+            if len(out) >= max(1, filter.limit):
+                break
+        return tuple(out)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _project(self, path: Path, text: str) -> Optional[MemoryShard]:
+        frontmatter, body = _split_frontmatter(text)
+        tags = _frontmatter_tags(frontmatter)
+        for raw_tag in _inline_hashtags(body):
+            tags.append(raw_tag)
+        created_at = (
+            _frontmatter_value(frontmatter, "created_at")
+            or _frontmatter_value(frontmatter, "date")
+            or _file_mtime_iso(path)
+        )
+        issue = _parse_issue_number(
+            _frontmatter_value(frontmatter, "issue")
+            or _suffix_issue(path.stem)
+        )
+        try:
+            rel = path.relative_to(self._vault_root)
+            relative_source = str(rel)
+        except ValueError:
+            relative_source = path.name
+        return MemoryShard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            source=f"{self._source_label}:{relative_source}",
+            content=body.strip() or text.strip(),
+            created_at=created_at,
+            topic_tags=tuple(_dedupe_lower(tags)),
+            related_issue=issue,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Session.extra source
+# ---------------------------------------------------------------------------
+
+
+class SessionExtraSource:
+    """Project round-1 session.extra ledger entries into shards.
+
+    The caller (typically the workflow runtime) injects a snapshot at
+    construction. The snapshot is a sequence of mappings with at
+    least ``content`` + ``created_at``; ``topic_tags`` / ``role`` /
+    ``issue`` are read when present.
+    """
+
+    kind = ShardKind.SESSION_EXTRA
+
+    def __init__(
+        self,
+        entries: Sequence[Mapping[str, Any]],
+        *,
+        source_label: Optional[str] = None,
+    ) -> None:
+        self._entries: Tuple[Mapping[str, Any], ...] = tuple(
+            dict(entry) for entry in entries if isinstance(entry, Mapping)
+        )
+        self._source_label = source_label or "session.extra"
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        out: List[MemoryShard] = []
+        for entry in self._entries:
+            content = str(entry.get("content") or "").strip()
+            if not content:
+                continue
+            tags = tuple(_dedupe_lower(entry.get("topic_tags") or []))
+            shard = MemoryShard(
+                kind=ShardKind.SESSION_EXTRA,
+                source=(
+                    f"{self._source_label}:{entry.get('role') or 'unknown'}"
+                ),
+                content=content,
+                created_at=str(entry.get("created_at") or _utc_now_iso()),
+                topic_tags=tags,
+                related_issue=_parse_issue_number(entry.get("issue")),
+                related_pr=_parse_issue_number(entry.get("pr")),
+            )
+            if not _filter_matches(shard, filter):
+                continue
+            out.append(shard)
+            if len(out) >= max(1, filter.limit):
+                break
+        return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Mistake ledger source
+# ---------------------------------------------------------------------------
+
+
+class MistakeLedgerSource:
+    """Read-only adapter over the F2 MistakeLedger.
+
+    Calls ``list_for_role`` (or ``all_records`` when no role filter)
+    and projects each row into a shard. The ``blocker_level`` field
+    is preserved so :class:`RelevanceSelector` can detect BLOCK and
+    surface it top.
+
+    The adapter only invokes public *read* methods on the ledger.
+    The governance regression test asserts no other method is called.
+    """
+
+    kind = ShardKind.MISTAKE
+
+    def __init__(self, ledger: Any, *, source_label: Optional[str] = None) -> None:
+        self._ledger = ledger
+        self._source_label = source_label or "mistake-ledger"
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        role = (filter.role or "").strip()
+        limit = max(1, int(filter.limit or 1))
+        rows: Sequence[Any]
+        if role:
+            try:
+                rows = self._ledger.list_for_role(role, limit=limit)
+            except Exception:  # noqa: BLE001 - fail-closed read
+                return ()
+        else:
+            try:
+                rows = self._ledger.all_records(include_resolved=False)[:limit]
+            except Exception:  # noqa: BLE001
+                return ()
+        out: List[MemoryShard] = []
+        for row in rows:
+            shard = self._project(row)
+            if shard is None:
+                continue
+            if not _filter_matches(shard, filter):
+                continue
+            out.append(shard)
+            if len(out) >= limit:
+                break
+        return tuple(out)
+
+    def _project(self, row: Any) -> Optional[MemoryShard]:
+        try:
+            role = str(getattr(row, "role"))
+            pattern = str(getattr(row, "pattern"))
+            signature = str(getattr(row, "signature"))
+            last_seen = str(getattr(row, "last_seen"))
+            blocker_level = str(getattr(row, "blocker_level"))
+        except AttributeError:
+            return None
+        # MistakeRecord stores blocker_level as Enum — coerce to value
+        if hasattr(row.blocker_level, "value"):
+            blocker_value = row.blocker_level.value
+        else:
+            blocker_value = blocker_level
+        return MemoryShard(
+            kind=ShardKind.MISTAKE,
+            source=f"{self._source_label}:{role}",
+            content=f"[{pattern}] {signature}",
+            created_at=last_seen,
+            topic_tags=tuple(_dedupe_lower([pattern, role])),
+            blocker_level=str(blocker_value).upper(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Decision source
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _AuditEntryView:
+    """Lightweight read-only view over an audit/decision mapping.
+
+    Source-injected. Helps the adapters reject mappings that lack the
+    minimum required fields without raising.
+    """
+
+    role: str
+    content: str
+    created_at: str
+    topic_tags: Tuple[str, ...]
+    related_issue: Optional[int]
+    related_pr: Optional[int]
+    source_id: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> Optional["_AuditEntryView"]:
+        if not isinstance(payload, Mapping):
+            return None
+        role = str(
+            payload.get("role")
+            or payload.get("actor")
+            or payload.get("role_id")
+            or ""
+        ).strip()
+        content = str(
+            payload.get("summary")
+            or payload.get("reason")
+            or payload.get("content")
+            or ""
+        ).strip()
+        if not content:
+            return None
+        created_at = str(
+            payload.get("recorded_at")
+            or payload.get("created_at")
+            or payload.get("timestamp")
+            or _utc_now_iso()
+        )
+        topic_tags = tuple(_dedupe_lower(payload.get("topic_tags") or []))
+        related_issue = _parse_issue_number(
+            payload.get("issue")
+            or payload.get("issue_number")
+            or payload.get("related_issue")
+        )
+        related_pr = _parse_issue_number(
+            payload.get("pr")
+            or payload.get("pr_number")
+            or payload.get("related_pr")
+        )
+        source_id = str(
+            payload.get("decision_id")
+            or payload.get("entry_id")
+            or payload.get("id")
+            or "anon"
+        )
+        return cls(
+            role=role,
+            content=content,
+            created_at=created_at,
+            topic_tags=topic_tags,
+            related_issue=related_issue,
+            related_pr=related_pr,
+            source_id=source_id,
+        )
+
+
+class DecisionSource:
+    """Project DECISION audit entries into shards.
+
+    Caller fetches decisions from agent_ops_audit (or any equivalent
+    durable log) and passes the resulting sequence in. The adapter
+    keeps a defensive snapshot — later caller mutations cannot leak.
+    """
+
+    kind = ShardKind.DECISION
+
+    def __init__(
+        self,
+        entries: Sequence[Mapping[str, Any]],
+        *,
+        source_label: Optional[str] = None,
+    ) -> None:
+        self._entries: Tuple[_AuditEntryView, ...] = tuple(
+            view
+            for view in (_AuditEntryView.from_mapping(e) for e in entries)
+            if view is not None
+        )
+        self._source_label = source_label or "agent-ops-audit:decision"
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        return _project_audit_views(
+            self._entries,
+            kind=ShardKind.DECISION,
+            source_label=self._source_label,
+            filter=filter,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Audit source
+# ---------------------------------------------------------------------------
+
+
+class AuditSource:
+    """Project general audit events into shards.
+
+    Same shape as :class:`DecisionSource` but a different kind so the
+    relevance selector applies a different source-trust score (0.8
+    vs. 0.9). Intended for non-DECISION action verbs (e.g. retries,
+    blocked_completion, postmortem).
+    """
+
+    kind = ShardKind.AUDIT
+
+    def __init__(
+        self,
+        entries: Sequence[Mapping[str, Any]],
+        *,
+        source_label: Optional[str] = None,
+    ) -> None:
+        self._entries: Tuple[_AuditEntryView, ...] = tuple(
+            view
+            for view in (_AuditEntryView.from_mapping(e) for e in entries)
+            if view is not None
+        )
+        self._source_label = source_label or "agent-ops-audit"
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        return _project_audit_views(
+            self._entries,
+            kind=ShardKind.AUDIT,
+            source_label=self._source_label,
+            filter=filter,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared internals
+# ---------------------------------------------------------------------------
+
+
+def _project_audit_views(
+    entries: Sequence[_AuditEntryView],
+    *,
+    kind: ShardKind,
+    source_label: str,
+    filter: MemoryFilter,
+) -> Tuple[MemoryShard, ...]:
+    out: List[MemoryShard] = []
+    for view in entries:
+        shard = MemoryShard(
+            kind=kind,
+            source=f"{source_label}:{view.source_id}",
+            content=view.content,
+            created_at=view.created_at,
+            topic_tags=view.topic_tags,
+            related_issue=view.related_issue,
+            related_pr=view.related_pr,
+        )
+        if not _filter_matches(shard, filter, role_override=view.role):
+            continue
+        out.append(shard)
+        if len(out) >= max(1, filter.limit):
+            break
+    return tuple(out)
+
+
+def _filter_matches(
+    shard: MemoryShard,
+    filter: MemoryFilter,
+    *,
+    role_override: Optional[str] = None,
+) -> bool:
+    if filter.issue is not None and shard.related_issue != filter.issue:
+        return False
+    if filter.pr is not None and shard.related_pr != filter.pr:
+        return False
+    if filter.role:
+        role = (role_override or "").strip().lower()
+        source = (shard.source or "").lower()
+        wanted = filter.role.strip().lower()
+        if wanted and wanted not in role and wanted not in source:
+            # Also try last segment of slashed role spec.
+            last_segment = wanted.rsplit("/", 1)[-1]
+            if not (last_segment and (last_segment in role or last_segment in source)):
+                return False
+    if filter.topic_tags:
+        wanted_tokens = set()
+        for tag in filter.topic_tags:
+            wanted_tokens |= set(tokenize(tag))
+        if wanted_tokens:
+            shard_tokens = set()
+            for tag in shard.topic_tags:
+                shard_tokens |= set(tokenize(tag))
+            if not (wanted_tokens & shard_tokens):
+                return False
+    if filter.since:
+        if shard.created_at < filter.since:
+            return False
+    return True
+
+
+def _split_frontmatter(text: str) -> Tuple[str, str]:
+    """Return (frontmatter, body). Empty frontmatter when none."""
+
+    if not text.startswith("---"):
+        return ("", text)
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return ("", text)
+    end_idx = -1
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_idx = idx
+            break
+    if end_idx == -1:
+        return ("", text)
+    frontmatter = "\n".join(lines[1:end_idx])
+    body = "\n".join(lines[end_idx + 1 :])
+    return (frontmatter, body)
+
+
+def _frontmatter_value(frontmatter: str, key: str) -> Optional[str]:
+    if not frontmatter:
+        return None
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        k, _, v = stripped.partition(":")
+        if k.strip().lower() == key.strip().lower():
+            return v.strip().strip('"').strip("'")
+    return None
+
+
+def _frontmatter_tags(frontmatter: str) -> List[str]:
+    if not frontmatter:
+        return []
+    raw = _frontmatter_value(frontmatter, "tags")
+    if not raw:
+        return []
+    # Accept either `[a, b]` or `a, b` or a single token.
+    raw = raw.strip().strip("[").strip("]")
+    return [token.strip().strip('"').strip("'") for token in raw.split(",") if token.strip()]
+
+
+def _inline_hashtags(body: str) -> List[str]:
+    if not body:
+        return []
+    out: List[str] = []
+    for token in body.split():
+        if token.startswith("#") and len(token) > 1:
+            cleaned = token.lstrip("#").rstrip(".,:;)]")
+            if cleaned:
+                out.append(cleaned)
+    return out
+
+
+def _parse_issue_number(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        if isinstance(value, int):
+            return int(value)
+        text = str(value).strip()
+        if not text:
+            return None
+        if text.startswith("#"):
+            text = text[1:]
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _suffix_issue(stem: str) -> Optional[str]:
+    if not stem:
+        return None
+    parts = stem.split("-issue-")
+    if len(parts) != 2:
+        return None
+    tail = parts[1].split("-")[0]
+    return tail or None
+
+
+def _file_mtime_iso(path: Path) -> str:
+    try:
+        ts = path.stat().st_mtime
+    except OSError:
+        return _utc_now_iso()
+    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _dedupe_lower(values: Iterable[Any]) -> List[str]:
+    seen: set = set()
+    out: List[str] = []
+    for v in values:
+        text = str(v or "").strip().lower()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+__all__ = (
+    "AuditSource",
+    "DecisionSource",
+    "MistakeLedgerSource",
+    "ObsidianVaultSource",
+    "SessionExtraSource",
+)

--- a/src/yule_orchestrator/agents/memory/topic_index.py
+++ b/src/yule_orchestrator/agents/memory/topic_index.py
@@ -1,0 +1,151 @@
+"""Token-based inverse index for memory shards (F10 / #101).
+
+Pure in-memory secondary index built on top of a shard sequence. The
+index pre-tokenises every shard's ``topic_tags`` + ``content`` head
+once, then offers O(|query tokens|) lookup. The :class:`LongTermMemory`
+facade uses it to narrow source-fanout candidates before passing them
+to :class:`RelevanceSelector`.
+
+Hard rails:
+
+  * **Read-only**: :meth:`TopicIndex.add` builds the index in-place
+    but no method ever mutates the underlying shards.
+  * **Deterministic**: query results are sorted by (shard.created_at
+    desc, shard.hash asc) so two equal builds yield equal ordering.
+  * **Bounded**: only the first ``content_token_budget`` tokens of
+    each shard contribute to the index so very long content cannot
+    dominate the inverse map.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, FrozenSet, Iterable, List, Sequence, Set, Tuple
+
+from . import MemoryShard, _TOKEN_RE, tokenize
+
+
+DEFAULT_CONTENT_TOKEN_BUDGET: int = 32
+
+
+class TopicIndex:
+    """Inverse map ``token -> set[shard_hash]``.
+
+    Construct empty and :meth:`add` shards, or pass an iterable to
+    :meth:`from_shards`. The index is intentionally simple — no
+    weighting, no stemming, no stopword filter. Token Jaccard for
+    relevance happens in :class:`RelevanceSelector`; this class only
+    answers "which shards share at least one token with this query".
+    """
+
+    def __init__(self, *, content_token_budget: int = DEFAULT_CONTENT_TOKEN_BUDGET) -> None:
+        self._inverse: Dict[str, Set[str]] = defaultdict(set)
+        self._shards_by_hash: Dict[str, MemoryShard] = {}
+        self._content_token_budget = max(0, int(content_token_budget))
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_shards(
+        cls,
+        shards: Iterable[MemoryShard],
+        *,
+        content_token_budget: int = DEFAULT_CONTENT_TOKEN_BUDGET,
+    ) -> "TopicIndex":
+        index = cls(content_token_budget=content_token_budget)
+        for shard in shards:
+            index.add(shard)
+        return index
+
+    def add(self, shard: MemoryShard) -> None:
+        """Index *shard* by its tokens.
+
+        Idempotent: re-adding the same shard hash is a no-op.
+        """
+
+        if shard.hash in self._shards_by_hash:
+            return
+        self._shards_by_hash[shard.hash] = shard
+        for token in self._shard_tokens(shard):
+            self._inverse[token].add(shard.hash)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def lookup(self, tokens: Iterable[str]) -> Tuple[MemoryShard, ...]:
+        """Return shards sharing at least one normalised token with *tokens*.
+
+        Each input string is tokenised through :func:`tokenize` (lower
+        case ASCII word split) so callers can pass either single
+        tokens or multi-word topics like ``"paste-guard"`` and the
+        index matches via the underlying word components.
+
+        Empty token set → empty result. Ordering is deterministic:
+        ``(created_at desc, hash asc)``.
+        """
+
+        expanded: set = set()
+        for raw in tokens:
+            if not raw:
+                continue
+            expanded |= set(tokenize(str(raw)))
+        normalised = frozenset(t for t in expanded if t)
+        if not normalised:
+            return ()
+        candidate_hashes: Set[str] = set()
+        for token in normalised:
+            candidate_hashes |= self._inverse.get(token, set())
+        if not candidate_hashes:
+            return ()
+        shards = [self._shards_by_hash[h] for h in candidate_hashes]
+        shards.sort(key=lambda s: (s.created_at, s.hash), reverse=False)
+        shards.sort(key=lambda s: s.created_at, reverse=True)
+        return tuple(shards)
+
+    def tokens_for(self, shard_hash: str) -> FrozenSet[str]:
+        """Diagnostic helper — list tokens recorded for a shard hash."""
+
+        out: Set[str] = set()
+        for token, hashes in self._inverse.items():
+            if shard_hash in hashes:
+                out.add(token)
+        return frozenset(out)
+
+    def __len__(self) -> int:
+        return len(self._shards_by_hash)
+
+    def __contains__(self, shard_hash: object) -> bool:
+        return shard_hash in self._shards_by_hash
+
+    @property
+    def size(self) -> int:
+        return len(self._shards_by_hash)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _shard_tokens(self, shard: MemoryShard) -> FrozenSet[str]:
+        tokens: Set[str] = set()
+        for tag in shard.topic_tags or ():
+            tokens.update(tokenize(tag))
+        if self._content_token_budget > 0 and shard.content:
+            # Preserve order so the budget caps the *leading* head of
+            # the content, not an arbitrary subset of the frozenset.
+            ordered = _TOKEN_RE.findall(shard.content.lower())
+            tokens.update(ordered[: self._content_token_budget])
+        return frozenset(t for t in tokens if t)
+
+    @staticmethod
+    def _normalise(token: str) -> str:
+        text = str(token or "").strip().lower()
+        return text
+
+
+__all__ = (
+    "DEFAULT_CONTENT_TOKEN_BUDGET",
+    "TopicIndex",
+)

--- a/tests/agents/test_long_term_memory.py
+++ b/tests/agents/test_long_term_memory.py
@@ -1,0 +1,265 @@
+"""LongTermMemory + build_memory_pack tests (F10 / #101).
+
+Covers:
+
+  * `build_memory_pack` returns empty pack when env OFF
+  * `build_memory_pack` returns ranked, deduped pack when env ON
+  * BLOCK mistake shard pinned to MemoryPack.shards[0]
+  * Per-source fanout cap honoured
+  * Adapter exception isolated — one bad source does not block others
+  * for_topic / for_role / for_issue dispatch the right filter
+  * recent_decisions filters to DECISION kind only
+  * query_signature stable for identical request_context
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Iterable, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.memory import (
+    ENV_LONG_TERM_MEMORY_ENABLED,
+    LongTermMemory,
+    MemoryFilter,
+    MemoryPack,
+    MemoryShard,
+    MemorySource,
+    RequestContext,
+    ShardKind,
+    build_memory_pack,
+)
+
+
+class _FakeSource:
+    """Minimal MemorySource implementation for unit tests."""
+
+    def __init__(
+        self,
+        kind: ShardKind,
+        shards: Sequence[MemoryShard],
+        *,
+        raise_on_query: bool = False,
+    ) -> None:
+        self.kind = kind
+        self._shards = tuple(shards)
+        self._raise = raise_on_query
+        self.calls: list = []
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        self.calls.append(filter)
+        if self._raise:
+            raise RuntimeError("boom")
+        return self._shards
+
+
+def _shard(
+    *,
+    kind: ShardKind = ShardKind.OBSIDIAN_NOTE,
+    content: str,
+    source: str = "fake-source",
+    created_at: str = "2026-05-10T12:00:00+00:00",
+    topic_tags=(),
+    related_issue=None,
+    blocker_level=None,
+) -> MemoryShard:
+    return MemoryShard(
+        kind=kind,
+        source=source,
+        content=content,
+        created_at=created_at,
+        topic_tags=tuple(topic_tags),
+        related_issue=related_issue,
+        blocker_level=blocker_level,
+    )
+
+
+class LongTermMemoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Test enable / disable via env var; ensure cleanup.
+        self._prev_env = os.environ.get(ENV_LONG_TERM_MEMORY_ENABLED)
+        os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = "true"
+
+    def tearDown(self) -> None:
+        if self._prev_env is None:
+            os.environ.pop(ENV_LONG_TERM_MEMORY_ENABLED, None)
+        else:
+            os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = self._prev_env
+
+    # ------------------------------------------------------------------
+    # build_memory_pack
+    # ------------------------------------------------------------------
+
+    def test_empty_pack_when_env_disabled(self) -> None:
+        os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = "false"
+        source = _FakeSource(
+            ShardKind.OBSIDIAN_NOTE,
+            [_shard(content="x")],
+        )
+        ltm = LongTermMemory([source])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(role="ai-engineer"),
+        )
+        self.assertIsInstance(pack, MemoryPack)
+        self.assertEqual(pack.shards, ())
+        # source never queried
+        self.assertEqual(source.calls, [])
+
+    def test_empty_pack_when_long_term_memory_none(self) -> None:
+        pack = build_memory_pack(
+            long_term_memory=None,
+            request_context=RequestContext(),
+        )
+        self.assertEqual(pack.shards, ())
+
+    def test_pack_dedupes_by_hash(self) -> None:
+        shard_a = _shard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            content="same content",
+            source="fake-source",
+            topic_tags=("topic",),
+        )
+        shard_b = _shard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            content="same content",
+            source="fake-source",
+            topic_tags=("topic",),
+        )
+        src1 = _FakeSource(ShardKind.OBSIDIAN_NOTE, [shard_a])
+        src2 = _FakeSource(ShardKind.OBSIDIAN_NOTE, [shard_b])
+        ltm = LongTermMemory([src1, src2])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(topic_tags=("topic",)),
+        )
+        self.assertEqual(len(pack.shards), 1)
+
+    def test_block_mistake_pinned_to_top(self) -> None:
+        recent_note = _shard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            content="fresh & topical",
+            topic_tags=("topic",),
+            created_at="2026-05-11T00:00:00+00:00",
+        )
+        ancient_block = _shard(
+            kind=ShardKind.MISTAKE,
+            content="[force_push] protected branch",
+            source="mistake-ledger:ai-engineer",
+            created_at="2020-01-01T00:00:00+00:00",  # very old
+            topic_tags=(),
+            blocker_level="BLOCK",
+        )
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, [recent_note, ancient_block])
+        ltm = LongTermMemory([src])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(topic_tags=("topic",)),
+            limit=5,
+        )
+        self.assertGreater(len(pack.shards), 0)
+        self.assertEqual(pack.shards[0].kind, ShardKind.MISTAKE)
+        self.assertEqual((pack.shards[0].blocker_level or "").upper(), "BLOCK")
+
+    def test_source_exception_isolated(self) -> None:
+        good = _FakeSource(
+            ShardKind.OBSIDIAN_NOTE,
+            [_shard(content="good", topic_tags=("topic",))],
+        )
+        bad = _FakeSource(
+            ShardKind.AUDIT, [_shard(content="bad")], raise_on_query=True
+        )
+        ltm = LongTermMemory([bad, good])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(topic_tags=("topic",)),
+        )
+        self.assertGreaterEqual(len(pack.shards), 1)
+        contents = {s.content for s in pack.shards}
+        self.assertIn("good", contents)
+
+    def test_query_signature_stable_for_equal_context(self) -> None:
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, [])
+        ltm = LongTermMemory([src])
+        ctx = RequestContext(role="ai-engineer", topic_tags=("a", "b"), issue=101)
+        first = build_memory_pack(long_term_memory=ltm, request_context=ctx)
+        second = build_memory_pack(long_term_memory=ltm, request_context=ctx)
+        self.assertEqual(first.query_signature, second.query_signature)
+
+    def test_limit_caps_pack_size(self) -> None:
+        shards = [
+            _shard(
+                content=f"s{i}",
+                topic_tags=("topic",),
+                source=f"fake-source:{i}",
+                created_at=f"2026-05-{i+1:02d}T00:00:00+00:00",
+            )
+            for i in range(8)
+        ]
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, shards)
+        ltm = LongTermMemory([src])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(topic_tags=("topic",)),
+            limit=3,
+        )
+        self.assertEqual(len(pack.shards), 3)
+
+    # ------------------------------------------------------------------
+    # LongTermMemory convenience methods
+    # ------------------------------------------------------------------
+
+    def test_for_topic_dispatches_topic_filter(self) -> None:
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, [])
+        ltm = LongTermMemory([src])
+        ltm.for_topic(["alpha"], limit=4)
+        self.assertEqual(len(src.calls), 1)
+        self.assertEqual(src.calls[0].topic_tags, ("alpha",))
+        self.assertEqual(src.calls[0].limit, 4)
+
+    def test_for_role_dispatches_role_filter(self) -> None:
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, [])
+        ltm = LongTermMemory([src])
+        ltm.for_role("ai-engineer", limit=2)
+        self.assertEqual(src.calls[0].role, "ai-engineer")
+
+    def test_for_issue_dispatches_issue_filter(self) -> None:
+        src = _FakeSource(ShardKind.OBSIDIAN_NOTE, [])
+        ltm = LongTermMemory([src])
+        ltm.for_issue(101)
+        self.assertEqual(src.calls[0].issue, 101)
+
+    def test_recent_decisions_filters_to_decision_kind(self) -> None:
+        decision_src = _FakeSource(
+            ShardKind.DECISION, [_shard(kind=ShardKind.DECISION, content="d")]
+        )
+        note_src = _FakeSource(
+            ShardKind.OBSIDIAN_NOTE, [_shard(content="note")]
+        )
+        ltm = LongTermMemory([decision_src, note_src])
+        result = ltm.recent_decisions(limit=10)
+        # Only decision_src is queried, only DECISION shards returned.
+        self.assertEqual(len(note_src.calls), 0)
+        self.assertEqual(len(decision_src.calls), 1)
+        self.assertTrue(all(s.kind == ShardKind.DECISION for s in result))
+
+    def test_fanout_dedupes_across_sources(self) -> None:
+        shard = _shard(
+            content="same",
+            source="fake-source",
+            topic_tags=("topic",),
+        )
+        src1 = _FakeSource(ShardKind.OBSIDIAN_NOTE, [shard])
+        src2 = _FakeSource(ShardKind.OBSIDIAN_NOTE, [shard])
+        ltm = LongTermMemory([src1, src2])
+        result = ltm.for_topic(["topic"])
+        self.assertEqual(len(result), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_relevance_selector.py
+++ b/tests/agents/test_relevance_selector.py
@@ -1,0 +1,152 @@
+"""RelevanceSelector unit tests (F10 / #101).
+
+Coverage:
+
+  * Score is clamped to [0.0, 1.0]
+  * Recency decays linearly across the horizon, hits 0 at boundary
+  * Topic overlap is Jaccard, returns 0 when either side empty
+  * Role match recognises both full role string and trailing segment
+  * Source-trust uses the static SOURCE_TRUST table
+  * MISTAKE + BLOCK shards always return 1.0 (hard rail)
+  * Deterministic — identical inputs yield identical scores
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.memory import (
+    MemoryShard,
+    RequestContext,
+    ShardKind,
+)
+from yule_orchestrator.agents.memory.relevance_selector import RelevanceSelector
+
+
+def _shard(
+    *,
+    kind: ShardKind,
+    created_at: str = "2026-05-10T12:00:00+00:00",
+    topic_tags=(),
+    source: str = "obsidian-vault:notes/x.md",
+    content: str = "x",
+    blocker_level=None,
+) -> MemoryShard:
+    return MemoryShard(
+        kind=kind,
+        source=source,
+        content=content,
+        created_at=created_at,
+        topic_tags=tuple(topic_tags),
+        blocker_level=blocker_level,
+    )
+
+
+class RelevanceSelectorTests(unittest.TestCase):
+    def test_score_clamped_to_unit_interval(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(kind=ShardKind.OBSIDIAN_NOTE)
+        score = selector.score(shard, request_context=RequestContext())
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 1.0)
+
+    def test_block_mistake_always_one(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(
+            kind=ShardKind.MISTAKE,
+            created_at="2000-01-01T00:00:00+00:00",  # ancient — recency 0
+            topic_tags=(),  # no overlap
+            source="mistake-ledger:nobody",
+            blocker_level="BLOCK",
+        )
+        score = selector.score(shard, request_context=RequestContext(role="anyone"))
+        self.assertEqual(score, 1.0)
+
+    def test_recency_zero_beyond_horizon(self) -> None:
+        selector = RelevanceSelector(horizon_days=30)
+        old_iso = "2020-01-01T00:00:00+00:00"
+        shard = _shard(kind=ShardKind.OBSIDIAN_NOTE, created_at=old_iso)
+        score = selector._recency_score(shard, RequestContext())
+        self.assertEqual(score, 0.0)
+
+    def test_recency_full_score_for_now(self) -> None:
+        selector = RelevanceSelector(horizon_days=30)
+        now = datetime.now(tz=timezone.utc).replace(microsecond=0)
+        shard = _shard(kind=ShardKind.OBSIDIAN_NOTE, created_at=now.isoformat())
+        score = selector._recency_score(shard, RequestContext(now=now))
+        self.assertEqual(score, 1.0)
+
+    def test_topic_overlap_jaccard(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            topic_tags=("paste", "guard"),
+        )
+        ctx = RequestContext(topic_tags=("guard", "router"))
+        score = selector._topic_overlap_score(shard, ctx)
+        # intersection={guard}, union={paste,guard,router} → 1/3
+        self.assertAlmostEqual(score, 1 / 3)
+
+    def test_topic_overlap_zero_when_either_side_empty(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(kind=ShardKind.OBSIDIAN_NOTE, topic_tags=())
+        self.assertEqual(
+            selector._topic_overlap_score(shard, RequestContext(topic_tags=("a",))),
+            0.0,
+        )
+        shard2 = _shard(kind=ShardKind.OBSIDIAN_NOTE, topic_tags=("a",))
+        self.assertEqual(
+            selector._topic_overlap_score(shard2, RequestContext(topic_tags=())),
+            0.0,
+        )
+
+    def test_role_match_matches_trailing_segment(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(
+            kind=ShardKind.AUDIT,
+            source="agent-ops-audit:engineering-agent/ai-engineer-x",
+        )
+        score = selector._role_match_score(
+            shard,
+            RequestContext(role="engineering-agent/ai-engineer"),
+        )
+        self.assertEqual(score, 1.0)
+
+    def test_source_trust_table(self) -> None:
+        selector = RelevanceSelector()
+        decision = _shard(kind=ShardKind.DECISION)
+        obsidian = _shard(kind=ShardKind.OBSIDIAN_NOTE)
+        session = _shard(kind=ShardKind.SESSION_EXTRA)
+        self.assertGreater(
+            selector._source_trust_score(decision),
+            selector._source_trust_score(obsidian),
+        )
+        self.assertGreater(
+            selector._source_trust_score(obsidian),
+            selector._source_trust_score(session),
+        )
+
+    def test_deterministic_for_equal_inputs(self) -> None:
+        selector = RelevanceSelector()
+        shard = _shard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            topic_tags=("a", "b"),
+            source="obsidian-vault:notes/x.md",
+        )
+        fixed_now = datetime(2026, 5, 11, tzinfo=timezone.utc)
+        ctx = RequestContext(
+            role="ai-engineer", topic_tags=("a",), now=fixed_now
+        )
+        first = selector.score(shard, request_context=ctx)
+        second = selector.score(shard, request_context=ctx)
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_topic_index.py
+++ b/tests/agents/test_topic_index.py
@@ -1,0 +1,95 @@
+"""TopicIndex unit tests (F10 / #101).
+
+Coverage:
+
+  * Empty / single / multi shard add + lookup
+  * Token normalisation (case insensitive, ASCII tokenisation)
+  * Content head budget honoured (long content tail does not pollute)
+  * Idempotent re-add by hash
+  * Deterministic ordering (created_at desc, hash asc tiebreak)
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.memory import MemoryShard, ShardKind
+from yule_orchestrator.agents.memory.topic_index import TopicIndex
+
+
+def _shard(
+    *,
+    content: str,
+    created_at: str = "2026-05-10T12:00:00+00:00",
+    topic_tags=(),
+    kind: ShardKind = ShardKind.OBSIDIAN_NOTE,
+    source: str = "obsidian-vault:note.md",
+) -> MemoryShard:
+    return MemoryShard(
+        kind=kind,
+        source=source,
+        content=content,
+        created_at=created_at,
+        topic_tags=tuple(topic_tags),
+    )
+
+
+class TopicIndexTests(unittest.TestCase):
+    def test_empty_index_returns_no_results(self) -> None:
+        index = TopicIndex()
+        self.assertEqual(index.lookup(["anything"]), ())
+        self.assertEqual(len(index), 0)
+
+    def test_lookup_by_tag_matches(self) -> None:
+        shard = _shard(content="hello", topic_tags=("paste-guard", "f1"))
+        index = TopicIndex.from_shards([shard])
+        result = index.lookup(["paste-guard"])
+        self.assertEqual(result, (shard,))
+
+    def test_lookup_is_case_insensitive(self) -> None:
+        shard = _shard(content="hello", topic_tags=("PasteGuard",))
+        index = TopicIndex.from_shards([shard])
+        result = index.lookup(["pasteguard"])
+        self.assertEqual(result, (shard,))
+
+    def test_lookup_returns_empty_for_unknown_token(self) -> None:
+        shard = _shard(content="known", topic_tags=("known",))
+        index = TopicIndex.from_shards([shard])
+        self.assertEqual(index.lookup(["unrelated"]), ())
+
+    def test_lookup_ignores_empty_tokens(self) -> None:
+        shard = _shard(content="x", topic_tags=("t",))
+        index = TopicIndex.from_shards([shard])
+        self.assertEqual(index.lookup(["", "  ", None]), ())  # type: ignore[list-item]
+
+    def test_content_tokens_indexed_within_budget(self) -> None:
+        long_tail = " ".join(["needle"] + ["filler"] * 50 + ["tail"])
+        shard = _shard(content=long_tail, topic_tags=())
+        index = TopicIndex.from_shards([shard], content_token_budget=5)
+        self.assertEqual(index.lookup(["needle"]), (shard,))
+        # "tail" is beyond budget — should not match.
+        self.assertEqual(index.lookup(["tail"]), ())
+
+    def test_idempotent_re_add(self) -> None:
+        shard = _shard(content="alpha", topic_tags=("a",))
+        index = TopicIndex()
+        index.add(shard)
+        index.add(shard)
+        self.assertEqual(len(index), 1)
+        self.assertEqual(index.lookup(["alpha"]), (shard,))
+
+    def test_deterministic_ordering_by_created_at_desc(self) -> None:
+        older = _shard(content="old", created_at="2025-01-01T00:00:00+00:00", topic_tags=("z",))
+        newer = _shard(content="new", created_at="2026-05-10T00:00:00+00:00", topic_tags=("z",))
+        index = TopicIndex.from_shards([older, newer])
+        result = index.lookup(["z"])
+        self.assertEqual(result, (newer, older))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_memory_unifier_governance.py
+++ b/tests/engineering/test_memory_unifier_governance.py
@@ -1,0 +1,250 @@
+"""Memory unifier governance regression (F10 / #101).
+
+Pins the hard rails defined in issue #101 so a future refactor that
+breaks one trips a clearly named test:
+
+  1. ``YULE_LONG_TERM_MEMORY_ENABLED`` defaults to OFF — calling
+     :func:`build_memory_pack` without the env returns an empty
+     :class:`MemoryPack`.
+  2. Source adapters are read-only — they expose only ``query`` (no
+     ``write`` / ``insert`` / ``upsert`` / ``delete`` / ``mutate``).
+  3. A BLOCK-level mistake shard always lands at ``shards[0]``, even
+     when its recency / topic / role signals are 0.
+  4. ContextPack carries the ``memory_pack`` field and ``to_payload``
+     emits it (None or full payload) — downstream payload renderers
+     never silently drop the channel.
+  5. Adapter exceptions never propagate to caller — a broken adapter
+     yields an empty contribution, not a worker crash.
+  6. PasteGuard module remains importable + functional — F10 must
+     not regress F1's outbound rails.
+  7. MistakeLedger module remains importable + functional — F10
+     must not regress F2's durable mistake ledger.
+  8. ``memory`` package exposes every public surface in ``__all__``
+     so import drift is caught early.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Iterable
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.decision.context_pack import (
+    ContextPack,
+    build_context_pack,
+)
+from yule_orchestrator.agents.learning.mistake_ledger import (
+    BlockerLevel,
+    MistakeLedger,
+)
+from yule_orchestrator.agents.memory import (
+    ENV_LONG_TERM_MEMORY_ENABLED,
+    AuditSource,
+    DecisionSource,
+    LongTermMemory,
+    MemoryFilter,
+    MemoryPack,
+    MemoryShard,
+    MistakeLedgerSource,
+    ObsidianVaultSource,
+    RequestContext,
+    SessionExtraSource,
+    ShardKind,
+    build_memory_pack,
+)
+from yule_orchestrator.agents.security.paste_guard import (
+    OutboundChannel,
+    guard_outbound,
+)
+
+
+READ_ONLY_FORBIDDEN_METHODS = (
+    "write",
+    "insert",
+    "upsert",
+    "delete",
+    "mutate",
+    "drop",
+    "create_table",
+    "save",
+)
+
+
+class _AlwaysRaisingSource:
+    """Sentinel source that fails every call — used in isolation test."""
+
+    kind = ShardKind.AUDIT
+
+    def query(self, filter: MemoryFilter) -> Iterable[MemoryShard]:
+        raise RuntimeError("intentional sentinel failure")
+
+
+class MemoryUnifierGovernanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev_env = os.environ.get(ENV_LONG_TERM_MEMORY_ENABLED)
+
+    def tearDown(self) -> None:
+        if self._prev_env is None:
+            os.environ.pop(ENV_LONG_TERM_MEMORY_ENABLED, None)
+        else:
+            os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = self._prev_env
+
+    # 1
+    def test_env_off_by_default_returns_empty_pack(self) -> None:
+        os.environ.pop(ENV_LONG_TERM_MEMORY_ENABLED, None)
+        ltm = LongTermMemory([])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(),
+        )
+        self.assertIsInstance(pack, MemoryPack)
+        self.assertEqual(pack.shards, ())
+
+    # 2
+    def test_all_source_adapters_are_read_only(self) -> None:
+        ledger = MistakeLedger(database_path=":memory:")
+        try:
+            adapters = [
+                ObsidianVaultSource("/nonexistent-vault"),
+                SessionExtraSource([]),
+                MistakeLedgerSource(ledger),
+                DecisionSource([]),
+                AuditSource([]),
+            ]
+            for adapter in adapters:
+                public_methods = {
+                    name
+                    for name in dir(adapter)
+                    if not name.startswith("_")
+                }
+                for forbidden in READ_ONLY_FORBIDDEN_METHODS:
+                    self.assertNotIn(
+                        forbidden,
+                        public_methods,
+                        f"{type(adapter).__name__} exposes mutating "
+                        f"method {forbidden!r}",
+                    )
+                self.assertIn("query", public_methods)
+        finally:
+            ledger.close()
+
+    # 3
+    def test_block_mistake_always_pinned_top(self) -> None:
+        os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = "true"
+        block_shard = MemoryShard(
+            kind=ShardKind.MISTAKE,
+            source="mistake-ledger:ai-engineer",
+            content="[force_push] never bypass protected branch",
+            created_at="2000-01-01T00:00:00+00:00",
+            topic_tags=(),
+            blocker_level="BLOCK",
+        )
+        fresh_note = MemoryShard(
+            kind=ShardKind.OBSIDIAN_NOTE,
+            source="obsidian-vault:notes/relevant.md",
+            content="relevant",
+            created_at="2026-05-11T00:00:00+00:00",
+            topic_tags=("topic",),
+        )
+
+        class _Src:
+            kind = ShardKind.OBSIDIAN_NOTE
+
+            def query(self, filter: MemoryFilter):
+                return [fresh_note, block_shard]
+
+        ltm = LongTermMemory([_Src()])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(topic_tags=("topic",)),
+        )
+        self.assertGreater(len(pack.shards), 0)
+        self.assertEqual(pack.shards[0].kind, ShardKind.MISTAKE)
+
+    # 4
+    def test_context_pack_carries_memory_pack(self) -> None:
+        os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = "true"
+        ltm = LongTermMemory([])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(),
+        )
+        ctx_pack = build_context_pack(prompt="hello", memory_pack=pack)
+        self.assertIsInstance(ctx_pack, ContextPack)
+        self.assertEqual(ctx_pack.memory_pack, pack)
+        payload = ctx_pack.to_payload()
+        self.assertIn("memory_pack", payload)
+
+        # And None survives round-trip.
+        ctx_pack_none = build_context_pack(prompt="hello")
+        self.assertIsNone(ctx_pack_none.memory_pack)
+        self.assertIsNone(ctx_pack_none.to_payload()["memory_pack"])
+
+    # 5
+    def test_adapter_exception_isolated(self) -> None:
+        os.environ[ENV_LONG_TERM_MEMORY_ENABLED] = "true"
+        ltm = LongTermMemory([_AlwaysRaisingSource()])
+        pack = build_memory_pack(
+            long_term_memory=ltm,
+            request_context=RequestContext(),
+        )
+        # No exception escaped. Empty pack is acceptable; the rail is
+        # "caller never sees the adapter fault".
+        self.assertEqual(pack.shards, ())
+
+    # 6
+    def test_paste_guard_still_importable_and_functional(self) -> None:
+        verdict = guard_outbound(
+            channel=OutboundChannel.LLM, payload="hello world"
+        )
+        self.assertFalse(verdict.blocked)
+        self.assertEqual(verdict.redacted, "hello world")
+
+    # 7
+    def test_mistake_ledger_still_functional(self) -> None:
+        ledger = MistakeLedger(database_path=":memory:")
+        try:
+            record = ledger.record_mistake(
+                role="ai-engineer",
+                pattern="ci",
+                signature="ci test failed",
+                blocker_level=BlockerLevel.WARNING,
+            )
+            self.assertEqual(record.role, "ai-engineer")
+            self.assertEqual(record.occurrences, 1)
+        finally:
+            ledger.close()
+
+    # 8
+    def test_public_surface_explicit(self) -> None:
+        import yule_orchestrator.agents.memory as memory_pkg
+
+        expected = {
+            "AuditSource",
+            "DecisionSource",
+            "LongTermMemory",
+            "MemoryFilter",
+            "MemoryPack",
+            "MemoryShard",
+            "MemorySource",
+            "MistakeLedgerSource",
+            "ObsidianVaultSource",
+            "RelevanceSelector",
+            "RequestContext",
+            "SessionExtraSource",
+            "ShardKind",
+            "TopicIndex",
+            "build_memory_pack",
+        }
+        actual = set(memory_pkg.__all__)
+        missing = expected - actual
+        self.assertEqual(missing, set(), f"missing public exports: {missing}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #101
- parent #81
- 의존 (머지됨): PR #94 (PasteGuard) / PR #96 (mistake_ledger)

## 🎯 목적
"기억 상실증" 을 막는 단일 진실 계층. Obsidian vault-mirror +
session.extra + topic ledger + mistake_ledger + agent_ops_audit 을
한 인터페이스로 묶어 다음 작업 시작 시 "이전 세션 / 결정 / 실수"
가 자동으로 surface 되게 한다.

## 📐 범위
신규 모듈
- `src/yule_orchestrator/agents/memory/__init__.py` — 핵심 dataclass
  (MemoryShard / MemoryPack / MemoryFilter / RequestContext) +
  MemorySource Protocol + 환경 변수 헬퍼.
- `src/yule_orchestrator/agents/memory/relevance_selector.py` —
  recency / topic_overlap / role_match / source_trust 4 component
  가중평균. BLOCK mistake 는 1.0 고정.
- `src/yule_orchestrator/agents/memory/topic_index.py` — token-based
  inverse map (head budget + deterministic ordering).
- `src/yule_orchestrator/agents/memory/sources.py` — 5 source adapter
  (ObsidianVault / SessionExtra / MistakeLedger / Decision / Audit)
  read-only 구현.
- `src/yule_orchestrator/agents/memory/long_term_memory.py` —
  LongTermMemory facade + `build_memory_pack`.

통합 지점
- `agents/decision/context_pack.py` — `memory_pack: Optional[MemoryPack]`
  필드 추가, `to_payload` / `is_empty` 갱신.
- `.env.example` — `YULE_LONG_TERM_MEMORY_ENABLED` (default false)
  / `YULE_MEMORY_FRESHNESS_DAYS=30` / `YULE_MEMORY_MAX_SHARDS_PER_QUERY=10`.

비범위
- F6 Discord UX 소비 wiring (별도 PR).
- F8 vault auto-push 연동 (별도 PR).

## ✅ Acceptance Criteria
1. 5 source `query` 가능 — adapter 구현 + governance test
   ``test_all_source_adapters_are_read_only``.
2. RelevanceSelector deterministic — 고정 ``RequestContext.now``
   에서 동일 입력 동일 출력. ``test_deterministic_for_equal_inputs``.
3. mistake BLOCK shard 항상 top surface — RelevanceSelector +
   build_memory_pack 양쪽 보호. ``test_block_mistake_pinned_top``.
4. env OFF → 빈 MemoryPack — ``test_env_off_by_default_returns_empty_pack``.
5. PasteGuard 통합 — 모듈 import + functional 회귀
   (``test_paste_guard_still_importable_and_functional``); shard
   ``content`` 의 outbound masking 은 caller 책임으로 위임.

## 🔒 Hard rails
- 모든 source `query` only — mutator method 부재를 governance
  test 가 검사 (write / insert / upsert / delete / mutate / drop
  / create_table / save).
- env OFF default + 회로 단절 — `build_memory_pack` 이 즉시 빈 pack.
- BLOCK shard 검열 금지 — score 1.0 + ``shards[0]`` pinning.
- adapter 예외 격리 — 한 source 가 raise 해도 다른 source 의
  shard 가 surface (``test_adapter_exception_isolated``).
- force push / `--no-verify` 미사용.

## 🔗 의존성
- 선행: PR #94 (PasteGuard), PR #96 (Hookify mistake_ledger), 기존
  agent_ops_audit. 모두 머지됨.
- 통합: `ContextPack.memory_pack` — 본 PR 에서 확장.
- 관련: F6 Discord UX 가 본 모듈을 소비 (후속 PR).

## 🧰 Harness
- 신규 테스트
  * `tests/agents/test_topic_index.py` — 8 cases.
  * `tests/agents/test_relevance_selector.py` — 9 cases.
  * `tests/agents/test_long_term_memory.py` — 12 cases.
  * `tests/engineering/test_memory_unifier_governance.py` — 8 cases.
- 전체 회귀: ``pytest tests/`` → **3940 passed, 1 skipped** (기존
  skip 그대로).
- 신규 회귀만: 37 passed.

## 무엇을 변경했는지
| commit | 목적 |
| --- | --- |
| `eaf2c44` | F10 Claude Mem unifier 신설 + ContextPack 통합 + 회귀 37 |

## 🤖 Agent WorkOS Audit
- audit_id: f10-issue-101-v2
- branch: feature/claude-mem-unifier-issue-101-v2 (from main)
- role: engineering-agent/ai-engineer + backend-engineer
- autonomy_level: L2_AUTONOMOUS_RECORD
- mode: draft → ready (자체 회귀 PASS 시 mark-ready)