### PR TITLE
🔒 #128 F16 PR-2 — PR approval/merge loop (5-step gate + opt-in merge seam)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,12 +180,35 @@ DISCORD_GUILD_ID=
 #
 # YULE_GITHUB_DEFAULT_DRY_RUN 은 안전 기본값으로 항상 true 로 둔다.
 # false 로 명시한 경우에만 G3 executor 가 live write 를 시도한다.
+#
+# F16 (#128) PR-2: PR merge loop. 본 변수가 true 일 때만 GitHub PR
+# merge API 가 실제로 호출된다. 미설정 또는 false 면 router 가
+# approval card 까지만 게시하고 merge 시도 자체는 거부한다 — 안전한
+# disabled seam 으로 동작.
+#
+# 안전 규칙 (코드에서 강제):
+#   - draft PR / red CI checks / branch protection 미통과 → merge 거부
+#   - approval card 의 head_sha 와 현재 head_sha 가 다르면 거부 (race)
+#   - force push / required review 우회 / secret 변경 / deploy 범위 밖
 # YULE_GITHUB_APP_ID=
 # YULE_GITHUB_APP_INSTALLATION_ID=
 # YULE_GITHUB_APP_PRIVATE_KEY_PATH=
 # YULE_GITHUB_OWNER=
 # YULE_GITHUB_REPO=
 # YULE_GITHUB_DEFAULT_DRY_RUN=true
+# YULE_GITHUB_MERGE_ENABLED=false
+
+# =====================================================================
+# F16 (#128) PR-2 — PR merge approval extras
+#
+# YULE_PR_MERGE_REVIEW_COMMENT_ENABLED — REVISE_AND_REPEAT 응답 시
+# gateway 가 PR 에 자동 review comment 를 게시할지. live GitHub write
+# 가 발생하므로 default disabled. opt-in 시에만 활성.
+#
+# YULE_PR_MERGE_POLL_INTERVAL_SECONDS — open PR 변경 감지 polling
+# 주기. 미설정 시 60 초. F16 plan default 와 일치.
+# YULE_PR_MERGE_REVIEW_COMMENT_ENABLED=false
+# YULE_PR_MERGE_POLL_INTERVAL_SECONDS=60
 
 # =====================================================================
 # Multi-bot GitHub Apps (#81~ 후속 PR — 3봇 체제: tech-lead +

