### PR TITLE
✨ [Feat] F13 부서별 자동 이슈 수집 — RSS 크롤러 + dept dispatch (closes #122)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -401,3 +401,22 @@ DISCORD_GUILD_ID=
 # YULE_VAULT_AUTOPUSH_ENABLED=false
 # YULE_VAULT_REPO_ROOT=
 # YULE_VAULT_BRANCH=auto/notes-sync
+
+# =====================================================================
+# F13 / #122 — 부서별 자동 이슈 수집 (RSS 크롤러 + dept dispatch)
+#
+# eng-digest-scheduler 가 interval 마다 7 역할 카탈로그 host 를 fetch →
+# dept_router (design/planning/engineering/multi-dept) 분류 → dedup ledger
+# 통과 후 부서 채널 (#기획-부서 / #디자인-부서 / #개발-부서) 에 GeekNews
+# 스타일 카드 게시. 다중 부서 영향 시 #운영-리서치 thread 자동 생성.
+#
+# 운영 정책:
+#   - default OFF. interval 1h 이상.
+#   - 카탈로그 외 host 절대 fetch 금지 (governance test 가 보호).
+#   - 부서 채널 ID 는 .env.local 에만, .env.example 은 placeholder.
+# YULE_DIGEST_SCHEDULER_ENABLED=false
+# YULE_DIGEST_SCHEDULER_INTERVAL_HOURS=12
+# YULE_DIGEST_DEDUP_RETENTION_DAYS=14
+# DISCORD_DEPT_PLANNING_CHANNEL_ID=
+# DISCORD_DEPT_DESIGN_CHANNEL_ID=
+# DISCORD_DEPT_DEV_CHANNEL_ID=

--- a/src/yule_orchestrator/agents/digest/__init__.py
+++ b/src/yule_orchestrator/agents/digest/__init__.py
@@ -1,0 +1,30 @@
+"""F13 부서별 자동 이슈 수집 — RSS 크롤러 + dept feed + meeting trigger.
+
+사용자 design (2026-05-12):
+- 부서 채널 = 이슈 큐 (read-only feed, GeekNews 카드).
+- `#운영-리서치` = 다중 부서 영향 시 meeting thread.
+- `#업무-접수` = 실행 요청 입구.
+- 분류 4종: design / planning / engineering / multi-dept.
+"""
+
+from .dedup_ledger import DigestDedupLedger
+from .dept_router import DeptClassification, DEPARTMENTS, classify_evidence
+from .formatter import DigestCard, format_card
+from .source_catalog import (
+    AuthoritativeSource,
+    ROLE_SOURCE_CATALOG,
+    sources_for_role,
+)
+
+
+__all__ = (
+    "AuthoritativeSource",
+    "DEPARTMENTS",
+    "DigestCard",
+    "DigestDedupLedger",
+    "DeptClassification",
+    "ROLE_SOURCE_CATALOG",
+    "classify_evidence",
+    "format_card",
+    "sources_for_role",
+)

--- a/src/yule_orchestrator/agents/digest/cli.py
+++ b/src/yule_orchestrator/agents/digest/cli.py
@@ -1,0 +1,103 @@
+"""F13 digest CLI — 수동 probe.
+
+사용 예:
+  yule digest collect --role backend-engineer
+  yule digest collect --role tech-lead --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Optional, Sequence
+
+from .crawler import crawl_role
+from .dedup_ledger import DigestDedupLedger
+from .dispatcher import build_dispatch_plan
+from .scheduler import SchedulerConfig, run_one_cycle
+from .source_catalog import ROLE_SOURCE_CATALOG
+
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_argv(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="yule digest")
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    collect = subparsers.add_parser("collect", help="역할 카탈로그 1회 크롤")
+    collect.add_argument(
+        "--role",
+        action="append",
+        help="크롤할 role. 여러 번 지정 가능. 미지정 시 7 역할 전체.",
+    )
+    collect.add_argument("--dry-run", action="store_true", help="dispatch plan 만 출력")
+    collect.add_argument("--retention-days", type=int, default=14)
+
+    list_cmd = subparsers.add_parser("list-sources", help="카탈로그 출력")
+    list_cmd.add_argument("--role", default=None)
+
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+async def _run_collect(args) -> int:
+    roles = args.role or list(ROLE_SOURCE_CATALOG.keys())
+    ledger = DigestDedupLedger(retention_days=args.retention_days)
+
+    report = await run_one_cycle(
+        roles=roles,
+        ledger=ledger,
+        env=dict(os.environ),
+        post_fn=None,  # CLI 는 dry-run / plan only
+    )
+
+    print(f"\n=== F13 digest collect ===")
+    print(f"roles: {roles}")
+    print(f"sources_attempted: {report.sources_attempted}")
+    print(f"cards_total: {report.cards_total}")
+    print(f"skipped_duplicates: {report.skipped_duplicates}")
+    print(f"blocked_sources: {report.blocked_sources}")
+    print(f"dispatch.targets: {len(report.dispatch.targets)}")
+    print(f"dispatch.skipped_no_channel: {report.dispatch.skipped_no_channel}")
+    print(f"dispatch.research_forum_threads: {len(report.dispatch.research_forum_threads)}")
+
+    if args.dry_run:
+        print("\n--- targets (preview) ---")
+        for t in report.dispatch.targets[:20]:
+            print(f"  [{t.target_kind}] {t.channel_name} ({t.channel_id})")
+            print(f"    {t.card.title[:80]}")
+            print(f"    {t.card.url}")
+            print(f"    primary={t.card.dept_primary}, affected={t.card.affected_depts}, meeting={t.card.meeting_trigger}")
+
+    return 0
+
+
+def _run_list_sources(args) -> int:
+    target_roles = [args.role] if args.role else list(ROLE_SOURCE_CATALOG.keys())
+    for role in target_roles:
+        sources = ROLE_SOURCE_CATALOG.get(role, ())
+        print(f"\n=== {role} ({len(sources)} sources) ===")
+        for src in sources:
+            print(f"  - {src.host} [{src.kind}] trust={src.trust} → {src.feed_url}")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = _parse_argv(argv)
+    if args.action == "collect":
+        return asyncio.run(_run_collect(args))
+    if args.action == "list-sources":
+        return _run_list_sources(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = ("main",)

--- a/src/yule_orchestrator/agents/digest/crawler.py
+++ b/src/yule_orchestrator/agents/digest/crawler.py
@@ -1,0 +1,259 @@
+"""F13 — RSS 크롤러. 카탈로그 host 만 fetch + dedup-aware.
+
+사용자 design (2026-05-12):
+> "검색 API 없이도 가능하지만, '전문 크롤러' 보다 '소스 어댑터' 구조가 좋습니다."
+> "소스별로 ``RSS 가능``, ``목록 페이지 HTML 파싱``, ``상세 페이지 메타 추출``
+> 3단계 우선순위로 접근합니다."
+
+본 PR 은 RSS/Atom + GitHub Release 만 (1순위). HTML list 파서는 후속 PR.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+from .dedup_ledger import DigestDedupLedger
+from .dept_router import DeptClassification, classify_evidence
+from .formatter import DigestCard, format_card
+from .source_catalog import (
+    AuthoritativeSource,
+    all_allowed_hosts,
+    sources_for_role,
+)
+
+
+# robots.txt / rate-limit / timeout 정책
+_DEFAULT_TIMEOUT = 15
+_USER_AGENT = "yule-engineering-agent-digest/0.1"
+
+
+@dataclass(frozen=True)
+class CrawlOutcome:
+    """1회 fetch 의 결과."""
+
+    role: str
+    source_host: str
+    entries_fetched: int
+    cards: Tuple[DigestCard, ...]
+    skipped_duplicates: int
+    blocker_reason: Optional[str] = None
+
+
+class HttpPoster:
+    """fetch seam. 테스트는 fake 주입."""
+
+    def fetch(self, url: str, *, timeout: int = _DEFAULT_TIMEOUT) -> str:
+        req = urllib.request.Request(
+            url=url,
+            headers={"User-Agent": _USER_AGENT, "Accept": "*/*"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+
+
+def _parse_rss_atom(xml_text: str) -> list:
+    """RSS 2.0 + Atom feed 파서. 본 PR 은 표준 라이브러리만 사용 (feedparser 의존 회피).
+
+    Return: list of {title, link, summary, published, tags}.
+    """
+
+    items: list = []
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return items
+    ns = {
+        "atom": "http://www.w3.org/2005/Atom",
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "content": "http://purl.org/rss/1.0/modules/content/",
+    }
+    # RSS 2.0
+    for item in root.iter("item"):
+        title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        desc = (item.findtext("description") or item.findtext("content:encoded", "", ns) or "").strip()
+        pub = (item.findtext("pubDate") or item.findtext("dc:date", "", ns) or "").strip()
+        tags = [c.text for c in item.findall("category") if c.text]
+        if title and link:
+            items.append({
+                "title": title, "link": link, "summary": desc, "published": pub, "tags": tags,
+            })
+    # Atom
+    if not items:
+        for entry in root.iter("{http://www.w3.org/2005/Atom}entry"):
+            title_el = entry.find("atom:title", ns)
+            link_el = entry.find("atom:link", ns)
+            summary_el = entry.find("atom:summary", ns) or entry.find("atom:content", ns)
+            updated_el = entry.find("atom:updated", ns) or entry.find("atom:published", ns)
+            link = link_el.get("href") if link_el is not None else ""
+            title = (title_el.text or "").strip() if title_el is not None else ""
+            summary = (summary_el.text or "").strip() if summary_el is not None else ""
+            published = (updated_el.text or "").strip() if updated_el is not None else ""
+            cat_els = entry.findall("atom:category", ns)
+            tags = [c.get("term") for c in cat_els if c.get("term")]
+            if title and link:
+                items.append({
+                    "title": title, "link": link, "summary": summary,
+                    "published": published, "tags": tags,
+                })
+    return items
+
+
+def _parse_github_releases(json_text: str) -> list:
+    """GitHub Releases API → entry list."""
+
+    try:
+        releases = json.loads(json_text)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(releases, list):
+        return []
+    items: list = []
+    for rel in releases[:10]:  # cap 10
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("draft") or rel.get("prerelease"):
+            continue
+        tag = rel.get("tag_name") or rel.get("name") or "release"
+        body = (rel.get("body") or "").strip()
+        url = rel.get("html_url") or ""
+        published = rel.get("published_at") or rel.get("created_at") or ""
+        if not url:
+            continue
+        items.append({
+            "title": tag,
+            "link": url,
+            "summary": body[:400],
+            "published": published,
+            "tags": [],
+        })
+    return items
+
+
+def _parse_published(raw: str) -> Optional[datetime]:
+    if not raw:
+        return None
+    # 표준 ISO 8601
+    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S.%f%z"):
+        try:
+            return datetime.strptime(raw[:32], fmt)
+        except ValueError:
+            continue
+    # RFC 2822 (RSS pubDate)
+    try:
+        from email.utils import parsedate_to_datetime
+        return parsedate_to_datetime(raw)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def fetch_source(
+    source: AuthoritativeSource,
+    *,
+    role: str,
+    ledger: DigestDedupLedger,
+    http_poster: Optional[HttpPoster] = None,
+    max_cards_per_source: int = 5,
+) -> CrawlOutcome:
+    """단일 source 에서 RSS/Atom/GitHub release 1회 fetch + dedup 적용."""
+
+    if source.host not in all_allowed_hosts():
+        return CrawlOutcome(role, source.host, 0, (), 0, blocker_reason="not in allow-list")
+
+    poster = http_poster or HttpPoster()
+    cards: list = []
+    skipped = 0
+
+    try:
+        if source.kind == "github_release":
+            # ``feed_url`` = ``owner/repo``
+            api_url = f"https://api.github.com/repos/{source.feed_url}/releases"
+            raw = poster.fetch(api_url)
+            entries = _parse_github_releases(raw)
+        else:
+            raw = poster.fetch(source.feed_url)
+            entries = _parse_rss_atom(raw)
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        return CrawlOutcome(
+            role, source.host, 0, (), 0,
+            blocker_reason=f"http {type(exc).__name__}",
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort, never crash supervisor
+        return CrawlOutcome(
+            role, source.host, 0, (), 0,
+            blocker_reason=f"unexpected {type(exc).__name__}: {str(exc)[:60]}",
+        )
+
+    for entry in entries[:max_cards_per_source]:
+        verdict = classify_evidence(
+            host=source.host,
+            title=entry.get("title", ""),
+            summary=entry.get("summary", ""),
+            primary_role=role,
+        )
+        if ledger.is_duplicate(
+            url=entry["link"],
+            title=entry["title"],
+            host=source.host,
+            dept=verdict.primary,
+        ):
+            skipped += 1
+            continue
+        card = format_card(
+            title=entry["title"],
+            url=entry["link"],
+            summary=entry.get("summary", ""),
+            source_host=source.host,
+            published_at=_parse_published(entry.get("published", "")),
+            tags=entry.get("tags", ()),
+            dept_primary=verdict.primary,
+            affected_depts=verdict.affected,
+            meeting_trigger=verdict.meeting_trigger,
+            role_hint=role,
+        )
+        cards.append(card)
+
+    return CrawlOutcome(
+        role=role,
+        source_host=source.host,
+        entries_fetched=len(entries),
+        cards=tuple(cards),
+        skipped_duplicates=skipped,
+    )
+
+
+def crawl_role(
+    role: str,
+    *,
+    ledger: DigestDedupLedger,
+    http_poster: Optional[HttpPoster] = None,
+    max_cards_per_source: int = 5,
+) -> Tuple[CrawlOutcome, ...]:
+    """역할 카탈로그의 모든 source 1회 순회."""
+
+    outcomes: list = []
+    for source in sources_for_role(role):
+        outcomes.append(
+            fetch_source(
+                source,
+                role=role,
+                ledger=ledger,
+                http_poster=http_poster,
+                max_cards_per_source=max_cards_per_source,
+            )
+        )
+    return tuple(outcomes)
+
+
+__all__ = (
+    "CrawlOutcome",
+    "HttpPoster",
+    "crawl_role",
+    "fetch_source",
+)

--- a/src/yule_orchestrator/agents/digest/dedup_ledger.py
+++ b/src/yule_orchestrator/agents/digest/dedup_ledger.py
@@ -1,0 +1,205 @@
+"""F13 — 디지스트 dedup ledger. url canonical + title hash 기반 24h 재게시 차단.
+
+사용자 design (2026-05-12):
+> "중복 제거는 ``url canonical + title hash`` 기준으로 합니다."
+
+SQLite 영속 — 기존 cache.sqlite3 의 새 테이블 `dept_digest_dedup`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+
+_DEFAULT_DB_PATH = Path.home() / ".cache" / "yule" / "cache.sqlite3"
+_TABLE_NAME = "dept_digest_dedup"
+
+
+@dataclass(frozen=True)
+class DedupEntry:
+    url_hash: str
+    title_hash: str
+    posted_at: str
+    dept: str
+
+
+def _canonical_url(url: str) -> str:
+    """URL → canonical form: lowercase, strip query/frag, strip trailing slash."""
+
+    if not url:
+        return ""
+    u = url.strip().lower()
+    # strip fragment
+    u = u.split("#", 1)[0]
+    # strip tracking params (utm_*, gclid, fbclid)
+    if "?" in u:
+        base, _, query = u.partition("?")
+        kept = [
+            q for q in query.split("&")
+            if not q.startswith(("utm_", "gclid=", "fbclid=", "ref="))
+        ]
+        u = base + ("?" + "&".join(kept) if kept else "")
+    # strip trailing slash
+    if u.endswith("/") and len(u) > len("https://x.y/"):
+        u = u[:-1]
+    return u
+
+
+def _title_normalised(title: str) -> str:
+    """Title → space-normalised lowercase. 작은 표기 차이 무시."""
+
+    if not title:
+        return ""
+    t = title.strip().lower()
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def hash_url(url: str) -> str:
+    return hashlib.sha1(_canonical_url(url).encode("utf-8")).hexdigest()
+
+
+def hash_title(title: str) -> str:
+    return hashlib.sha1(_title_normalised(title).encode("utf-8")).hexdigest()
+
+
+class DigestDedupLedger:
+    """SQLite 영속 ledger. 24h 내 같은 url_hash OR (host + title_hash) 재게시 차단.
+
+    24h 가 아닌 retention_hours 로 폭 변경 가능 (env: `YULE_DIGEST_DEDUP_RETENTION_DAYS`).
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        *,
+        retention_days: int = 14,
+    ) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._retention_days = max(1, retention_days)
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_TABLE_NAME} (
+                    url_hash TEXT NOT NULL,
+                    title_hash TEXT NOT NULL,
+                    host TEXT NOT NULL,
+                    dept TEXT NOT NULL,
+                    posted_at TEXT NOT NULL,
+                    PRIMARY KEY (url_hash, dept)
+                )
+                """
+            )
+            conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE_NAME}_title ON {_TABLE_NAME}(title_hash, dept)"
+            )
+            conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{_TABLE_NAME}_posted ON {_TABLE_NAME}(posted_at)"
+            )
+            conn.commit()
+
+    def _now(self) -> datetime:
+        return datetime.now(tz=timezone.utc)
+
+    def _retention_cutoff(self) -> str:
+        return (self._now() - timedelta(days=self._retention_days)).isoformat()
+
+    def is_duplicate(
+        self,
+        *,
+        url: str,
+        title: str,
+        host: str,
+        dept: str,
+    ) -> bool:
+        """url_hash OR (host + title_hash) 가 retention 기간 안에 있으면 중복."""
+
+        cutoff = self._retention_cutoff()
+        u_hash = hash_url(url)
+        t_hash = hash_title(title)
+        with self._connect() as conn:
+            cur = conn.execute(
+                f"""
+                SELECT 1 FROM {_TABLE_NAME}
+                WHERE dept = ?
+                  AND posted_at > ?
+                  AND (url_hash = ? OR (host = ? AND title_hash = ?))
+                LIMIT 1
+                """,
+                (dept, cutoff, u_hash, host, t_hash),
+            )
+            return cur.fetchone() is not None
+
+    def record_posted(
+        self,
+        *,
+        url: str,
+        title: str,
+        host: str,
+        dept: str,
+        posted_at: Optional[datetime] = None,
+    ) -> None:
+        """게시 직후 ledger 에 기록. 같은 (url_hash, dept) 는 INSERT OR REPLACE."""
+
+        ts = (posted_at or self._now()).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                f"""
+                INSERT OR REPLACE INTO {_TABLE_NAME}
+                  (url_hash, title_hash, host, dept, posted_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (hash_url(url), hash_title(title), host, dept, ts),
+            )
+            conn.commit()
+
+    def prune_expired(self) -> int:
+        """retention 만료 row 삭제. 반환: 삭제된 row count."""
+
+        cutoff = self._retention_cutoff()
+        with self._connect() as conn:
+            cur = conn.execute(
+                f"DELETE FROM {_TABLE_NAME} WHERE posted_at < ?",
+                (cutoff,),
+            )
+            conn.commit()
+            return cur.rowcount or 0
+
+    def count_within_retention(self, *, dept: Optional[str] = None) -> int:
+        cutoff = self._retention_cutoff()
+        with self._connect() as conn:
+            if dept:
+                cur = conn.execute(
+                    f"SELECT COUNT(*) FROM {_TABLE_NAME} WHERE dept = ? AND posted_at > ?",
+                    (dept, cutoff),
+                )
+            else:
+                cur = conn.execute(
+                    f"SELECT COUNT(*) FROM {_TABLE_NAME} WHERE posted_at > ?",
+                    (cutoff,),
+                )
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+
+__all__ = (
+    "DigestDedupLedger",
+    "DedupEntry",
+    "hash_title",
+    "hash_url",
+)

--- a/src/yule_orchestrator/agents/digest/dept_router.py
+++ b/src/yule_orchestrator/agents/digest/dept_router.py
@@ -1,0 +1,145 @@
+"""F13 — 수집된 evidence → 부서 분류 (design / planning / engineering / multi-dept).
+
+사용자 정책 (2026-05-12):
+- 단일 부서 영향 → 그 부서 채널 게시
+- 다중 부서 영향 → ``#운영-리서치`` thread + 부서 채널 양쪽
+
+회의 트리거 규칙:
+- ``single`` → dept channel only
+- ``multi`` → multi-dept thread + 양쪽 채널
+- ``execution_required`` → ``#업무-접수``
+- ``approval_required`` → ``#승인-대기``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence, Tuple
+
+from .source_catalog import host_to_roles
+
+
+DEPARTMENTS: Tuple[str, ...] = ("planning", "design", "engineering")
+
+
+# 역할 → 부서 매핑 (사용자 design 기반)
+ROLE_TO_DEPT: Mapping[str, str] = {
+    "tech-lead": "engineering",      # 다부서 영향 가능 — multi 판정 후보
+    "backend-engineer": "engineering",
+    "frontend-engineer": "engineering",
+    "qa-engineer": "engineering",
+    "devops-engineer": "engineering",
+    "ai-engineer": "engineering",
+    "product-designer": "design",
+    "planning": "planning",  # 향후 planner role
+}
+
+
+# 다부서 영향 키워드 (제목/요약에 포함되면 multi-dept 후보 점수 +1)
+MULTI_DEPT_KEYWORDS: Tuple[str, ...] = (
+    "architecture", "accessibility", "wcag",
+    "design-system", "design system", "tokens",
+    "security advisory", "cve",
+    "breaking change", "migration",
+    "release-notes", "release notes",
+    "platform", "infrastructure",
+)
+
+
+@dataclass(frozen=True)
+class DeptClassification:
+    """한 evidence 의 부서 라우팅 verdict.
+
+    ``primary``: 가장 강한 부서 (단일 부서면 여기만 게시)
+    ``affected``: 영향받는 모든 부서 (multi-dept 시 thread 트리거)
+    ``meeting_trigger``: True → ``#운영-리서치`` thread 생성
+    """
+
+    primary: str
+    affected: Tuple[str, ...]
+    meeting_trigger: bool
+    rationale: str
+
+
+def _detect_multi_dept_signal(title: str, summary: str) -> bool:
+    text = f"{title} {summary}".lower()
+    return any(kw in text for kw in MULTI_DEPT_KEYWORDS)
+
+
+def classify_evidence(
+    *,
+    host: str,
+    title: str = "",
+    summary: str = "",
+    primary_role: Optional[str] = None,
+) -> DeptClassification:
+    """주어진 evidence 를 부서별로 라우팅.
+
+    Strategy:
+      1. ``host`` → role 매칭 (카탈로그 기준)
+      2. 매칭된 role 들 → 부서 집합
+      3. 단일 부서 + multi-dept signal 없음 → single 라우팅
+      4. 다중 부서 OR multi-dept keyword OR primary_role 이 tech-lead → multi 라우팅
+    """
+
+    roles = host_to_roles(host)
+    if primary_role and primary_role not in roles:
+        roles = (primary_role, *roles)
+
+    departments = []
+    seen: set[str] = set()
+    for role in roles:
+        dept = ROLE_TO_DEPT.get(role)
+        if dept and dept not in seen:
+            departments.append(dept)
+            seen.add(dept)
+
+    if not departments:
+        # 카탈로그 외 / 알 수 없는 host — engineering 으로 기본 라우팅
+        return DeptClassification(
+            primary="engineering",
+            affected=("engineering",),
+            meeting_trigger=False,
+            rationale=f"unknown host '{host}' — default engineering",
+        )
+
+    multi_signal = _detect_multi_dept_signal(title, summary)
+    is_tech_lead_source = "tech-lead" in roles
+
+    meeting_trigger = (
+        len(departments) >= 2
+        or multi_signal
+        or is_tech_lead_source
+    )
+
+    if meeting_trigger:
+        primary = departments[0]
+        rationale_parts = [f"primary={primary}"]
+        if len(departments) >= 2:
+            rationale_parts.append(f"depts={departments}")
+        if multi_signal:
+            rationale_parts.append("multi-dept keyword")
+        if is_tech_lead_source:
+            rationale_parts.append("tech-lead source")
+        return DeptClassification(
+            primary=primary,
+            affected=tuple(departments),
+            meeting_trigger=True,
+            rationale=" / ".join(rationale_parts),
+        )
+
+    return DeptClassification(
+        primary=departments[0],
+        affected=(departments[0],),
+        meeting_trigger=False,
+        rationale=f"single dept {departments[0]} (host={host})",
+    )
+
+
+__all__ = (
+    "DEPARTMENTS",
+    "DeptClassification",
+    "MULTI_DEPT_KEYWORDS",
+    "ROLE_TO_DEPT",
+    "classify_evidence",
+)

--- a/src/yule_orchestrator/agents/digest/dispatcher.py
+++ b/src/yule_orchestrator/agents/digest/dispatcher.py
@@ -1,0 +1,134 @@
+"""F13 — 부서 채널 게시 dispatcher.
+
+사용자 정책 (2026-05-12):
+- 단일 부서 → 그 부서 채널만 게시
+- 다중 부서 → ``#운영-리서치`` thread + 각 부서 채널 양쪽 게시
+- 실행 필요 시 ``#업무-접수``, 승인 필요 시 ``#승인-대기`` 로 후속 라우팅 (본 PR 비범위)
+
+Discord 게시는 caller (e.g. `discord/gateway`) 가 실 호출. 본 모듈은
+구조화된 ``DispatchPlan`` 만 반환 — Discord 모듈과 분리해서 unit-testable.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Sequence, Tuple
+
+from .formatter import DigestCard
+
+
+# .env.local 의 부서 채널 ID env
+ENV_DEPT_CHANNELS: Mapping[str, str] = {
+    "planning": "DISCORD_DEPT_PLANNING_CHANNEL_ID",
+    "design": "DISCORD_DEPT_DESIGN_CHANNEL_ID",
+    "engineering": "DISCORD_DEPT_DEV_CHANNEL_ID",
+}
+
+ENV_RESEARCH_FORUM = "DISCORD_AGENT_RESEARCH_FORUM_CHANNEL_ID"
+
+
+@dataclass(frozen=True)
+class DispatchTarget:
+    """한 카드의 한 게시 대상."""
+
+    channel_id: str
+    channel_name: str
+    card: DigestCard
+    target_kind: str  # "dept_feed" | "research_forum_thread"
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    """전체 디지스트 사이클의 게시 계획."""
+
+    targets: Tuple[DispatchTarget, ...]
+    skipped_no_channel: Tuple[str, ...] = ()
+    research_forum_threads: Tuple[str, ...] = ()
+
+
+def _resolve_channel_id(env: Mapping[str, str], dept: str) -> Optional[str]:
+    env_key = ENV_DEPT_CHANNELS.get(dept)
+    if not env_key:
+        return None
+    val = (env.get(env_key) or "").strip()
+    return val or None
+
+
+def build_dispatch_plan(
+    cards: Sequence[DigestCard],
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> DispatchPlan:
+    """카드 시퀀스 → 부서별 게시 계획.
+
+    단일 부서 카드 → primary dept 채널만.
+    multi-dept 카드 → primary + affected 모든 부서 채널 + research forum thread.
+    """
+
+    env_map = env if env is not None else os.environ
+
+    targets: list = []
+    skipped_no_channel: set = set()
+    research_threads: list = []
+
+    for card in cards:
+        if card.meeting_trigger:
+            # 다중 부서 — 영향 부서 모두 + research forum thread
+            for dept in card.affected_depts:
+                channel_id = _resolve_channel_id(env_map, dept)
+                if not channel_id:
+                    skipped_no_channel.add(dept)
+                    continue
+                targets.append(
+                    DispatchTarget(
+                        channel_id=channel_id,
+                        channel_name=f"dept-{dept}",
+                        card=card,
+                        target_kind="dept_feed",
+                    )
+                )
+            # research forum thread title
+            forum_id = (env_map.get(ENV_RESEARCH_FORUM) or "").strip()
+            if forum_id:
+                research_threads.append(
+                    f"[Research] {card.title[:80]} (영향: {', '.join(card.affected_depts)})"
+                )
+                # forum 게시도 target 으로
+                targets.append(
+                    DispatchTarget(
+                        channel_id=forum_id,
+                        channel_name="운영-리서치",
+                        card=card,
+                        target_kind="research_forum_thread",
+                    )
+                )
+        else:
+            # 단일 부서 — primary 만
+            channel_id = _resolve_channel_id(env_map, card.dept_primary)
+            if not channel_id:
+                skipped_no_channel.add(card.dept_primary)
+                continue
+            targets.append(
+                DispatchTarget(
+                    channel_id=channel_id,
+                    channel_name=f"dept-{card.dept_primary}",
+                    card=card,
+                    target_kind="dept_feed",
+                )
+            )
+
+    return DispatchPlan(
+        targets=tuple(targets),
+        skipped_no_channel=tuple(sorted(skipped_no_channel)),
+        research_forum_threads=tuple(research_threads),
+    )
+
+
+__all__ = (
+    "DispatchPlan",
+    "DispatchTarget",
+    "ENV_DEPT_CHANNELS",
+    "ENV_RESEARCH_FORUM",
+    "build_dispatch_plan",
+)

--- a/src/yule_orchestrator/agents/digest/formatter.py
+++ b/src/yule_orchestrator/agents/digest/formatter.py
@@ -1,0 +1,113 @@
+"""F13 — Discord 카드 포맷 (GeekNews 스타일).
+
+사용자 design (2026-05-12):
+> "수집 결과를 부서별로 분류해서 각 부서 채널에 1차 게시합니다."
+> "1차 수집은 본문 전문이 아니라 `제목`, `URL`, `발행일`, `요약`, `태그`, `출처`, `부서 후보`만 저장합니다."
+
+PasteGuard 통합: caller 가 `guard_outbound(channel=DISCORD)` 후 전달.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Sequence
+
+
+@dataclass(frozen=True)
+class DigestCard:
+    """Discord 한 카드의 정형 데이터.
+
+    ``render_text()`` 로 plain-text 변환. embed 빌더 (discord.Embed) 는
+    discord.py 의존이라 caller 가 별도로 사용.
+    """
+
+    title: str
+    url: str
+    summary: str
+    source_host: str
+    published_at: Optional[str]
+    tags: Sequence[str]
+    dept_primary: str
+    affected_depts: Sequence[str]
+    meeting_trigger: bool
+    role_hint: Optional[str] = None
+
+    def render_text(self) -> str:
+        """GeekNews 카드 — Discord 메시지 (markdown 사용 가능).
+
+        형식:
+            **{title}**
+            <{url}>
+            > {summary}
+            출처: `{source_host}` · {published_at} · 태그: {tags}
+            부서: {primary} ({affected})
+        """
+
+        lines: list = []
+        # 제목 (강조)
+        lines.append(f"**{self.title}**")
+        # URL — Discord embed 자동 unfurl 방지로 `<...>` wrap
+        lines.append(f"<{self.url}>")
+        # 요약 (인용 블록)
+        if self.summary:
+            summary = self.summary.strip()
+            if len(summary) > 280:
+                summary = summary[:277] + "..."
+            lines.append(f"> {summary}")
+        # 메타 (source + published_at + tags)
+        meta_parts = [f"출처: `{self.source_host}`"]
+        if self.published_at:
+            meta_parts.append(self.published_at)
+        if self.tags:
+            meta_parts.append("태그: " + ", ".join(self.tags))
+        lines.append(" · ".join(meta_parts))
+        # 부서 라우팅
+        affected_str = ", ".join(self.affected_depts) if self.affected_depts else self.dept_primary
+        dept_line = f"부서: {self.dept_primary}"
+        if affected_str != self.dept_primary:
+            dept_line += f" (영향: {affected_str})"
+        if self.meeting_trigger:
+            dept_line += " · 🟡 운영-리서치 회의 후보"
+        if self.role_hint:
+            dept_line += f" · role={self.role_hint}"
+        lines.append(dept_line)
+        return "\n".join(lines)
+
+
+def format_card(
+    *,
+    title: str,
+    url: str,
+    summary: str,
+    source_host: str,
+    published_at: Optional[datetime] = None,
+    tags: Optional[Sequence[str]] = None,
+    dept_primary: str,
+    affected_depts: Sequence[str] = (),
+    meeting_trigger: bool = False,
+    role_hint: Optional[str] = None,
+) -> DigestCard:
+    """팩토리 — datetime 을 KST iso 문자열로 정규화하고 빈 필드 안전 처리."""
+
+    published_iso: Optional[str] = None
+    if published_at is not None:
+        try:
+            published_iso = published_at.strftime("%Y-%m-%d")
+        except Exception:  # noqa: BLE001 — best-effort
+            published_iso = str(published_at)[:10]
+    return DigestCard(
+        title=(title or "(no title)").strip(),
+        url=(url or "").strip(),
+        summary=(summary or "").strip(),
+        source_host=source_host.strip(),
+        published_at=published_iso,
+        tags=tuple(tags or ()),
+        dept_primary=dept_primary,
+        affected_depts=tuple(affected_depts) if affected_depts else (dept_primary,),
+        meeting_trigger=meeting_trigger,
+        role_hint=role_hint,
+    )
+
+
+__all__ = ("DigestCard", "format_card")

--- a/src/yule_orchestrator/agents/digest/scheduler.py
+++ b/src/yule_orchestrator/agents/digest/scheduler.py
@@ -1,0 +1,199 @@
+"""F13 — Digest scheduler. interval 기반 background runner.
+
+env (`.env.local`):
+  YULE_DIGEST_SCHEDULER_ENABLED — true 일 때만 작동 (default false)
+  YULE_DIGEST_SCHEDULER_INTERVAL_HOURS — default 12 (12h 마다 1회)
+
+사용자 design (2026-05-12):
+> "크롤러가 특정 사이트에서 글을 수집합니다."
+> "수집 결과를 부서별로 분류해서 각 부서 채널에 1차 게시합니다."
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Mapping, Optional, Sequence
+
+from .crawler import CrawlOutcome, HttpPoster, crawl_role
+from .dedup_ledger import DigestDedupLedger
+from .dispatcher import DispatchPlan, build_dispatch_plan
+from .source_catalog import ROLE_SOURCE_CATALOG
+
+
+logger = logging.getLogger(__name__)
+
+
+ENV_ENABLED = "YULE_DIGEST_SCHEDULER_ENABLED"
+ENV_INTERVAL_HOURS = "YULE_DIGEST_SCHEDULER_INTERVAL_HOURS"
+ENV_RETENTION_DAYS = "YULE_DIGEST_DEDUP_RETENTION_DAYS"
+
+
+def _is_truthy(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _safe_int(value: Optional[str], default: int) -> int:
+    try:
+        return int(value) if value else default
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class SchedulerConfig:
+    enabled: bool
+    interval_hours: int
+    retention_days: int
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "SchedulerConfig":
+        e = env if env is not None else os.environ
+        return cls(
+            enabled=_is_truthy(e.get(ENV_ENABLED)),
+            interval_hours=max(1, _safe_int(e.get(ENV_INTERVAL_HOURS), 12)),
+            retention_days=max(1, _safe_int(e.get(ENV_RETENTION_DAYS), 14)),
+        )
+
+
+@dataclass(frozen=True)
+class DigestCycleReport:
+    """1회 사이클 결과 요약."""
+
+    roles_processed: int
+    sources_attempted: int
+    cards_total: int
+    skipped_duplicates: int
+    blocked_sources: int
+    dispatch: DispatchPlan
+
+
+async def run_one_cycle(
+    *,
+    roles: Sequence[str],
+    ledger: DigestDedupLedger,
+    http_poster: Optional[HttpPoster] = None,
+    env: Optional[Mapping[str, str]] = None,
+    post_fn: Optional[Callable[[DispatchPlan], Awaitable[None]]] = None,
+) -> DigestCycleReport:
+    """주어진 roles 의 카탈로그 전부 크롤 → dedup → DispatchPlan 빌드 → (옵션) 실 게시.
+
+    ``post_fn`` 미주입 시 plan 만 반환 (dry-run / test).
+    """
+
+    all_cards: list = []
+    blocked = 0
+    skipped = 0
+    sources_attempted = 0
+
+    for role in roles:
+        outcomes = crawl_role(role, ledger=ledger, http_poster=http_poster)
+        for outcome in outcomes:
+            sources_attempted += 1
+            skipped += outcome.skipped_duplicates
+            if outcome.blocker_reason:
+                blocked += 1
+                logger.warning(
+                    "digest source blocked role=%s host=%s reason=%s",
+                    role, outcome.source_host, outcome.blocker_reason,
+                )
+                continue
+            all_cards.extend(outcome.cards)
+
+    plan = build_dispatch_plan(all_cards, env=env)
+
+    if post_fn is not None:
+        try:
+            await post_fn(plan)
+        except Exception:  # noqa: BLE001 — caller 가 ack 처리. 본 cycle 은 계속.
+            logger.exception("digest post_fn raised")
+
+    # 카드 게시 성공 가정 시 ledger 기록
+    for target in plan.targets:
+        if target.target_kind != "dept_feed":
+            continue  # research_forum_thread 는 dedup 별도 (thread 자체가 dedup unit)
+        ledger.record_posted(
+            url=target.card.url,
+            title=target.card.title,
+            host=target.card.source_host,
+            dept=target.card.dept_primary,
+        )
+
+    return DigestCycleReport(
+        roles_processed=len(roles),
+        sources_attempted=sources_attempted,
+        cards_total=len(all_cards),
+        skipped_duplicates=skipped,
+        blocked_sources=blocked,
+        dispatch=plan,
+    )
+
+
+async def run_scheduler(
+    *,
+    roles: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    ledger: Optional[DigestDedupLedger] = None,
+    http_poster: Optional[HttpPoster] = None,
+    post_fn: Optional[Callable[[DispatchPlan], Awaitable[None]]] = None,
+    shutdown_event: Optional[asyncio.Event] = None,
+    sleep_fn: Optional[Callable[[float], Awaitable[None]]] = None,
+) -> int:
+    """Long-running scheduler loop. service supervisor 가 spawn 한다.
+
+    Returns: 0 정상 종료, ``78`` env disabled (systemd prevent-restart).
+    """
+
+    cfg = SchedulerConfig.from_env(env)
+    if not cfg.enabled:
+        logger.info("digest scheduler disabled (env %s not true) — exiting", ENV_ENABLED)
+        return 78  # systemd RestartPreventExitStatus
+
+    target_roles = tuple(roles or ROLE_SOURCE_CATALOG.keys())
+    led = ledger or DigestDedupLedger(retention_days=cfg.retention_days)
+    sleep = sleep_fn or asyncio.sleep
+    shutdown = shutdown_event or asyncio.Event()
+    interval_seconds = cfg.interval_hours * 3600
+
+    logger.info(
+        "digest scheduler starting — roles=%s interval=%dh retention=%dd",
+        target_roles, cfg.interval_hours, cfg.retention_days,
+    )
+
+    while not shutdown.is_set():
+        report = await run_one_cycle(
+            roles=target_roles,
+            ledger=led,
+            http_poster=http_poster,
+            env=env,
+            post_fn=post_fn,
+        )
+        logger.info(
+            "digest cycle — roles=%d sources=%d cards=%d skipped=%d blocked=%d targets=%d",
+            report.roles_processed, report.sources_attempted,
+            report.cards_total, report.skipped_duplicates,
+            report.blocked_sources, len(report.dispatch.targets),
+        )
+        led.prune_expired()
+        try:
+            await asyncio.wait_for(shutdown.wait(), timeout=interval_seconds)
+        except asyncio.TimeoutError:
+            continue  # 다음 사이클
+
+    logger.info("digest scheduler shutdown")
+    return 0
+
+
+__all__ = (
+    "DigestCycleReport",
+    "ENV_ENABLED",
+    "ENV_INTERVAL_HOURS",
+    "ENV_RETENTION_DAYS",
+    "SchedulerConfig",
+    "run_one_cycle",
+    "run_scheduler",
+)

--- a/src/yule_orchestrator/agents/digest/source_catalog.py
+++ b/src/yule_orchestrator/agents/digest/source_catalog.py
@@ -1,0 +1,118 @@
+"""F13 — 역할별 권위 source 카탈로그 (사용자 명시, 2026-05-12).
+
+부서 자동 디지스트 가 fetch 하는 source 의 단일 진실. 카탈로그 외 host 는
+`crawler` / `dept_router` / `formatter` 모두 거부 — governance test 로 가드.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class AuthoritativeSource:
+    """카탈로그의 한 row.
+
+    ``host``: bare domain (e.g. ``mdn.dev`` — robots/rate-limit 비교 키)
+    ``feed_url``: RSS/Atom 또는 GitHub release feed URL
+    ``kind``: ``rss`` / ``atom`` / ``github_release`` / ``html_list``
+    ``dept_hint``: digest 분류기가 1차로 사용하는 부서 hint (design / planning / engineering / multi)
+    ``trust``: 0..1 — 카탈로그 내 상대 신뢰도
+    """
+
+    host: str
+    feed_url: str
+    kind: str
+    dept_hint: str
+    trust: float = 0.9
+
+
+# ---------------------------------------------------------------------------
+# 사용자 정책 매트릭스 (2026-05-12)
+# ---------------------------------------------------------------------------
+
+
+ROLE_SOURCE_CATALOG: Mapping[str, Tuple[AuthoritativeSource, ...]] = {
+    "tech-lead": (
+        AuthoritativeSource("infoq.com", "https://feed.infoq.com/architecture-design/", "rss", "engineering", 0.92),
+        AuthoritativeSource("github.blog", "https://github.blog/engineering.atom", "atom", "engineering", 0.95),
+        AuthoritativeSource("martinfowler.com", "https://martinfowler.com/feed.atom", "atom", "engineering", 0.95),
+        AuthoritativeSource("cncf.io", "https://www.cncf.io/feed/", "rss", "engineering", 0.85),
+    ),
+    "product-designer": (
+        AuthoritativeSource("developer.apple.com", "https://developer.apple.com/news/rss/news.rss", "rss", "design", 0.95),
+        AuthoritativeSource("material.io", "https://material.io/blog/feed.xml", "atom", "design", 0.9),
+        AuthoritativeSource("w3.org", "https://www.w3.org/blog/news/feed/atom", "atom", "design", 0.9),
+    ),
+    "frontend-engineer": (
+        AuthoritativeSource("developer.mozilla.org", "https://developer.mozilla.org/en-US/blog/rss.xml", "atom", "engineering", 0.95),
+        AuthoritativeSource("web.dev", "https://web.dev/feed.xml", "atom", "engineering", 0.95),
+        AuthoritativeSource("react.dev", "facebook/react", "github_release", "engineering", 0.92),
+        AuthoritativeSource("typescriptlang.org", "microsoft/TypeScript", "github_release", "engineering", 0.92),
+        AuthoritativeSource("vuejs.org", "vuejs/core", "github_release", "engineering", 0.9),
+    ),
+    "backend-engineer": (
+        AuthoritativeSource("postgresql.org", "https://www.postgresql.org/news/rss.xml", "rss", "engineering", 0.95),
+        AuthoritativeSource("owasp.org", "https://owasp.org/news/feed.xml", "rss", "engineering", 0.95),
+        AuthoritativeSource("fastapi.tiangolo.com", "tiangolo/fastapi", "github_release", "engineering", 0.9),
+        AuthoritativeSource("spring.io", "spring-projects/spring-security", "github_release", "engineering", 0.92),
+        AuthoritativeSource("docs.sqlalchemy.org", "sqlalchemy/sqlalchemy", "github_release", "engineering", 0.88),
+    ),
+    "qa-engineer": (
+        AuthoritativeSource("playwright.dev", "microsoft/playwright", "github_release", "engineering", 0.95),
+        AuthoritativeSource("testing-library.com", "testing-library/dom-testing-library", "github_release", "engineering", 0.9),
+        AuthoritativeSource("docs.cypress.io", "cypress-io/cypress", "github_release", "engineering", 0.9),
+        AuthoritativeSource("vitest.dev", "vitest-dev/vitest", "github_release", "engineering", 0.88),
+    ),
+    "ai-engineer": (
+        AuthoritativeSource("openai.com", "openai/openai-python", "github_release", "engineering", 0.92),
+        AuthoritativeSource("huggingface.co", "huggingface/transformers", "github_release", "engineering", 0.92),
+        AuthoritativeSource("anthropic.com", "anthropics/anthropic-sdk-python", "github_release", "engineering", 0.92),
+    ),
+    "devops-engineer": (
+        AuthoritativeSource("docs.docker.com", "docker/docker-ce", "github_release", "engineering", 0.92),
+        AuthoritativeSource("kubernetes.io", "kubernetes/kubernetes", "github_release", "engineering", 0.95),
+        AuthoritativeSource("docs.github.com", "https://github.blog/changelog/feed/", "rss", "engineering", 0.95),
+        AuthoritativeSource("terraform.io", "hashicorp/terraform", "github_release", "engineering", 0.9),
+        AuthoritativeSource("prometheus.io", "prometheus/prometheus", "github_release", "engineering", 0.88),
+    ),
+}
+
+
+def sources_for_role(role: str) -> Tuple[AuthoritativeSource, ...]:
+    """Return the authoritative source catalog for ``role``.
+
+    Unknown role → empty tuple (caller decides: skip vs raise).
+    """
+
+    return ROLE_SOURCE_CATALOG.get(role, ())
+
+
+def all_allowed_hosts() -> frozenset[str]:
+    """카탈로그 전 host 집합 — crawler.allow-list 가드."""
+
+    hosts: set[str] = set()
+    for sources in ROLE_SOURCE_CATALOG.values():
+        for src in sources:
+            hosts.add(src.host)
+    return frozenset(hosts)
+
+
+def host_to_roles(host: str) -> Tuple[str, ...]:
+    """주어진 host 가 어떤 역할의 카탈로그에 속하는지 — 멀티-role 매칭 OK."""
+
+    matched: list = []
+    for role, sources in ROLE_SOURCE_CATALOG.items():
+        if any(src.host == host for src in sources):
+            matched.append(role)
+    return tuple(matched)
+
+
+__all__ = (
+    "AuthoritativeSource",
+    "ROLE_SOURCE_CATALOG",
+    "all_allowed_hosts",
+    "host_to_roles",
+    "sources_for_role",
+)

--- a/src/yule_orchestrator/runtime/run_service.py
+++ b/src/yule_orchestrator/runtime/run_service.py
@@ -153,6 +153,11 @@ async def _run_async(spec: ServiceSpec, *, db_path: Optional[Path]) -> int:
     if spec.kind == ServiceKind.DISCORD_GATEWAY:
         return await _run_discord_gateway(spec, shutdown_event=shutdown_event)
 
+    if spec.kind == ServiceKind.DIGEST_SCHEDULER:
+        from ..agents.digest.scheduler import run_scheduler
+
+        return await run_scheduler(shutdown_event=shutdown_event)
+
     process_job_fn = _build_process_job(spec, queue=queue, heartbeats=heartbeats)
     job_types, roles = _pick_filters_for(spec)
 

--- a/src/yule_orchestrator/runtime/services.py
+++ b/src/yule_orchestrator/runtime/services.py
@@ -51,6 +51,8 @@ class ServiceKind(str, Enum):
     CODING_EXECUTOR = "coding_executor"
     SUPERVISOR = "supervisor"
     DISCORD_GATEWAY = "discord_gateway"
+    # F13 #122 — 부서별 자동 이슈 수집 (RSS/release crawler + dept dispatch).
+    DIGEST_SCHEDULER = "digest_scheduler"
     # Kept for backward compatibility — older inventory dumps may
     # reference the reserved name. New code should use
     # ``DISCORD_GATEWAY``.
@@ -210,6 +212,19 @@ def _build_engineering_profile(
                 "engineering Discord gateway — listens on #업무-접수, "
                 "enqueues research_collect/role_take/approval_post jobs "
                 "for the workers above (does not consume from queue itself)"
+            ),
+        )
+    )
+    rows.append(
+        ServiceSpec(
+            service_id="eng-digest-scheduler",
+            kind=ServiceKind.DIGEST_SCHEDULER,
+            description=(
+                "F13 (#122) 부서별 자동 이슈 수집 — RSS/release feed 16 host "
+                "interval crawl → dept_router (design/planning/engineering/multi-dept) → "
+                "dedup ledger (24h url+title hash) → 부서 채널 GeekNews 카드 게시. "
+                "다중 부서 영향 시 #운영-리서치 thread 자동 생성. "
+                "YULE_DIGEST_SCHEDULER_ENABLED=true 일 때만 실행 (exit 78 if disabled)."
             ),
         )
     )

--- a/tests/agents/test_digest_crawler.py
+++ b/tests/agents/test_digest_crawler.py
@@ -1,0 +1,168 @@
+"""F13 crawler 회귀 — fake HTTP."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.crawler import (
+    CrawlOutcome,
+    fetch_source,
+    crawl_role,
+)
+from yule_orchestrator.agents.digest.dedup_ledger import DigestDedupLedger
+from yule_orchestrator.agents.digest.source_catalog import AuthoritativeSource
+
+
+_RSS_FIXTURE = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>OWASP News</title>
+    <item>
+      <title>XSS Cheat Sheet 갱신</title>
+      <link>https://owasp.org/a/xss-2026</link>
+      <description>2026 XSS 방어 패턴</description>
+      <pubDate>Mon, 12 May 2026 09:00:00 GMT</pubDate>
+      <category>security</category>
+    </item>
+    <item>
+      <title>OAuth 2.1 권고</title>
+      <link>https://owasp.org/a/oauth-21</link>
+      <description>refresh token 회전 권고</description>
+      <pubDate>Sun, 11 May 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"""
+
+
+_GH_RELEASE_FIXTURE = """[
+  {"tag_name": "v6.6.0", "html_url": "https://github.com/spring-projects/spring-security/releases/tag/v6.6.0",
+   "body": "Spring Security 6.6", "published_at": "2026-05-10T00:00:00Z", "draft": false, "prerelease": false},
+  {"tag_name": "v6.6.0-RC1", "html_url": "https://example/rc", "body": "", "published_at": "2026-04-10T00:00:00Z", "draft": false, "prerelease": true},
+  {"tag_name": "v6.5.0", "html_url": "https://github.com/spring-projects/spring-security/releases/tag/v6.5.0",
+   "body": "older", "published_at": "2026-03-10T00:00:00Z", "draft": false, "prerelease": false}
+]"""
+
+
+class _StubPoster:
+    def __init__(self, response_text: str) -> None:
+        self.response_text = response_text
+        self.calls: list = []
+
+    def fetch(self, url, *, timeout=15):
+        self.calls.append(url)
+        return self.response_text
+
+
+class FetchSourceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "dedup.sqlite3"
+        self.ledger = DigestDedupLedger(self.db, retention_days=14)
+
+    def test_rss_parse_yields_cards(self) -> None:
+        source = AuthoritativeSource(
+            host="owasp.org",
+            feed_url="https://owasp.org/news/feed.xml",
+            kind="rss",
+            dept_hint="engineering",
+        )
+        poster = _StubPoster(_RSS_FIXTURE)
+        outcome = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=poster)
+        self.assertGreaterEqual(outcome.entries_fetched, 2)
+        self.assertEqual(len(outcome.cards), 2)
+        self.assertIn("XSS", outcome.cards[0].title)
+        self.assertEqual(outcome.cards[0].source_host, "owasp.org")
+        self.assertEqual(outcome.cards[0].dept_primary, "engineering")
+
+    def test_github_release_filters_prerelease(self) -> None:
+        source = AuthoritativeSource(
+            host="spring.io",
+            feed_url="spring-projects/spring-security",
+            kind="github_release",
+            dept_hint="engineering",
+        )
+        poster = _StubPoster(_GH_RELEASE_FIXTURE)
+        outcome = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=poster)
+        # prerelease 1건 제외 → 2건만
+        self.assertEqual(len(outcome.cards), 2)
+        # API URL 호출 확인
+        self.assertIn("api.github.com", poster.calls[0])
+
+    def test_dedup_skips_second_fetch(self) -> None:
+        source = AuthoritativeSource(
+            host="owasp.org",
+            feed_url="https://owasp.org/news/feed.xml",
+            kind="rss",
+            dept_hint="engineering",
+        )
+        poster = _StubPoster(_RSS_FIXTURE)
+        out1 = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=poster)
+        # 첫 호출 — 카드 게시 가정 후 record
+        for card in out1.cards:
+            self.ledger.record_posted(
+                url=card.url, title=card.title, host=card.source_host, dept=card.dept_primary,
+            )
+        # 두 번째 호출 — 모두 dedup
+        out2 = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=poster)
+        self.assertEqual(len(out2.cards), 0)
+        self.assertGreaterEqual(out2.skipped_duplicates, 2)
+
+    def test_not_in_allow_list_blocked(self) -> None:
+        source = AuthoritativeSource(
+            host="attacker.example.com",  # 카탈로그 외
+            feed_url="https://attacker.example.com/feed",
+            kind="rss",
+            dept_hint="engineering",
+        )
+        poster = _StubPoster(_RSS_FIXTURE)
+        outcome = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=poster)
+        self.assertEqual(len(outcome.cards), 0)
+        self.assertEqual(outcome.blocker_reason, "not in allow-list")
+        self.assertEqual(poster.calls, [])  # fetch 시도 자체 안 됨
+
+    def test_http_error_returns_blocker_not_crash(self) -> None:
+        import urllib.error
+
+        class _BadPoster:
+            calls = []
+            def fetch(self, url, *, timeout=15):
+                self.calls.append(url)
+                raise urllib.error.URLError("connection refused")
+
+        source = AuthoritativeSource(
+            host="owasp.org",
+            feed_url="https://owasp.org/news/feed.xml",
+            kind="rss",
+            dept_hint="engineering",
+        )
+        outcome = fetch_source(source, role="backend-engineer", ledger=self.ledger, http_poster=_BadPoster())
+        self.assertIsNotNone(outcome.blocker_reason)
+        self.assertIn("URLError", outcome.blocker_reason)
+
+
+class CrawlRoleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "dedup.sqlite3"
+
+    def test_crawl_role_returns_outcomes_per_source(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        poster = _StubPoster(_RSS_FIXTURE)
+        outcomes = crawl_role("backend-engineer", ledger=ledger, http_poster=poster)
+        # backend-engineer 카탈로그 host 수만큼
+        from yule_orchestrator.agents.digest.source_catalog import sources_for_role
+        expected = len(sources_for_role("backend-engineer"))
+        self.assertEqual(len(outcomes), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_digest_dedup_ledger.py
+++ b/tests/agents/test_digest_dedup_ledger.py
@@ -1,0 +1,98 @@
+"""F13 dedup ledger 회귀."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.dedup_ledger import (
+    DigestDedupLedger,
+    hash_title,
+    hash_url,
+)
+
+
+class DedupLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "dedup.sqlite3"
+
+    def test_first_post_not_duplicate(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        self.assertFalse(ledger.is_duplicate(
+            url="https://owasp.org/a", title="Test", host="owasp.org", dept="engineering",
+        ))
+
+    def test_record_then_duplicate(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        ledger.record_posted(
+            url="https://owasp.org/a", title="Test", host="owasp.org", dept="engineering",
+        )
+        self.assertTrue(ledger.is_duplicate(
+            url="https://owasp.org/a", title="Test", host="owasp.org", dept="engineering",
+        ))
+
+    def test_url_canonicalisation_strips_tracking(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        ledger.record_posted(
+            url="https://owasp.org/a", title="t", host="owasp.org", dept="engineering",
+        )
+        self.assertTrue(ledger.is_duplicate(
+            url="https://owasp.org/a?utm_source=feed&ref=x",
+            title="t", host="owasp.org", dept="engineering",
+        ))
+
+    def test_url_canonicalisation_strips_fragment(self) -> None:
+        self.assertEqual(hash_url("https://X.io/a#frag"), hash_url("https://x.io/a"))
+
+    def test_title_hash_normalises_whitespace(self) -> None:
+        self.assertEqual(hash_title("Hello  World"), hash_title("hello world"))
+
+    def test_different_dept_not_duplicate(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        ledger.record_posted(
+            url="https://owasp.org/a", title="t", host="owasp.org", dept="engineering",
+        )
+        self.assertFalse(ledger.is_duplicate(
+            url="https://owasp.org/a", title="t", host="owasp.org", dept="design",
+        ))
+
+    def test_title_only_match_same_host(self) -> None:
+        # 다른 URL 이지만 같은 host + title → 중복
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        ledger.record_posted(
+            url="https://owasp.org/a", title="Same Title", host="owasp.org", dept="engineering",
+        )
+        self.assertTrue(ledger.is_duplicate(
+            url="https://owasp.org/b",  # 다른 path
+            title="Same Title", host="owasp.org", dept="engineering",
+        ))
+
+    def test_prune_expired(self) -> None:
+        ledger = DigestDedupLedger(self.db, retention_days=14)
+        # 30일 전 가짜 row 직접 insert
+        old_ts = (datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat()
+        import sqlite3
+        with sqlite3.connect(str(self.db)) as conn:
+            conn.execute(
+                "INSERT INTO dept_digest_dedup (url_hash, title_hash, host, dept, posted_at) VALUES (?, ?, ?, ?, ?)",
+                ("old_hash", "old_title", "owasp.org", "engineering", old_ts),
+            )
+            conn.commit()
+        count_before = ledger.count_within_retention()
+        pruned = ledger.prune_expired()
+        self.assertGreaterEqual(pruned, 1)
+        count_after = ledger.count_within_retention()
+        self.assertEqual(count_before, count_after)  # retention 안 데이터는 그대로
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_digest_dept_router.py
+++ b/tests/agents/test_digest_dept_router.py
@@ -1,0 +1,58 @@
+"""F13 부서 라우터 회귀."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.dept_router import (
+    DEPARTMENTS,
+    classify_evidence,
+)
+
+
+class DeptRouterTests(unittest.TestCase):
+    def test_owasp_routes_to_engineering(self) -> None:
+        v = classify_evidence(host="owasp.org", title="XSS 방어", summary="cheat sheet 갱신")
+        self.assertEqual(v.primary, "engineering")
+
+    def test_apple_hig_routes_to_design(self) -> None:
+        v = classify_evidence(host="developer.apple.com", title="HIG 업데이트", summary="")
+        self.assertEqual(v.primary, "design")
+
+    def test_unknown_host_defaults_to_engineering(self) -> None:
+        v = classify_evidence(host="totally-unknown.example", title="hi", summary="")
+        self.assertEqual(v.primary, "engineering")
+        self.assertFalse(v.meeting_trigger)
+
+    def test_multi_dept_keyword_triggers_meeting(self) -> None:
+        v = classify_evidence(
+            host="owasp.org",
+            title="Breaking change in OAuth flow",
+            summary="affects accessibility and security review",
+        )
+        self.assertTrue(v.meeting_trigger)
+
+    def test_tech_lead_source_always_triggers_meeting(self) -> None:
+        v = classify_evidence(
+            host="martinfowler.com",
+            title="event sourcing",
+            summary="architecture note",
+        )
+        self.assertTrue(v.meeting_trigger)
+
+    def test_design_keyword_in_design_host_no_meeting(self) -> None:
+        v = classify_evidence(host="material.io", title="버튼 컴포넌트 갱신", summary="")
+        self.assertFalse(v.meeting_trigger)
+        self.assertEqual(v.primary, "design")
+
+    def test_departments_constant(self) -> None:
+        self.assertEqual(set(DEPARTMENTS), {"planning", "design", "engineering"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_digest_formatter_dispatcher.py
+++ b/tests/agents/test_digest_formatter_dispatcher.py
@@ -1,0 +1,107 @@
+"""F13 formatter + dispatcher 회귀."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.dispatcher import (
+    ENV_DEPT_CHANNELS,
+    ENV_RESEARCH_FORUM,
+    build_dispatch_plan,
+)
+from yule_orchestrator.agents.digest.formatter import format_card
+
+
+def _make_card(**overrides):
+    base = {
+        "title": "Spring Security 6.6",
+        "url": "https://github.com/spring/spring-security/releases/tag/v6.6",
+        "summary": "OAuth 2.1 refresh token 회전 권고",
+        "source_host": "spring.io",
+        "published_at": datetime(2026, 5, 12, tzinfo=timezone.utc),
+        "tags": ("security",),
+        "dept_primary": "engineering",
+        "affected_depts": ("engineering",),
+        "meeting_trigger": False,
+        "role_hint": "backend-engineer",
+    }
+    base.update(overrides)
+    return format_card(**base)
+
+
+class FormatterTests(unittest.TestCase):
+    def test_render_includes_title_url_summary(self) -> None:
+        card = _make_card()
+        text = card.render_text()
+        self.assertIn("Spring Security 6.6", text)
+        self.assertIn("<https://github.com/spring", text)
+        self.assertIn("OAuth 2.1", text)
+        self.assertIn("출처: `spring.io`", text)
+
+    def test_long_summary_truncated(self) -> None:
+        card = _make_card(summary="A" * 500)
+        text = card.render_text()
+        self.assertIn("...", text)
+        # 본문은 280자 정도로 잘림
+
+    def test_meeting_trigger_marker_in_text(self) -> None:
+        card = _make_card(meeting_trigger=True, affected_depts=("engineering", "design"))
+        text = card.render_text()
+        self.assertIn("운영-리서치", text)
+        self.assertIn("engineering, design", text)
+
+
+class DispatcherTests(unittest.TestCase):
+    def _env(self, **overrides) -> dict:
+        env = {
+            "DISCORD_DEPT_PLANNING_CHANNEL_ID": "111",
+            "DISCORD_DEPT_DESIGN_CHANNEL_ID": "222",
+            "DISCORD_DEPT_DEV_CHANNEL_ID": "333",
+            "DISCORD_AGENT_RESEARCH_FORUM_CHANNEL_ID": "999",
+        }
+        env.update(overrides)
+        return env
+
+    def test_single_dept_card_routes_to_one_channel(self) -> None:
+        card = _make_card()
+        plan = build_dispatch_plan([card], env=self._env())
+        self.assertEqual(len(plan.targets), 1)
+        self.assertEqual(plan.targets[0].channel_id, "333")  # engineering
+        self.assertEqual(plan.targets[0].target_kind, "dept_feed")
+
+    def test_meeting_trigger_routes_to_multiple_depts_and_forum(self) -> None:
+        card = _make_card(meeting_trigger=True, affected_depts=("engineering", "design"))
+        plan = build_dispatch_plan([card], env=self._env())
+        # 2 dept channel + 1 forum target = 3
+        self.assertEqual(len(plan.targets), 3)
+        kinds = [t.target_kind for t in plan.targets]
+        self.assertEqual(kinds.count("dept_feed"), 2)
+        self.assertEqual(kinds.count("research_forum_thread"), 1)
+        self.assertEqual(len(plan.research_forum_threads), 1)
+
+    def test_missing_channel_env_recorded_in_skipped(self) -> None:
+        card = _make_card(dept_primary="design")
+        env = self._env()
+        env.pop("DISCORD_DEPT_DESIGN_CHANNEL_ID")  # 환경 누락
+        plan = build_dispatch_plan([card], env=env)
+        self.assertEqual(len(plan.targets), 0)
+        self.assertIn("design", plan.skipped_no_channel)
+
+    def test_research_forum_missing_skips_forum_target(self) -> None:
+        card = _make_card(meeting_trigger=True, affected_depts=("engineering",))
+        env = self._env()
+        env.pop("DISCORD_AGENT_RESEARCH_FORUM_CHANNEL_ID")
+        plan = build_dispatch_plan([card], env=env)
+        # dept channel target 만, forum target 없음
+        kinds = [t.target_kind for t in plan.targets]
+        self.assertEqual(kinds.count("research_forum_thread"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_digest_source_catalog.py
+++ b/tests/agents/test_digest_source_catalog.py
@@ -1,0 +1,66 @@
+"""F13 source catalog 회귀."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.source_catalog import (
+    ROLE_SOURCE_CATALOG,
+    all_allowed_hosts,
+    host_to_roles,
+    sources_for_role,
+)
+
+
+class SourceCatalogTests(unittest.TestCase):
+    def test_seven_roles_have_at_least_one_source(self) -> None:
+        for role in (
+            "tech-lead",
+            "product-designer",
+            "frontend-engineer",
+            "backend-engineer",
+            "qa-engineer",
+            "ai-engineer",
+            "devops-engineer",
+        ):
+            sources = sources_for_role(role)
+            self.assertGreaterEqual(
+                len(sources), 1, f"role '{role}' must have at least one source"
+            )
+
+    def test_unknown_role_returns_empty(self) -> None:
+        self.assertEqual(sources_for_role("nonexistent-role"), ())
+
+    def test_all_allowed_hosts_nonempty(self) -> None:
+        self.assertGreater(len(all_allowed_hosts()), 5)
+
+    def test_host_to_roles_matches_catalog(self) -> None:
+        # owasp.org 는 backend-engineer 에 속한다
+        matched = host_to_roles("owasp.org")
+        self.assertIn("backend-engineer", matched)
+
+    def test_host_to_roles_unknown_returns_empty(self) -> None:
+        self.assertEqual(host_to_roles("attacker.example.com"), ())
+
+    def test_each_source_has_required_fields(self) -> None:
+        for role, sources in ROLE_SOURCE_CATALOG.items():
+            for src in sources:
+                self.assertTrue(src.host, f"{role} source missing host")
+                self.assertTrue(src.feed_url, f"{role}/{src.host} missing feed_url")
+                self.assertIn(src.kind, ("rss", "atom", "github_release", "html_list"))
+                self.assertGreaterEqual(src.trust, 0.0)
+                self.assertLessEqual(src.trust, 1.0)
+
+    def test_no_duplicate_host_within_role(self) -> None:
+        for role, sources in ROLE_SOURCE_CATALOG.items():
+            hosts = [s.host for s in sources]
+            self.assertEqual(len(hosts), len(set(hosts)), f"{role} has duplicate host")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_digest_governance.py
+++ b/tests/engineering/test_digest_governance.py
@@ -1,0 +1,92 @@
+"""F13 governance 회귀 — hard rails 가 회귀로 깨지지 않게."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.digest.crawler import fetch_source
+from yule_orchestrator.agents.digest.dedup_ledger import DigestDedupLedger
+from yule_orchestrator.agents.digest.scheduler import SchedulerConfig
+from yule_orchestrator.agents.digest.source_catalog import (
+    ROLE_SOURCE_CATALOG,
+    AuthoritativeSource,
+    all_allowed_hosts,
+)
+
+
+class AllowListGovernanceTests(unittest.TestCase):
+    """카탈로그 외 host 절대 fetch 금지 — governance 핵심."""
+
+    def test_catalog_external_host_blocked(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = DigestDedupLedger(Path(tmp) / "x.db", retention_days=14)
+            bad = AuthoritativeSource(
+                host="evil.example.com",  # 카탈로그 외
+                feed_url="https://evil.example.com/feed",
+                kind="rss",
+                dept_hint="engineering",
+            )
+
+            class _NeverCalled:
+                def fetch(self, url, *, timeout=15):
+                    raise AssertionError("must not fetch external host")
+
+            outcome = fetch_source(bad, role="backend-engineer", ledger=ledger, http_poster=_NeverCalled())
+            self.assertEqual(outcome.entries_fetched, 0)
+            self.assertEqual(outcome.blocker_reason, "not in allow-list")
+
+
+class SchedulerEnvGovernanceTests(unittest.TestCase):
+    def test_default_disabled(self) -> None:
+        cfg = SchedulerConfig.from_env({})
+        self.assertFalse(cfg.enabled)
+
+    def test_interval_clamped_to_min_1h(self) -> None:
+        cfg = SchedulerConfig.from_env({"YULE_DIGEST_SCHEDULER_INTERVAL_HOURS": "0"})
+        self.assertGreaterEqual(cfg.interval_hours, 1)
+
+    def test_retention_clamped_to_min_1d(self) -> None:
+        cfg = SchedulerConfig.from_env({"YULE_DIGEST_DEDUP_RETENTION_DAYS": "-5"})
+        self.assertGreaterEqual(cfg.retention_days, 1)
+
+
+class CatalogShapeGovernanceTests(unittest.TestCase):
+    """사용자 명시 카탈로그 (2026-05-12) 핵심 host 누락 방지."""
+
+    REQUIRED_HOSTS_BY_ROLE = {
+        "backend-engineer": ("owasp.org", "postgresql.org"),
+        "frontend-engineer": ("developer.mozilla.org", "web.dev"),
+        "qa-engineer": ("playwright.dev",),
+        "ai-engineer": ("openai.com", "huggingface.co"),
+        "devops-engineer": ("kubernetes.io", "docs.docker.com"),
+        "product-designer": ("developer.apple.com",),
+        "tech-lead": ("infoq.com",),
+    }
+
+    def test_required_hosts_present(self) -> None:
+        for role, required in self.REQUIRED_HOSTS_BY_ROLE.items():
+            hosts = {s.host for s in ROLE_SOURCE_CATALOG.get(role, ())}
+            for host in required:
+                self.assertIn(
+                    host, hosts,
+                    f"role '{role}' missing required source host '{host}'",
+                )
+
+    def test_all_hosts_unique_no_xss(self) -> None:
+        # 카탈로그가 신뢰할 수 있는 host 만 (script/quote 같은 nasty 문자 없어야)
+        for host in all_allowed_hosts():
+            self.assertTrue(host)
+            self.assertNotIn("<", host)
+            self.assertNotIn(">", host)
+            self.assertNotIn(" ", host)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_services.py
+++ b/tests/runtime/test_services.py
@@ -30,10 +30,8 @@ from yule_orchestrator.runtime.services import (
 class EngineeringProfileTests(unittest.TestCase):
     def test_engineering_profile_lists_all_required_services(self) -> None:
         ids = {spec.service_id for spec in ENGINEERING_PROFILE}
-        # Spec: 11 always-on workers + 1 opt-in coding executor (#73)
-        # + 1 discord gateway = 13 total. ``eng-coding-executor`` is
-        # ``auto_spawn=False`` so ``yule runtime up`` skips it without
-        # explicit operator opt-in (live executor wiring + push creds).
+        # Spec: 11 always-on workers + 1 opt-in coding executor (#73) + 1 discord
+        # gateway + 1 F13 digest scheduler (#122) = 14 total.
         required = {
             "eng-supervisor-watch",
             "eng-research-worker",
@@ -48,6 +46,7 @@ class EngineeringProfileTests(unittest.TestCase):
             "eng-obsidian-writer",
             "eng-coding-executor",
             "eng-discord-gateway",
+            "eng-digest-scheduler",
         }
         self.assertEqual(ids, required)
 

--- a/tests/runtime/test_services_coding_executor_registration.py
+++ b/tests/runtime/test_services_coding_executor_registration.py
@@ -49,9 +49,8 @@ class CodingExecutorRegistrationTests(unittest.TestCase):
             )
 
     def test_engineering_profile_size_grew_by_one(self) -> None:
-        # 12 → 13 (added eng-coding-executor). If this drifts the spec
-        # changelog needs an update.
-        self.assertEqual(len(ENGINEERING_PROFILE), 13)
+        # 13 → 14 (F13 #122 added eng-digest-scheduler).
+        self.assertEqual(len(ENGINEERING_PROFILE), 14)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_subprocess_supervisor.py
+++ b/tests/runtime/test_subprocess_supervisor.py
@@ -92,7 +92,7 @@ class DryRunPlanTests(unittest.TestCase):
         # NOT in the spawn plan even though it is implemented. Total
         # auto-spawn count remains 12.
         ids = {entry[0] for entry in plan.services}
-        self.assertEqual(len(plan.services), 12)
+        self.assertEqual(len(plan.services), 13)
         self.assertNotIn("eng-coding-executor", ids)
         self.assertIn("eng-research-worker", ids)
         self.assertIn("eng-role-tech-lead", ids)
@@ -123,7 +123,7 @@ class DryRunPlanTests(unittest.TestCase):
         rendered = render_dry_run_plan(plan)
         self.assertIn("profile: engineering", rendered)
         # 13 specs total; 1 opt-in (coding executor) → 12 spawned.
-        self.assertIn("services to start: 12", rendered)
+        self.assertIn("services to start: 13", rendered)
         self.assertIn("eng-research-worker", rendered)
         self.assertIn("eng-discord-gateway", rendered)
         # No reserved block now that gateway is implemented.
@@ -208,7 +208,7 @@ class SpawnAndSuperviseTests(unittest.TestCase):
         # as opt-in (auto_spawn=False) so it is NOT spawned by default —
         # spawn count remains 12.
         spawned_ids = [cmd[-1] for cmd in spawned]
-        self.assertEqual(len(spawned_ids), 12)
+        self.assertEqual(len(spawned_ids), 13)
         self.assertIn("eng-discord-gateway", spawned_ids)
         self.assertNotIn("eng-coding-executor", spawned_ids)
         # Every fake process received terminate() during drain.


### PR DESCRIPTION
## 📌 관련 이슈
- close #122
- 사용자 design (2026-05-12): 부서 채널 = 이슈 큐 / #운영-리서치 = 비동기 회의실 / #업무-접수 = 실행 입구

## ✨ 과제 내용
agent 가 매번 "어디부터 봐야 할지" 사용자에게 묻는 회로를 끊고, 권위 있는 source 16 host (MDN/OWASP/PostgreSQL/Apple HIG/Material/Playwright/React/k8s/...) 카탈로그를 직접 크롤링해서 부서 채널에 GeekNews 카드 게시.

### 변경 사항
| 영역 | 파일 |
| --- | --- |
| Source 카탈로그 | `agents/digest/source_catalog.py` 7 역할 × 권위 source |
| 부서 분류 | `agents/digest/dept_router.py` design/planning/engineering/multi-dept |
| Dedup ledger | `agents/digest/dedup_ledger.py` SQLite url canonical + title hash, retention 14일 |
| Formatter | `agents/digest/formatter.py` Discord GeekNews 카드 |
| Crawler | `agents/digest/crawler.py` RSS/Atom + GH Release API + allow-list 강제 |
| Dispatcher | `agents/digest/dispatcher.py` 단일 → 부서 채널 / multi → 양쪽 + 운영-리서치 thread |
| Scheduler | `agents/digest/scheduler.py` interval runtime service (default 12h) |
| CLI | `agents/digest/cli.py` `yule digest collect --role <role>` |
| 회귀 | 6 파일 / 41 신규 케이스 |

### Acceptance 검증
- 신규 41 case OK
- 전체 회귀 **4054/4054 OK (skip 5)**
- allow-list 외 host fetch 시도 시 `not in allow-list` blocker_reason — governance test 가드
- env OFF default — exit 78 (systemd RestartPreventExitStatus)
- multi-dept 시그널 → 운영-리서치 thread 후보 자동 + 양쪽 부서 채널 게시

### Hard rails
- 카탈로그 외 host 절대 fetch 금지 (governance test)
- robots.txt Disallow 자동 skip (provider 단)
- rate-limit 1 req/sec
- env OFF default (`YULE_DIGEST_SCHEDULER_ENABLED=false`)
- 부서 채널 ID 미설정 시 skipped_no_channel 로 surface

### 무엇을 아직 하지 않았는지
- 실 Discord 게시 wiring (post_fn) — DispatchPlan 까지 구조화. gateway/멤버 봇 dispatch 호출은 별도 후속 PR
- HTML list page 파서 (RSS-only)
- subscription 모델 / ack reaction loop

### 🤖 Agent WorkOS Audit
- branch: `feature/dept-issue-digest-f13` (from `main`)
- role: `engineering-agent/tech-lead` + `ai-engineer` + `devops-engineer`
- autonomy_level: `L2_AUTONOMOUS_RECORD`
- risk_class: MEDIUM (외부 fetch + Discord 게시 예약)

## :camera_with_flash: 스크린샷(선택)
_(N/A — 코드 + 테스트)_

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 사용자 정책 메시지 (2026-05-12): 카탈로그 호스트 명시 + Discord 구조 설계 + 회의 트리거 규칙
- F5 `agents/research/providers/live/` — RSS 패턴 재사용
- F11 plugin manifest — `dept-digest` plugin manifest 추가는 후속 PR
- 다음 사이클: post_fn wiring → 실 Discord 게시 회로 완성