### PR TITLE
✨ [Feat] F11.3 — F5/F7/F8/F9/F10 manifest + example marketing-agent (closes #102)

### DIFF
--- a/agents/marketing-agent/example/manifest.json
+++ b/agents/marketing-agent/example/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "marketing-agent-example",
+  "name": "Example Marketing Agent",
+  "role": "example-marketing",
+  "version": "0.1.0",
+  "capabilities": [
+    "campaign_draft",
+    "audience_research_summary"
+  ],
+  "plugins_required": [
+    "paste-guard",
+    "hookify",
+    "claude-mem"
+  ],
+  "prompt_template_ref": "agents/marketing-agent/example/prompt.md",
+  "github_app_env_prefix": "YULE_GITHUB_APP_MARKETING_EXAMPLE_",
+  "autonomy_level": "advisory",
+  "risk_class": "LOW",
+  "module_path": "agents.marketing_agent.example.runner"
+}

--- a/agents/marketing-agent/example/prompt.md
+++ b/agents/marketing-agent/example/prompt.md
@@ -1,0 +1,19 @@
+# example-marketing-agent — prompt template
+
+> F11 의 "사용자 요청 기반 새 agent 추가" 흐름을 검증하는 데모 manifest 의 프롬프트 슬롯.
+> 실제 운영 marketing-agent 가 land 될 때 본 디렉터리 (`agents/marketing-agent/`) 가 확장된다.
+
+## 역할
+
+- campaign 초안 작성 + audience research 요약.
+
+## 책임 경계
+
+- 본 demo agent 는 어떤 외부 API 도 호출하지 않는다.
+- engineering-agent 의 책임 영역 (코드 / PR / Obsidian write) 은 절대 침범하지 않는다.
+
+## Hard rails
+
+- `paste-guard` plugin 통과 (outbound payload secret 차단).
+- `hookify` plugin 의 mistake_ledger preflight 통과.
+- `claude-mem` plugin 으로 cross-session 기억 surface.

--- a/plugins/auto-merge-decider/manifest.json
+++ b/plugins/auto-merge-decider/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "auto-merge-decider",
+  "name": "Auto-merge Decider",
+  "version": "0.1.0",
+  "kind": "delivery",
+  "hooks_provided": [
+    "OUTBOUND_GITHUB"
+  ],
+  "hooks_consumed": [],
+  "env_keys": [
+    "YULE_AUTOMERGE_CYCLE"
+  ],
+  "autonomy_level": "supervised",
+  "paste_guard_required": true,
+  "risk_class": "HIGH",
+  "module_path": "yule_orchestrator.agents.release.auto_merge_decider"
+}

--- a/plugins/claude-mem/manifest.json
+++ b/plugins/claude-mem/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "claude-mem",
+  "name": "Claude Mem Unifier",
+  "version": "0.1.0",
+  "kind": "learning",
+  "hooks_provided": [
+    "PREFLIGHT"
+  ],
+  "hooks_consumed": [
+    "COMPLETION"
+  ],
+  "env_keys": [
+    "YULE_LONG_TERM_MEMORY_ENABLED",
+    "YULE_MEMORY_FRESHNESS_DAYS",
+    "YULE_MEMORY_MAX_SHARDS_PER_QUERY"
+  ],
+  "autonomy_level": "advisory",
+  "paste_guard_required": true,
+  "risk_class": "MEDIUM",
+  "module_path": "yule_orchestrator.agents.memory.long_term_memory"
+}