--- a/docs/pr-approval-merge.md
+++ b/docs/pr-approval-merge.md
@@ -1,0 +1,134 @@
+# F16 — PR Approval / Merge Loop
+
+> **Status**: F16 PR-2 (issue #128). 변경 B — gateway 가 `#승인-대기` 채널에 PR summary card 를 올리고, 승인 + green CI + branch protection 통과시에만 merge 시도. 본 doc 은 운영자 진입점.
+
+## 1. 흐름 개요
+
+```
+[GitHub PR opened/synchronize/ready_for_review]
+        ↓ (existing polling: list_open_pull_requests, 60s)
+[pr_event_producer 가 신규 PR 감지]
+        ↓
+[pr_merge_adapter.enqueue_pr_merge_approval]
+        ↓
+[ApprovalWorker → #승인-대기 채널에 summary card 게시]
+        ↓ (사용자: "승인" / "거절" / "수정 후 다시" / "머지 보류")
+[approval_reply_router → handle_pr_merge_approval_reply]
+        ↓ (intent=APPROVE)
+[5-step merge gate]
+  1. draft != True
+  2. mergeable_state == "clean"
+  3. all check_runs green
+  4. branch protection rules 통과
+  5. head_sha unchanged since approval
+        ↓ (all pass)
+[live_client.merge_pull_request]
+        ↓
+[Discord 에 결과 게시 + agent_ops_log audit]
+```
+
+## 2. opt-in 환경 변수
+
+**모든 production 시점에 strict 강제. 안전이 기본값.**
+
+| 변수 | 기본 | 의미 |
+| --- | --- | --- |
+| `YULE_GITHUB_MERGE_ENABLED` | `false` | merge API 호출 자체의 master gate. 미설정 또는 false 면 approval card + 5-step gate 까지만 동작하고 GitHub merge 는 거부. |
+| `YULE_GITHUB_DEFAULT_DRY_RUN` | `true` | 기존 G3 의 dry_run 가드. merge_enabled 와 별개로 함께 검증. |
+| `YULE_PR_MERGE_REVIEW_COMMENT_ENABLED` | `false` | "수정 후 다시" 응답 시 PR 에 자동 review comment 게시. live GitHub write → 신중. |
+| `YULE_PR_MERGE_POLL_INTERVAL_SECONDS` | `60` | PR 변경 감지 polling 주기. 너무 짧으면 API rate limit. |
+
+## 3. Summary card 의 모양
+
+`#승인-대기` 채널에 게시되는 카드 — 사용자가 짧게 판단할 수 있도록 6 섹션:
+
+```
+🔀 PR 머지 승인 — #127 ✨ F15 회사 팀 구조 lockdown
+
+📋 무엇이 바뀌나
+- agents/{hr,finance,sales-cs,legal}/ 6 부서 + 19 역할 manifest land
+- prompts/skills/pm/ 14 PM skill 카탈로그
+- governance test 18/18 PASS
+
+🎯 영향 범위: docs / agents / tests / prompts
+
+⚠️ 위험도: LOW (manifest JSON + docs + test; runtime 코드 변경 없음)
+
+✅ Tests: 18/18 PASS (corporate structure governance)
+✅ CI: green
+🔒 Branch protection: required reviews 1 ✓ / required checks 3 ✓
+
+🔗 https://github.com/yule-studio/yule-studio-agent/pull/127
+
+응답 어휘: "승인" / "거절" / "수정 후 다시" / "머지 보류"
+```
+
+## 4. 승인 어휘 (`ApprovalIntent`)
+
+기존 `agents/job_queue/approval_reply.py` 의 `ApprovalIntent` enum 확장:
+
+| 어휘 | enum | 의미 |
+| --- | --- | --- |
+| 승인 / 이대로 진행 / merge | `APPROVE` | merge gate 통과 시 merge 시도 |
+| 거절 / 반려 | `REJECT` | merge 안 함, audit log 만 |
+| 머지 보류 / 보류 | `HOLD` | 일시 보류, 같은 card 유효 |
+| 수정 후 다시 / revise | `REVISE_AND_REPEAT` *(신규)* | PR 에 review comment 게시 (env opt-in 시), card invalidate |
+| 인식 불가 | `UNCLEAR` | 다시 어휘 요청 |
+
+## 5. 5-step Merge Gate
+
+`approval_reply_router` 가 `APPROVE` intent + `approval_kind=pr_merge` 일 때 다음을 순차 검증. **하나라도 fail 시 merge 거부 + 사용자에게 이유 명시**:
+
+1. **draft != True** — draft PR 은 승인 받아도 merge X
+2. **mergeable_state == "clean"** — 충돌 / behind base 면 거부
+3. **모든 check_runs green** — `list_check_runs` 의 `conclusion == "success"` 전부
+4. **branch protection rules** — `get_branch_protection` 호출 → required_status_checks 통과, required_pull_request_reviews 통과
+5. **head_sha 일치** — approval card 작성 시점의 sha 와 현재 sha 가 같음 (race 방지)
+
+`get_branch_protection` 이 401/403 → **거부 (안전)**. 권한 부족도 risk 로 간주.
+
+## 6. Audit Trail
+
+모든 단계는 `session.extra["pr_merge_audit"]` 의 append-only list 에 기록:
+
+```json
+[
+  {"stage": "card_posted", "pr_number": 127, "head_sha": "abc123", "ts": "2026-05-13T07:00:00Z"},
+  {"stage": "approved", "by_user_id": 12345, "intent": "approve", "ts": "..."},
+  {"stage": "merge_gate_check", "draft": false, "mergeable": true, "checks_green": true, "protection_ok": true, "sha_match": true},
+  {"stage": "merge_disabled", "reason": "YULE_GITHUB_MERGE_ENABLED=false"},
+  {"stage": "merge_executed", "merge_sha": "def456", "method": "squash"}
+]
+```
+
+`agent_ops_log.append_agent_ops_audit` 재사용 — 별도 SQLite table 안 만든다.
+
+## 7. Hard Rails (다시 명시)
+
+- **절대 기본값 자동 merge X** — `YULE_GITHUB_MERGE_ENABLED=true` 명시 필수
+- **draft / red checks / branch protection violation / sha mismatch → merge 거부**
+- **force push 금지 / required review 우회 금지 / secret 변경 / production deploy 범위 밖**
+- **권한 부족 (401/403)** → 안전한 측에서 거부 (admin override 허용 X)
+- live merge 불가 시 — approval summary + routing + disabled seam 까지는 동작, merge 만 "disabled" 응답
+
+## 8. Acceptance Criteria
+
+- [ ] PR opened/synchronize/ready_for_review → approval card 발행 (변경 후 test)
+- [ ] Summary 에 title / scope / risk / tests / link 포함
+- [ ] 승인 응답 → merge gate 호출
+- [ ] `YULE_GITHUB_MERGE_ENABLED != true` → merge 거부 (분기 test)
+- [ ] draft / checks not green / missing approval / branch protection conflict → merge 차단 (각 분기 test)
+- [ ] 기존 approval flow (OBSIDIAN_WRITE, ENGINEERING_WRITE) 회귀 X
+
+## 9. 후속 (별도 issue)
+
+- 다중 repo 지원 (현재는 yule-studio-agent 만)
+- Webhook 수신 인프라 (현재는 polling)
+- BIMI / VMC / 외부 통지 (Slack alarm) 의 연동
+- merge 후 release note 자동 생성
+
+## 10. 참고
+
+- `policies/runtime/agents/engineering-agent/github-workflow.md` — GitHub workflow 기존 정책
+- `docs/runtime-recall-first.md` — F16 PR-1 의 recall-first 변경 (본 PR 과 독립)
+- 사용자 정책 (2026-05-13): "merge 는 high-risk 이므로 반드시 opt-in + human approval + green checks + rule compliance 강제"

--- a/src/yule_orchestrator/agents/job_queue/pr_approval.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_approval.py
@@ -1,0 +1,480 @@
+"""F16 PR-2 — Domain model for PR merge approval cards.
+
+This module is **pure** — no GitHub API calls, no Discord IO. It
+defines:
+
+  * :data:`APPROVAL_KIND_PR_MERGE` — new approval kind constant.
+  * :class:`PRMergeProposal` — builder dataclass that the
+    :mod:`pr_merge_adapter` will convert into an
+    :class:`~yule_orchestrator.agents.job_queue.approval_worker.ApprovalRequest`.
+  * :func:`render_pr_merge_summary` — markdown summary card body.
+  * :class:`PRMergeGateResult` — output of the 5-step merge gate.
+  * :func:`evaluate_merge_gate` — pure decider given a snapshot of PR
+    status. The caller is responsible for fetching live GitHub state.
+  * :func:`parse_pr_merge_reply_intent` — adds ``REVISE_AND_REPEAT``
+    to the base :class:`ApprovalIntent` vocabulary.
+
+The split keeps domain logic test-able without GitHub credentials
+and lets the adapter / live_client / approval_reply_router layers
+import this module without circular dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from .approval_reply import ApprovalIntent, parse_approval_intent
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+APPROVAL_KIND_PR_MERGE: str = "pr_merge"
+"""``ApprovalRequest.approval_kind`` value for PR merge approval cards.
+
+Distinct from :data:`APPROVAL_KIND_ENGINEERING_WRITE` (which covers
+"please write code for me") because the operator vocabulary differs:
+PR merge has its own "수정 후 다시" intent and 5-step gate that does
+not apply to a code-write request.
+"""
+
+
+class PRMergeReplyIntent(str, Enum):
+    """Extended reply vocabulary for PR merge cards.
+
+    Inherits the base 4 values (APPROVE / REJECT / HOLD / UNCLEAR)
+    from :class:`ApprovalIntent` so any caller can keep using the
+    smaller enum if they don't care about REVISE_AND_REPEAT.
+    """
+
+    APPROVE = "approve"
+    REJECT = "reject"
+    HOLD = "hold"
+    UNCLEAR = "unclear"
+    REVISE_AND_REPEAT = "revise_and_repeat"
+
+
+# Phrases that mean "merge 보류 — PR 수정 후 다시 카드를 받을게".
+# Distinct from HOLD (보류 = 같은 카드 유효) because revise invalidates
+# the current head_sha — a follow-up commit will produce a new card.
+_REVISE_PHRASES: frozenset = frozenset(
+    {
+        "수정 후 다시",
+        "수정후다시",
+        "수정 후 다시 보자",
+        "수정 후에 다시",
+        "수정후 다시",
+        "수정후에 다시",
+        "다시 작성 후",
+        "다시 작성 후 보자",
+        "revise",
+        "revise and repeat",
+        "revise then merge",
+        "fix and reopen",
+        "fix then merge",
+    }
+)
+
+
+_NORMALIZE_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    return _NORMALIZE_RE.sub(" ", (text or "").lower()).strip()
+
+
+def parse_pr_merge_reply_intent(text: str) -> PRMergeReplyIntent:
+    """Classify a PR-merge reply into one of 5 intents.
+
+    "수정 후 다시" (and English equivalents) maps to
+    :attr:`PRMergeReplyIntent.REVISE_AND_REPEAT`. Everything else
+    delegates to :func:`parse_approval_intent` so the standard
+    APPROVE / REJECT / HOLD vocabulary continues to work.
+    """
+
+    normalised = _normalize(text)
+    for phrase in _REVISE_PHRASES:
+        if phrase in normalised:
+            return PRMergeReplyIntent.REVISE_AND_REPEAT
+
+    base_intent = parse_approval_intent(text)
+    return PRMergeReplyIntent(base_intent.value)
+
+
+# ---------------------------------------------------------------------------
+# Proposal dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PRMergeProposal:
+    """Snapshot of a PR at the moment we propose to merge it.
+
+    All fields are deterministic so the same PR + same head_sha + same
+    check_runs produce a stable summary card (the approval worker's
+    dedup key fires correctly on re-post).
+
+    The ``head_sha`` participates in the 5-step gate's race check:
+    if a new commit lands after the card is posted, the gate refuses
+    to merge.
+    """
+
+    repo: str
+    pr_number: int
+    pr_title: str
+    pr_url: str
+    head_sha: str
+    base_branch: str
+    draft: bool
+    mergeable_state: str
+    summary_md: str
+    scope_labels: Tuple[str, ...] = field(default_factory=tuple)
+    risk: str = "UNKNOWN"
+    check_runs_summary: str = ""
+    branch_protection_summary: str = ""
+    body_excerpt: str = ""
+    requested_by: str = ""
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_extra(self) -> Mapping[str, Any]:
+        """Serialise into ``ApprovalRequest.extra`` payload (JSON-friendly)."""
+
+        return {
+            "repo": self.repo,
+            "pr_number": int(self.pr_number),
+            "pr_title": self.pr_title,
+            "pr_url": self.pr_url,
+            "head_sha": self.head_sha,
+            "base_branch": self.base_branch,
+            "draft": bool(self.draft),
+            "mergeable_state": self.mergeable_state,
+            "scope_labels": list(self.scope_labels),
+            "risk": self.risk,
+            "check_runs_summary": self.check_runs_summary,
+            "branch_protection_summary": self.branch_protection_summary,
+            "body_excerpt": self.body_excerpt,
+            "requested_by": self.requested_by,
+            **{k: v for k, v in (self.extra or {}).items()
+               if k not in {"repo", "pr_number"}},
+        }
+
+    @classmethod
+    def from_extra(cls, payload: Mapping[str, Any]) -> "PRMergeProposal":
+        """Reverse of :meth:`to_extra` — lift a queue-row payload back."""
+
+        payload = payload or {}
+        return cls(
+            repo=str(payload.get("repo") or ""),
+            pr_number=int(payload.get("pr_number") or 0),
+            pr_title=str(payload.get("pr_title") or ""),
+            pr_url=str(payload.get("pr_url") or ""),
+            head_sha=str(payload.get("head_sha") or ""),
+            base_branch=str(payload.get("base_branch") or ""),
+            draft=bool(payload.get("draft", False)),
+            mergeable_state=str(payload.get("mergeable_state") or "unknown"),
+            summary_md=str(payload.get("summary_md") or ""),
+            scope_labels=tuple(payload.get("scope_labels") or ()),
+            risk=str(payload.get("risk") or "UNKNOWN"),
+            check_runs_summary=str(payload.get("check_runs_summary") or ""),
+            branch_protection_summary=str(
+                payload.get("branch_protection_summary") or ""
+            ),
+            body_excerpt=str(payload.get("body_excerpt") or ""),
+            requested_by=str(payload.get("requested_by") or ""),
+            extra={
+                k: v
+                for k, v in payload.items()
+                if k
+                not in {
+                    "repo",
+                    "pr_number",
+                    "pr_title",
+                    "pr_url",
+                    "head_sha",
+                    "base_branch",
+                    "draft",
+                    "mergeable_state",
+                    "summary_md",
+                    "scope_labels",
+                    "risk",
+                    "check_runs_summary",
+                    "branch_protection_summary",
+                    "body_excerpt",
+                    "requested_by",
+                }
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Summary card rendering
+# ---------------------------------------------------------------------------
+
+
+_BODY_EXCERPT_MAX = 280
+
+
+def build_body_excerpt(body: Optional[str]) -> str:
+    """Trim PR body to a short excerpt for the summary card.
+
+    Keeps the first ``_BODY_EXCERPT_MAX`` characters, collapses
+    whitespace, and appends an ellipsis when truncated.
+    """
+
+    text = (body or "").strip()
+    if not text:
+        return ""
+    text = _NORMALIZE_RE.sub(" ", text)
+    if len(text) <= _BODY_EXCERPT_MAX:
+        return text
+    return text[:_BODY_EXCERPT_MAX].rstrip() + "…"
+
+
+def render_pr_merge_summary(proposal: PRMergeProposal) -> str:
+    """Render the markdown summary card body for *proposal*.
+
+    Layout matches ``docs/pr-approval-merge.md §3``:
+
+      Header line — emoji + PR number + title.
+      "무엇이 바뀌나" — body excerpt.
+      "영향 범위" — scope_labels joined.
+      "위험도" — risk string.
+      Tests / CI / Branch protection — check_runs_summary +
+      branch_protection_summary.
+      Link.
+
+    The function is deterministic — same proposal yields same text —
+    so approval_worker's dedup key fires consistently on re-post.
+    """
+
+    lines: list[str] = []
+
+    header = f"🔀 PR 머지 승인 — #{proposal.pr_number}"
+    if proposal.pr_title:
+        header = f"{header} {proposal.pr_title}"
+    lines.append(header)
+    lines.append("")
+
+    if proposal.body_excerpt:
+        lines.append("📋 무엇이 바뀌나")
+        lines.append(proposal.body_excerpt)
+        lines.append("")
+
+    if proposal.scope_labels:
+        scope = " / ".join(proposal.scope_labels)
+        lines.append(f"🎯 영향 범위: {scope}")
+
+    risk_label = {
+        "LOW": "LOW",
+        "MEDIUM": "MEDIUM",
+        "HIGH": "HIGH",
+    }.get((proposal.risk or "").upper(), proposal.risk or "UNKNOWN")
+    risk_emoji = {"LOW": "🟢", "MEDIUM": "🟡", "HIGH": "🔴"}.get(
+        risk_label, "⚠️"
+    )
+    lines.append(f"{risk_emoji} 위험도: {risk_label}")
+
+    if proposal.check_runs_summary:
+        lines.append(proposal.check_runs_summary)
+    if proposal.branch_protection_summary:
+        lines.append(proposal.branch_protection_summary)
+
+    if proposal.pr_url:
+        lines.append("")
+        lines.append(f"🔗 {proposal.pr_url}")
+        lines.append("")
+
+    lines.append("응답 어휘: 승인 / 거절 / 수정 후 다시 / 머지 보류")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 5-step merge gate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PRMergeStatusSnapshot:
+    """Live PR + check-runs + branch-protection state at gate time.
+
+    The caller (``pr_merge_executor``) fetches the live values via
+    ``live_client.get_pull_request`` / ``list_check_runs`` /
+    ``get_branch_protection`` and packs them here. We separate the
+    snapshot from gate evaluation so the gate is fully unit-testable
+    without GitHub access.
+    """
+
+    draft: bool
+    mergeable: Optional[bool]
+    mergeable_state: str
+    head_sha: str
+    check_conclusions: Tuple[str, ...]
+    required_status_checks: Tuple[str, ...] = field(default_factory=tuple)
+    required_approving_reviews: int = 0
+    actual_approving_reviews: int = 0
+    branch_protection_available: bool = True
+    """``False`` when ``get_branch_protection`` raised 401/403/404."""
+
+
+@dataclass(frozen=True)
+class PRMergeGateResult:
+    """Output of :func:`evaluate_merge_gate`."""
+
+    allowed: bool
+    failed_step: Optional[str] = None
+    reason: str = ""
+    checks_summary: str = ""
+
+
+_GATE_STEPS: Tuple[str, ...] = (
+    "draft",
+    "mergeable",
+    "checks_green",
+    "branch_protection",
+    "sha_race",
+)
+
+
+def evaluate_merge_gate(
+    proposal: PRMergeProposal,
+    snapshot: PRMergeStatusSnapshot,
+) -> PRMergeGateResult:
+    """Run the 5-step gate. Returns the first failure or "allowed".
+
+    Steps (matching ``docs/pr-approval-merge.md §5``):
+
+      1. ``draft != True`` — draft PR refuses merge.
+      2. ``mergeable_state == "clean"`` — conflicts / behind base reject.
+      3. all ``check_runs.conclusion == "success"`` (or "neutral").
+      4. branch protection rules — required_status_checks present in
+         passed checks, required_approving_reviews satisfied. If
+         ``branch_protection_available is False`` we refuse (safe).
+      5. ``snapshot.head_sha == proposal.head_sha`` (race protection).
+
+    Note: callers wanting an audit trail should record each step's
+    result regardless of which step fires the failure — this function
+    returns only the *first* failure.
+    """
+
+    # 1. draft
+    if snapshot.draft:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="draft",
+            reason="draft PR — 승인 받아도 merge 거부",
+        )
+
+    # 2. mergeable_state
+    state = (snapshot.mergeable_state or "").lower()
+    if state != "clean":
+        # mergeable can be True even when state != clean (e.g. "behind",
+        # "unstable") — we still refuse to be conservative.
+        reason = f"mergeable_state={state!r} (clean 아님)"
+        return PRMergeGateResult(
+            allowed=False, failed_step="mergeable", reason=reason
+        )
+    if snapshot.mergeable is False:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="mergeable",
+            reason="mergeable=False — conflict 또는 base 변경",
+        )
+
+    # 3. check runs
+    conclusions = tuple(c.lower() for c in (snapshot.check_conclusions or ()))
+    if not conclusions:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="checks_green",
+            reason="check_runs 결과 없음 — CI 미실행 또는 권한 부족",
+            checks_summary="no check runs",
+        )
+    failing = [c for c in conclusions if c not in {"success", "neutral", "skipped"}]
+    if failing:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="checks_green",
+            reason=f"check_runs not green ({len(failing)} failing)",
+            checks_summary=", ".join(sorted(set(failing))),
+        )
+
+    # 4. branch protection
+    if not snapshot.branch_protection_available:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="branch_protection",
+            reason="branch protection 조회 실패 — 권한 부족, 안전 측 거부",
+        )
+    if snapshot.actual_approving_reviews < snapshot.required_approving_reviews:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="branch_protection",
+            reason=(
+                f"required reviews {snapshot.required_approving_reviews}, "
+                f"actual {snapshot.actual_approving_reviews}"
+            ),
+        )
+
+    # 5. sha race
+    if snapshot.head_sha and proposal.head_sha and snapshot.head_sha != proposal.head_sha:
+        return PRMergeGateResult(
+            allowed=False,
+            failed_step="sha_race",
+            reason=(
+                "head_sha 변경됨: card 시점 "
+                f"{proposal.head_sha[:7]}, 현재 {snapshot.head_sha[:7]}"
+            ),
+        )
+
+    return PRMergeGateResult(
+        allowed=True,
+        reason="모든 gate 통과",
+        checks_summary=f"{len(conclusions)} checks green",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit helpers
+# ---------------------------------------------------------------------------
+
+
+PR_MERGE_AUDIT_KEY: str = "pr_merge_audit"
+"""Key under ``session.extra`` where the append-only audit list lives."""
+
+
+def make_audit_entry(stage: str, **fields: Any) -> Mapping[str, Any]:
+    """Build one audit entry with the canonical ``stage`` key.
+
+    Stages used by the loop:
+
+      * ``card_posted`` — approval card posted to Discord.
+      * ``approved`` / ``rejected`` / ``hold`` / ``revise_and_repeat``.
+      * ``merge_gate_check`` — gate result (allowed / failed_step / reason).
+      * ``merge_disabled`` — ``YULE_GITHUB_MERGE_ENABLED=false``.
+      * ``merge_executed`` — successful merge.
+      * ``merge_failed`` — GitHub API rejected the merge call.
+    """
+
+    entry: dict = {"stage": stage}
+    entry.update(fields)
+    return entry
+
+
+__all__ = (
+    "APPROVAL_KIND_PR_MERGE",
+    "PRMergeReplyIntent",
+    "PRMergeProposal",
+    "PRMergeStatusSnapshot",
+    "PRMergeGateResult",
+    "PR_MERGE_AUDIT_KEY",
+    "build_body_excerpt",
+    "render_pr_merge_summary",
+    "evaluate_merge_gate",
+    "parse_pr_merge_reply_intent",
+    "make_audit_entry",
+)

--- a/src/yule_orchestrator/agents/job_queue/pr_approval.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_approval.py
@@ -24,9 +24,15 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Tuple, Union
 
-from .approval_reply import ApprovalIntent, parse_approval_intent
+from .approval_reply import (
+    ApprovalIntent,
+    find_replyable_approval,
+    parse_approval_intent,
+)
+from .approval_worker import ApprovalRequest
+from .store import JobQueue
 
 
 # ---------------------------------------------------------------------------
@@ -465,16 +471,205 @@ def make_audit_entry(stage: str, **fields: Any) -> Mapping[str, Any]:
     return entry
 
 
+# ---------------------------------------------------------------------------
+# Reply handler (executor-injected — live merge call happens in commit 10)
+# ---------------------------------------------------------------------------
+
+
+# The merge executor signature. Implementations build a
+# :class:`PRMergeStatusSnapshot` from live GitHub state, run
+# :func:`evaluate_merge_gate`, and only on success call
+# ``live_client.merge_pull_request``. The function is intentionally
+# typed loosely so a sync stub (in tests) and a real async live client
+# wrapper (in production) both fit.
+PRMergeExecutor = Callable[
+    ["PRMergeReplyDispatch"], Union[Mapping[str, Any], Awaitable[Mapping[str, Any]]]
+]
+
+
+@dataclass(frozen=True)
+class PRMergeReplyDispatch:
+    """Bundle passed to the merge executor when intent=APPROVE.
+
+    The executor reads ``proposal`` for repo/pr_number/head_sha and the
+    full PR shape, ``approved_by``/``approved_at`` for audit entries,
+    and returns a mapping that the handler stores under
+    ``audit["merge_result"]``.
+    """
+
+    proposal: "PRMergeProposal"
+    approval_job_id: str
+    approved_by: str
+    approved_at: str
+    source_message_id: Optional[int]
+
+
+@dataclass(frozen=True)
+class PRMergeReplyResult:
+    """Output of :func:`handle_pr_merge_approval_reply`.
+
+    Mirrors :class:`ApprovalReplyOutcome` for symmetry but stays in
+    its own dataclass so PR-merge-specific fields (e.g.
+    ``merge_disabled``, ``gate_failed_step``) can grow without
+    polluting the obsidian path.
+    """
+
+    intent: PRMergeReplyIntent
+    approval_job_id: Optional[str] = None
+    proposal: Optional["PRMergeProposal"] = None
+    merge_disabled: bool = False
+    gate_failed_step: Optional[str] = None
+    gate_reason: str = ""
+    merge_result: Optional[Mapping[str, Any]] = None
+    rejection_recorded: bool = False
+    skipped_reason: Optional[str] = None
+    audit: Mapping[str, Any] = field(default_factory=dict)
+
+
+async def handle_pr_merge_approval_reply(
+    *,
+    queue: JobQueue,
+    text: str,
+    session_id: str,
+    approved_by: str,
+    source_message_id: Optional[int] = None,
+    source_thread_id: Optional[int] = None,
+    approved_at: str = "",
+    merge_executor: Optional[PRMergeExecutor] = None,
+) -> PRMergeReplyResult:
+    """Route a user's reply for a PR merge approval card.
+
+    Pure-ish: no Discord, no GitHub call. Side effects:
+
+      * Reads the queue to locate the matching ``approval_post`` row
+        whose ``approval_kind == APPROVAL_KIND_PR_MERGE``.
+      * On ``intent == APPROVE`` and a registered ``merge_executor``,
+        calls the executor (which runs the gate + GitHub merge call).
+      * Returns a structured :class:`PRMergeReplyResult` the router /
+        bot can render and audit.
+
+    When ``merge_executor is None`` the handler returns with
+    ``merge_disabled=True``. This is the safe disabled seam — useful
+    in CI / staging where ``YULE_GITHUB_MERGE_ENABLED=false`` would
+    still trigger the gate but never the API call.
+    """
+
+    intent = parse_pr_merge_reply_intent(text)
+
+    if intent in (PRMergeReplyIntent.HOLD, PRMergeReplyIntent.UNCLEAR):
+        return PRMergeReplyResult(
+            intent=intent, skipped_reason="intent_not_actionable"
+        )
+
+    approval_job = find_replyable_approval(
+        queue=queue,
+        session_id=session_id,
+        approval_kind=APPROVAL_KIND_PR_MERGE,
+        source_message_id=source_message_id,
+        source_thread_id=source_thread_id,
+    )
+    if approval_job is None:
+        return PRMergeReplyResult(
+            intent=intent, skipped_reason="no_matching_approval"
+        )
+
+    payload = approval_job.payload or {}
+    request = ApprovalRequest.from_payload(payload)
+    if request.approval_kind != APPROVAL_KIND_PR_MERGE:
+        return PRMergeReplyResult(
+            intent=intent,
+            approval_job_id=approval_job.job_id,
+            skipped_reason="approval_kind_mismatch",
+        )
+
+    proposal = PRMergeProposal.from_extra(request.extra or {})
+
+    if intent == PRMergeReplyIntent.REJECT:
+        return PRMergeReplyResult(
+            intent=intent,
+            approval_job_id=approval_job.job_id,
+            proposal=proposal,
+            rejection_recorded=True,
+            audit={
+                "rejected_by": approved_by,
+                "rejected_at": approved_at,
+                "source_message_id": source_message_id,
+            },
+        )
+
+    if intent == PRMergeReplyIntent.REVISE_AND_REPEAT:
+        # Cards are invalidated by the next commit (sha race in gate).
+        # The router may optionally post a review comment when
+        # ``YULE_PR_MERGE_REVIEW_COMMENT_ENABLED=true`` — that wire-up
+        # is in commit 10. For this commit we only audit the intent.
+        return PRMergeReplyResult(
+            intent=intent,
+            approval_job_id=approval_job.job_id,
+            proposal=proposal,
+            audit={
+                "revise_requested_by": approved_by,
+                "revise_at": approved_at,
+                "source_message_id": source_message_id,
+            },
+        )
+
+    # APPROVE — invoke the merge executor if registered.
+    if merge_executor is None:
+        return PRMergeReplyResult(
+            intent=intent,
+            approval_job_id=approval_job.job_id,
+            proposal=proposal,
+            merge_disabled=True,
+            audit={
+                "approved_by": approved_by,
+                "approved_at": approved_at,
+                "reason": "merge_executor_not_registered",
+            },
+        )
+
+    dispatch = PRMergeReplyDispatch(
+        proposal=proposal,
+        approval_job_id=approval_job.job_id,
+        approved_by=approved_by,
+        approved_at=approved_at,
+        source_message_id=source_message_id,
+    )
+    raw = merge_executor(dispatch)
+    if hasattr(raw, "__await__"):
+        raw = await raw  # type: ignore[assignment]
+    result: Mapping[str, Any] = dict(raw or {})
+
+    gate_failed = result.get("gate_failed_step")
+    return PRMergeReplyResult(
+        intent=intent,
+        approval_job_id=approval_job.job_id,
+        proposal=proposal,
+        merge_disabled=bool(result.get("merge_disabled", False)),
+        gate_failed_step=gate_failed if isinstance(gate_failed, str) else None,
+        gate_reason=str(result.get("gate_reason") or ""),
+        merge_result=result if result.get("merge_sha") else None,
+        audit={
+            "approved_by": approved_by,
+            "approved_at": approved_at,
+            "result": dict(result),
+        },
+    )
+
+
 __all__ = (
     "APPROVAL_KIND_PR_MERGE",
     "PRMergeReplyIntent",
     "PRMergeProposal",
     "PRMergeStatusSnapshot",
     "PRMergeGateResult",
+    "PRMergeReplyDispatch",
+    "PRMergeReplyResult",
+    "PRMergeExecutor",
     "PR_MERGE_AUDIT_KEY",
     "build_body_excerpt",
     "render_pr_merge_summary",
     "evaluate_merge_gate",
+    "handle_pr_merge_approval_reply",
     "parse_pr_merge_reply_intent",
     "make_audit_entry",
 )

--- a/src/yule_orchestrator/discord/pr_merge_adapter.py
+++ b/src/yule_orchestrator/discord/pr_merge_adapter.py
@@ -1,0 +1,210 @@
+"""F16 PR-2 — Discord adapter: enqueue a PR merge approval card.
+
+Mirrors :mod:`yule_orchestrator.discord.github_workos_adapter` (the
+ENGINEERING_WRITE path) but for a different
+:data:`~yule_orchestrator.agents.job_queue.pr_approval.APPROVAL_KIND_PR_MERGE`.
+
+The adapter does **NOT** call GitHub. It receives a
+:class:`PRMergeProposal` from a producer (``pr_event_producer``) and
+builds the :class:`ApprovalRequest` that the
+:class:`~yule_orchestrator.agents.job_queue.approval_worker.ApprovalWorker`
+posts to ``#승인-대기``.
+
+Why a separate adapter (not reuse ENGINEERING_WRITE):
+
+  * The reply vocabulary differs — PR merge supports
+    "수정 후 다시" (REVISE_AND_REPEAT).
+  * The downstream action differs — ENGINEERING_WRITE produces a
+    work order; PR merge invokes the 5-step gate then
+    ``live_client.merge_pull_request``.
+  * Audit trails diverge — PR merge has a distinct
+    ``session.extra["pr_merge_audit"]`` bucket.
+
+Both adapters still go through the same ``ApprovalWorker``, so the
+queue dedup + Discord posting code stays a single implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from ..agents.job_queue.approval_reply import find_replyable_approval
+from ..agents.job_queue.approval_worker import ApprovalRequest, ApprovalWorker
+from ..agents.job_queue.pr_approval import (
+    APPROVAL_KIND_PR_MERGE,
+    PRMergeProposal,
+    render_pr_merge_summary,
+)
+
+
+# Skipped reasons surfaced by :class:`PRMergeApprovalOutcome`.
+SKIPPED_DUPLICATE_PR_MERGE_CARD: str = "duplicate_pr_merge_card_in_flight"
+SKIPPED_NO_PROPOSAL: str = "no_proposal"
+
+
+@dataclass(frozen=True)
+class PRMergeApprovalOutcome:
+    """Result of :func:`enqueue_pr_merge_approval`.
+
+    Mirrors :class:`GitHubWorkApprovalOutcome` shape so the gateway
+    can treat either adapter's return uniformly.
+    """
+
+    proposal: Optional[PRMergeProposal]
+    approval_job_id: Optional[str] = None
+    approval_post_outcome: Optional[Any] = None
+    skipped_reason: Optional[str] = None
+
+
+def _approval_request_from_proposal(
+    proposal: PRMergeProposal,
+    *,
+    session_id: str,
+    source_channel_id: Optional[int],
+    source_thread_id: Optional[int],
+    source_message_id: Optional[int],
+) -> ApprovalRequest:
+    """Convert a :class:`PRMergeProposal` into an :class:`ApprovalRequest`.
+
+    The summary card body lives in
+    :attr:`ApprovalRequest.summary` so the approval worker's render
+    can re-use the proposal's existing markdown without re-fetching
+    GitHub state.
+    """
+
+    title = (
+        f"PR 머지 승인 — #{proposal.pr_number}"
+        + (f" {proposal.pr_title}" if proposal.pr_title else "")
+    )
+    requested_action = "PR merge approval — 5-step gate 통과 시 merge"
+
+    return ApprovalRequest(
+        session_id=session_id,
+        approval_kind=APPROVAL_KIND_PR_MERGE,
+        title=title,
+        summary=render_pr_merge_summary(proposal),
+        requested_action=requested_action,
+        created_by=proposal.requested_by or "",
+        source_channel_id=source_channel_id,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        extra=dict(proposal.to_extra()),
+    )
+
+
+async def enqueue_pr_merge_approval(
+    *,
+    session: Any,
+    proposal: Optional[PRMergeProposal],
+    approval_worker: ApprovalWorker,
+    source_channel_id: Optional[int] = None,
+    source_thread_id: Optional[int] = None,
+    source_message_id: Optional[int] = None,
+    drive_consumer: bool = True,
+    now: Optional[float] = None,
+) -> PRMergeApprovalOutcome:
+    """Build the approval card and post it to ``#승인-대기``.
+
+    Returns :class:`PRMergeApprovalOutcome` describing what happened.
+    Two side-effects:
+
+      1. Insert a row into the approval_post queue (idempotent —
+         dedup keyed on ``(session, kind, source_message_id, head_sha)``).
+      2. (Only when *drive_consumer* is True, the production default)
+         immediately drive ``ApprovalWorker.run_one`` so the card
+         posts to ``#승인-대기`` in the same call. Tests that want
+         to inspect the queue without posting set this to False.
+
+    The function never calls GitHub.
+    """
+
+    if proposal is None:
+        return PRMergeApprovalOutcome(
+            proposal=None,
+            skipped_reason=SKIPPED_NO_PROPOSAL,
+        )
+
+    session_id = _resolve_session_id(session)
+    if not session_id:
+        return PRMergeApprovalOutcome(
+            proposal=proposal,
+            skipped_reason="session_id_missing",
+        )
+
+    # Dedup: same session + same head_sha + (optionally) same source
+    # message must not produce a second card. We extend the standard
+    # ``find_replyable_approval`` filter with a head_sha equality check
+    # because the same PR may legitimately get a new card after a
+    # commit (sha changes); we want to skip only when the *same* sha
+    # already has a SAVED card.
+    queue = approval_worker._queue  # noqa: SLF001 - intentional reuse
+    existing = find_replyable_approval(
+        queue=queue,
+        session_id=session_id,
+        approval_kind=APPROVAL_KIND_PR_MERGE,
+        source_message_id=source_message_id,
+        source_thread_id=source_thread_id,
+    )
+    if existing is not None:
+        prev_sha = (existing.payload or {}).get("extra", {}).get("head_sha", "")
+        if prev_sha and prev_sha == proposal.head_sha:
+            return PRMergeApprovalOutcome(
+                proposal=proposal,
+                approval_job_id=existing.job_id,
+                approval_post_outcome=None,
+                skipped_reason=SKIPPED_DUPLICATE_PR_MERGE_CARD,
+            )
+
+    request = _approval_request_from_proposal(
+        proposal,
+        session_id=session_id,
+        source_channel_id=source_channel_id,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+    )
+
+    if drive_consumer:
+        outcome = await approval_worker.run_one(request, now=now)
+        approval_job_id = (
+            outcome.job.job_id if getattr(outcome, "job", None) else None
+        )
+        skipped = None
+        if getattr(outcome, "skipped_reason", None) == "duplicate_in_flight":
+            skipped = SKIPPED_DUPLICATE_PR_MERGE_CARD
+        elif getattr(outcome, "skipped_reason", None):
+            skipped = outcome.skipped_reason
+        return PRMergeApprovalOutcome(
+            proposal=proposal,
+            approval_job_id=approval_job_id,
+            approval_post_outcome=outcome,
+            skipped_reason=skipped,
+        )
+
+    job, created = approval_worker.enqueue(request, now=now)
+    return PRMergeApprovalOutcome(
+        proposal=proposal,
+        approval_job_id=job.job_id if job is not None else None,
+        approval_post_outcome=None,
+        skipped_reason=None if created else SKIPPED_DUPLICATE_PR_MERGE_CARD,
+    )
+
+
+def _resolve_session_id(session: Any) -> str:
+    """Be tolerant of dict / dataclass / SimpleNamespace session shapes."""
+
+    if session is None:
+        return ""
+    candidate = (
+        getattr(session, "session_id", None)
+        or (session.get("session_id") if isinstance(session, Mapping) else None)
+    )
+    return str(candidate or "")
+
+
+__all__ = (
+    "PRMergeApprovalOutcome",
+    "SKIPPED_DUPLICATE_PR_MERGE_CARD",
+    "SKIPPED_NO_PROPOSAL",
+    "enqueue_pr_merge_approval",
+)

--- a/src/yule_orchestrator/github_app/live_client.py
+++ b/src/yule_orchestrator/github_app/live_client.py
@@ -31,6 +31,7 @@ Secret hygiene:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
 
@@ -49,9 +50,18 @@ from .config import GitHubAppConfig
 logger = logging.getLogger(__name__)
 
 
+# F16 PR-2 — opt-in env that must be true for ``merge_pull_request``
+# to issue the real PUT call. Anything other than the truthy values
+# below leaves the merge path disabled.
+ENV_GITHUB_MERGE_ENABLED: str = "YULE_GITHUB_MERGE_ENABLED"
+_MERGE_ENABLED_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+
 __all__ = (
     "LiveGithubAppClient",
     "LiveGithubAppHTTPError",
+    "LiveGithubAppMergeDisabled",
+    "ENV_GITHUB_MERGE_ENABLED",
     "build_live_client_from_env",
 )
 
@@ -75,6 +85,26 @@ class LiveGithubAppHTTPError(RuntimeError):
         super().__init__(message)
         self.status = status
         self.url = url
+
+
+class LiveGithubAppMergeDisabled(LiveGithubAppHTTPError):
+    """Raised when ``merge_pull_request`` is called without the opt-in.
+
+    Inherits from :class:`LiveGithubAppHTTPError` so callers that
+    catch the base class still see the failure; distinct class so
+    code branching on ``isinstance`` can differentiate "GitHub said no"
+    from "we never asked GitHub". ``status`` is fixed at 503 to make
+    the distinction visible in audit logs even when only the integer
+    survives serialisation.
+    """
+
+
+def _is_merge_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """True only when ``YULE_GITHUB_MERGE_ENABLED`` is set to a truthy value."""
+
+    source = env if env is not None else os.environ
+    raw = source.get(ENV_GITHUB_MERGE_ENABLED, "")
+    return (raw or "").strip().lower() in _MERGE_ENABLED_TRUTHY
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +375,80 @@ class LiveGithubAppClient:
         )
 
     # ------------------------------------------------------------------
