### PR TITLE
✨ [Feat] F9 LSP-style preflight (rebased)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -369,20 +369,19 @@ DISCORD_GUILD_ID=
 
 # =====================================================================
 # F7 / #98 — Auto-merge decider cycle authorization
-#
-# `src/yule_orchestrator/agents/release/auto_merge_decider.py` 는 PR 의
-# 8 자율 머지 조건 을 평가해 tech-lead agent 자율 머지 가능 여부를 결정.
-# 사이클 이름 또는 ``true`` 명시 시에만 활성. HIGH/CRITICAL 항상 BLOCK.
 # YULE_AUTOMERGE_CYCLE=
 
 # =====================================================================
 # F5 / #92 — Role-based research live providers (RSS / Atom / release)
-#
-# `src/yule_orchestrator/agents/research/providers/live/` 가 외부
-# read-only source 를 `LiveEvidence` 로 ingest. default OFF — allow-list
-# 외 host fetch 금지, robots.txt 존중, rate-limit 1 req/sec.
 # YULE_RESEARCH_LIVE_ENABLED=false
 # YULE_RESEARCH_LIVE_ALLOW_HOSTS=
 # YULE_RESEARCH_LIVE_DISABLE_HOSTS=
 # YULE_RESEARCH_LIVE_KINDS=rss,atom,github_release
 # YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC=1.0
+
+# =====================================================================
+# F9 / #100 — LSP-style preflight (ruff / pyright / mypy / tsc / go / rust)
+# default OFF — env ON 시에만 외부 binary 호출. 30s 하드캡. PasteGuard 통과.
+# YULE_LSP_PREFLIGHT_ENABLED=false
+# YULE_LSP_RUNNERS=
+# YULE_LSP_TIMEOUT_SECONDS=30

--- a/src/yule_orchestrator/agents/static_analysis/__init__.py
+++ b/src/yule_orchestrator/agents/static_analysis/__init__.py
@@ -1,0 +1,47 @@
+"""Static analysis preflight seam — F9 / issue #100.
+
+Role-aware wrapper around external LSP / linter / type-checker
+binaries (ruff / pyright / mypy / tsc / golangci-lint / cargo-clippy).
+Live LLM editor (F4) calls :func:`judge_lsp_preflight` between
+retries so trivially-broken code never ships to the model again.
+
+Hard rails (governance-tested):
+
+  * The module **never** mutates target files — read-only analysis.
+  * External binaries always run under a 30s timeout (env override).
+  * Missing binary → advisory verdict, **never** a block.
+  * ``YULE_LSP_PREFLIGHT_ENABLED`` defaults to ``false``; with the
+    env OFF the verdict is always advisory and no subprocess runs.
+  * Every subprocess ``stderr`` tail is passed through
+    :func:`yule_orchestrator.agents.security.paste_guard.guard_outbound`
+    (``channel=VAULT``) so masked output is the only artefact that
+    leaves the runner.
+"""
+
+from __future__ import annotations
+
+from .lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LSP_ROLE_RUNNER_CHAINS,
+    LspFinding,
+    LspResult,
+    LspRunnerProtocol,
+    PreflightLspLevel,
+    PreflightLspVerdict,
+    is_lsp_preflight_enabled,
+    judge_lsp_preflight,
+    resolve_runner_chain,
+)
+
+__all__ = (
+    "DEFAULT_TIMEOUT_SECONDS",
+    "LSP_ROLE_RUNNER_CHAINS",
+    "LspFinding",
+    "LspResult",
+    "LspRunnerProtocol",
+    "PreflightLspLevel",
+    "PreflightLspVerdict",
+    "is_lsp_preflight_enabled",
+    "judge_lsp_preflight",
+    "resolve_runner_chain",
+)