--- a/plugins/live-research-provider/manifest.json
+++ b/plugins/live-research-provider/manifest.json
@@ -1,0 +1,23 @@
+{
+  "id": "live-research-provider",
+  "name": "Live Research Provider",
+  "version": "0.1.0",
+  "kind": "delivery",
+  "hooks_provided": [
+    "OUTBOUND_VAULT"
+  ],
+  "hooks_consumed": [
+    "PREFLIGHT"
+  ],
+  "env_keys": [
+    "YULE_RESEARCH_LIVE_ENABLED",
+    "YULE_RESEARCH_LIVE_ALLOW_HOSTS",
+    "YULE_RESEARCH_LIVE_DISABLE_HOSTS",
+    "YULE_RESEARCH_LIVE_KINDS",
+    "YULE_RESEARCH_LIVE_RATE_LIMIT_PER_SEC"
+  ],
+  "autonomy_level": "advisory",
+  "paste_guard_required": true,
+  "risk_class": "MEDIUM",
+  "module_path": "yule_orchestrator.agents.research.providers.live.registry"
+}

--- a/plugins/lsp-preflight/manifest.json
+++ b/plugins/lsp-preflight/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "lsp-preflight",
+  "name": "LSP-style Preflight",
+  "version": "0.1.0",
+  "kind": "guard",
+  "hooks_provided": [
+    "PREFLIGHT"
+  ],
+  "hooks_consumed": [],
+  "env_keys": [
+    "YULE_LSP_PREFLIGHT_ENABLED",
+    "YULE_LSP_RUNNERS",
+    "YULE_LSP_TIMEOUT_SECONDS"
+  ],
+  "autonomy_level": "advisory",
+  "paste_guard_required": true,
+  "risk_class": "MEDIUM",
+  "module_path": "yule_orchestrator.agents.static_analysis.lsp_preflight"
+}

--- a/plugins/obsidian-vault-push/manifest.json
+++ b/plugins/obsidian-vault-push/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "obsidian-vault-push",
+  "name": "Obsidian Vault Auto-push",
+  "version": "0.1.0",
+  "kind": "delivery",
+  "hooks_provided": [
+    "OUTBOUND_VAULT",
+    "COMPLETION"
+  ],
+  "hooks_consumed": [],
+  "env_keys": [
+    "YULE_VAULT_AUTOPUSH_ENABLED",
+    "YULE_VAULT_REPO_ROOT",
+    "YULE_VAULT_BRANCH"
+  ],
+  "autonomy_level": "supervised",
+  "paste_guard_required": true,
+  "risk_class": "MEDIUM",
+  "module_path": "yule_orchestrator.agents.obsidian.vault_auto_push"
+}

--- a/tests/engineering/test_extension_governance.py
+++ b/tests/engineering/test_extension_governance.py
@@ -42,8 +42,23 @@ _EXPECTED_ROLES = (
     "product-designer",
 )
 
-_HIGH_RISK_PLUGIN_IDS = ("paste-guard", "live-llm-editor", "tool-call-gate")
+_HIGH_RISK_PLUGIN_IDS = (
+    "paste-guard",
+    "live-llm-editor",
+    "tool-call-gate",
+    "auto-merge-decider",
+)
 _F11_2_PLUGIN_IDS = ("live-llm-editor", "tool-call-gate", "discussion-response")
+# F11.3 — F5/F7/F8/F9/F10 manifest 마지막 한 번에 land (closes #102).
+_F11_3_PLUGIN_IDS = (
+    "live-research-provider",
+    "auto-merge-decider",
+    "obsidian-vault-push",
+    "lsp-preflight",
+    "claude-mem",
+)
+# 새 부서 추가 흐름 데모 — agents/marketing-agent/example/manifest.json.
+_EXAMPLE_DEPT_AGENT = Path("marketing-agent") / "example"
 
 
 def _read_manifest_json(path: Path) -> dict:
@@ -75,6 +90,39 @@ class ExtensionGovernanceTests(unittest.TestCase):
             payload = _read_manifest_json(_PLUGINS_DIR / plugin_id / "manifest.json")
             manifest = load_plugin_manifest_from_dict(payload)
             self.assertEqual(manifest.id, plugin_id)
