### PR TITLE
✨ #134 P0-E — typing keepalive defense-in-depth (thread continuation wrap + active-role gate)

### DIFF
--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -2394,14 +2394,24 @@ async def _handle_join_or_append(
 
     if thread_continuation_fn is None:
         return None
-    continuation = await _maybe_await(
-        thread_continuation_fn(
-            message=message,
-            prompt=intake_prompt,
-            write_requested=outcome.write_requested,
-            thread_topic=outcome.thread_topic,
+    # P0-E (#134 후속): JOIN/APPEND 의 thread lookup + resume 도 long-running
+    # path (Discord API 조회 + 세션 hydration). conversation_fn wrap 과 동일
+    # 6s interval 로 typing 유지 — 끊김 race 방지.
+    from .typing_indicator import typing_keepalive
+
+    async with typing_keepalive(
+        getattr(message, "channel", None),
+        interval=6.0,
+        label="gateway:thread-continuation",
+    ):
+        continuation = await _maybe_await(
+            thread_continuation_fn(
+                message=message,
+                prompt=intake_prompt,
+                write_requested=outcome.write_requested,
+                thread_topic=outcome.thread_topic,
+            )
         )
-    )
     if continuation is None:
         return None
 

--- a/src/yule_orchestrator/discord/member_bot.py
+++ b/src/yule_orchestrator/discord/member_bot.py
@@ -24,7 +24,11 @@ from .engineering_team_runtime import (
 )
 from .member_bots import GATEWAY_ROLE_KEY, MemberBotProfile
 from .research_forum import ResearchForumContext, chunk_for_discord_message
-from .typing_indicator import typing_context, typing_keepalive
+from .typing_indicator import (
+    should_type_for_member_research,
+    typing_context,
+    typing_keepalive,
+)
 
 
 @dataclass(frozen=True)
@@ -289,14 +293,35 @@ async def _dispatch_member_message(
             file=sys.stderr,
         )
     if research_outcome is not None:
+        # P0-E (#134 후속): explicit defense-in-depth gate for typing.
+        # Even though the handler already returned non-None (=will_post),
+        # we cross-check that profile.role is in the session's persisted
+        # active_research_roles before showing typing. If the helper
+        # says False (e.g., the handler returned an outcome for a role
+        # that's not in the active set — should never happen, but if
+        # it does we don't want a stale typing indicator), the post
+        # still goes through, just without the typing wrap.
+        active_roles = _resolve_active_roles_for_typing_gate(
+            getattr(research_outcome, "session_id", None)
+        )
+        will_type = should_type_for_member_research(
+            role=profile.role,
+            active_roles=active_roles,
+            will_post=True,
+        )
         try:
-            # P0-D (#134): typing_keepalive 가 ~6s 마다 Discord typing
-            # event 재발사. 1-shot typing_context 는 Discord ~10s 만료
-            # 안에 _post_research_turn 의 chained synthesis (8-15s)
-            # 가 끝나지 않으면 typing 사라짐. interval=6.0s → 4s 버퍼.
-            async with typing_keepalive(
-                message.channel, interval=6.0, label="member:research-turn"
-            ):
+            if will_type:
+                # P0-D (#134): typing_keepalive 가 ~6s 마다 Discord typing
+                # event 재발사. 1-shot typing_context 는 Discord ~10s 만료
+                # 안에 _post_research_turn 의 chained synthesis (8-15s)
+                # 가 끝나지 않으면 typing 사라짐. interval=6.0s → 4s 버퍼.
+                async with typing_keepalive(
+                    message.channel, interval=6.0, label="member:research-turn"
+                ):
+                    await _post_research_turn(
+                        message.channel, research_outcome
+                    )
+            else:
                 await _post_research_turn(
                     message.channel, research_outcome
                 )
@@ -324,13 +349,25 @@ async def _dispatch_member_message(
     if team_outcome is None:
         return
 
+    # P0-E (#134 후속): defense-in-depth gate matching the research-turn
+    # branch. team_outcome.turn.session_id is the canonical anchor.
+    team_session_id = getattr(getattr(team_outcome, "turn", None), "session_id", None)
+    active_roles = _resolve_active_roles_for_typing_gate(team_session_id)
+    will_type = should_type_for_member_research(
+        role=profile.role,
+        active_roles=active_roles,
+        will_post=True,
+    )
     try:
-        # P0-D (#134): same keepalive rationale as research-turn above —
-        # handle_team_turn_message 의 deliberation re-render 가 8-15s
-        # 걸리는 경우 1-shot typing 으로는 fade 발생.
-        async with typing_keepalive(
-            message.channel, interval=6.0, label="member:team-turn"
-        ):
+        if will_type:
+            # P0-D (#134): same keepalive rationale as research-turn above —
+            # handle_team_turn_message 의 deliberation re-render 가 8-15s
+            # 걸리는 경우 1-shot typing 으로는 fade 발생.
+            async with typing_keepalive(
+                message.channel, interval=6.0, label="member:team-turn"
+            ):
+                await _post_team_turn(message.channel, team_outcome)
+        else:
             await _post_team_turn(message.channel, team_outcome)
     except Exception as exc:  # noqa: BLE001
         try:
@@ -339,6 +376,42 @@ async def _dispatch_member_message(
             )
         except Exception:  # noqa: BLE001
             pass
+
+
+def _resolve_active_roles_for_typing_gate(
+    session_id: Optional[str],
+) -> Optional[tuple]:
+    """Best-effort load of persisted active_research_roles for typing gate.
+
+    Returns ``None`` when the session can't be loaded or has no
+    explicit ``active_research_roles`` metadata — caller passes
+    ``None`` to :func:`should_type_for_member_research` which
+    interprets it as legacy fallback (helper returns True so typing
+    follows the handler's outcome contract).
+
+    Never raises — typing must not break dispatch.
+    """
+
+    if not session_id:
+        return None
+    try:
+        session = load_session(session_id)
+    except Exception:  # noqa: BLE001 - typing decision must never crash
+        return None
+    if session is None:
+        return None
+    extra = getattr(session, "extra", None)
+    if not isinstance(extra, dict):
+        return None
+    raw_roles = extra.get("active_research_roles")
+    if not raw_roles:
+        return None
+    cleaned = tuple(
+        str(role).strip()
+        for role in raw_roles
+        if isinstance(role, str) and str(role).strip()
+    )
+    return cleaned or None
 
 
 def _member_bot_permission_targets_from_env() -> tuple[_PermissionTarget, ...]:

--- a/tests/discord/test_typing_defense_in_depth_p0e.py
+++ b/tests/discord/test_typing_defense_in_depth_p0e.py
@@ -1,0 +1,303 @@
+"""P0-E (#134 후속) — typing keepalive defense-in-depth 회귀.
+
+두 가지 변경 사항을 보호:
+
+  1. _handle_join_or_append 의 thread_continuation_fn 호출이
+     typing_keepalive 로 wrap → long-running JOIN/APPEND 시 typing 유지.
+  2. member bot 의 _dispatch_member_message 가 should_type_for_member_research
+     helper 를 wiring → inactive role 에 대해 typing 차단 (post 는 유지).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import unittest
+from types import SimpleNamespace
+from typing import Any, List, Optional
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.member_bot import (
+    _dispatch_member_message,
+    _resolve_active_roles_for_typing_gate,
+)
+from yule_orchestrator.discord.member_bots import MemberBotProfile
+
+
+class _CountingChannel:
+    """Tracks typing() enters + sent messages."""
+
+    def __init__(self) -> None:
+        self.enters: int = 0
+        self.sent: list = []
+
+    @contextlib.asynccontextmanager
+    async def _typing_ctx(self):
+        self.enters += 1
+        try:
+            yield
+        finally:
+            pass
+
+    def typing(self):
+        return self._typing_ctx()
+
+    async def send(self, content: str = "", **kwargs: Any) -> None:
+        self.sent.append(content)
+
+
+def _profile(role: str = "tech-lead") -> MemberBotProfile:
+    return MemberBotProfile(
+        agent_id="engineering-agent",
+        role=role,
+        env_key="ENGINEERING_AGENT_BOT_TECH_LEAD_TOKEN",
+        token="x.y.z",
+        display_label=f"engineering-agent/{role}",
+    )
+
+
+def _run(coro_factory):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro_factory())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+# ---------------------------------------------------------------------------
+# Commit 1 — _handle_join_or_append typing_keepalive wrap
+# ---------------------------------------------------------------------------
+
+
+class ThreadContinuationKeepaliveTests(unittest.TestCase):
+    """`thread_continuation_fn` 의 long-running await 중 typing 유지 확인."""
+
+    def test_join_or_append_wraps_thread_continuation_in_keepalive(self) -> None:
+        from yule_orchestrator.discord import engineering_channel_router as router
+
+        channel = _CountingChannel()
+        message = SimpleNamespace(content="기존 세션 s", channel=channel)
+        outcome = SimpleNamespace(
+            write_requested=False,
+            thread_topic=None,
+            research_pack=None,
+            collection_outcome=None,
+        )
+        decision = SimpleNamespace(action="JOIN_SESSION")
+
+        async def slow_continuation(*, message, prompt, write_requested, thread_topic):
+            # 0.12s 지연 → fast keepalive (interval=0.05) 에서 enters >= 2.
+            await asyncio.sleep(0.12)
+            return None  # 매칭 실패 → handler 가 None 반환, 다른 분기 발생 X
+
+        async def fake_send_chunks(channel_arg, content, *args, **kwargs):
+            channel_arg.sent.append(content)
+
+        # patch typing_keepalive locally to use a 0.05s interval so we
+        # can witness ≥2 enters during the 0.12s continuation work.
+        from yule_orchestrator.discord.typing_indicator import (
+            typing_keepalive as original_keepalive,
+        )
+
+        @contextlib.asynccontextmanager
+        async def fast_keepalive(ch, **kwargs):
+            kwargs["interval"] = 0.05
+            async with original_keepalive(ch, **kwargs):
+                yield
+
+        # The router module imports typing_keepalive *inside* the
+        # function bodies, so we patch the typing_indicator module
+        # symbol it pulls in.
+        from yule_orchestrator.discord import typing_indicator as ti_mod
+
+        with patch.object(ti_mod, "typing_keepalive", fast_keepalive):
+            _run(
+                lambda: router._handle_join_or_append(
+                    message=message,
+                    outcome=outcome,
+                    decision=decision,
+                    intake_prompt="prompt",
+                    send_chunks=fake_send_chunks,
+                    thread_continuation_fn=slow_continuation,
+                    research_loop_fn=None,
+                )
+            )
+
+        # Keepalive 가 0.05s interval 로 0.12s 동안 떴다 → 최소 2회 enter.
+        self.assertGreaterEqual(channel.enters, 2)
+
+
+# ---------------------------------------------------------------------------
+# Commit 2 — should_type_for_member_research wiring
+# ---------------------------------------------------------------------------
+
+
+class ActiveRolesGateTests(unittest.TestCase):
+    """`_resolve_active_roles_for_typing_gate` best-effort 동작."""
+
+    def test_missing_session_id_returns_none(self) -> None:
+        self.assertIsNone(_resolve_active_roles_for_typing_gate(None))
+        self.assertIsNone(_resolve_active_roles_for_typing_gate(""))
+
+    def test_load_session_failure_returns_none(self) -> None:
+        # load_session 예외 → 절대 raise 안 함, None 반환.
+        from yule_orchestrator.discord import member_bot as mb
+
+        def boom(_):
+            raise RuntimeError("db down")
+
+        with patch.object(mb, "load_session", side_effect=boom):
+            result = _resolve_active_roles_for_typing_gate("sess-x")
+        self.assertIsNone(result)
+
+    def test_session_without_metadata_returns_none(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        session = SimpleNamespace(extra={})
+        with patch.object(mb, "load_session", return_value=session):
+            result = _resolve_active_roles_for_typing_gate("sess-x")
+        self.assertIsNone(result)
+
+    def test_session_with_persisted_roles_returns_tuple(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        session = SimpleNamespace(
+            extra={"active_research_roles": ["tech-lead", "ai-engineer"]}
+        )
+        with patch.object(mb, "load_session", return_value=session):
+            result = _resolve_active_roles_for_typing_gate("sess-x")
+        self.assertEqual(result, ("tech-lead", "ai-engineer"))
+
+
+class InactiveRoleSkipsTypingTests(unittest.TestCase):
+    """active_research_roles 에 없는 role 은 typing 안 켜지지만 post 는 유지."""
+
+    def test_inactive_role_posts_without_typing(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _CountingChannel()
+        message = SimpleNamespace(
+            content="[research-turn:sess-1 frontend-engineer] go", channel=channel
+        )
+        # frontend-engineer 가 active 아님 — tech-lead/ai-engineer 만.
+        sentinel = SimpleNamespace(
+            comment="x", session_id="sess-1", message="hi"
+        )
+        session = SimpleNamespace(
+            extra={"active_research_roles": ["tech-lead", "ai-engineer"]}
+        )
+
+        keepalive_calls: list = []
+
+        @contextlib.asynccontextmanager
+        async def counting_keepalive(ch, **kwargs):
+            keepalive_calls.append(kwargs.get("label"))
+            yield
+
+        async def fake_post(ch, outcome):
+            await ch.send("posted")
+
+        with patch.object(
+            mb, "handle_research_turn_message", return_value=sentinel
+        ), patch.object(mb, "load_session", return_value=session), patch.object(
+            mb, "_post_research_turn", side_effect=fake_post
+        ), patch.object(mb, "typing_keepalive", counting_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("frontend-engineer"), message=message
+                )
+            )
+
+        # Post 는 발생 (handler 가 outcome 줬으니).
+        self.assertEqual(channel.sent, ["posted"])
+        # Gate False → keepalive wrap 미진입.
+        self.assertEqual(keepalive_calls, [])
+
+    def test_active_role_keeps_typing(self) -> None:
+        # 같은 session 에서 active 인 role (ai-engineer) 으로 dispatch → keepalive wrap 진입.
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _CountingChannel()
+        message = SimpleNamespace(
+            content="[research-turn:sess-1 ai-engineer] go", channel=channel
+        )
+        sentinel = SimpleNamespace(
+            comment="x", session_id="sess-1", message="hi"
+        )
+        session = SimpleNamespace(
+            extra={"active_research_roles": ["tech-lead", "ai-engineer"]}
+        )
+
+        keepalive_calls: list = []
+
+        @contextlib.asynccontextmanager
+        async def counting_keepalive(ch, **kwargs):
+            keepalive_calls.append(kwargs.get("label"))
+            yield
+
+        async def fake_post(ch, outcome):
+            await ch.send("posted")
+
+        with patch.object(
+            mb, "handle_research_turn_message", return_value=sentinel
+        ), patch.object(mb, "load_session", return_value=session), patch.object(
+            mb, "_post_research_turn", side_effect=fake_post
+        ), patch.object(mb, "typing_keepalive", counting_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("ai-engineer"), message=message
+                )
+            )
+
+        self.assertEqual(channel.sent, ["posted"])
+        # Gate let the wrap fire — exactly one keepalive entry for research-turn.
+        self.assertEqual(keepalive_calls, ["member:research-turn"])
+
+    def test_legacy_session_no_metadata_keeps_typing(self) -> None:
+        # active_research_roles 메타 없음 → helper 가 None → legacy fallback
+        # (will_type=True) → keepalive wrap 진입.
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _CountingChannel()
+        message = SimpleNamespace(
+            content="[research-turn:sess-legacy tech-lead] go", channel=channel
+        )
+        sentinel = SimpleNamespace(
+            comment="x", session_id="sess-legacy", message="hi"
+        )
+
+        keepalive_calls: list = []
+
+        @contextlib.asynccontextmanager
+        async def counting_keepalive(ch, **kwargs):
+            keepalive_calls.append(kwargs.get("label"))
+            yield
+
+        async def fake_post(ch, outcome):
+            await ch.send("posted")
+
+        with patch.object(
+            mb, "handle_research_turn_message", return_value=sentinel
+        ), patch.object(mb, "load_session", return_value=None), patch.object(
+            mb, "_post_research_turn", side_effect=fake_post
+        ), patch.object(mb, "typing_keepalive", counting_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("tech-lead"), message=message
+                )
+            )
+
+        self.assertEqual(channel.sent, ["posted"])
+        # Legacy → wrap fires.
+        self.assertEqual(keepalive_calls, ["member:research-turn"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
related #134

## ✨ 과제 내용

P0-D (#134) 머지 후 잔존했던 audit doc 의 2가지 typing keepalive 항목을 마무리.

### 잔존 항목 → 본 PR 처리

**audit doc spot 2 — `_handle_join_or_append` 의 thread_continuation_fn typing wrap**
- 기존: gateway 의 conversation_fn 만 keepalive wrap (PR #135). JOIN / APPEND_CONTEXT path 의 thread lookup + resume (Discord API + session hydration, long-running) 은 wrap 없음.
- 변경: `_handle_join_or_append` 안 `thread_continuation_fn` await 주변을 `typing_keepalive(interval=6.0, label="gateway:thread-continuation")` 로 wrap. None-check 는 wrap 바깥에 유지 → invalid path silence 보존.

**audit doc spot 5 — `should_type_for_*` defense-in-depth wiring**
- 기존: `typing_indicator.py` 에 helper 정의만 있고 production 호출 X. inactive role 의 silence 는 handler outcome-is-None 우연.
- 변경: member bot `_dispatch_member_message` 의 두 분기 (research-turn / team-turn) 에서 `typing_keepalive` 진입 *전* `should_type_for_member_research(...)` 호출. helper 가 False 면 wrap 스킵 후 post 만 진행.
  - `_resolve_active_roles_for_typing_gate(session_id)` 신규: `load_session` → `session.extra['active_research_roles']` best-effort 로드. 어떤 예외도 raise X (typing 결정이 dispatch 를 깨뜨리면 안 됨).
  - 메타 없거나 load 실패 시 None → helper 의 legacy fallback (return True) → typing 정상 진행.
  - gateway `should_type_for_gateway_action` 은 wiring 스킵: 호출 site 가 이미 `is_engineering_channel + handled_branch_likely` guard 통과한 다음 자리라 입력이 정적으로 True. 추가 호출은 ceremony.

### Commit 구성 (3)
1. `0d324eb` ✨ `_handle_join_or_append` 의 thread_continuation_fn typing_keepalive 보강
2. `f38602a` ✨ `should_type_for_member_research` 를 member bot dispatch 에 wiring
3. `a4e8507` ✅ typing defense-in-depth 회귀 test 추가 (3 TestCase / 8 test)

### 회귀
- `tests/` 전체 **4282 PASS** + 1 skipped (4274 → 4282, P0-E 신규 8 추가).
- 회귀 test 는 counting_keepalive shim 으로 wrap 진입 여부 자체를 검증 — fake post 의 task-스케줄링 의존성 회피.

### Acceptance
- [x] JOIN/APPEND 의 thread continuation 도 long-running 시 typing 유지
- [x] inactive role 에 대해 typing 차단 (post 는 유지)
- [x] active role + legacy session (메타 없음) 은 keepalive wrap 유지 (회귀 없음)
- [x] helper 로드 실패 시 graceful fallback (raise X)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- `docs/runtime-member-bot-dispatch-parity.md` — P0-D PR (#135) 의 audit doc. 본 PR 로 spot 2 + spot 5 잔존 항목 클로즈.
- 향후 typing/post split refactor 가 진행되면 본 PR 의 `should_type_*` gate 가 typing 단독 차단점으로 활용 가능.