### PR TITLE
🐞 ci: Discord 알림 silent skip 진단 + workflow 강화 + 운영자 안내 doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    # Manual trigger for testing the notify path without opening a PR.
+    # Pick "Run workflow" on the Actions tab; the notify job will fire
+    # against the current ``DISCORD_CI_WEBHOOK_URL`` secret.
 
 concurrency:
   group: "CI for PR #${{ github.event.pull_request.number }}"
@@ -36,8 +40,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Preflight — verify DISCORD_CI_WEBHOOK_URL is set
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CI_WEBHOOK_URL }}
+        run: |
+          # Surface a ::warning:: annotation on the PR / Actions page
+          # when the secret is missing so operators see why Discord
+          # alerts silently disappeared. The step still succeeds so the
+          # workflow doesn't flap red purely on a config gap.
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "::warning title=Discord CI notification skipped::Repository secret DISCORD_CI_WEBHOOK_URL is empty or unset. Notifications for the CI test job (test.result=${{ needs.test.result }}) will NOT be sent. Set it under Settings → Secrets and variables → Actions to enable Discord CI alerts. See docs/ci-discord-notifications.md."
+            echo "DISCORD_WEBHOOK_URL_PRESENT=false" >> "$GITHUB_ENV"
+          else
+            echo "DISCORD_WEBHOOK_URL_PRESENT=true" >> "$GITHUB_ENV"
+            echo "Discord webhook secret is configured. Continuing with notification."
+          fi
+
       - name: Notify success
-        if: needs.test.result == 'success'
+        if: needs.test.result == 'success' && env.DISCORD_WEBHOOK_URL_PRESENT == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CI_WEBHOOK_URL }}
           IMAGE_URL: ${{ vars.DISCORD_CI_SUCCESS_IMAGE_URL }}
@@ -46,15 +66,13 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           ACTOR: ${{ github.actor }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
-            echo "DISCORD_CI_WEBHOOK_URL is empty. Skip notification."
-            exit 0
-          fi
-
+          # ``${PR_NUMBER:-manual}`` keeps the ``PR`` field readable when
+          # the workflow fires via ``workflow_dispatch`` (no PR context).
           payload=$(jq -n \
             --arg repo "$REPO" \
-            --arg pr "#$PR_NUMBER $PR_TITLE" \
+            --arg pr "#${PR_NUMBER:-manual} ${PR_TITLE:-$EVENT_NAME}" \
             --arg actor "$ACTOR" \
             --arg url "$RUN_URL" \
             --arg image "$IMAGE_URL" \
@@ -73,10 +91,24 @@ jobs:
               }]
             }')
 
-          curl -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"
+          # ``--fail-with-body`` makes curl exit non-zero on HTTP 4xx/5xx
+          # so a revoked / misrouted webhook flips the step red instead
+          # of silently swallowing the failure. ``-w '%{http_code}'``
+          # surfaces the status for the operator-facing log.
+          http_code=$(curl -sS -o /tmp/discord_resp.txt -w '%{http_code}' \
+            --fail-with-body \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK_URL") || true
+          echo "Discord webhook responded with HTTP $http_code"
+          if [ "${http_code:-0}" -ge 400 ] || [ -z "$http_code" ]; then
+            echo "::error title=Discord webhook rejected the notification::HTTP $http_code"
+            cat /tmp/discord_resp.txt || true
+            exit 1
+          fi
 
       - name: Notify failure
-        if: needs.test.result == 'failure'
+        if: needs.test.result == 'failure' && env.DISCORD_WEBHOOK_URL_PRESENT == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CI_WEBHOOK_URL }}
           IMAGE_URL: ${{ vars.DISCORD_CI_FAIL_IMAGE_URL }}
@@ -85,15 +117,11 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           ACTOR: ${{ github.actor }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
-            echo "DISCORD_CI_WEBHOOK_URL is empty. Skip notification."
-            exit 0
-          fi
-
           payload=$(jq -n \
             --arg repo "$REPO" \
-            --arg pr "#$PR_NUMBER $PR_TITLE" \
+            --arg pr "#${PR_NUMBER:-manual} ${PR_TITLE:-$EVENT_NAME}" \
             --arg actor "$ACTOR" \
             --arg url "$RUN_URL" \
             --arg image "$IMAGE_URL" \
@@ -112,4 +140,63 @@ jobs:
               }]
             }')
 