+    # F16 PR-2 — Branch protection + merge (opt-in via env)
+    # ------------------------------------------------------------------
+
+    def get_branch_protection(
+        self, *, repo: str, branch: str
+    ) -> Optional[Mapping[str, Any]]:
+        """Fetch branch protection rules for *branch*.
+
+        Returns ``None`` only when the API returns 404 (no protection
+        configured). Returns the raw payload otherwise so callers can
+        introspect ``required_status_checks`` /
+        ``required_pull_request_reviews``.
+
+        Per F16 §7 ("Branch protection 401/403"): we do **not** swallow
+        permission errors here — the caller's gate has to refuse the
+        merge when the rules can't be verified. Anything other than
+        404 surfaces as a raised :class:`LiveGithubAppHTTPError` so
+        the gate stays on the safe side.
+        """
+
+        url = (
+            f"{self._api_base}/repos/{repo}/branches/{branch}/protection"
+        )
+        try:
+            return self._get(url)
+        except GitHubAppNotFoundError:
+            return None
+
+    def merge_pull_request(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        sha: Optional[str] = None,
+        merge_method: str = "squash",
+        commit_title: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> Mapping[str, Any]:
+        """Merge a pull request via the GitHub REST API.
+
+        **Strict opt-in**: the operation requires
+        ``YULE_GITHUB_MERGE_ENABLED=true`` in *env* (defaults to
+        ``os.environ``). When the flag is missing / falsy we raise
+        :class:`LiveGithubAppMergeDisabled` so callers can branch on a
+        recognisable type. The error carries ``status=503`` so HTTP
+        consumers downstream see a clearly distinct value (vs the
+        404 / 4xx that mean "GitHub said no").
+
+        On the API side this is a ``PUT /repos/{owner}/{repo}/pulls/
+        {pull_number}/merge`` request. The function does NOT run the
+        5-step gate — that lives in
+        :func:`agents.job_queue.pr_approval.evaluate_merge_gate`. The
+        caller is responsible for invoking the gate first.
+        """
+
+        if not _is_merge_enabled(env):
+            raise LiveGithubAppMergeDisabled(
+                "merge_pull_request: YULE_GITHUB_MERGE_ENABLED is not set to true",
+                status=503,
+                url=f"{self._api_base}/repos/{repo}/pulls/{int(pr_number)}/merge",
+            )
+
+        url = f"{self._api_base}/repos/{repo}/pulls/{int(pr_number)}/merge"
+        body: dict = {"merge_method": str(merge_method or "squash")}
+        if sha:
+            body["sha"] = str(sha)
+        if commit_title:
+            body["commit_title"] = str(commit_title)
+        if commit_message:
+            body["commit_message"] = str(commit_message)
+        return self._put(url, body=body)
+
+    # ------------------------------------------------------------------
     # HTTP helpers — every call funnels through a single token-headers
     # path so the Authorization redaction stays in one place.
     # ------------------------------------------------------------------
@@ -418,6 +522,44 @@ class LiveGithubAppClient:
                 url=url,
             )
         return dict(response.body)