--- a/src/yule_orchestrator/agents/static_analysis/lsp_preflight.py
+++ b/src/yule_orchestrator/agents/static_analysis/lsp_preflight.py
@@ -1,0 +1,595 @@
+"""LSP-style preflight — role-aware static analysis verdict (#100).
+
+This module is the **judgement seam**. Concrete runners live next
+door under :mod:`yule_orchestrator.agents.static_analysis.runners`
+and expose :class:`LspRunnerProtocol`. The seam is intentionally
+small so the live LLM editor (#91 / F4) and downstream retry loops
+can pull a single :class:`PreflightLspVerdict` per attempt.
+
+Dataclass shape:
+
+  * :class:`LspFinding` — one line emitted by a runner.
+  * :class:`LspResult` — every finding from one runner invocation
+    plus the exit code and a masked ``stderr_tail``.
+  * :class:`PreflightLspVerdict` — aggregated verdict carrying the
+    overall :class:`PreflightLspLevel`, summarised counts, and the
+    ordered chain of ``runner_id`` values consulted.
+
+Role → runner chain (read-only mapping; tests pin):
+
+  * ``backend`` / ``ai``          → ``python_ruff`` → ``python_pyright`` → ``python_mypy``
+  * ``frontend``                  → ``typescript``
+  * ``qa`` / ``devops``           → ``python_ruff``
+  * everything else               → ``python_ruff`` (safe default)
+
+Verdict levelling rules:
+
+  * Any ``error`` finding             → ``block``
+  * Otherwise ≥1 ``warning`` finding  → ``warning``
+  * Otherwise ``info`` / ``hint``     → ``advisory``
+  * Clean / env-off / binary-missing  → ``advisory``
+
+The level is **never** elevated to ``block`` by a missing binary
+or by env OFF — that is a hard rail enforced here and pinned in
+:mod:`tests.engineering.test_lsp_preflight_governance`.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+#: Default subprocess timeout. The hard rail is 30s — runners must
+#: pass ``timeout`` down to ``subprocess.run`` so a hanging binary
+#: cannot block the retry loop indefinitely.
+DEFAULT_TIMEOUT_SECONDS: int = 30
+
+
+#: Env var that gates the preflight. ``false`` (default) means the
+#: seam always returns an advisory verdict and **no** subprocess is
+#: spawned. Operators flip this to ``true`` when they want the
+#: retry loop to consult external LSP / linter / type checker output.
+ENV_PREFLIGHT_ENABLED: str = "YULE_LSP_PREFLIGHT_ENABLED"
+
+#: Comma-separated override for the runner chain. Empty (default)
+#: → fall back to the role mapping. When set, every runner_id must
+#: appear in the registry or it is silently dropped.
+ENV_RUNNERS: str = "YULE_LSP_RUNNERS"
+
+#: Subprocess timeout override (seconds). Capped at 30s — values
+#: above the cap are clamped because the hard rail wins over env.
+ENV_TIMEOUT_SECONDS: str = "YULE_LSP_TIMEOUT_SECONDS"
+
+
+#: Severity values a runner may emit. Anything else is normalised
+#: to ``"info"`` so a runner cannot accidentally introduce an
+#: unknown severity that bypasses the levelling table.
+SEVERITY_ERROR: str = "error"
+SEVERITY_WARNING: str = "warning"
+SEVERITY_INFO: str = "info"
+SEVERITY_HINT: str = "hint"
+
+_ALL_SEVERITIES: Tuple[str, ...] = (
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    SEVERITY_INFO,
+    SEVERITY_HINT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LspFinding:
+    """A single finding emitted by a runner.
+
+    ``file`` is the path the runner reported (relative or absolute
+    — the seam does not normalise so audit consumers can decide).
+    ``line`` and ``column`` are 1-based; both default to 1 when the
+    runner does not pinpoint a position (e.g. project-level config
+    errors).
+
+    ``severity`` is normalised on construction: anything outside
+    :data:`_ALL_SEVERITIES` is coerced to ``"info"`` so a runner
+    cannot smuggle an unknown level past the verdict aggregator.
+    """
+
+    file: str
+    line: int
+    column: int
+    severity: str
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        normalised = _normalise_severity(self.severity)
+        if normalised != self.severity:
+            object.__setattr__(self, "severity", normalised)
+
+    @property
+    def is_error(self) -> bool:
+        return self.severity == SEVERITY_ERROR
+
+    @property
+    def is_warning(self) -> bool:
+        return self.severity == SEVERITY_WARNING
+
+
+@dataclass(frozen=True)
+class LspResult:
+    """One runner invocation's result.
+
+    ``language`` is the human-readable label (python / typescript /
+    go / rust). ``runner_id`` is the registry key (``python_ruff``
+    etc.) used to drive the role chain. ``findings`` is a tuple so
+    callers can treat it as an immutable audit record. ``exit_code``
+    is ``None`` when the runner returned an advisory result without
+    spawning a subprocess (binary missing / env OFF). ``stderr_tail``
+    must already be PasteGuard-masked before being attached.
+    """
+
+    language: str
+    runner_id: str
+    findings: Tuple[LspFinding, ...]
+    exit_code: Optional[int]
+    stderr_tail: str
+    advisory: bool = False
+    note: str = ""
+
+    @property
+    def has_errors(self) -> bool:
+        return any(f.is_error for f in self.findings)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(f.is_warning for f in self.findings)
+
+
+class PreflightLspLevel(str, enum.Enum):
+    """Aggregated verdict level.
+
+    Mirrors :class:`~yule_orchestrator.agents.learning.mistake_ledger.BlockerLevel`
+    naming so downstream consumers (retry loop / mistake ledger
+    surface) can switch on a single string without translation.
+    """
+
+    ADVISORY = "advisory"
+    WARNING = "warning"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class PreflightLspVerdict:
+    """Aggregated LSP preflight verdict for a retry-loop iteration.
+
+    ``level`` reflects the harshest finding across all consulted
+    runners (block > warning > advisory). ``blocker_count`` counts
+    the number of error-severity findings — the retry loop uses it
+    to decide whether to escalate to ``needs_approval``.
+
+    ``runner_id_chain`` mirrors the order the runners executed so a
+    failed run can be reproduced step-by-step. ``findings_summary``
+    is the per-runner roll-up: ``{runner_id: {severity: count}}``.
+
+    ``advisory_reason`` carries a short Korean string for the
+    operator surface (env OFF / binary missing / no findings).
+    """
+
+    level: PreflightLspLevel
+    findings_summary: Mapping[str, Mapping[str, int]]
+    blocker_count: int
+    runner_id_chain: Tuple[str, ...]
+    results: Tuple[LspResult, ...]
+    role: str
+    advisory_reason: str = ""
+
+    @property
+    def is_block(self) -> bool:
+        return self.level == PreflightLspLevel.BLOCK
+
+    @property
+    def is_advisory(self) -> bool:
+        return self.level == PreflightLspLevel.ADVISORY
+
+    @property
+    def recommend_needs_approval(self) -> bool:
+        """True iff the caller must route to the approval lane."""
+
+        return self.is_block
+
+    def to_payload(self) -> Mapping[str, Any]:
+        """Serialise to a payload safe to attach to job metadata.
+
+        Findings are flattened to a list of dicts so JSON encoders
+        can round-trip them. ``stderr_tail`` is already masked at
+        the runner boundary so no further redaction is needed here.
+        """
+
+        return {
+            "level": self.level.value,
+            "blocker_count": self.blocker_count,
+            "runner_id_chain": list(self.runner_id_chain),
+            "findings_summary": {
+                runner_id: dict(counts)
+                for runner_id, counts in self.findings_summary.items()
+            },
+            "role": self.role,
+            "advisory_reason": self.advisory_reason,
+            "results": [
+                {
+                    "language": r.language,
+                    "runner_id": r.runner_id,
+                    "exit_code": r.exit_code,
+                    "advisory": r.advisory,
+                    "note": r.note,
+                    "stderr_tail": r.stderr_tail,
+                    "findings": [
+                        {
+                            "file": f.file,
+                            "line": f.line,
+                            "column": f.column,
+                            "severity": f.severity,
+                            "code": f.code,
+                            "message": f.message,
+                        }
+                        for f in r.findings
+                    ],
+                }
+                for r in self.results
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Runner protocol
+# ---------------------------------------------------------------------------
+
+
+class LspRunnerProtocol(Protocol):
+    """Common contract for every runner under :mod:`.runners`.
+
+    Implementations must:
+
+      1. Honour ``timeout`` and clamp it at :data:`DEFAULT_TIMEOUT_SECONDS`.
+      2. Return an advisory :class:`LspResult` (``advisory=True``,
+         ``exit_code=None``) when the binary is missing — never raise.
+      3. Pass any subprocess ``stderr`` through PasteGuard
+         (``channel=VAULT``) before stuffing it into ``stderr_tail``.
+      4. Accept ``subprocess_runner`` so tests can inject a fake.
+    """
+
+    runner_id: str
+    language: str
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:  # pragma: no cover - protocol stub
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Role → runner chain mapping
+# ---------------------------------------------------------------------------
+
+
+LSP_ROLE_RUNNER_CHAINS: Mapping[str, Tuple[str, ...]] = {
+    "backend": ("python_ruff", "python_pyright", "python_mypy"),
+    "ai": ("python_ruff", "python_pyright", "python_mypy"),
+    "ai_engineer": ("python_ruff", "python_pyright", "python_mypy"),
+    "backend_engineer": ("python_ruff", "python_pyright", "python_mypy"),
+    "frontend": ("typescript",),
+    "frontend_engineer": ("typescript",),
+    "qa": ("python_ruff",),
+    "qa_engineer": ("python_ruff",),
+    "devops": ("python_ruff",),
+    "devops_engineer": ("python_ruff",),
+}
+
+#: Default fallback chain used when the role is unknown.
+LSP_DEFAULT_RUNNER_CHAIN: Tuple[str, ...] = ("python_ruff",)
+
+
+def resolve_runner_chain(
+    *,
+    role: str,
+    runners: Any = "AUTO",
+) -> Tuple[str, ...]:
+    """Pick the runner chain for ``role``.
+
+    ``runners="AUTO"`` (default) consults the role mapping; the env
+    override :data:`ENV_RUNNERS` is honoured only when ``runners`` is
+    AUTO so callers can pin a chain regardless of operator env.
+
+    Returns an empty tuple when no resolvable runner remains.
+    """
+
+    if isinstance(runners, str) and runners.upper() == "AUTO":
+        env_value = os.getenv(ENV_RUNNERS, "")
+        if env_value.strip():
+            chain = tuple(
+                token.strip() for token in env_value.split(",") if token.strip()
+            )
+            return chain
+        normalised = (role or "").strip().lower()
+        return LSP_ROLE_RUNNER_CHAINS.get(normalised, LSP_DEFAULT_RUNNER_CHAIN)
+
+    if isinstance(runners, str):
+        chain = tuple(
+            token.strip() for token in runners.split(",") if token.strip()
+        )
+        return chain
+    if isinstance(runners, Iterable):
+        return tuple(str(r).strip() for r in runners if str(r).strip())
+    return ()
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+def is_lsp_preflight_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """Return True when the env var is set to a truthy string.
+
+    Truthy values mirror typical operator habits: ``1`` / ``true`` /
+    ``yes`` / ``on`` (case-insensitive). Anything else — including
+    the unset case — is False so the preflight stays *advisory-only*
+    by default.
+    """
+
+    source = env if env is not None else os.environ
+    raw = str(source.get(ENV_PREFLIGHT_ENABLED, "")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _resolve_timeout(env: Optional[Mapping[str, str]] = None) -> int:
+    source = env if env is not None else os.environ
+    raw = str(source.get(ENV_TIMEOUT_SECONDS, "")).strip()
+    if not raw:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TIMEOUT_SECONDS
+    if value <= 0:
+        return DEFAULT_TIMEOUT_SECONDS
+    # Hard rail: cap at 30s regardless of operator override so a
+    # mistyped env value cannot wedge the retry loop.
+    return min(value, DEFAULT_TIMEOUT_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Runner registry
+# ---------------------------------------------------------------------------
+
+
+def _load_runner_registry() -> Mapping[str, "LspRunnerProtocol"]:
+    """Lazy-load the runner registry.
+
+    Concrete runner modules are imported lazily so the seam stays
+    light-weight when env is OFF (no need to compile every regex /
+    parser in :mod:`.runners`).
+    """
+
+    from .runners import build_runner_registry  # local import — see docstring
+
+    return build_runner_registry()
+
+
+# ---------------------------------------------------------------------------
+# Judgement entry point
+# ---------------------------------------------------------------------------
+
+
+def judge_lsp_preflight(
+    *,
+    paths: Sequence[str],
+    role: str,
+    runners: Any = "AUTO",
+    subprocess_runner: Optional[Callable[..., Any]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    timeout: Optional[int] = None,
+    registry: Optional[Mapping[str, "LspRunnerProtocol"]] = None,
+) -> PreflightLspVerdict:
+    """Run the configured runner chain and aggregate the verdict.
+
+    Parameters mirror the operator surface — ``paths`` is the list
+    of files / dirs to lint, ``role`` drives the chain selection,
+    ``runners`` lets callers override the chain.
+
+    When the env var :data:`ENV_PREFLIGHT_ENABLED` is False (default)
+    the function short-circuits and returns an advisory verdict
+    *without* invoking any runner — this is the safe-by-default
+    posture pinned in governance tests.
+
+    ``subprocess_runner`` is forwarded to every runner so tests can
+    inject a fake without monkeypatching :mod:`subprocess`.
+    """
+
+    role_value = (role or "").strip()
+    enabled = is_lsp_preflight_enabled(env=env)
+    chain = resolve_runner_chain(role=role_value, runners=runners)
+    resolved_timeout = timeout if timeout is not None else _resolve_timeout(env=env)
+    # Hard rail: timeout is capped even when the caller passes a
+    # larger value explicitly — defence in depth against a misuse
+    # in a producer that loads from operator-controlled config.
+    resolved_timeout = max(1, min(resolved_timeout, DEFAULT_TIMEOUT_SECONDS))
+
+    if not enabled:
+        return PreflightLspVerdict(
+            level=PreflightLspLevel.ADVISORY,
+            findings_summary={},
+            blocker_count=0,
+            runner_id_chain=tuple(chain),
+            results=(),
+            role=role_value,
+            advisory_reason="env OFF — preflight 비활성, advisory only",
+        )
+
+    if not chain:
+        return PreflightLspVerdict(
+            level=PreflightLspLevel.ADVISORY,
+            findings_summary={},
+            blocker_count=0,
+            runner_id_chain=(),
+            results=(),
+            role=role_value,
+            advisory_reason="role 매핑 / runners 인자 결과 빈 chain",
+        )
+
+    if not paths:
+        return PreflightLspVerdict(
+            level=PreflightLspLevel.ADVISORY,
+            findings_summary={},
+            blocker_count=0,
+            runner_id_chain=tuple(chain),
+            results=(),
+            role=role_value,
+            advisory_reason="paths 비어있음 — 분석 대상 없음",
+        )
+
+    active_registry: Mapping[str, LspRunnerProtocol]
+    active_registry = registry if registry is not None else _load_runner_registry()
+
+    executed_chain: List[str] = []
+    results: List[LspResult] = []
+    for runner_id in chain:
+        runner = active_registry.get(runner_id)
+        if runner is None:
+            # Unknown runner_id — skip silently. Operators see the
+            # gap in ``runner_id_chain`` for the audit trail.
+            continue
+        executed_chain.append(runner_id)
+        result = runner.run(
+            list(paths),
+            timeout=resolved_timeout,
+            subprocess_runner=subprocess_runner,
+        )
+        results.append(result)
+
+    return _aggregate(
+        role=role_value,
+        chain=tuple(executed_chain),
+        results=tuple(results),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(
+    *,
+    role: str,
+    chain: Tuple[str, ...],
+    results: Tuple[LspResult, ...],
+) -> PreflightLspVerdict:
+    summary: dict[str, dict[str, int]] = {}
+    blocker_count = 0
+    has_error = False
+    has_warning = False
+    advisory_notes: List[str] = []
+
+    for result in results:
+        counts: dict[str, int] = {sev: 0 for sev in _ALL_SEVERITIES}
+        for finding in result.findings:
+            counts[finding.severity] = counts.get(finding.severity, 0) + 1
+        if result.advisory and result.note:
+            advisory_notes.append(f"{result.runner_id}: {result.note}")
+        summary[result.runner_id] = counts
+        if counts.get(SEVERITY_ERROR, 0):
+            has_error = True
+            blocker_count += counts[SEVERITY_ERROR]
+        if counts.get(SEVERITY_WARNING, 0):
+            has_warning = True
+
+    if has_error:
+        level = PreflightLspLevel.BLOCK
+    elif has_warning:
+        level = PreflightLspLevel.WARNING
+    else:
+        level = PreflightLspLevel.ADVISORY
+
+    advisory_reason = ""
+    if level == PreflightLspLevel.ADVISORY:
+        if advisory_notes:
+            advisory_reason = "; ".join(advisory_notes)
+        else:
+            advisory_reason = "clean — runner 출력에 error/warning 없음"
+
+    return PreflightLspVerdict(
+        level=level,
+        findings_summary=summary,
+        blocker_count=blocker_count,
+        runner_id_chain=chain,
+        results=results,
+        role=role,
+        advisory_reason=advisory_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _normalise_severity(value: str) -> str:
+    lowered = str(value or "").strip().lower()
+    if lowered in _ALL_SEVERITIES:
+        return lowered
+    # Common runner aliases — keep the table tiny and defensive.
+    if lowered in {"err", "fatal", "critical"}:
+        return SEVERITY_ERROR
+    if lowered in {"warn"}:
+        return SEVERITY_WARNING
+    if lowered in {"note", "information"}:
+        return SEVERITY_INFO
+    return SEVERITY_INFO
+
+
+__all__ = (
+    "DEFAULT_TIMEOUT_SECONDS",
+    "ENV_PREFLIGHT_ENABLED",
+    "ENV_RUNNERS",
+    "ENV_TIMEOUT_SECONDS",
+    "LSP_DEFAULT_RUNNER_CHAIN",
+    "LSP_ROLE_RUNNER_CHAINS",
+    "LspFinding",
+    "LspResult",
+    "LspRunnerProtocol",
+    "PreflightLspLevel",
+    "PreflightLspVerdict",
+    "SEVERITY_ERROR",
+    "SEVERITY_HINT",
+    "SEVERITY_INFO",
+    "SEVERITY_WARNING",
+    "is_lsp_preflight_enabled",
+    "judge_lsp_preflight",
+    "resolve_runner_chain",
+)

--- a/src/yule_orchestrator/agents/static_analysis/runners/__init__.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/__init__.py
@@ -1,0 +1,166 @@
+"""Runner registry + shared helpers for the LSP preflight seam (#100).
+
+Each runner is a thin subprocess wrapper that returns an
+:class:`~yule_orchestrator.agents.static_analysis.lsp_preflight.LspResult`.
+Runners are split into 6 small modules so the judgement seam only
+needs to know runner IDs. Shared subprocess + PasteGuard glue lives
+here so each runner can stay laser-focused on parsing its tool's
+output format.
+
+Hard rails enforced here:
+
+  * ``run_subprocess`` always passes ``timeout`` (capped at the
+    seam's ``DEFAULT_TIMEOUT_SECONDS=30``) so a hanging binary
+    cannot wedge the retry loop.
+  * ``stderr`` is passed through PasteGuard ``guard_outbound``
+    (``channel=VAULT``) before the runner stuffs it into the
+    :class:`LspResult`. The PasteGuard wrapper is forgiving: when
+    the security module is somehow unavailable (e.g. early CI
+    bootstrap) we redact by truncation rather than fail-open.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
+
+
+#: Hard cap on stderr length stored inside an :class:`LspResult`.
+#: PasteGuard already masks credentials; this cap protects audit
+#: log size when a runner spews a stack trace.
+STDERR_TAIL_CHAR_LIMIT: int = 2000
+
+
+def which_binary(name: str) -> Optional[str]:
+    """Thin wrapper around :func:`shutil.which` for test seams."""
+
+    return shutil.which(name)
+
+
+def run_subprocess(
+    argv: Sequence[str],
+    *,
+    timeout: int,
+    cwd: Optional[str] = None,
+    subprocess_runner: Optional[Callable[..., Any]] = None,
+) -> Tuple[int, str, str]:
+    """Execute ``argv`` and return ``(exit_code, stdout, stderr)``.
+
+    ``subprocess_runner`` is the injection seam used by the test
+    suite. When ``None`` we call :func:`subprocess.run` with the
+    standard safe flags (no shell, capture both streams). Both
+    ``TimeoutExpired`` and ``FileNotFoundError`` are normalised to
+    a synthetic exit code + a short stderr note so the caller can
+    always degrade to an advisory result without raising.
+    """
+
+    runner = subprocess_runner if subprocess_runner is not None else _default_subprocess_runner
+
+    try:
+        result = runner(
+            list(argv),
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except FileNotFoundError:
+        return 127, "", "binary not found"
+    except Exception as exc:  # noqa: BLE001 — fail-soft surface
+        return 1, "", f"subprocess error: {type(exc).__name__}"
+
+    return (
+        getattr(result, "returncode", 0) or 0,
+        getattr(result, "stdout", "") or "",
+        getattr(result, "stderr", "") or "",
+    )
+
+
+def mask_stderr(stderr: str) -> str:
+    """Mask ``stderr`` through PasteGuard and truncate to the tail cap.
+
+    The runner contract requires that any stderr stored in
+    :class:`LspResult` is already masked. We delegate to
+    :func:`guard_outbound` (``channel=VAULT``) so the same secret
+    catalogue protects the LSP audit trail as the rest of the
+    outbound surface. When PasteGuard is unavailable we still
+    truncate so an oversized stderr cannot blow up the verdict.
+    """
+
+    if not isinstance(stderr, str) or not stderr:
+        return ""
+
+    redacted = _redact_via_paste_guard(stderr)
+    if len(redacted) <= STDERR_TAIL_CHAR_LIMIT:
+        return redacted
+    overflow = len(redacted) - STDERR_TAIL_CHAR_LIMIT
+    return redacted[-STDERR_TAIL_CHAR_LIMIT:] + f"\n[...truncated {overflow} chars]"
+
+
+def _redact_via_paste_guard(stderr: str) -> str:
+    try:
+        from yule_orchestrator.agents.security.paste_guard import (
+            OutboundChannel,
+            guard_outbound,
+        )
+    except Exception:  # pragma: no cover - bootstrap fallback
+        return stderr[-STDERR_TAIL_CHAR_LIMIT:]
+
+    try:
+        verdict = guard_outbound(
+            channel=OutboundChannel.VAULT,
+            payload=stderr,
+            fail_closed=True,
+        )
+    except Exception:  # pragma: no cover - defensive
+        return stderr[-STDERR_TAIL_CHAR_LIMIT:]
+    if verdict.blocked:
+        return "[stderr blocked by PasteGuard]"
+    return verdict.redacted
+
+
+def _default_subprocess_runner(*args: Any, **kwargs: Any) -> Any:
+    return subprocess.run(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def build_runner_registry() -> Mapping[str, object]:
+    """Return a fresh registry mapping runner IDs to instances.
+
+    A new registry is constructed per call so unit tests can mutate
+    their copy without leaking state across cases. The instances
+    are cheap to build (no I/O until ``run`` is invoked).
+    """
+
+    from .python_ruff import PythonRuffRunner
+    from .python_pyright import PythonPyrightRunner
+    from .python_mypy import PythonMypyRunner
+    from .typescript import TypescriptRunner
+    from .go import GoRunner
+    from .rust import RustRunner
+
+    return {
+        "python_ruff": PythonRuffRunner(),
+        "python_pyright": PythonPyrightRunner(),
+        "python_mypy": PythonMypyRunner(),
+        "typescript": TypescriptRunner(),
+        "go": GoRunner(),
+        "rust": RustRunner(),
+    }
+
+
+__all__ = (
+    "STDERR_TAIL_CHAR_LIMIT",
+    "build_runner_registry",
+    "mask_stderr",
+    "run_subprocess",
+    "which_binary",
+)

--- a/src/yule_orchestrator/agents/static_analysis/runners/go.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/go.py
@@ -1,0 +1,123 @@
+"""``go vet`` runner — Go preflight (#100).
+
+Invokes ``go vet ./...`` (or the supplied paths) and parses the
+``path:line:col: message`` diagnostic shape. ``go vet`` is the
+lightweight default — operators who want a richer chain can swap
+in ``golangci-lint`` by binding a custom registry, the parser
+already accepts the same line shape.
+
+Missing binary → advisory :class:`LspResult` (``advisory=True``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+# go vet line shape (and golangci-lint default):
+#   path/to/file.go:42:9: shadow: declaration of "err" shadows ...
+# column is optional when the tool didn't pinpoint it.
+_GO_LINE_RE = re.compile(
+    r"^(?P<file>[^:\n]+\.go):(?P<line>\d+)(?::(?P<col>\d+))?:\s*(?P<message>.+)$"
+)
+
+
+@dataclass
+class GoRunner:
+    """``go vet`` wrapper.
+
+    Go does not separate "error" / "warning" in vet output —
+    every diagnostic from ``go vet`` is treated as ``error`` so
+    the verdict aggregates to a block when the binary has anything
+    to say. Operators who want softer levelling can override the
+    runner instance attribute after construction.
+    """
+
+    runner_id: str = "go"
+    language: str = "go"
+    binary: str = "go"
+    default_severity: str = SEVERITY_ERROR
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="go binary missing — advisory only",
+            )
+
+        argv = [self.binary, "vet", *(paths or ["./..."])]
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        # ``go vet`` emits diagnostics on stderr.
+        findings = _parse_go_output(stderr, default_severity=self.default_severity)
+        if not findings:
+            findings = _parse_go_output(stdout, default_severity=self.default_severity)
+
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_go_output(text: str, *, default_severity: str) -> List[LspFinding]:
+    if not text:
+        return []
+    findings: List[LspFinding] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _GO_LINE_RE.match(line)
+        if match is None:
+            continue
+        col_raw = match.group("col")
+        findings.append(
+            LspFinding(
+                file=match.group("file"),
+                line=_coerce_int(match.group("line"), default=1),
+                column=_coerce_int(col_raw, default=1) if col_raw else 1,
+                severity=default_severity,
+                code="",
+                message=match.group("message").strip(),
+            )
+        )
+    return findings
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result >= 1 else default
+
+
+__all__ = ("GoRunner",)

--- a/src/yule_orchestrator/agents/static_analysis/runners/python_mypy.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/python_mypy.py
@@ -1,0 +1,129 @@
+"""``mypy`` runner — Python type-check preflight (#100).
+
+Invokes ``mypy --no-color-output --show-column-numbers`` and parses
+its ``file:line:col: severity: message [code]`` line format. Mypy
+does not emit JSON natively, so the parser must be tolerant of
+``note``-only outputs (treated as ``info``) and stray summary
+lines like ``Success: no issues found in 1 source file``.
+
+Missing binary → advisory :class:`LspResult` (``advisory=True``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+# Mypy diagnostic line shape:
+#   path/to/file.py:42:7: error: Incompatible return value type  [return-value]
+# Column may be absent — the optional group handles that.
+_MYPY_LINE_RE = re.compile(
+    r"^(?P<file>[^:\n]+):(?P<line>\d+)(?::(?P<col>\d+))?:\s*"
+    r"(?P<severity>error|warning|note):\s*(?P<message>.+?)"
+    r"(?:\s+\[(?P<code>[a-zA-Z0-9._-]+)\])?$"
+)
+
+
+_MYPY_SEVERITY_MAP = {
+    "error": SEVERITY_ERROR,
+    "warning": SEVERITY_WARNING,
+    "note": SEVERITY_INFO,
+}
+
+
+@dataclass
+class PythonMypyRunner:
+    """``mypy`` text-output wrapper."""
+
+    runner_id: str = "python_mypy"
+    language: str = "python"
+    binary: str = "mypy"
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="mypy binary missing — advisory only",
+            )
+
+        argv = [
+            self.binary,
+            "--no-color-output",
+            "--show-column-numbers",
+            *paths,
+        ]
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        findings = _parse_mypy_output(stdout)
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_mypy_output(stdout: str) -> List[LspFinding]:
+    if not stdout:
+        return []
+    findings: List[LspFinding] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _MYPY_LINE_RE.match(line)
+        if match is None:
+            continue
+        severity = _MYPY_SEVERITY_MAP.get(match.group("severity"), SEVERITY_INFO)
+        column_raw = match.group("col")
+        column = _coerce_int(column_raw, default=1) if column_raw else 1
+        findings.append(
+            LspFinding(
+                file=match.group("file"),
+                line=_coerce_int(match.group("line"), default=1),
+                column=column,
+                severity=severity,
+                code=match.group("code") or "",
+                message=match.group("message").strip(),
+            )
+        )
+    return findings
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result >= 1 else default
+
+
+__all__ = ("PythonMypyRunner",)

--- a/src/yule_orchestrator/agents/static_analysis/runners/python_pyright.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/python_pyright.py
@@ -1,0 +1,137 @@
+"""``pyright`` runner — Python type-check preflight (#100).
+
+Invokes ``pyright --outputjson`` on the supplied paths and
+translates each diagnostic. Pyright already classifies severity
+(``error`` / ``warning`` / ``information`` / ``hint``) so the
+mapping is direct.
+
+When ``pyright`` is not installed the runner returns an advisory
+:class:`LspResult` (``advisory=True``). Missing binary must
+**never** block.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+    SEVERITY_HINT,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+_PYRIGHT_SEVERITY_MAP = {
+    "error": SEVERITY_ERROR,
+    "warning": SEVERITY_WARNING,
+    "information": SEVERITY_INFO,
+    "info": SEVERITY_INFO,
+    "hint": SEVERITY_HINT,
+}
+
+
+@dataclass
+class PythonPyrightRunner:
+    """``pyright --outputjson`` wrapper."""
+
+    runner_id: str = "python_pyright"
+    language: str = "python"
+    binary: str = "pyright"
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="pyright binary missing — advisory only",
+            )
+
+        argv = [self.binary, "--outputjson", *paths]
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        findings = _parse_pyright_output(stdout)
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_pyright_output(stdout: str) -> List[LspFinding]:
+    """Parse pyright's ``--outputjson`` envelope into findings."""
+
+    if not stdout or not stdout.strip():
+        return []
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    diagnostics = payload.get("generalDiagnostics")
+    if not isinstance(diagnostics, list):
+        return []
+
+    findings: List[LspFinding] = []
+    for entry in diagnostics:
+        if not isinstance(entry, dict):
+            continue
+        file_path = str(entry.get("file") or "")
+        severity_raw = str(entry.get("severity") or "").lower()
+        severity = _PYRIGHT_SEVERITY_MAP.get(severity_raw, SEVERITY_INFO)
+        message = str(entry.get("message") or "")
+        rule = str(entry.get("rule") or "")
+        line = 1
+        column = 1
+        range_value = entry.get("range")
+        if isinstance(range_value, dict):
+            start = range_value.get("start")
+            if isinstance(start, dict):
+                # pyright uses 0-based offsets; normalise to 1-based.
+                line = _coerce_int(start.get("line"), default=0) + 1
+                column = _coerce_int(start.get("character"), default=0) + 1
+        findings.append(
+            LspFinding(
+                file=file_path,
+                line=line,
+                column=column,
+                severity=severity,
+                code=rule,
+                message=message,
+            )
+        )
+    return findings
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = ("PythonPyrightRunner",)

--- a/src/yule_orchestrator/agents/static_analysis/runners/python_ruff.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/python_ruff.py
@@ -1,0 +1,137 @@
+"""``ruff`` runner — Python lint preflight (#100).
+
+Invokes ``ruff check --output-format=json`` on the supplied paths
+and translates each finding into :class:`LspFinding`. Severity
+maps as follows:
+
+  * fix-applicable errors (rule codes starting ``E`` / ``F``) →
+    ``error`` so the verdict aggregates to a block.
+  * Other lint rules → ``warning`` so the retry loop sees them
+    but does not escalate to approval.
+
+When ``ruff`` is not installed the runner returns an advisory
+:class:`LspResult` (``advisory=True``). This is the hard rail
+pinned by governance: missing binary must **never** block.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+@dataclass
+class PythonRuffRunner:
+    """``ruff check --output-format=json`` wrapper."""
+
+    runner_id: str = "python_ruff"
+    language: str = "python"
+    binary: str = "ruff"
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="ruff binary missing — advisory only",
+            )
+
+        argv = [self.binary, "check", "--output-format=json", *paths]
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        findings = _parse_ruff_output(stdout)
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_ruff_output(stdout: str) -> List[LspFinding]:
+    """Translate ruff JSON output into :class:`LspFinding` records.
+
+    Ruff emits a JSON array of dicts with ``code`` / ``message`` /
+    ``location`` (``row`` + ``column``) / ``filename``. We treat
+    rule codes whose prefix is ``E`` or ``F`` as errors (syntax /
+    pyflakes); everything else is a warning. Malformed output is
+    silently ignored — the audit chain still records the runner
+    invocation so the gap is visible.
+    """
+
+    if not stdout or not stdout.strip():
+        return []
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(payload, list):
+        return []
+
+    findings: List[LspFinding] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        code = str(entry.get("code") or "")
+        message = str(entry.get("message") or "")
+        filename = str(entry.get("filename") or "")
+        location = entry.get("location") or {}
+        if not isinstance(location, dict):
+            location = {}
+        line = _coerce_int(location.get("row"), default=1)
+        column = _coerce_int(location.get("column"), default=1)
+        severity = _ruff_severity(code)
+        findings.append(
+            LspFinding(
+                file=filename,
+                line=line,
+                column=column,
+                severity=severity,
+                code=code,
+                message=message,
+            )
+        )
+    return findings
+
+
+def _ruff_severity(code: str) -> str:
+    head = (code[:1] or "").upper()
+    if head in {"E", "F"}:
+        return SEVERITY_ERROR
+    return SEVERITY_WARNING
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result >= 1 else default
+
+
+__all__ = ("PythonRuffRunner",)

--- a/src/yule_orchestrator/agents/static_analysis/runners/rust.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/rust.py
@@ -1,0 +1,148 @@
+"""``cargo clippy`` runner — Rust preflight (#100).
+
+Invokes ``cargo clippy --message-format=json --quiet`` and parses
+the streaming JSONL output. Each line is one cargo message; only
+``compiler-message`` records with a non-empty diagnostic body are
+forwarded as :class:`LspFinding`.
+
+Missing binary → advisory :class:`LspResult` (``advisory=True``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+    SEVERITY_HINT,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+_RUST_SEVERITY_MAP = {
+    "error": SEVERITY_ERROR,
+    "warning": SEVERITY_WARNING,
+    "note": SEVERITY_INFO,
+    "help": SEVERITY_HINT,
+}
+
+
+@dataclass
+class RustRunner:
+    """``cargo clippy`` wrapper."""
+
+    runner_id: str = "rust"
+    language: str = "rust"
+    binary: str = "cargo"
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="cargo binary missing — advisory only",
+            )
+
+        # ``paths`` is treated as a list of crate roots; cargo
+        # operates on the workspace by default so we just forward
+        # any explicit ``--manifest-path`` markers the caller
+        # included. Empty paths → workspace-level scan.
+        argv = [self.binary, "clippy", "--message-format=json", "--quiet"]
+        for path in paths or ():
+            if str(path).endswith("Cargo.toml"):
+                argv.extend(["--manifest-path", str(path)])
+
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        findings = _parse_clippy_output(stdout)
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_clippy_output(stdout: str) -> List[LspFinding]:
+    if not stdout:
+        return []
+    findings: List[LspFinding] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("reason") != "compiler-message":
+            continue
+        message_block = payload.get("message")
+        if not isinstance(message_block, dict):
+            continue
+        text = str(message_block.get("message") or "")
+        if not text:
+            continue
+        severity_raw = str(message_block.get("level") or "").lower()
+        severity = _RUST_SEVERITY_MAP.get(severity_raw, SEVERITY_INFO)
+        code_block = message_block.get("code") or {}
+        code = ""
+        if isinstance(code_block, dict):
+            code = str(code_block.get("code") or "")
+        spans = message_block.get("spans") or []
+        file_path = ""
+        line_no = 1
+        column_no = 1
+        if isinstance(spans, list):
+            for span in spans:
+                if isinstance(span, dict) and span.get("is_primary"):
+                    file_path = str(span.get("file_name") or "")
+                    line_no = _coerce_int(span.get("line_start"), default=1)
+                    column_no = _coerce_int(span.get("column_start"), default=1)
+                    break
+        findings.append(
+            LspFinding(
+                file=file_path,
+                line=line_no,
+                column=column_no,
+                severity=severity,
+                code=code,
+                message=text,
+            )
+        )
+    return findings
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result >= 1 else default
+
+
+__all__ = ("RustRunner",)

--- a/src/yule_orchestrator/agents/static_analysis/runners/typescript.py
+++ b/src/yule_orchestrator/agents/static_analysis/runners/typescript.py
@@ -1,0 +1,117 @@
+"""``tsc`` runner — TypeScript type-check preflight (#100).
+
+Invokes ``tsc --noEmit --pretty false`` and parses the standard
+``file(line,col): error TSxxxx: message`` diagnostic shape. The
+``tsc`` family does not have a JSON output mode that ships with
+every install, so we parse the canonical text format.
+
+Missing binary → advisory :class:`LspResult` (``advisory=True``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from ..lsp_preflight import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LspFinding,
+    LspResult,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+)
+from . import mask_stderr, run_subprocess, which_binary
+
+
+# tsc diagnostic shape:
+#   src/foo.ts(12,5): error TS2322: Type 'string' is not assignable to 'number'.
+_TSC_LINE_RE = re.compile(
+    r"^(?P<file>[^()]+)\((?P<line>\d+),(?P<col>\d+)\):\s*"
+    r"(?P<severity>error|warning)\s+(?P<code>TS\d+):\s*(?P<message>.+)$"
+)
+
+
+@dataclass
+class TypescriptRunner:
+    """``tsc --noEmit`` wrapper."""
+
+    runner_id: str = "typescript"
+    language: str = "typescript"
+    binary: str = "tsc"
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Optional[Callable[..., Any]] = None,
+    ) -> LspResult:
+        if which_binary(self.binary) is None:
+            return LspResult(
+                language=self.language,
+                runner_id=self.runner_id,
+                findings=(),
+                exit_code=None,
+                stderr_tail="",
+                advisory=True,
+                note="tsc binary missing — advisory only",
+            )
+
+        argv = [self.binary, "--noEmit", "--pretty", "false", *paths]
+        exit_code, stdout, stderr = run_subprocess(
+            argv,
+            timeout=min(timeout, DEFAULT_TIMEOUT_SECONDS),
+            subprocess_runner=subprocess_runner,
+        )
+
+        # tsc emits diagnostics on stdout by default; some tool
+        # wrappers route them to stderr. Parse both for robustness.
+        findings = _parse_tsc_output(stdout)
+        if not findings:
+            findings = _parse_tsc_output(stderr)
+
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=tuple(findings),
+            exit_code=exit_code,
+            stderr_tail=mask_stderr(stderr),
+        )
+
+
+def _parse_tsc_output(text: str) -> List[LspFinding]:
+    if not text:
+        return []
+    findings: List[LspFinding] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _TSC_LINE_RE.match(line)
+        if match is None:
+            continue
+        severity_raw = match.group("severity")
+        severity = SEVERITY_ERROR if severity_raw == "error" else SEVERITY_WARNING
+        findings.append(
+            LspFinding(
+                file=match.group("file"),
+                line=_coerce_int(match.group("line"), default=1),
+                column=_coerce_int(match.group("col"), default=1),
+                severity=severity,
+                code=match.group("code"),
+                message=match.group("message").strip(),
+            )
+        )
+    return findings
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result >= 1 else default
+
+
+__all__ = ("TypescriptRunner",)

--- a/tests/agents/test_lsp_preflight.py
+++ b/tests/agents/test_lsp_preflight.py
@@ -1,0 +1,575 @@
+"""LSP preflight unit tests — F9 / #100.
+
+Covers the slim acceptance criteria:
+
+  * 6 runner modules — binary presence check + subprocess fake seam.
+  * Severity levelling: error → block / warning → warning /
+    info → advisory / clean → advisory.
+  * Binary missing → advisory (never block).
+  * PasteGuard masks the subprocess stderr tail.
+  * Env OFF → always advisory + no subprocess fires.
+  * Role → runner chain mapping is stable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from typing import Any, Sequence
+from unittest import mock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.static_analysis import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LSP_ROLE_RUNNER_CHAINS,
+    LspFinding,
+    LspResult,
+    PreflightLspLevel,
+    PreflightLspVerdict,
+    is_lsp_preflight_enabled,
+    judge_lsp_preflight,
+    resolve_runner_chain,
+)
+from yule_orchestrator.agents.static_analysis.lsp_preflight import (
+    ENV_PREFLIGHT_ENABLED,
+    ENV_RUNNERS,
+    ENV_TIMEOUT_SECONDS,
+    SEVERITY_ERROR,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+)
+from yule_orchestrator.agents.static_analysis.runners import build_runner_registry
+from yule_orchestrator.agents.static_analysis.runners.go import GoRunner
+from yule_orchestrator.agents.static_analysis.runners.python_mypy import (
+    PythonMypyRunner,
+)
+from yule_orchestrator.agents.static_analysis.runners.python_pyright import (
+    PythonPyrightRunner,
+)
+from yule_orchestrator.agents.static_analysis.runners.python_ruff import (
+    PythonRuffRunner,
+)
+from yule_orchestrator.agents.static_analysis.runners.rust import RustRunner
+from yule_orchestrator.agents.static_analysis.runners.typescript import (
+    TypescriptRunner,
+)
+
+
+class _FakeCompletedProcess:
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_runner(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Return a callable shaped like ``subprocess.run`` for tests."""
+
+    captured: dict[str, Any] = {}
+
+    def runner(*args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+        captured["argv"] = args[0] if args else kwargs.get("args")
+        captured["timeout"] = kwargs.get("timeout")
+        return _FakeCompletedProcess(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    runner.captured = captured  # type: ignore[attr-defined]
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+class EnvHelperTests(unittest.TestCase):
+    def test_truthy_and_falsy_matrix(self) -> None:
+        self.assertFalse(is_lsp_preflight_enabled(env={}))
+        for value in ("1", "true", "TRUE", "yes", "on"):
+            self.assertTrue(
+                is_lsp_preflight_enabled(env={ENV_PREFLIGHT_ENABLED: value}),
+                msg=f"expected truthy: {value}",
+            )
+        for value in ("", "0", "false", "no", "off", "garbage"):
+            self.assertFalse(
+                is_lsp_preflight_enabled(env={ENV_PREFLIGHT_ENABLED: value}),
+                msg=f"expected falsy: {value}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Role → chain mapping
+# ---------------------------------------------------------------------------
+
+
+class RoleChainResolutionTests(unittest.TestCase):
+    def test_role_chains_for_documented_roles(self) -> None:
+        py_chain = ("python_ruff", "python_pyright", "python_mypy")
+        self.assertEqual(resolve_runner_chain(role="backend", runners="AUTO"), py_chain)
+        self.assertEqual(resolve_runner_chain(role="ai", runners="AUTO"), py_chain)
+        self.assertEqual(
+            resolve_runner_chain(role="frontend", runners="AUTO"), ("typescript",)
+        )
+        self.assertEqual(
+            resolve_runner_chain(role="devops", runners="AUTO"), ("python_ruff",)
+        )
+        self.assertEqual(
+            resolve_runner_chain(role="qa", runners="AUTO"), ("python_ruff",)
+        )
+
+    def test_unknown_role_falls_back_to_default(self) -> None:
+        self.assertEqual(
+            resolve_runner_chain(role="mystery", runners="AUTO"),
+            ("python_ruff",),
+        )
+
+    def test_explicit_runners_override_role(self) -> None:
+        chain = resolve_runner_chain(role="backend", runners=("rust",))
+        self.assertEqual(chain, ("rust",))
+        self.assertEqual(
+            resolve_runner_chain(role="qa", runners="go,rust"),
+            ("go", "rust"),
+        )
+
+    def test_env_runners_used_when_auto(self) -> None:
+        with mock.patch.dict(os.environ, {ENV_RUNNERS: "go,rust"}, clear=False):
+            chain = resolve_runner_chain(role="backend", runners="AUTO")
+        self.assertEqual(chain, ("go", "rust"))
+
+
+# ---------------------------------------------------------------------------
+# Env OFF / short-circuits
+# ---------------------------------------------------------------------------
+
+
+class EnvOffShortCircuitTests(unittest.TestCase):
+    def test_env_off_returns_advisory_without_running(self) -> None:
+        captured: list[str] = []
+
+        def runner(*args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+            captured.append("called")
+            return _FakeCompletedProcess()
+
+        verdict = judge_lsp_preflight(
+            paths=["foo.py"],
+            role="backend",
+            subprocess_runner=runner,
+            env={},
+        )
+        self.assertEqual(verdict.level, PreflightLspLevel.ADVISORY)
+        self.assertEqual(verdict.blocker_count, 0)
+        self.assertEqual(captured, [])
+        self.assertIn("env OFF", verdict.advisory_reason)
+
+    def test_empty_paths_advisory(self) -> None:
+        verdict = judge_lsp_preflight(
+            paths=[],
+            role="backend",
+            env={ENV_PREFLIGHT_ENABLED: "true"},
+        )
+        self.assertEqual(verdict.level, PreflightLspLevel.ADVISORY)
+        self.assertIn("paths", verdict.advisory_reason)
+
+
+# ---------------------------------------------------------------------------
+# Runner unit tests (subprocess fake)
+# ---------------------------------------------------------------------------
+
+
+class PythonRuffRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = PythonRuffRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_ruff.which_binary",
+            return_value=None,
+        ):
+            result = runner.run(["foo.py"], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+        self.assertIsNone(result.exit_code)
+        self.assertEqual(result.findings, ())
+
+    def test_parses_json_findings(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "code": "F401",
+                    "message": "Unused import",
+                    "filename": "foo.py",
+                    "location": {"row": 3, "column": 1},
+                },
+                {
+                    "code": "W291",
+                    "message": "Trailing whitespace",
+                    "filename": "foo.py",
+                    "location": {"row": 5, "column": 10},
+                },
+            ]
+        )
+        runner = PythonRuffRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_ruff.which_binary",
+            return_value="/usr/bin/ruff",
+        ):
+            result = runner.run(
+                ["foo.py"],
+                subprocess_runner=_fake_runner(stdout=payload),
+            )
+        self.assertEqual(len(result.findings), 2)
+        self.assertEqual(result.findings[0].severity, SEVERITY_ERROR)
+        self.assertEqual(result.findings[1].severity, SEVERITY_WARNING)
+        self.assertEqual(result.findings[0].code, "F401")
+
+
+class PythonPyrightRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = PythonPyrightRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_pyright.which_binary",
+            return_value=None,
+        ):
+            result = runner.run(["foo.py"], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+
+    def test_parses_general_diagnostics(self) -> None:
+        payload = json.dumps(
+            {
+                "generalDiagnostics": [
+                    {
+                        "file": "foo.py",
+                        "severity": "error",
+                        "message": "Type error",
+                        "rule": "reportGeneralTypeIssues",
+                        "range": {"start": {"line": 9, "character": 4}},
+                    },
+                    {
+                        "file": "foo.py",
+                        "severity": "warning",
+                        "message": "Unused var",
+                        "rule": "reportUnusedVariable",
+                    },
+                ]
+            }
+        )
+        runner = PythonPyrightRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_pyright.which_binary",
+            return_value="/usr/bin/pyright",
+        ):
+            result = runner.run(
+                ["foo.py"],
+                subprocess_runner=_fake_runner(stdout=payload),
+            )
+        self.assertEqual(len(result.findings), 2)
+        self.assertEqual(result.findings[0].severity, SEVERITY_ERROR)
+        self.assertEqual(result.findings[0].line, 10)  # 0-based → 1-based
+        self.assertEqual(result.findings[1].severity, SEVERITY_WARNING)
+
+
+class PythonMypyRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = PythonMypyRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_mypy.which_binary",
+            return_value=None,
+        ):
+            result = runner.run(["foo.py"], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+
+    def test_parses_text_lines(self) -> None:
+        stdout = (
+            "foo.py:42:7: error: Incompatible return value type  [return-value]\n"
+            "foo.py:50: note: Revealed type is 'int'\n"
+            "Success: no issues found in 0 source file\n"
+        )
+        runner = PythonMypyRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_mypy.which_binary",
+            return_value="/usr/bin/mypy",
+        ):
+            result = runner.run(
+                ["foo.py"],
+                subprocess_runner=_fake_runner(stdout=stdout),
+            )
+        self.assertEqual(len(result.findings), 2)
+        self.assertEqual(result.findings[0].severity, SEVERITY_ERROR)
+        self.assertEqual(result.findings[0].code, "return-value")
+        self.assertEqual(result.findings[1].severity, SEVERITY_INFO)
+
+
+class TypescriptRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = TypescriptRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.typescript.which_binary",
+            return_value=None,
+        ):
+            result = runner.run(["src/foo.ts"], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+
+    def test_parses_tsc_diagnostics(self) -> None:
+        stdout = (
+            "src/foo.ts(12,5): error TS2322: Type 'string' is not assignable to 'number'.\n"
+            "src/bar.ts(3,1): warning TS6133: 'x' is declared but never used.\n"
+        )
+        runner = TypescriptRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.typescript.which_binary",
+            return_value="/usr/bin/tsc",
+        ):
+            result = runner.run(
+                ["src"],
+                subprocess_runner=_fake_runner(stdout=stdout),
+            )
+        self.assertEqual(len(result.findings), 2)
+        self.assertEqual(result.findings[0].severity, SEVERITY_ERROR)
+        self.assertEqual(result.findings[0].code, "TS2322")
+        self.assertEqual(result.findings[1].severity, SEVERITY_WARNING)
+
+
+class GoRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = GoRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.go.which_binary",
+            return_value=None,
+        ):
+            result = runner.run(["./..."], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+
+    def test_parses_go_vet_stderr(self) -> None:
+        stderr = "main.go:14:9: shadow: declaration of \"err\" shadows declaration\n"
+        runner = GoRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.go.which_binary",
+            return_value="/usr/bin/go",
+        ):
+            result = runner.run(
+                ["./..."],
+                subprocess_runner=_fake_runner(stderr=stderr, returncode=1),
+            )
+        self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.findings[0].severity, SEVERITY_ERROR)
+        self.assertEqual(result.findings[0].file, "main.go")
+
+
+class RustRunnerTests(unittest.TestCase):
+    def test_missing_binary_advisory(self) -> None:
+        runner = RustRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.rust.which_binary",
+            return_value=None,
+        ):
+            result = runner.run([], subprocess_runner=_fake_runner())
+        self.assertTrue(result.advisory)
+
+    def test_parses_clippy_jsonl(self) -> None:
+        stdout = (
+            json.dumps(
+                {
+                    "reason": "compiler-message",
+                    "message": {
+                        "message": "unused variable",
+                        "level": "warning",
+                        "code": {"code": "unused_variables"},
+                        "spans": [
+                            {
+                                "is_primary": True,
+                                "file_name": "src/main.rs",
+                                "line_start": 7,
+                                "column_start": 9,
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\n"
+            + json.dumps({"reason": "build-finished", "success": True})
+            + "\n"
+        )
+        runner = RustRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.rust.which_binary",
+            return_value="/usr/bin/cargo",
+        ):
+            result = runner.run(
+                [],
+                subprocess_runner=_fake_runner(stdout=stdout),
+            )
+        self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.findings[0].severity, SEVERITY_WARNING)
+        self.assertEqual(result.findings[0].file, "src/main.rs")
+        self.assertEqual(result.findings[0].code, "unused_variables")
+
+
+# ---------------------------------------------------------------------------
+# Verdict aggregation
+# ---------------------------------------------------------------------------
+
+
+class VerdictAggregationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # A registry of stub runners that emit a deterministic
+        # set of findings without touching subprocess.
+        self.registry = {
+            "stub_error": _StubRunner(
+                runner_id="stub_error",
+                language="python",
+                findings=(
+                    LspFinding(
+                        file="foo.py",
+                        line=1,
+                        column=1,
+                        severity=SEVERITY_ERROR,
+                        code="E001",
+                        message="boom",
+                    ),
+                ),
+            ),
+            "stub_warn": _StubRunner(
+                runner_id="stub_warn",
+                language="python",
+                findings=(
+                    LspFinding(
+                        file="foo.py",
+                        line=2,
+                        column=1,
+                        severity=SEVERITY_WARNING,
+                        code="W001",
+                        message="warn",
+                    ),
+                ),
+            ),
+            "stub_info": _StubRunner(
+                runner_id="stub_info",
+                language="python",
+                findings=(
+                    LspFinding(
+                        file="foo.py",
+                        line=3,
+                        column=1,
+                        severity=SEVERITY_INFO,
+                        code="I001",
+                        message="note",
+                    ),
+                ),
+            ),
+            "stub_clean": _StubRunner(
+                runner_id="stub_clean",
+                language="python",
+                findings=(),
+            ),
+        }
+
+    def _judge(self, runner_id: str) -> PreflightLspVerdict:
+        return judge_lsp_preflight(
+            paths=["foo.py"],
+            role="backend",
+            runners=(runner_id,),
+            env={ENV_PREFLIGHT_ENABLED: "true"},
+            registry=self.registry,
+        )
+
+    def test_severity_levelling_table(self) -> None:
+        # error → block / warning → warning / info → advisory / clean → advisory
+        block = self._judge("stub_error")
+        self.assertEqual(block.level, PreflightLspLevel.BLOCK)
+        self.assertEqual(block.blocker_count, 1)
+        self.assertTrue(block.recommend_needs_approval)
+
+        warn = self._judge("stub_warn")
+        self.assertEqual(warn.level, PreflightLspLevel.WARNING)
+        self.assertEqual(warn.blocker_count, 0)
+
+        info = self._judge("stub_info")
+        self.assertEqual(info.level, PreflightLspLevel.ADVISORY)
+
+        clean = self._judge("stub_clean")
+        self.assertEqual(clean.level, PreflightLspLevel.ADVISORY)
+
+    def test_to_payload_round_trips(self) -> None:
+        verdict = self._judge("stub_error")
+        payload = verdict.to_payload()
+        self.assertEqual(payload["level"], "block")
+        self.assertEqual(payload["blocker_count"], 1)
+        self.assertEqual(payload["runner_id_chain"], ["stub_error"])
+
+    def test_registry_skips_unknown_runner_ids(self) -> None:
+        verdict = judge_lsp_preflight(
+            paths=["foo.py"],
+            role="backend",
+            runners=("does_not_exist", "stub_warn"),
+            env={ENV_PREFLIGHT_ENABLED: "true"},
+            registry=self.registry,
+        )
+        self.assertEqual(verdict.runner_id_chain, ("stub_warn",))
+
+
+class _StubRunner:
+    def __init__(self, *, runner_id: str, language: str, findings: tuple) -> None:
+        self.runner_id = runner_id
+        self.language = language
+        self._findings = findings
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Any = None,
+    ) -> LspResult:
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=self._findings,
+            exit_code=0,
+            stderr_tail="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timeout handling
+# ---------------------------------------------------------------------------
+
+
+class TimeoutClampTests(unittest.TestCase):
+    def test_user_supplied_timeout_capped(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def runner(*args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+            captured["timeout"] = kwargs.get("timeout")
+            return _FakeCompletedProcess(returncode=0, stdout="[]", stderr="")
+
+        ruff = PythonRuffRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_ruff.which_binary",
+            return_value="/usr/bin/ruff",
+        ):
+            ruff.run(["foo.py"], timeout=600, subprocess_runner=runner)
+        self.assertEqual(captured["timeout"], DEFAULT_TIMEOUT_SECONDS)
+
+
+class RegistryWiringTests(unittest.TestCase):
+    def test_six_runners_registered_and_mapping_matches(self) -> None:
+        registry = build_runner_registry()
+        expected = {
+            "python_ruff",
+            "python_pyright",
+            "python_mypy",
+            "typescript",
+            "go",
+            "rust",
+        }
+        self.assertEqual(set(registry.keys()), expected)
+        self.assertEqual(
+            LSP_ROLE_RUNNER_CHAINS["backend"],
+            ("python_ruff", "python_pyright", "python_mypy"),
+        )
+        self.assertEqual(LSP_ROLE_RUNNER_CHAINS["frontend"], ("typescript",))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/engineering/test_lsp_preflight_governance.py
+++ b/tests/engineering/test_lsp_preflight_governance.py
@@ -1,0 +1,232 @@
+"""LSP preflight governance regression — hard rails pinned (#100).
+
+Mirrors :mod:`tests.engineering.test_paste_guard_governance` in
+posture: one suite pinning the most important hard rails of F9
+so a single rename / regex flip / env-default flip trips a
+clearly named test.
+
+Rails pinned:
+
+  1. ``YULE_LSP_PREFLIGHT_ENABLED`` default is ``false`` — env OFF
+     means advisory + no subprocess call.
+  2. Missing binary → advisory result, **never** block.
+  3. Timeout is hard-capped at 30s regardless of caller / env.
+  4. subprocess stderr is masked through PasteGuard before being
+     attached to the result (no raw secret bytes leak).
+  5. Role → runner chain mapping is the documented one.
+  6. The judgement seam never mutates target files (read-only).
+  7. Aggregation table: error → block, warning → warning,
+     info / clean → advisory.
+  8. Public surface of :mod:`static_analysis` remains importable
+     under the documented names.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Sequence
+from unittest import mock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.static_analysis import (
+    DEFAULT_TIMEOUT_SECONDS,
+    LSP_ROLE_RUNNER_CHAINS,
+    LspFinding,
+    LspResult,
+    PreflightLspLevel,
+    judge_lsp_preflight,
+)
+from yule_orchestrator.agents.static_analysis.lsp_preflight import (
+    ENV_PREFLIGHT_ENABLED,
+    ENV_TIMEOUT_SECONDS,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+)
+from yule_orchestrator.agents.static_analysis.runners import (
+    build_runner_registry,
+    mask_stderr,
+)
+from yule_orchestrator.agents.static_analysis.runners.python_ruff import (
+    PythonRuffRunner,
+)
+
+
+# A fake-but-pattern-shaped sentinel that PasteGuard treats as a
+# critical secret. Never a real key.
+ANTHROPIC_RAW = "sk-ant-" + "X" * 40 + "ZZ"
+
+
+class _StubRunner:
+    def __init__(self, *, runner_id: str, findings: tuple) -> None:
+        self.runner_id = runner_id
+        self.language = "python"
+        self._findings = findings
+
+    def run(
+        self,
+        paths: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        subprocess_runner: Any = None,
+    ) -> LspResult:
+        return LspResult(
+            language=self.language,
+            runner_id=self.runner_id,
+            findings=self._findings,
+            exit_code=0,
+            stderr_tail="",
+        )
+
+
+class LspPreflightGovernanceTests(unittest.TestCase):
+    def test_env_default_off_returns_advisory(self) -> None:
+        spawned = []
+
+        def runner(*args: Any, **kwargs: Any) -> Any:
+            spawned.append("called")
+            raise AssertionError("subprocess must not run when env is off")
+
+        verdict = judge_lsp_preflight(
+            paths=["foo.py"],
+            role="backend",
+            subprocess_runner=runner,
+            env={},
+        )
+        self.assertEqual(verdict.level, PreflightLspLevel.ADVISORY)
+        self.assertEqual(spawned, [])
+
+    def test_missing_binary_yields_advisory_not_block(self) -> None:
+        ruff = PythonRuffRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_ruff.which_binary",
+            return_value=None,
+        ):
+            result = ruff.run(["foo.py"])
+        self.assertTrue(result.advisory)
+        self.assertIsNone(result.exit_code)
+        self.assertEqual(result.findings, ())
+
+    def test_timeout_capped_at_30_seconds(self) -> None:
+        # Even if the operator / .env wants 9999s, the seam clamps
+        # the runner-side timeout to the documented hard cap.
+        captured: dict[str, Any] = {}
+
+        def runner(*args: Any, **kwargs: Any) -> Any:
+            captured["timeout"] = kwargs.get("timeout")
+
+            class _R:
+                returncode = 0
+                stdout = "[]"
+                stderr = ""
+
+            return _R()
+
+        ruff = PythonRuffRunner()
+        with mock.patch(
+            "yule_orchestrator.agents.static_analysis.runners.python_ruff.which_binary",
+            return_value="/usr/bin/ruff",
+        ):
+            ruff.run(["foo.py"], timeout=9999, subprocess_runner=runner)
+        self.assertEqual(captured["timeout"], DEFAULT_TIMEOUT_SECONDS)
+
+    def test_paste_guard_redacts_stderr_secret(self) -> None:
+        stderr = f"ruff crashed: token={ANTHROPIC_RAW} bye"
+        masked = mask_stderr(stderr)
+        self.assertNotIn(ANTHROPIC_RAW, masked)
+
+    def test_role_chain_mapping_pinned(self) -> None:
+        self.assertEqual(
+            LSP_ROLE_RUNNER_CHAINS["backend"],
+            ("python_ruff", "python_pyright", "python_mypy"),
+        )
+        self.assertEqual(LSP_ROLE_RUNNER_CHAINS["frontend"], ("typescript",))
+        self.assertEqual(LSP_ROLE_RUNNER_CHAINS["qa"], ("python_ruff",))
+        self.assertEqual(LSP_ROLE_RUNNER_CHAINS["devops"], ("python_ruff",))
+        self.assertEqual(LSP_ROLE_RUNNER_CHAINS["ai"], LSP_ROLE_RUNNER_CHAINS["backend"])
+
+    def test_aggregation_levelling_table(self) -> None:
+        registry = {
+            "stub_error": _StubRunner(
+                runner_id="stub_error",
+                findings=(
+                    LspFinding(
+                        file="f.py",
+                        line=1,
+                        column=1,
+                        severity=SEVERITY_ERROR,
+                        code="E1",
+                        message="boom",
+                    ),
+                ),
+            ),
+            "stub_warn": _StubRunner(
+                runner_id="stub_warn",
+                findings=(
+                    LspFinding(
+                        file="f.py",
+                        line=1,
+                        column=1,
+                        severity=SEVERITY_WARNING,
+                        code="W1",
+                        message="warn",
+                    ),
+                ),
+            ),
+            "stub_clean": _StubRunner(runner_id="stub_clean", findings=()),
+        }
+        env = {ENV_PREFLIGHT_ENABLED: "true"}
+
+        block = judge_lsp_preflight(
+            paths=["f.py"], role="backend", runners=("stub_error",),
+            env=env, registry=registry,
+        )
+        warn = judge_lsp_preflight(
+            paths=["f.py"], role="backend", runners=("stub_warn",),
+            env=env, registry=registry,
+        )
+        clean = judge_lsp_preflight(
+            paths=["f.py"], role="backend", runners=("stub_clean",),
+            env=env, registry=registry,
+        )
+        self.assertEqual(block.level, PreflightLspLevel.BLOCK)
+        self.assertEqual(warn.level, PreflightLspLevel.WARNING)
+        self.assertEqual(clean.level, PreflightLspLevel.ADVISORY)
+
+    def test_public_surface_importable(self) -> None:
+        registry = build_runner_registry()
+        # The 6 runner_ids documented in the issue must remain
+        # available under the same registry keys.
+        for runner_id in (
+            "python_ruff",
+            "python_pyright",
+            "python_mypy",
+            "typescript",
+            "go",
+            "rust",
+        ):
+            self.assertIn(runner_id, registry)
+
+    def test_env_timeout_clamped_via_judge(self) -> None:
+        # Even if env says 9999, the verdict computation should not
+        # raise and the clamped timeout flows to runners.
+        verdict = judge_lsp_preflight(
+            paths=["f.py"],
+            role="backend",
+            runners=("stub_clean",),
+            env={
+                ENV_PREFLIGHT_ENABLED: "true",
+                ENV_TIMEOUT_SECONDS: "9999",
+            },
+            registry={
+                "stub_clean": _StubRunner(runner_id="stub_clean", findings=()),
+            },
+        )
+        self.assertEqual(verdict.level, PreflightLspLevel.ADVISORY)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
- close #100
- supersedes #113 (rebase 후 충돌 해결)

## ✨ 과제 내용
F9 LSP-style preflight — ruff/pyright/mypy/tsc/go/rust 6 runner. env OFF default + 30s 하드캡 + PasteGuard 통과.

### Acceptance 검증
- 신규 test PASS / full regression OK
- env OFF 시 항상 advisory + 외부 binary 미실행
- binary 미설치 → advisory (block 금지)

### Hard rails
- timeout 30s 강제
- 코드 mutate 금지 (read-only)
- PasteGuard stderr 마스킹

### 🤖 Agent WorkOS Audit
- branch: feature/lsp-preflight-issue-100-v3 (rebased from v2)
- role: devops-engineer / ai-engineer
- risk_class: MEDIUM

## :camera_with_flash: 스크린샷(선택)
_(N/A)_

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 후속: F4 live editor retry loop 통합