-          curl -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"
+          http_code=$(curl -sS -o /tmp/discord_resp.txt -w '%{http_code}' \
+            --fail-with-body \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK_URL") || true
+          echo "Discord webhook responded with HTTP $http_code"
+          if [ "${http_code:-0}" -ge 400 ] || [ -z "$http_code" ]; then
+            echo "::error title=Discord webhook rejected the notification::HTTP $http_code"
+            cat /tmp/discord_resp.txt || true
+            exit 1
+          fi
+
+      - name: Notify cancelled / other
+        if: needs.test.result != 'success' && needs.test.result != 'failure' && env.DISCORD_WEBHOOK_URL_PRESENT == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CI_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TEST_RESULT: ${{ needs.test.result }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # Without this step, ``cancelled`` / ``skipped`` (e.g. when a
+          # newer push pre-empts the run via concurrency cancellation)
+          # leaves zero Discord trace and operators wrongly conclude
+          # notifications are dead. Emit a low-noise warning embed so
+          # the silence breaks but the channel doesn't get spammed.
+          payload=$(jq -n \
+            --arg repo "$REPO" \
+            --arg pr "#${PR_NUMBER:-manual} ${PR_TITLE:-$EVENT_NAME}" \
+            --arg actor "$ACTOR" \
+            --arg url "$RUN_URL" \
+            --arg result "$TEST_RESULT" \
+            '{
+              content: "⚠️ CI \($result)",
+              embeds: [{
+                title: "Python CI — test \($result)",
+                color: 16763904,
+                fields: [
+                  {name: "Repository", value: $repo, inline: true},
+                  {name: "PR", value: $pr, inline: false},
+                  {name: "Triggered by", value: $actor, inline: true},
+                  {name: "Workflow", value: "[실행 보기](\($url))", inline: false}
+                ]
+              }]
+            }')
+
+          http_code=$(curl -sS -o /tmp/discord_resp.txt -w '%{http_code}' \
+            --fail-with-body \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK_URL") || true
+          echo "Discord webhook responded with HTTP $http_code"
+          if [ "${http_code:-0}" -ge 400 ] || [ -z "$http_code" ]; then
+            echo "::error title=Discord webhook rejected the notification::HTTP $http_code"
+            cat /tmp/discord_resp.txt || true
+            exit 1
+          fi

--- a/docs/ci-discord-notifications.md
+++ b/docs/ci-discord-notifications.md
@@ -1,0 +1,78 @@
+# CI Discord 알림 운영 가이드
+
+> **현재 증상**: `.github/workflows/ci.yml` 의 `notify` job 이 `success` 로 끝나지만 Discord 채널엔 메시지가 안 옴.
+
+## 1. 원인
+
+`secrets.DISCORD_CI_WEBHOOK_URL` 가 비어있으면 workflow 가 다음 라인을 찍고 step 을 그대로 `success` 로 종료한다:
+
+```
+DISCORD_CI_WEBHOOK_URL is empty. Skip notification.
+```
+
+- 사람 눈에는 보이지 않는다 (Actions 탭의 step log 안에만 있음).
+- `step.conclusion` 이 `success` 라서 PR 페이지에서 정상 처리된 것처럼 보인다.
+- 따라서 운영자는 "알림 시스템 자체가 죽었나?" 로 오해한다.
+
+이 PR (`chore/ci-discord-notification-fix`) 에서 workflow 자체는 다음 3 가지를 추가했지만, **실제 알림이 가려면 운영자가 webhook secret 을 설정해야 한다**:
+
+1. `::warning::` annotation — secret 미설정 시 PR / Actions 페이지에 큰 노란 박스로 표시
+2. `curl --fail-with-body` + HTTP status 검증 — webhook 이 revoked / wrong URL 인 경우 step 이 red
+3. `cancelled` / `skipped` 분기 — 옛 build 가 concurrency cancel 됐을 때도 ⚠️ embed 게시
+4. `workflow_dispatch` trigger — Actions 탭에서 "Run workflow" 로 PR 없이 알림 path 테스트 가능
+
+## 2. Secret 설정 절차 (운영자 수동 작업)
+
+### 2.1 Discord webhook URL 생성
+1. Discord 서버 → 채널 (CI 알림 받을 채널) → 톱니바퀴 → 통합 (Integrations) → 웹훅 → 새 웹훅
+2. 이름 (예: `yule-studio-ci`) + 채널 선택
+3. **웹훅 URL 복사** — `https://discord.com/api/webhooks/XXXXXX/YYYYYY` 형태
+
+### 2.2 GitHub repo secret 등록
+1. https://github.com/yule-studio/yule-studio-agent/settings/secrets/actions
+2. **New repository secret** 클릭
+3. Name: `DISCORD_CI_WEBHOOK_URL`
+4. Value: 2.1 에서 복사한 URL
+5. Add secret
+
+### 2.3 (선택) 이미지 변수 등록
+첨부 이미지를 쓰고 싶으면 — **Settings → Secrets and variables → Actions → Variables** 탭에서:
+- `DISCORD_CI_SUCCESS_IMAGE_URL` (성공 시 표시할 이미지 URL)
+- `DISCORD_CI_FAIL_IMAGE_URL` (실패 시 표시할 이미지 URL)
+
+## 3. 검증 절차
+
+### 3.1 manual trigger 로 즉시 검증
+secret 등록 후 PR 안 만들고도 검증 가능:
+1. https://github.com/yule-studio/yule-studio-agent/actions/workflows/ci.yml
+2. **Run workflow** → 브랜치 선택 → 실행
+3. 약 1-2 분 후 — 등록한 Discord 채널에 `✅ CI Success` 메시지가 와야 함
+
+### 3.2 step log 검증
+secret 이 제대로 설정됐는지는 `Preflight — verify DISCORD_CI_WEBHOOK_URL is set` step 의 log 에서:
+- 정상: `Discord webhook secret is configured. Continuing with notification.`
+- 미설정: `::warning:: Discord CI notification skipped` + PR 페이지 노란 박스
+
+### 3.3 webhook 자체의 응답 검증
+Notify success / failure / cancelled step 의 마지막 라인:
+```
+Discord webhook responded with HTTP 204
+```
+- `204 No Content` — Discord 정상 수신.
+- `401 / 404 / 410 / 5xx` — webhook 잘못됨 / revoked / Discord 장애. step 이 red 로 fail 처리되어 명확히 표시됨.
+
+## 4. 실패 시 분기 동작 표
+
+| 조건 | 본 PR 후 동작 |
+| --- | --- |
+| Secret 미설정 + test success | `::warning::` annotation + step skip (red 안 됨) |
+| Secret 미설정 + test failure | `::warning::` annotation + step skip (test 실패만 visible) |
+| Secret 설정 + webhook 정상 + test success | `✅ CI Success` 메시지 |
+| Secret 설정 + webhook 정상 + test failure | `❌ CI Failure` 메시지 |
+| Secret 설정 + webhook 정상 + test cancelled | `⚠️ CI cancelled` 메시지 |
+| Secret 설정 + webhook revoked (HTTP 401) | step red + `::error:: Discord webhook rejected` annotation |
+
+## 5. 본 doc 의 단일 진실
+
+- Secret 이름: `DISCORD_CI_WEBHOOK_URL` (변경 시 `.github/workflows/ci.yml` 의 모든 step 환경 변수도 함께)
+- 사용자 정책: ".env.local 에는 다 세팅되어 있을 것" — 이는 application 동작용 env 의 얘기이고, **GitHub Actions 의 repo secret 은 별개로 등록해야 함**. .env.local 은 GitHub workflow 가 읽지 않는다.


### PR DESCRIPTION
## 어떤 기능인가요?

CI 의 test 결과가 Discord 채널에 안 오는 현상 진단 + workflow 강화 + 운영자 안내.

**진단 결과** (\`gh run view 25782895259 --log\`):
\`\`\`
notify  Notify success  DISCORD_WEBHOOK_URL: <empty>
notify  Notify success  DISCORD_CI_WEBHOOK_URL is empty. Skip notification.
\`\`\`

repo secret \`DISCORD_CI_WEBHOOK_URL\` 가 미설정 → workflow 가 silent \`exit 0\` 으로 끝나서 \`step.conclusion=success\` 이고 PR 페이지엔 정상 처리된 것처럼 보임. 운영자는 "알림 시스템 자체가 죽었나?" 로 오해.

## 작업 상세 내용

- [x] commit 1: \`.github/workflows/ci.yml\` 강화
  - 신규 \`Preflight — verify DISCORD_CI_WEBHOOK_URL is set\` step → secret 미설정 시 \`::warning::\` annotation 으로 PR/Actions 페이지 노란 박스 노출
  - 모든 notify step 에 \`curl --fail-with-body\` + HTTP status 검증 → webhook revoked/잘못된 URL 시 step 이 red 로 fail (이전엔 silent success)
  - 신규 \`Notify cancelled / other\` step → \`cancelled\`/\`skipped\` (concurrency cancel-in-progress 로 자주 발생) 도 ⚠️ embed 게시. 이전엔 success/failure 둘 다 안 매칭돼 무음.
  - \`workflow_dispatch\` trigger 추가 → Actions 탭에서 PR 없이 수동 검증 가능
  - \`\${PR_NUMBER:-manual}\` fallback → manual dispatch 시도 PR 필드 깨지지 않음
- [x] \`docs/ci-discord-notifications.md\` 신설 → 원인 / secret 생성 절차 / 검증 절차 / 실패 분기 매트릭스

## Acceptance Criteria

- [x] Secret 미설정 시 PR 페이지에 노란 \`::warning::\` 박스 visible (이전엔 step log 안에만)
- [x] webhook revoked 시 step red (이전엔 silent success)
- [x] \`cancelled\` test result 도 Discord 메시지 발생 (이전엔 무음)
- [x] manual \`workflow_dispatch\` 로 PR 없이 알림 path 테스트 가능
- [x] YAML syntax 검증 통과

## 운영자 후속 작업 (코드 외)

본 PR 머지만으로는 알림이 활성화되지 않음. 운영자가 다음을 수동 등록해야 함:

1. Discord 채널에서 webhook URL 생성 (docs/ci-discord-notifications.md §2.1)
2. https://github.com/yule-studio/yule-studio-agent/settings/secrets/actions 에서 \`DISCORD_CI_WEBHOOK_URL\` secret 등록 (§2.2)
3. (선택) \`DISCORD_CI_SUCCESS_IMAGE_URL\` / \`DISCORD_CI_FAIL_IMAGE_URL\` Variables 등록
4. Actions 탭에서 \`Run workflow\` 로 즉시 검증 (§3.1)

## Hard rails

- \`.env.local\` 은 GitHub Actions workflow 가 읽지 않음 — repo secret 등록은 별개 절차 (doc 에 명시).
- secret 미설정 시 workflow 가 red 로 flap 하지 않음 (config 안 됐다고 PR 전체 차단 X).
- webhook 자체가 잘못된 경우는 step 이 red 로 표시 (silent 미통보보다 fail-loud).

## 🤖 Agent

- role: engineering-agent/devops-engineer
- autonomy: L2_AUTONOMOUS_RECORD
- risk_class: LOW (CI workflow + docs only; production runtime 무영향)

## 참고

- 진단 단서: \`gh run view 25782895259 --log\` (PR-2 #130 의 CI run, 알림 안 옴)
- 본 PR 의 CI run 결과로 self-validate 가능 — preflight warning 이 PR 페이지에 노출되어야 정상
- 사용자 P0 요구사항 C (\`runtime up\` 단일 진입점) 와 D (typing indicator 유지) 는 본 PR 스코프 밖. 별도 issue 로 진행.