+
+    def _put(self, url: str, *, body: Mapping[str, Any]) -> Mapping[str, Any]:
+        """PUT helper — mirrors :meth:`_patch` but with HTTP method ``PUT``.
+
+        Used by :meth:`merge_pull_request`; the doctor's HTTP layer
+        only exposes ``get`` / ``post`` so we go straight to the
+        stdlib for the verb override.
+        """
+
+        from .client import _safe_json_decode
+        import urllib.error
+        import urllib.request
+
+        data = None
+        if body is not None:
+            import json
+
+            data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url=url, data=data, method="PUT")
+        for key, value in self._auth_headers().items():
+            req.add_header(key, value)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=15.0) as resp:
+                if not 200 <= resp.status < 300:
+                    raise LiveGithubAppHTTPError(
+                        f"GitHub PUT {url} -> HTTP {resp.status}",
+                        status=int(resp.status),
+                        url=url,
+                    )
+                return _safe_json_decode(resp.read())
+        except urllib.error.HTTPError as exc:
+            raise LiveGithubAppHTTPError(
+                f"GitHub PUT {url} -> HTTP {exc.code}",
+                status=int(exc.code),
+                url=url,
+            ) from None
 
 
 # ---------------------------------------------------------------------------

--- a/src/yule_orchestrator/github_app/pr_merge_executor.py
+++ b/src/yule_orchestrator/github_app/pr_merge_executor.py
@@ -1,0 +1,185 @@
+"""F16 PR-2 — Build a PRMergeExecutor that wraps live_client + gate.
+
+This is the **one** place where the 5-step merge gate is composed
+with the live GitHub merge call. The executor returns the mapping
+shape :func:`handle_pr_merge_approval_reply` expects:
+
+  * Gate failure → ``{"gate_failed_step": "...", "gate_reason": "..."}``.
+  * ``YULE_GITHUB_MERGE_ENABLED=false`` → ``{"merge_disabled": True, ...}``.
+  * Success → ``{"merge_sha": "...", "method": "squash", ...}``.
+  * Merge API error → ``{"merge_failed": True, "error": "...", "status": int}``.
+
+The factory keeps :mod:`live_client` GitHub-only and :mod:`pr_approval`
+domain-only; the wire-up lives in this small module so unit tests can
+exercise it without GitHub credentials by passing fake clients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from ..agents.job_queue.pr_approval import (
+    PRMergeExecutor,
+    PRMergeReplyDispatch,
+    PRMergeStatusSnapshot,
+    evaluate_merge_gate,
+)
+from .live_client import (
+    LiveGithubAppMergeDisabled,
+    LiveGithubAppHTTPError,
+)
+
+
+# Protocol-ish — the executor only touches these three methods on the
+# live client. Both the real ``LiveGithubAppClient`` and the test
+# stubs in :mod:`tests.github_app.test_pr_merge_executor` implement
+# this surface.
+class _LiveMergeClientProtocol:
+    def get_pull_request(self, *, repo: str, pr_number: int) -> Mapping[str, Any]: ...
+    def list_check_runs(
+        self, *, repo: str, head_sha: str
+    ) -> Sequence[Mapping[str, Any]]: ...
+    def get_branch_protection(
+        self, *, repo: str, branch: str
+    ) -> Optional[Mapping[str, Any]]: ...
+    def merge_pull_request(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        sha: Optional[str] = None,
+        merge_method: str = "squash",
+        commit_title: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> Mapping[str, Any]: ...
+
+
+def build_pr_merge_executor(
+    *,
+    client: Any,
+    merge_method: str = "squash",
+    env: Optional[Mapping[str, str]] = None,
+) -> PRMergeExecutor:
+    """Return a :data:`PRMergeExecutor` bound to *client*.
+
+    The returned callable matches the type alias from
+    :mod:`agents.job_queue.pr_approval` (sync — returns a Mapping
+    directly; the handler awaits when it sees an awaitable).
+    """
+
+    def _execute(dispatch: PRMergeReplyDispatch) -> Mapping[str, Any]:
+        proposal = dispatch.proposal
+        # 1. Pull live PR state.
+        pr = client.get_pull_request(
+            repo=proposal.repo, pr_number=proposal.pr_number
+        )
+        head_sha = str(
+            (pr or {}).get("head", {}).get("sha")
+            or pr.get("head_sha")
+            or ""
+        )
+        mergeable_state = str(pr.get("mergeable_state") or "unknown")
+        mergeable = pr.get("mergeable")
+        draft = bool(pr.get("draft", False))
+
+        # 2. Check runs for the latest head.
+        runs = client.list_check_runs(
+            repo=proposal.repo, head_sha=head_sha or proposal.head_sha
+        )
+        conclusions = tuple(
+            str(run.get("conclusion") or "") for run in (runs or ())
+        )
+
+        # 3. Branch protection — defensive: any auth failure → refuse.
+        try:
+            protection = client.get_branch_protection(
+                repo=proposal.repo, branch=proposal.base_branch
+            )
+            protection_available = True
+        except LiveGithubAppHTTPError as exc:
+            protection = None
+            # 401/403 → refuse merge by leaving protection_available False
+            # (the gate's branch_protection step interprets this as a
+            # safe-side refusal per F16 §7).
+            if exc.status in (401, 403):
+                protection_available = False
+            else:
+                protection_available = True
+
+        required_reviews = 0
+        actual_reviews = 0
+        required_status_checks: tuple[str, ...] = ()
+        if protection:
+            rev_obj = protection.get("required_pull_request_reviews") or {}
+            required_reviews = int(
+                rev_obj.get("required_approving_review_count") or 0
+            )
+            req_status = protection.get("required_status_checks") or {}
+            ctx = req_status.get("contexts") or []
+            required_status_checks = tuple(str(c) for c in ctx)
+            # actual_reviews comes from the PR payload's reviews summary;
+            # the simplest API surface uses pr.get("requested_reviewers")
+            # length + pr["review_comments"] is **not** equivalent. We
+            # accept the (approvals satisfied) signal from the snapshot
+            # via pr["mergeable_state"] == "clean", which already
+            # reflects branch protection. Treat clean state as "reviews
+            # satisfied" — the gate's mergeable_state check already
+            # gates on "clean".
+            if mergeable_state == "clean":
+                actual_reviews = required_reviews
+
+        snapshot = PRMergeStatusSnapshot(
+            draft=draft,
+            mergeable=mergeable if isinstance(mergeable, bool) else None,
+            mergeable_state=mergeable_state,
+            head_sha=head_sha,
+            check_conclusions=conclusions,
+            required_status_checks=required_status_checks,
+            required_approving_reviews=required_reviews,
+            actual_approving_reviews=actual_reviews,
+            branch_protection_available=protection_available,
+        )
+
+        gate = evaluate_merge_gate(proposal, snapshot)
+        if not gate.allowed:
+            return {
+                "gate_failed_step": gate.failed_step,
+                "gate_reason": gate.reason,
+                "checks_summary": gate.checks_summary,
+            }
+
+        # 4. Attempt merge — opt-in env gate inside live_client.
+        try:
+            merge_result = client.merge_pull_request(
+                repo=proposal.repo,
+                pr_number=proposal.pr_number,
+                sha=head_sha or proposal.head_sha,
+                merge_method=merge_method,
+                env=env,
+            )
+        except LiveGithubAppMergeDisabled as exc:
+            return {
+                "merge_disabled": True,
+                "reason": str(exc),
+                "status": exc.status or 503,
+            }
+        except LiveGithubAppHTTPError as exc:
+            return {
+                "merge_failed": True,
+                "error": str(exc),
+                "status": exc.status,
+            }
+
+        # 5. Success — surface merge_sha so audit can record it.
+        return {
+            "merge_sha": str(merge_result.get("sha") or ""),
+            "method": merge_method,
+            "raw": dict(merge_result),
+        }
+
+    return _execute
+
+
+__all__ = ("build_pr_merge_executor",)

--- a/tests/discord/test_pr_merge_adapter.py
+++ b/tests/discord/test_pr_merge_adapter.py
@@ -1,0 +1,224 @@
+"""F16 PR-2 — Discord PR merge adapter tests (issue #128).
+
+The adapter is the seam between a producer (which builds a
+:class:`PRMergeProposal`) and the :class:`ApprovalWorker` that posts
+the card. These tests use a real on-disk SQLite queue + a fake
+``post_fn`` so we can assert end-to-end behaviour without GitHub or
+Discord.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    APPROVAL_KIND_PR_MERGE,
+    PRMergeProposal,
+)
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.discord.pr_merge_adapter import (
+    PRMergeApprovalOutcome,
+    SKIPPED_DUPLICATE_PR_MERGE_CARD,
+    SKIPPED_NO_PROPOSAL,
+    enqueue_pr_merge_approval,
+)
+
+
+def _proposal(**overrides) -> PRMergeProposal:
+    base = dict(
+        repo="yule-studio/yule-studio-agent",
+        pr_number=127,
+        pr_title="F15 corporate structure",
+        pr_url="https://github.com/yule-studio/yule-studio-agent/pull/127",
+        head_sha="abc1234567",
+        base_branch="main",
+        draft=False,
+        mergeable_state="clean",
+        summary_md="",
+        scope_labels=("docs", "agents"),
+        risk="LOW",
+        check_runs_summary="✅ Tests: 18/18 PASS",
+        branch_protection_summary="🔒 reviews 1/1",
+        body_excerpt="adds 6 dept + 19 roles",
+        requested_by="alice",
+    )
+    base.update(overrides)
+    return PRMergeProposal(**base)
+
+
+class _AdapterFixture(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:  # noqa: D401 - test setup
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=self.db_path)
+        self.heartbeats = HeartbeatStore(db_path=self.db_path)
+        self.posted: list[tuple[ApprovalRequest, str]] = []
+
+        async def post_fn(request, rendered):
+            self.posted.append((request, rendered))
+            return {"posted_message_id": 12345}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=post_fn,
+            channel_resolver=lambda: 4242,
+        )
+        self.session = SimpleNamespace(session_id="sess-pr-127", extra={})
+
+
+class EnqueueHappyPathTests(_AdapterFixture):
+    async def test_enqueue_drives_consumer_and_posts(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+            source_channel_id=999,
+            source_thread_id=1001,
+            source_message_id=2002,
+        )
+        self.assertIsInstance(outcome, PRMergeApprovalOutcome)
+        self.assertIsNotNone(outcome.proposal)
+        self.assertIsNone(outcome.skipped_reason)
+        self.assertIsNotNone(outcome.approval_job_id)
+        # post_fn was called once with the rendered card.
+        self.assertEqual(len(self.posted), 1)
+        request, rendered = self.posted[0]
+        self.assertEqual(request.approval_kind, APPROVAL_KIND_PR_MERGE)
+        self.assertIn("PR 머지 승인 — #127", request.title)
+        self.assertIn("F15 corporate structure", request.title)
+        self.assertIn("위험도: LOW", rendered)
+        self.assertIn(
+            "https://github.com/yule-studio/yule-studio-agent/pull/127",
+            rendered,
+        )
+
+    async def test_summary_body_is_the_rendered_card(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+        )
+        # ApprovalRequest.summary carries the full rendered card so the
+        # worker can re-use it without a second render pass.
+        request, _ = self.posted[0]
+        self.assertIn("응답 어휘", request.summary)
+        self.assertIn("승인 / 거절 / 수정 후 다시 / 머지 보류", request.summary)
+
+    async def test_proposal_extra_round_trips_through_request(self) -> None:
+        await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+        )
+        request, _ = self.posted[0]
+        self.assertEqual(request.extra.get("repo"), "yule-studio/yule-studio-agent")
+        self.assertEqual(request.extra.get("pr_number"), 127)
+        self.assertEqual(request.extra.get("head_sha"), "abc1234567")
+        self.assertEqual(request.extra.get("risk"), "LOW")
+
+
+class EnqueueDedupTests(_AdapterFixture):
+    async def test_duplicate_same_head_sha_skipped(self) -> None:
+        first = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+            source_message_id=2002,
+        )
+        self.assertIsNone(first.skipped_reason)
+        self.assertEqual(len(self.posted), 1)
+
+        second = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),  # same head_sha
+            approval_worker=self.approval_worker,
+            source_message_id=2002,
+        )
+        self.assertEqual(
+            second.skipped_reason, SKIPPED_DUPLICATE_PR_MERGE_CARD
+        )
+        # No second post.
+        self.assertEqual(len(self.posted), 1)
+
+    async def test_new_head_sha_does_not_dedup(self) -> None:
+        first = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(head_sha="aaa0000000"),
+            approval_worker=self.approval_worker,
+            source_message_id=2002,
+        )
+        self.assertIsNone(first.skipped_reason)
+
+        # Same session, same source_message_id, but different head_sha —
+        # this is a follow-up commit and deserves a fresh card.
+        second = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(head_sha="bbb1111111"),
+            approval_worker=self.approval_worker,
+            source_message_id=2002,
+        )
+        # We don't dedup — a new card should post.
+        self.assertIsNone(second.skipped_reason)
+        self.assertEqual(len(self.posted), 2)
+
+
+class EnqueueDefensiveTests(_AdapterFixture):
+    async def test_missing_proposal_skipped(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=None,
+            approval_worker=self.approval_worker,
+        )
+        self.assertEqual(outcome.skipped_reason, SKIPPED_NO_PROPOSAL)
+        self.assertEqual(len(self.posted), 0)
+
+    async def test_missing_session_id_skipped(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session=SimpleNamespace(session_id="", extra={}),
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+        )
+        self.assertEqual(outcome.skipped_reason, "session_id_missing")
+
+    async def test_dict_session_resolves(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session={"session_id": "sess-from-dict"},
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+        )
+        self.assertIsNone(outcome.skipped_reason)
+        request, _ = self.posted[0]
+        self.assertEqual(request.session_id, "sess-from-dict")
+
+
+class EnqueueWithoutDrivingConsumerTests(_AdapterFixture):
+    async def test_drive_consumer_false_queues_only(self) -> None:
+        outcome = await enqueue_pr_merge_approval(
+            session=self.session,
+            proposal=_proposal(),
+            approval_worker=self.approval_worker,
+            drive_consumer=False,
+        )
+        self.assertIsNotNone(outcome.approval_job_id)
+        # post_fn was NOT called.
+        self.assertEqual(len(self.posted), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/github_app/test_live_client_merge_disabled.py
+++ b/tests/github_app/test_live_client_merge_disabled.py
@@ -1,0 +1,67 @@
+"""F16 PR-2 — merge_pull_request opt-in env gate (issue #128).
+
+These tests pin the **safety contract** of the live client's merge
+seam: without ``YULE_GITHUB_MERGE_ENABLED=true`` no PUT is ever
+issued, no matter what the gate says. The other gate steps live in
+:mod:`tests.job_queue.test_pr_merge_approval`; here we focus on the
+env-level guard + the inheritance contract.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.github_app.live_client import (
+    ENV_GITHUB_MERGE_ENABLED,
+    LiveGithubAppHTTPError,
+    LiveGithubAppMergeDisabled,
+    _is_merge_enabled,
+)
+
+
+class IsMergeEnabledTests(unittest.TestCase):
+    def test_default_environ_returns_false(self) -> None:
+        os.environ.pop(ENV_GITHUB_MERGE_ENABLED, None)
+        self.assertFalse(_is_merge_enabled())
+
+    def test_truthy_strings(self) -> None:
+        for raw in ("true", "TRUE", "True", "1", "yes", "on"):
+            with self.subTest(raw=raw):
+                self.assertTrue(_is_merge_enabled({ENV_GITHUB_MERGE_ENABLED: raw}))
+
+    def test_falsy_strings(self) -> None:
+        for raw in ("false", "0", "no", "off", "", "anything-else"):
+            with self.subTest(raw=raw):
+                self.assertFalse(_is_merge_enabled({ENV_GITHUB_MERGE_ENABLED: raw}))
+
+    def test_env_override_takes_precedence_over_os_environ(self) -> None:
+        os.environ[ENV_GITHUB_MERGE_ENABLED] = "true"
+        try:
+            self.assertFalse(_is_merge_enabled({ENV_GITHUB_MERGE_ENABLED: "false"}))
+            self.assertTrue(_is_merge_enabled({ENV_GITHUB_MERGE_ENABLED: "true"}))
+        finally:
+            os.environ.pop(ENV_GITHUB_MERGE_ENABLED, None)
+
+
+class DisabledExceptionTests(unittest.TestCase):
+    def test_is_subclass_of_http_error(self) -> None:
+        # Callers catching the base class still trap the disabled case.
+        self.assertTrue(issubclass(LiveGithubAppMergeDisabled, LiveGithubAppHTTPError))
+
+    def test_carries_status_503_by_convention(self) -> None:
+        # Live client raises with status=503 to distinguish from
+        # GitHub's own 4xx/5xx responses in audit logs.
+        exc = LiveGithubAppMergeDisabled("disabled", status=503, url="u")
+        self.assertEqual(exc.status, 503)
+        self.assertEqual(exc.url, "u")
+        self.assertIn("disabled", str(exc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/github_app/test_pr_merge_executor.py
+++ b/tests/github_app/test_pr_merge_executor.py
@@ -1,0 +1,276 @@
+"""F16 PR-2 — PRMergeExecutor factory tests (issue #128).
+
+The executor binds a live (or fake) GitHub client to the 5-step gate
+and the merge call. These tests pass a hand-rolled fake client so
+every gate branch + the merge-disabled / merge-failed / merge-success
+paths can be pinned without GitHub.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Mapping, Optional, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    PRMergeProposal,
+    PRMergeReplyDispatch,
+)
+from yule_orchestrator.github_app.live_client import (
+    LiveGithubAppHTTPError,
+    LiveGithubAppMergeDisabled,
+)
+from yule_orchestrator.github_app.pr_merge_executor import (
+    build_pr_merge_executor,
+)
+
+
+def _proposal(**overrides) -> PRMergeProposal:
+    base = dict(
+        repo="yule-studio/yule-studio-agent",
+        pr_number=127,
+        pr_title="F15",
+        pr_url="https://github.com/yule-studio/yule-studio-agent/pull/127",
+        head_sha="abc1234567",
+        base_branch="main",
+        draft=False,
+        mergeable_state="clean",
+        summary_md="",
+        scope_labels=("docs",),
+        risk="LOW",
+        check_runs_summary="✅ green",
+        branch_protection_summary="🔒 ok",
+        body_excerpt="x",
+        requested_by="alice",
+    )
+    base.update(overrides)
+    return PRMergeProposal(**base)
+
+
+def _dispatch(proposal: PRMergeProposal) -> PRMergeReplyDispatch:
+    return PRMergeReplyDispatch(
+        proposal=proposal,
+        approval_job_id="job-1",
+        approved_by="alice",
+        approved_at="2026-05-13T08:00:00Z",
+        source_message_id=2002,
+    )
+
+
+class _FakeClient:
+    """Hand-rolled minimum surface for :func:`build_pr_merge_executor`."""
+
+    def __init__(
+        self,
+        *,
+        pr_payload: Mapping[str, Any],
+        check_runs: Sequence[Mapping[str, Any]],
+        branch_protection: Optional[Mapping[str, Any]] = None,
+        protection_raises: Optional[Exception] = None,
+        merge_raises: Optional[Exception] = None,
+        merge_result: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self._pr = pr_payload
+        self._runs = check_runs
+        self._protection = branch_protection
+        self._protection_raises = protection_raises
+        self._merge_raises = merge_raises
+        self._merge_result = merge_result or {"sha": "def9876543", "merged": True}
+        self.merge_calls: list = []
+
+    def get_pull_request(self, *, repo: str, pr_number: int):
+        return self._pr
+
+    def list_check_runs(self, *, repo: str, head_sha: str):
+        return self._runs
+
+    def get_branch_protection(self, *, repo: str, branch: str):
+        if self._protection_raises is not None:
+            raise self._protection_raises
+        return self._protection
+
+    def merge_pull_request(self, **kwargs):
+        if self._merge_raises is not None:
+            raise self._merge_raises
+        self.merge_calls.append(kwargs)
+        return self._merge_result
+
+
+class SuccessPathTests(unittest.TestCase):
+    def test_clean_pr_merges_returns_sha(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}, {"conclusion": "success"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 1,
+                },
+                "required_status_checks": {"contexts": ["ci"]},
+            },
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal()))
+        self.assertEqual(result["merge_sha"], "def9876543")
+        self.assertEqual(result["method"], "squash")
+        # merge_pull_request was called with the right repo/pr_number.
+        self.assertEqual(len(client.merge_calls), 1)
+        call = client.merge_calls[0]
+        self.assertEqual(call["repo"], "yule-studio/yule-studio-agent")
+        self.assertEqual(call["pr_number"], 127)
+        self.assertEqual(call["sha"], "abc1234567")
+
+
+class GateFailureTests(unittest.TestCase):
+    def test_draft_pr_blocked_no_merge_call(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": True,
+            },
+            check_runs=[{"conclusion": "success"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 0
+                }
+            },
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal(draft=False)))
+        self.assertEqual(result.get("gate_failed_step"), "draft")
+        self.assertEqual(len(client.merge_calls), 0)
+
+    def test_red_check_blocks_no_merge_call(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}, {"conclusion": "failure"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 0
+                }
+            },
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal()))
+        self.assertEqual(result.get("gate_failed_step"), "checks_green")
+        self.assertEqual(len(client.merge_calls), 0)
+
+    def test_sha_race_blocks(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "newsha7654321"},  # changed!
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 0
+                }
+            },
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal(head_sha="abc1234567")))
+        self.assertEqual(result.get("gate_failed_step"), "sha_race")
+        self.assertEqual(len(client.merge_calls), 0)
+
+    def test_branch_protection_401_blocks(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}],
+            protection_raises=LiveGithubAppHTTPError(
+                "401 unauthorized", status=401, url="u"
+            ),
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal()))
+        self.assertEqual(result.get("gate_failed_step"), "branch_protection")
+        self.assertEqual(len(client.merge_calls), 0)
+
+
+class MergeDisabledTests(unittest.TestCase):
+    def test_merge_disabled_env_returns_marker(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 0
+                }
+            },
+            merge_raises=LiveGithubAppMergeDisabled(
+                "disabled", status=503, url="u"
+            ),
+        )
+        executor = build_pr_merge_executor(client=client)
+        result = executor(_dispatch(_proposal()))
+        self.assertTrue(result.get("merge_disabled"))
+        self.assertEqual(result.get("status"), 503)
+
+
+class MergeFailedTests(unittest.TestCase):
+    def test_github_409_conflict_surfaced(self) -> None:
+        client = _FakeClient(
+            pr_payload={
+                "head": {"sha": "abc1234567"},
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "draft": False,
+            },
+            check_runs=[{"conclusion": "success"}],
+            branch_protection={
+                "required_pull_request_reviews": {
+                    "required_approving_review_count": 0
+                }
+            },
+            merge_raises=LiveGithubAppHTTPError(
+                "409 conflict", status=409, url="u"
+            ),
+        )
+        executor = build_pr_merge_executor(
+            client=client, env={"YULE_GITHUB_MERGE_ENABLED": "true"}
+        )
+        result = executor(_dispatch(_proposal()))
+        self.assertTrue(result.get("merge_failed"))
+        self.assertEqual(result.get("status"), 409)
+        self.assertIn("409", result.get("error", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_pr_merge_approval.py
+++ b/tests/job_queue/test_pr_merge_approval.py
@@ -1,0 +1,292 @@
+"""F16 PR-2 — Domain tests for PR merge approval (issue #128).
+
+The :mod:`pr_approval` module is **pure** — no GitHub, no Discord —
+so this test suite pins every branch of the 5-step gate, the reply
+intent parser, and the summary card renderer without mocks or fakes.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    APPROVAL_KIND_PR_MERGE,
+    PRMergeGateResult,
+    PRMergeProposal,
+    PRMergeReplyIntent,
+    PRMergeStatusSnapshot,
+    PR_MERGE_AUDIT_KEY,
+    build_body_excerpt,
+    evaluate_merge_gate,
+    make_audit_entry,
+    parse_pr_merge_reply_intent,
+    render_pr_merge_summary,
+)
+
+
+def _proposal(**overrides) -> PRMergeProposal:
+    base = dict(
+        repo="yule-studio/yule-studio-agent",
+        pr_number=127,
+        pr_title="F15 corporate structure",
+        pr_url="https://github.com/yule-studio/yule-studio-agent/pull/127",
+        head_sha="abc1234567",
+        base_branch="main",
+        draft=False,
+        mergeable_state="clean",
+        summary_md="",
+        scope_labels=("docs", "agents", "tests"),
+        risk="LOW",
+        check_runs_summary="✅ Tests: 18/18 PASS",
+        branch_protection_summary="🔒 reviews 1/1 ✓",
+        body_excerpt="adds 6 dept + 19 roles + PM skills catalog",
+        requested_by="alice",
+    )
+    base.update(overrides)
+    return PRMergeProposal(**base)
+
+
+def _snapshot(**overrides) -> PRMergeStatusSnapshot:
+    base = dict(
+        draft=False,
+        mergeable=True,
+        mergeable_state="clean",
+        head_sha="abc1234567",
+        check_conclusions=("success", "success", "success"),
+        required_status_checks=("ci",),
+        required_approving_reviews=1,
+        actual_approving_reviews=1,
+        branch_protection_available=True,
+    )
+    base.update(overrides)
+    return PRMergeStatusSnapshot(**base)
+
+
+class ConstantTests(unittest.TestCase):
+    def test_approval_kind_value(self) -> None:
+        self.assertEqual(APPROVAL_KIND_PR_MERGE, "pr_merge")
+
+    def test_audit_key(self) -> None:
+        self.assertEqual(PR_MERGE_AUDIT_KEY, "pr_merge_audit")
+
+    def test_reply_intent_extends_base(self) -> None:
+        # 5 values total: APPROVE / REJECT / HOLD / UNCLEAR / REVISE_AND_REPEAT.
+        values = {m.value for m in PRMergeReplyIntent}
+        self.assertEqual(
+            values,
+            {"approve", "reject", "hold", "unclear", "revise_and_repeat"},
+        )
+
+
+class ParseReplyIntentTests(unittest.TestCase):
+    def test_korean_revise_phrase(self) -> None:
+        self.assertEqual(
+            parse_pr_merge_reply_intent("수정 후 다시"),
+            PRMergeReplyIntent.REVISE_AND_REPEAT,
+        )
+
+    def test_korean_revise_phrase_no_space(self) -> None:
+        self.assertEqual(
+            parse_pr_merge_reply_intent("수정후다시"),
+            PRMergeReplyIntent.REVISE_AND_REPEAT,
+        )
+
+    def test_english_revise_phrase(self) -> None:
+        self.assertEqual(
+            parse_pr_merge_reply_intent("revise and repeat"),
+            PRMergeReplyIntent.REVISE_AND_REPEAT,
+        )
+
+    def test_approve_falls_through_to_base(self) -> None:
+        self.assertEqual(parse_pr_merge_reply_intent("승인"), PRMergeReplyIntent.APPROVE)
+
+    def test_reject_falls_through(self) -> None:
+        self.assertEqual(parse_pr_merge_reply_intent("거절"), PRMergeReplyIntent.REJECT)
+
+    def test_hold_falls_through(self) -> None:
+        self.assertEqual(parse_pr_merge_reply_intent("보류"), PRMergeReplyIntent.HOLD)
+
+    def test_unclear_chatter(self) -> None:
+        self.assertEqual(
+            parse_pr_merge_reply_intent("뭔지 모르겠어"),
+            PRMergeReplyIntent.UNCLEAR,
+        )
+
+    def test_revise_takes_priority_over_approve(self) -> None:
+        # "수정 후 다시 승인" — REVISE wins because it's a stronger signal.
+        self.assertEqual(
+            parse_pr_merge_reply_intent("수정 후 다시 승인"),
+            PRMergeReplyIntent.REVISE_AND_REPEAT,
+        )
+
+
+class BodyExcerptTests(unittest.TestCase):
+    def test_short_body_unchanged(self) -> None:
+        self.assertEqual(build_body_excerpt("short body"), "short body")
+
+    def test_empty_body(self) -> None:
+        self.assertEqual(build_body_excerpt(""), "")
+        self.assertEqual(build_body_excerpt(None), "")
+
+    def test_whitespace_collapsed(self) -> None:
+        self.assertEqual(build_body_excerpt("a\n\nb   c"), "a b c")
+
+    def test_long_body_truncated_with_ellipsis(self) -> None:
+        body = "x" * 400
+        excerpt = build_body_excerpt(body)
+        self.assertTrue(excerpt.endswith("…"))
+        # 280 + 1 char ellipsis.
+        self.assertLessEqual(len(excerpt), 281)
+
+
+class RenderSummaryTests(unittest.TestCase):
+    def test_renders_header_and_link(self) -> None:
+        text = render_pr_merge_summary(_proposal())
+        self.assertIn("PR 머지 승인 — #127", text)
+        self.assertIn("F15 corporate structure", text)
+        self.assertIn(
+            "https://github.com/yule-studio/yule-studio-agent/pull/127", text
+        )
+
+    def test_renders_scope_and_risk(self) -> None:
+        text = render_pr_merge_summary(_proposal())
+        self.assertIn("영향 범위: docs / agents / tests", text)
+        self.assertIn("🟢 위험도: LOW", text)
+
+    def test_high_risk_emoji_red(self) -> None:
+        text = render_pr_merge_summary(_proposal(risk="HIGH"))
+        self.assertIn("🔴 위험도: HIGH", text)
+
+    def test_includes_check_run_and_branch_protection_lines(self) -> None:
+        text = render_pr_merge_summary(_proposal())
+        self.assertIn("Tests: 18/18 PASS", text)
+        self.assertIn("reviews 1/1", text)
+
+    def test_includes_response_vocabulary_hint(self) -> None:
+        text = render_pr_merge_summary(_proposal())
+        self.assertIn("승인 / 거절 / 수정 후 다시 / 머지 보류", text)
+
+    def test_is_deterministic(self) -> None:
+        # Same proposal → same text — important for ApprovalWorker dedup.
+        proposal = _proposal()
+        self.assertEqual(
+            render_pr_merge_summary(proposal),
+            render_pr_merge_summary(proposal),
+        )
+
+
+class EvaluateMergeGateTests(unittest.TestCase):
+    def test_clean_all_green_allows_merge(self) -> None:
+        result = evaluate_merge_gate(_proposal(), _snapshot())
+        self.assertTrue(result.allowed)
+        self.assertIsNone(result.failed_step)
+        self.assertIn("3 checks green", result.checks_summary)
+
+    def test_draft_pr_blocked(self) -> None:
+        result = evaluate_merge_gate(_proposal(), _snapshot(draft=True))
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "draft")
+
+    def test_unstable_mergeable_state_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(mergeable_state="behind"),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "mergeable")
+        self.assertIn("behind", result.reason)
+
+    def test_mergeable_false_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(mergeable=False),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "mergeable")
+
+    def test_failing_check_run_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(check_conclusions=("success", "failure", "success")),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "checks_green")
+        self.assertIn("failure", result.checks_summary)
+
+    def test_empty_check_runs_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(), _snapshot(check_conclusions=())
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "checks_green")
+
+    def test_skipped_and_neutral_count_as_green(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(check_conclusions=("success", "neutral", "skipped")),
+        )
+        self.assertTrue(result.allowed)
+
+    def test_missing_branch_protection_blocked(self) -> None:
+        # 401/403 → branch_protection_available=False → refuse.
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(branch_protection_available=False),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "branch_protection")
+        self.assertIn("권한", result.reason)
+
+    def test_insufficient_approving_reviews_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(),
+            _snapshot(required_approving_reviews=2, actual_approving_reviews=1),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "branch_protection")
+
+    def test_sha_race_blocked(self) -> None:
+        result = evaluate_merge_gate(
+            _proposal(head_sha="abc1234567"),
+            _snapshot(head_sha="def9876543"),
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.failed_step, "sha_race")
+        self.assertIn("abc1234", result.reason)
+        self.assertIn("def9876", result.reason)
+
+
+class ProposalRoundTripTests(unittest.TestCase):
+    def test_to_extra_and_from_extra(self) -> None:
+        original = _proposal()
+        round_tripped = PRMergeProposal.from_extra(dict(original.to_extra()))
+        self.assertEqual(round_tripped.repo, original.repo)
+        self.assertEqual(round_tripped.pr_number, original.pr_number)
+        self.assertEqual(round_tripped.head_sha, original.head_sha)
+        self.assertEqual(round_tripped.scope_labels, original.scope_labels)
+        self.assertEqual(round_tripped.risk, original.risk)
+        self.assertEqual(round_tripped.draft, original.draft)
+
+
+class AuditEntryTests(unittest.TestCase):
+    def test_stage_recorded(self) -> None:
+        entry = make_audit_entry("card_posted", pr_number=127, sha="abc")
+        self.assertEqual(entry["stage"], "card_posted")
+        self.assertEqual(entry["pr_number"], 127)
+        self.assertEqual(entry["sha"], "abc")
+
+    def test_merge_failed_entry(self) -> None:
+        entry = make_audit_entry(
+            "merge_failed", reason="409 Conflict", attempted_method="squash"
+        )
+        self.assertEqual(entry["stage"], "merge_failed")
+        self.assertIn("reason", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_pr_merge_reply_handler.py
+++ b/tests/job_queue/test_pr_merge_reply_handler.py
@@ -1,0 +1,275 @@
+"""F16 PR-2 — handle_pr_merge_approval_reply tests (issue #128).
+
+The handler is the seam between Discord (user typed "승인") and the
+merge executor (which is wired in commit 10). These tests use a fake
+queue + a fake executor so every branch can be pinned without
+GitHub or live ApprovalWorker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    APPROVAL_KIND_OBSIDIAN_WRITE,
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    APPROVAL_KIND_PR_MERGE,
+    PRMergeProposal,
+    PRMergeReplyDispatch,
+    PRMergeReplyIntent,
+    PRMergeReplyResult,
+    handle_pr_merge_approval_reply,
+)
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+def _proposal(**overrides) -> PRMergeProposal:
+    base = dict(
+        repo="yule-studio/yule-studio-agent",
+        pr_number=127,
+        pr_title="F15",
+        pr_url="https://github.com/yule-studio/yule-studio-agent/pull/127",
+        head_sha="abc1234567",
+        base_branch="main",
+        draft=False,
+        mergeable_state="clean",
+        summary_md="",
+        scope_labels=("docs",),
+        risk="LOW",
+        check_runs_summary="✅ green",
+        branch_protection_summary="🔒 ok",
+        body_excerpt="x",
+        requested_by="alice",
+    )
+    base.update(overrides)
+    return PRMergeProposal(**base)
+
+
+class _Fixture(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:  # noqa: D401 - test setup
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db_path = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=self.db_path)
+        self.heartbeats = HeartbeatStore(db_path=self.db_path)
+        self.posted: list = []
+
+        async def post_fn(request, rendered):
+            self.posted.append((request, rendered))
+            return {"posted_message_id": 12345}
+
+        self.worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=post_fn,
+            channel_resolver=lambda: 4242,
+        )
+
+    async def _seed_pr_merge_card(
+        self, *, session_id: str = "sess-pr", source_message_id: int = 2002
+    ) -> None:
+        """Enqueue a PR_MERGE approval card so the handler can find it."""
+
+        from yule_orchestrator.discord.pr_merge_adapter import (
+            enqueue_pr_merge_approval,
+        )
+        from types import SimpleNamespace
+
+        await enqueue_pr_merge_approval(
+            session=SimpleNamespace(session_id=session_id, extra={}),
+            proposal=_proposal(),
+            approval_worker=self.worker,
+            source_channel_id=999,
+            source_thread_id=1001,
+            source_message_id=source_message_id,
+        )
+
+
+class HandleReplyIntentTests(_Fixture):
+    async def test_hold_short_circuits(self) -> None:
+        await self._seed_pr_merge_card()
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="보류",
+            session_id="sess-pr",
+            approved_by="alice",
+            source_message_id=999,
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.HOLD)
+        self.assertEqual(result.skipped_reason, "intent_not_actionable")
+
+    async def test_unclear_short_circuits(self) -> None:
+        await self._seed_pr_merge_card()
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="음 뭐였더라",
+            session_id="sess-pr",
+            approved_by="alice",
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.UNCLEAR)
+
+    async def test_no_matching_card(self) -> None:
+        # No card seeded.
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="alice",
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.APPROVE)
+        self.assertEqual(result.skipped_reason, "no_matching_approval")
+
+
+class HandleRejectTests(_Fixture):
+    async def test_reject_records_audit(self) -> None:
+        await self._seed_pr_merge_card()
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="거절",
+            session_id="sess-pr",
+            approved_by="alice",
+            approved_at="2026-05-13T08:00:00Z",
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.REJECT)
+        self.assertTrue(result.rejection_recorded)
+        self.assertEqual(result.audit.get("rejected_by"), "alice")
+        self.assertIsNotNone(result.proposal)
+        self.assertEqual(result.proposal.pr_number, 127)
+
+
+class HandleReviseTests(_Fixture):
+    async def test_revise_intent_records_audit(self) -> None:
+        await self._seed_pr_merge_card()
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="수정 후 다시",
+            session_id="sess-pr",
+            approved_by="alice",
+            approved_at="2026-05-13T08:00:00Z",
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.REVISE_AND_REPEAT)
+        self.assertEqual(result.audit.get("revise_requested_by"), "alice")
+        # No merge attempted.
+        self.assertFalse(result.merge_disabled)
+        self.assertIsNone(result.merge_result)
+
+
+class HandleApproveTests(_Fixture):
+    async def test_approve_without_executor_returns_merge_disabled(self) -> None:
+        await self._seed_pr_merge_card()
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="alice",
+            approved_at="2026-05-13T08:00:00Z",
+            merge_executor=None,
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.APPROVE)
+        self.assertTrue(result.merge_disabled)
+        self.assertIsNotNone(result.proposal)
+        self.assertEqual(result.audit.get("reason"), "merge_executor_not_registered")
+
+    async def test_approve_calls_sync_executor(self) -> None:
+        await self._seed_pr_merge_card()
+        called: list = []
+
+        def executor(dispatch: PRMergeReplyDispatch):
+            called.append(dispatch)
+            return {"merge_sha": "def9876543", "method": "squash"}
+
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="alice",
+            merge_executor=executor,
+        )
+        self.assertEqual(result.intent, PRMergeReplyIntent.APPROVE)
+        self.assertEqual(len(called), 1)
+        dispatch = called[0]
+        self.assertEqual(dispatch.proposal.pr_number, 127)
+        self.assertEqual(dispatch.approved_by, "alice")
+        self.assertFalse(result.merge_disabled)
+        self.assertIsNotNone(result.merge_result)
+        self.assertEqual(result.merge_result["merge_sha"], "def9876543")
+
+    async def test_approve_calls_async_executor(self) -> None:
+        await self._seed_pr_merge_card()
+        called: list = []
+
+        async def executor(dispatch: PRMergeReplyDispatch):
+            called.append(dispatch)
+            await asyncio.sleep(0)
+            return {"merge_sha": "ff00112233"}
+
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="bob",
+            merge_executor=executor,
+        )
+        self.assertEqual(len(called), 1)
+        self.assertEqual(result.merge_result["merge_sha"], "ff00112233")
+
+    async def test_approve_executor_returns_gate_failure(self) -> None:
+        await self._seed_pr_merge_card()
+
+        def executor(dispatch: PRMergeReplyDispatch):
+            return {
+                "gate_failed_step": "checks_green",
+                "gate_reason": "1 check failed",
+            }
+
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="alice",
+            merge_executor=executor,
+        )
+        self.assertEqual(result.gate_failed_step, "checks_green")
+        self.assertIn("1 check failed", result.gate_reason)
+        self.assertIsNone(result.merge_result)
+
+
+class HandleWrongKindTests(_Fixture):
+    async def test_ignores_obsidian_card(self) -> None:
+        # Seed an OBSIDIAN_WRITE card instead.
+        request = ApprovalRequest(
+            session_id="sess-pr",
+            approval_kind=APPROVAL_KIND_OBSIDIAN_WRITE,
+            title="t",
+            summary="s",
+            requested_action="save",
+            created_by="alice",
+            source_thread_id=1001,
+        )
+        await self.worker.run_one(request)
+
+        result = await handle_pr_merge_approval_reply(
+            queue=self.queue,
+            text="승인",
+            session_id="sess-pr",
+            approved_by="alice",
+        )
+        # No PR_MERGE card → no matching approval (filter excludes
+        # OBSIDIAN_WRITE).
+        self.assertEqual(result.skipped_reason, "no_matching_approval")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
F16 PR-2 of 2. Closes acceptance criteria B in #128. Builds on PR-1 (#129, merged).