+
+    def test_f11_3_plugin_manifests_load(self) -> None:
+        # F11.3 follow-up — F5/F7/F8/F9/F10 manifest 5종. PR #102 close.
+        for plugin_id in _F11_3_PLUGIN_IDS:
+            payload = _read_manifest_json(_PLUGINS_DIR / plugin_id / "manifest.json")
+            manifest = load_plugin_manifest_from_dict(payload)
+            self.assertEqual(manifest.id, plugin_id)
+            self.assertIn(
+                manifest.kind, ("guard", "delivery", "learning")
+            )
+            # auto-merge-decider 는 보안 critical — HIGH 명시 강제.
+            if plugin_id == "auto-merge-decider":
+                self.assertEqual(manifest.risk_class, "HIGH")
+
+    def test_example_marketing_agent_manifest_loads(self) -> None:
+        # 새 부서 추가 흐름 데모. agents/<dept>/<role>/manifest.json 구조 검증.
+        manifest_path = (
+            _REPO_ROOT
+            / "agents"
+            / _EXAMPLE_DEPT_AGENT
+            / "manifest.json"
+        )
+        self.assertTrue(manifest_path.is_file(), manifest_path)
+        payload = _read_manifest_json(manifest_path)
+        manifest = load_agent_manifest_from_dict(payload)
+        self.assertEqual(manifest.id, "marketing-agent-example")
+        # plugins_required 가 실제 등록된 plugin id 만 가리키는지 검증.
+        for plugin_id in manifest.plugins_required:
+            plugin_dir = _PLUGINS_DIR / plugin_id
+            self.assertTrue(
+                plugin_dir.is_dir(),
+                f"example agent references missing plugin '{plugin_id}'",
+            )
 
     def test_f11_2_plugin_manifests_load(self) -> None:
         # F11.2 follow-up — manifests for already-merged plugins F4 / F6 / F12.


### PR DESCRIPTION
## 📌 관련 이슈
- close #102
- follow-up of PR #105 (MVP) / #108 (F11.1) / #110 (F11.2)

## ✨ 과제 내용

### 변경 사항
| 영역 | 파일 |
| --- | --- |
| F5 manifest | `plugins/live-research-provider/manifest.json` |
| F7 manifest | `plugins/auto-merge-decider/manifest.json` (risk_class=HIGH) |
| F8 manifest | `plugins/obsidian-vault-push/manifest.json` |
| F9 manifest | `plugins/lsp-preflight/manifest.json` |
| F10 manifest | `plugins/claude-mem/manifest.json` |
| 새 부서 데모 | `agents/marketing-agent/example/{manifest.json, prompt.md}` |
| 회귀 가드 | `tests/engineering/test_extension_governance.py` 2 신규 case |

### Acceptance 검증
- 신규 case: `test_f11_3_plugin_manifests_load` + `test_example_marketing_agent_manifest_loads`
- 전체 회귀: `python3 -m unittest discover -s tests -t .` → **4013/4013 OK (skip 5)**
- HIGH risk plugin 4종 (paste-guard / live-llm-editor / tool-call-gate / auto-merge-decider) 모두 manifest 에 명시
- `agents/<dept>/<role>/` 컨벤션 — engineering-agent / planning-agent / marketing-agent (example) 3 부서

### 무엇을 아직 하지 않았는지
- HookChain invoke 의 실제 runtime 배선 (각 plugin 의 module 이 outbound 경로에 자동 연결되도록 wiring) — 별도 후속 PR
- 본 PR 은 manifest 카탈로그 완성까지만 — F11 close 의 마지막 조각

### 🤖 Agent WorkOS Audit
- branch: `feature/f11-final-manifests-issue-102` (from `main`)
- role: `engineering-agent/tech-lead`
- autonomy_level: `L2_AUTONOMOUS_RECORD`
- risk_class: LOW (JSON manifest + test 만, 코드 로직 변경 0)

## :camera_with_flash: 스크린샷(선택)
_(N/A — manifest JSON + 테스트)_

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 본 PR merge 후 `plugins/` = 11 manifest, `agents/` = 3 부서.
- 새 부서 추가 흐름 (manifest + prompt drop-in) 검증 완료.
- HookChain runtime wiring 은 별도 follow-up issue 로 분리 (각 plugin 의 module 진입점 호출 회로).