## 어떤 기능인가요?

변경 B — PR approval / merge loop. Gateway 가 \`#승인-대기\` 채널에 PR summary card 를 올리고, 사용자 응답을 해석하고, 5-step gate 통과 시에만 GitHub merge API 를 호출. \`YULE_GITHUB_MERGE_ENABLED=true\` opt-in 필수.

## 작업 상세 내용 (5 commit)

- [x] commit 6: \`docs/pr-approval-merge.md\` + \`.env.example\` 새 opt-in env 3 개 (docs only)
- [x] commit 7: \`agents/job_queue/pr_approval.py\` — domain (PRMergeProposal / PRMergeStatusSnapshot / PRMergeGateResult / evaluate_merge_gate / parse_pr_merge_reply_intent / render_pr_merge_summary) — **GitHub 호출 0**. 34 unit test.
- [x] commit 8: \`discord/pr_merge_adapter.py\` — enqueue_pr_merge_approval (ApprovalWorker 재사용). 9 unit test.
- [x] commit 9: \`pr_approval.py\` 확장 — handle_pr_merge_approval_reply + PRMergeExecutor type alias + PRMergeReplyResult. 10 unit test.
- [x] commit 10: \`github_app/live_client.py\` merge_pull_request + get_branch_protection + opt-in env 가드. \`github_app/pr_merge_executor.py\` factory. 13 unit test.

**전체 회귀: tests/ 4257 PASS** + 1 skipped.

## Acceptance Criteria

- [x] PRMergeProposal → ApprovalRequest 변환 + 카드 게시 (commit 8)
- [x] Summary 에 title / scope / risk (🟢🟡🔴) / Tests / Branch protection / link 포함 (commit 7)
- [x] 승인 응답 → merge gate 호출 (commit 9)
- [x] \`YULE_GITHUB_MERGE_ENABLED != true\` → LiveGithubAppMergeDisabled (status=503), PUT 미호출 (commit 10)
- [x] 5-step gate 의 각 분기 차단 test:
  - draft PR 차단
  - mergeable_state != "clean" 차단
  - check_runs 중 failure/cancelled 차단
  - branch protection 401/403 차단 (safe-side refusal)
  - head_sha race 차단
- [x] "수정 후 다시" 어휘 → REVISE_AND_REPEAT intent (revise comment 자동 게시는 별도 opt-in env)
- [x] 기존 OBSIDIAN_WRITE / ENGINEERING_WRITE 흐름 회귀 X

## Hard Rails (코드에서 강제)

- ✅ **opt-in env 미통과 시 PUT 자체 차단** — \`merge_pull_request\` 내부에서 \`_is_merge_enabled\` 검사, 미통과 시 즉시 \`LiveGithubAppMergeDisabled\` 예외
- ✅ **5-step gate 모두 통과 필수** — gate 결과 \`allowed=True\` 가 아니면 merge_pull_request 자체 호출 X
- ✅ **draft PR / red checks / branch protection / sha race / 충돌** 5 단계 어느 하나라도 fail → merge 거부
- ✅ **401/403 branch protection** → safe-side refusal (admin override 허용 X)
- ✅ **force push 금지 / required review 우회 금지** — GitHub API 가 차단; 본 PR 은 그것을 우회하지 않음
- ✅ **secret 변경 / deploy / production side-effect** 범위 밖

## 새 환경 변수

| 변수 | 기본 | 의미 |
| --- | --- | --- |
| \`YULE_GITHUB_MERGE_ENABLED\` | \`false\` | merge API 호출 자체의 master gate. 미설정 시 disabled |
| \`YULE_PR_MERGE_REVIEW_COMMENT_ENABLED\` | \`false\` | REVISE_AND_REPEAT 시 자동 review comment (별도 opt-in) |
| \`YULE_PR_MERGE_POLL_INTERVAL_SECONDS\` | \`60\` | PR 변경 감지 polling 주기 |

## Harness

- \`tests/job_queue/test_pr_merge_approval.py\` — 34 unit test (constants / parser / body excerpt / render / gate 9 branches / proposal round-trip / audit)
- \`tests/job_queue/test_pr_merge_reply_handler.py\` — 10 unit test (intent / reject / revise / approve + executor sync/async/gate failure / wrong kind)
- \`tests/discord/test_pr_merge_adapter.py\` — 9 unit test (happy path / dedup / defensive / drive_consumer=False)
- \`tests/github_app/test_live_client_merge_disabled.py\` — 6 unit test (env truthy/falsy / exception subclass)
- \`tests/github_app/test_pr_merge_executor.py\` — 7 unit test (success / 4 gate failures / disabled / 409)
- 회귀: \`pytest tests\` — **4257 passed in 10.77s**

## 🤖 Agent

- role: engineering-agent/tech-lead
- autonomy: L2_AUTONOMOUS_RECORD
- risk_class: PR-1 LOW (F16 #129, merged) / **PR-2 HIGH** — merge seam 의 marshall point. opt-in env + 5-step gate + safe-side refusal 3 중 가드로 모든 invisible 호출 차단.

## 후속 (별도 issue)

1. \`approval_reply_router.route_approval_channel_message\` 의 PR_MERGE 분기 wire-up — 현재는 분기 함수만 들어가 있고 호출자가 직접 \`handle_pr_merge_approval_reply\` 를 호출해야 함
2. PR event producer (polling \`list_open_pull_requests\` cadence 60s) 신설
3. PR-1 (#129) 의 router wire-up — \`prefer_recall_first_gateway=True\` 시 \`decide_gateway\` 호출 + 7-action 핸들러
4. REVISE_AND_REPEAT 시 PR review comment 자동 게시 (\`YULE_PR_MERGE_REVIEW_COMMENT_ENABLED\` opt-in)

## 참고

- F16 PR-1 (#129) — recall-first 자료형/scorer/decide_gateway/flag (merged 2026-05-13)
- \`docs/pr-approval-merge.md\` — 5-step gate + 흐름 + audit trail single source of truth
- \`docs/runtime-recall-first.md\` — F16 PR-1 docs