### PR TITLE
✨ P0-F — 운영-리서치 follow-up + query canonicalization + typing pre-parse

### DIFF
--- a/docs/forum-followup-canonical-typing.md
+++ b/docs/forum-followup-canonical-typing.md
@@ -1,0 +1,108 @@
+# Forum Follow-up + Query Canonicalization + Typing Pre-Parse (P0-F)
+
+> **Status**: 단일 PR — 라이브 Discord UX 의 3가지 잔존 회귀 한 묶음 해결. 코드 변경 전 lock down.
+
+## 0. 문제 정리
+
+세 가지 사용자 보고 사항:
+
+1. **`#운영-리서치` 가 사용자와 대화형 follow-up surface 로 동작하지 않음.** thread 에 "지금 뭐하고 있어?", "RAG 말고 CAG 얘기야", "이 링크도 참고해" 라고 써도 무반응.
+2. **`dRAG` / `cag` 같은 오타·소문자 변형이 그대로 research query 로 들어감.** mock fallback 일 때는 엉뚱한 canned 결과가 authoritative reference 처럼 forum 에 올라감.
+3. **member bot typing indicator 가 "생각 시작" 이 아니라 "보내기 직전" 에만 켜짐.** expensive handler (deliberation, synthesis) 가 도는 동안 indicator 비어 있어 사용자가 "봇이 죽었나" 의심.
+
+## 1. 인지 부조화 (원인 요약)
+
+### 문제 1 — forum thread fallthrough
+- `src/yule_orchestrator/discord/forum_message_adapter.py:103` 의 `route_forum_message` 가 처리하는 intent 는 **2개뿐**:
+  1. Branch 1 (line 141) — Obsidian save request.
+  2. Branch 2 (line 193) — role-change request.
+- 일반 follow-up 질문은 line 202 의 `parse_role_change_request(text) is None` 분기에서 `handled=False` 로 빠진다.
+- 그 다음 `bot.py:1685` 가 falsy 결과를 받고 engineering channel router 로 넘기지만, engineering router 는 `#업무-접수` (intake channel) 만 engineering channel 로 인식. forum thread 는 owner 가 없는 상태.
+- 결과: 사용자 follow-up 메시지가 어디서도 처리되지 않음.
+
+### 문제 2 — raw prompt query
+- `src/yule_orchestrator/agents/research/collector.py:570` `build_query_for_role` 가 prompt 첫 줄을 그대로 query 토큰화. 케이스 정규화, alias 보정, 도메인 lexicon 매칭 모두 없음.
+- 결과: `dRAG memory 구조 비교` → query `dRAG memory 구조 비교` 그대로. 도메인 용어 (`RAG`/`CAG`/`LLM`/`JWT`/`CI/CD`) 의 대소문자·variant 가 그대로 collector 에 도달.
+- mock fallback (provider/key 미설정 시) 은 query 토큰 매칭으로 hit bucket 을 고르므로, 정규화 안 된 query 는 잘못된 bucket 의 canned 결과를 끌어옴 → 사용자 눈엔 "엉뚱한 답" 으로 보임.
+
+### 문제 3 — typing 시작 시점
+- `src/yule_orchestrator/discord/member_bot.py:284` `handle_research_turn_message(...)` 호출이 **typing wrap 바깥**. 이 핸들러는 cheap 하지 않음 — `load_session`, deliberation re-render, synthesis 큐잉 수행 (`engineering_team_runtime.py:523` 이하).
+- typing_keepalive 진입은 line 318 (handler 결과가 non-None 인 다음). 즉 expensive computation 의 절반이 끝난 다음에야 typing 시작.
+
+## 2. 5 가지 의심 spot (이번 PR 처리 범위)
+
+| # | 위치 | 처리 commit |
+| --- | --- | --- |
+| A1 | `forum_message_adapter.route_forum_message` — branch 3 (follow-up) 추가 | commit 4 |
+| A2 | `forum_message_adapter._resolve_session_for_forum_thread` — 재사용 (기존 helper) | commit 4 |
+| B1 | `agents/research/query_canonicalizer.py` 신규 모듈 — single source of truth | commit 2 |
+| B2 | `collector.build_query_for_role` + recall observation — canonicalizer wire-in | commit 3 |
+| C1 | `member_bot._dispatch_member_message` — pre-parse 후 typing_keepalive 진입 | commit 5 |
+
+## 3. 설계 요약
+
+### A. Forum thread follow-up (commit 4)
+- 새 helper `forum_conversation_adapter.handle_forum_followup(message, text, session, ...)`:
+  - 기존 session anchor 를 `_resolve_session_for_forum_thread` (이미 forum_message_adapter 에 존재) 로 찾는다.
+  - 그 session 의 `prompt`, `extra`, `played_roles`, `active_research_roles` 를 컨텍스트로 `build_engineering_conversation_response` 호출 (이미 status query / clarification / general help 처리).
+  - 결과의 `is_status_query=True` 또는 `intent_id=GENERAL_ENGINEERING_HELP` 등은 직접 thread 에 응답.
+  - `ready_to_intake=True` 가 나와도 **새 intake 만들지 않는다**. 그 분기는 silent skip (forum 은 새 작업 제출처가 아님).
+  - correction/append-context 같은 특수 directive 는 별도 light parser (`parse_forum_correction_directive`) 로 식별 → session.extra 에 메모만 남기고 응답.
+- `route_forum_message` 에 branch 4 로 wire — save/role-change 처리 안 되면 follow-up 으로 fall-in. session anchor 없으면 silent fall-through (현행 fallthrough 와 동일).
+
+### B. Query canonicalization (commit 2 + 3)
+- 새 모듈 `agents/research/query_canonicalizer.py`:
+  - `canonicalize_query(raw: str) -> CanonicalQuery` — 단일 진입점.
+  - `CanonicalQuery` dataclass: `raw`, `canonical`, `applied: tuple[Replacement]`, `confidence: float` (0.0~1.0).
+  - 처리 단계 순서:
+    1. whitespace/case 정규화 (`  Drag ` → `drag`).
+    2. **engineering domain lexicon 매핑** — exact case-insensitive 매칭. 우선 `RAG`, `CAG`, `LLM`, `JWT`, `CI/CD`, `OSI`, `TCP`, `UDP`, `IP`, `HTTP`, `HTTPS`, `OAuth`, `REST`, `gRPC`, `SQL`, `NoSQL`, `MQTT`, `ETL`, `ML`, `AI` ~30 개.
+    3. **bounded fuzzy correction** — edit distance ≤1, lexicon 단어 길이 ≥3, 알파벳 prefix 조건. (`dRAG`→`RAG`, `cAg`→`CAG`, `llm`→`LLM`).
+    4. korean alias normalization (`알엠`→`LLM`, `씨아이씨디`→`CI/CD` 등 — 보수적, 5~10개).
+    5. confidence 산정: 모든 정규화가 exact case-insensitive 매핑이면 1.0, fuzzy 가 섞이면 0.6, 한국어 alias 가 섞이면 0.7.
+- `collector.build_query_for_role`:
+  - prompt 첫 줄 추출 직후 `canonicalize_query` 호출.
+  - canonical token 을 query 에 사용. raw 는 metadata 로 `collection_outcome.metadata['raw_query']` 에 보존.
+  - confidence < 0.5 이면 `low_confidence_query=True` 표시.
+- `collector.run_research_collection` 의 mock fallback 분기:
+  - `low_confidence_query=True` + mock fallback 조합 → `auto_publish=False` (collector 가 게시 보류, gateway 가 사용자에게 clarification 요청).
+
+### C. Typing pre-parse (commit 5)
+- `_dispatch_member_message` 의 흐름 재정렬:
+  1. **cheap pre-parse** (현재는 handler 안에서 발생):
+     - `parse_research_dispatch_marker(text)` 또는 `parse_research_open_marker(text)` 로 marker + session_id + role 추출 (단순 regex, microseconds).
+     - profile.role 과 marker role 비교 → 다르면 즉시 silent return (typing 안 켜짐).
+     - active_research_roles 빠른 조회 (이미 commit 2 of P0-E 의 `_resolve_active_roles_for_typing_gate` 가 있음).
+     - 통과한 marker 류가 있으면 → 다음 단계로.
+  2. **typing_keepalive 진입** (expensive handler 까지 감쌈).
+  3. `handle_research_turn_message` / `handle_team_turn_message` 실행 + `_post_*` 수행.
+- 결과: expensive handler 가 도는 5~15s 동안 typing 유지. inactive role / 잘못된 marker 는 typing 진입 X.
+
+## 4. Commit 시퀀스 (단일 PR, 6 commits)
+
+| commit | 내용 | risk |
+| --- | --- | --- |
+| 1 | 본 audit doc (코드 변경 0) | 0 |
+| 2 | `agents/research/query_canonicalizer.py` 신규 모듈 + unit test | LOW (순수 모듈) |
+| 3 | collector + recall observation 의 query 빌드 site 에 canonicalizer 와이어. low-confidence + mock fallback 보류 가드 | MEDIUM (production 분기 변화) |
+| 4 | `forum_conversation_adapter` + `route_forum_message` branch 4 (follow-up) | MEDIUM (forum thread routing 추가) |
+| 5 | `_dispatch_member_message` 의 pre-parse + typing_keepalive 진입 순서 재정렬 | MEDIUM (typing UX 시점 변경) |
+| 6 | regression test 추가 + 전체 pytest pass 확인 + PR | LOW |
+
+## 5. Acceptance Criteria 매핑
+
+| AC | 처리 commit |
+| --- | --- |
+| 1. 운영-리서치 thread 에서 status question 응답 | 4 |
+| 2. forum thread correction/append/summarize 가 새 intake 만들지 않고 처리 | 4 |
+| 3. `dRAG/CAG` canonicalization | 2 + 3 |
+| 4. low-confidence + mock fallback → auto-publish 보류 | 3 |
+| 5. member bot typing 이 expensive handler 시작 시점부터 유지 | 5 |
+| 6. ignore/no-op/inactive role typing 미진입 | 5 |
+| 7. save request / role-change / approval / intake 무회귀 | 전 commit 회귀 test |
+
+## 6. 남은 리스크
+
+- `forum_conversation_adapter` 의 status query 응답이 `#봇-상태` 채널의 기존 status diagnostic 과 표현이 달라질 수 있음 — text 만 공유, 별도 alarm 은 미관여.
+- canonicalizer 의 fuzzy correction 이 사용자 의도가 아닐 가능성 (예: 진짜 `Drag` 를 의도). confidence < 1.0 인 경우 결과 메시지에 `📝 "dRAG" → "RAG" 로 정규화함` 같은 audit 1 줄 노출 검토.
+- pre-parse 가 marker 식별을 잘못하면 typing 이 누락될 위험 — cheap regex 이므로 위양성 risk 는 낮으나, 회귀 test 로 보호.

--- a/src/yule_orchestrator/agents/research/collector.py
+++ b/src/yule_orchestrator/agents/research/collector.py
@@ -578,17 +578,52 @@ def build_query_for_role(
 
     Strategy:
     - Take the first line of the prompt (avoid runaway sentences).
+    - **P0-F**: Run the first line through the engineering-domain
+      ``canonicalize_query`` so typos / case variants / aliases
+      (``dRAG`` → ``RAG``, ``ci cd`` → ``CI/CD``, ``알엠`` → ``LLM``)
+      get rewritten before the collector and recall pipelines see them.
+      Raw prompt is left untouched; only the query token is normalized.
     - Append task_type as a keyword (e.g. ``landing-page``).
     - Append role-specific booster terms (`UI reference`, `official docs`).
     - Dedup tokens to keep the query short.
+
+    See :func:`build_canonical_query_for_role` for the version that
+    also returns the :class:`CanonicalQuery` audit envelope.
     """
+
+    return build_canonical_query_for_role(
+        role=role,
+        prompt=prompt,
+        task_type=task_type,
+        extra_keywords=extra_keywords,
+    )[0]
+
+
+def build_canonical_query_for_role(
+    *,
+    role: str,
+    prompt: str,
+    task_type: Optional[str] = None,
+    extra_keywords: Sequence[str] = (),
+) -> Tuple[str, Any]:
+    """Build the role-aware query *plus* return the canonicalization audit.
+
+    Returns ``(query_str, CanonicalQuery)``. Callers that want to log
+    or surface normalization metadata (raw vs canonical, confidence,
+    applied replacements) use this; thin shims that just need the
+    query string use :func:`build_query_for_role`.
+    """
+
+    from .query_canonicalizer import canonicalize_query
 
     short = short_role(role)
     base = (prompt or "").strip().splitlines()[0:1]
     base_text = base[0].strip() if base else ""
+    canonical = canonicalize_query(base_text)
+
     parts: list[str] = []
-    if base_text:
-        parts.append(base_text)
+    if canonical.canonical:
+        parts.append(canonical.canonical)
     if task_type:
         parts.append(task_type.strip())
     parts.extend(s for s in (extra_keywords or ()) if s and s.strip())
@@ -600,7 +635,7 @@ def build_query_for_role(
         if cleaned and cleaned.lower() not in seen:
             seen[cleaned.lower()] = None
 
-    return " ".join(seen.keys()).strip()
+    return " ".join(seen.keys()).strip(), canonical
 
 
 # ---------------------------------------------------------------------------
@@ -1702,6 +1737,17 @@ class CollectionOutcome:
     # Surfaced so the gateway / Discord preview / Obsidian work-report
     # can show *who* participated without re-running role_selection.
     active_roles: Tuple[str, ...] = ()
+    # P0-F query canonicalization metadata.
+    raw_query: str = ""
+    canonical_query: str = ""
+    normalization_applied: bool = False
+    normalization_confidence: float = 1.0
+    # P0-F guard: True when a low-confidence canonicalization landed
+    # on a mock-fallback collector. Gateway treats this as "do not
+    # publish to forum without user clarification" — the canned
+    # mock result for a typo'd query is almost never what the user
+    # actually wanted.
+    suppress_auto_publish: bool = False
 
 
 def auto_collect_or_request_more_input(
@@ -1801,7 +1847,20 @@ def auto_collect_or_request_more_input(
         1 for source in pack.sources if (source.extra or {}).get("provider")
     )
 
-    query = build_query_for_role(role=role, prompt=prompt, task_type=task_type)
+    query, canonical = build_canonical_query_for_role(
+        role=role, prompt=prompt, task_type=task_type
+    )
+
+    # P0-F: mock-fallback + low-confidence typo correction = do not
+    # auto-publish to forum. The mock provider returns canned hits
+    # keyed off the query token, so a fuzzy-rewritten typo will
+    # surface plausible-looking but unrelated references.
+    collector_is_mock = chosen.name == "mock"
+    suppress_auto_publish = (
+        collector_is_mock
+        and canonical.normalization_applied
+        and canonical.confidence < 0.7
+    )
 
     common_extras = {
         "budget_tier": policy.tier,
@@ -1811,6 +1870,11 @@ def auto_collect_or_request_more_input(
         "stop_reason": stop_reason,
         "under_covered_roles": under_covered,
         "active_roles": tuple(r for r in (active_roles or ()) if r),
+        "raw_query": canonical.raw,
+        "canonical_query": canonical.canonical,
+        "normalization_applied": canonical.normalization_applied,
+        "normalization_confidence": canonical.confidence,
+        "suppress_auto_publish": suppress_auto_publish,
     }
 
     if auto_collected_count > 0:

--- a/src/yule_orchestrator/agents/research/query_canonicalizer.py
+++ b/src/yule_orchestrator/agents/research/query_canonicalizer.py
@@ -1,0 +1,450 @@
+"""Engineering-domain query canonicalizer — P0-F.
+
+The autonomous collector and the recall observation pipeline both
+build research queries directly from the user's raw prompt. That
+worked for happy-path prompts ("RAG vs CAG memory 구조 비교") but
+broke down for:
+
+  * Typo / case variants: ``dRAG`` / ``rag`` / ``Cag`` / ``llm``
+    arrived as-is at the collector, which uses lowercased-token
+    dedup. With the mock-fallback provider those variants matched
+    *different* canned hit buckets than the user intended.
+  * Bilingual aliases: ``알엠`` / ``씨아이씨디`` never resolved to
+    ``LLM`` / ``CI/CD`` so the collector silently dropped the
+    domain signal.
+
+This module is the **single source of truth** for query
+normalization. Both the collector (``build_query_for_role``) and
+the runtime recall observation (``recall.compute_recall_coverage``)
+call :func:`canonicalize_query` so the recall pass and the
+collection pass see the exact same normalized text.
+
+Design constraints:
+
+  * **No general spellchecker dependency.** A lexicon of ~30
+    engineering acronyms + bounded fuzzy correction (edit distance
+    ≤ 1, candidate length ≥ 3) is enough to catch the live
+    regressions without auto-rewriting normal English/Korean.
+  * **Raw text preserved.** Callers receive both ``raw`` and
+    ``canonical`` and a list of replacements applied so the audit
+    trail and reference metadata can show what changed.
+  * **Confidence reported.** Exact case-insensitive matches earn
+    1.0; fuzzy edit-distance ≤1 earns 0.6; korean alias earns 0.7.
+    Multiple replacements take the min. Callers use the score to
+    gate auto-publish (collector skips authoritative publish when
+    confidence < 0.5 in mock-fallback mode).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Lexicons
+# ---------------------------------------------------------------------------
+
+
+# Canonical engineering acronyms. Map is case-insensitive on the key
+# side; the value is the canonical rendering we emit. Add carefully —
+# every entry trades a fuzzy-false-positive risk for a real-world
+# typo win.
+_ACRONYM_CANONICAL: Mapping[str, str] = {
+    "RAG": "RAG",
+    "CAG": "CAG",
+    "LLM": "LLM",
+    "VLM": "VLM",
+    "JWT": "JWT",
+    "OSI": "OSI",
+    "TCP": "TCP",
+    "UDP": "UDP",
+    "IP": "IP",
+    "HTTP": "HTTP",
+    "HTTPS": "HTTPS",
+    "OAUTH": "OAuth",
+    "REST": "REST",
+    "GRPC": "gRPC",
+    "SQL": "SQL",
+    "NOSQL": "NoSQL",
+    "MQTT": "MQTT",
+    "ETL": "ETL",
+    "ML": "ML",
+    "AI": "AI",
+    "API": "API",
+    "ADR": "ADR",
+    "SSE": "SSE",
+    "WS": "WS",
+    "JSON": "JSON",
+    "YAML": "YAML",
+    "DNS": "DNS",
+    "CDN": "CDN",
+    "S3": "S3",
+    "K8S": "K8s",
+    "MCP": "MCP",
+}
+
+
+# Two-token canonicalizations (run *after* per-token replacements).
+# We normalize whitespace + slash variants like "ci cd" / "ci-cd" /
+# "ci/cd" → "CI/CD". Match is case-insensitive on the pattern; the
+# value is the canonical form.
+_MULTITOKEN_CANONICAL: Tuple[Tuple[str, str], ...] = (
+    ("ci cd", "CI/CD"),
+    ("ci-cd", "CI/CD"),
+    ("ci/cd", "CI/CD"),
+    ("c i / c d", "CI/CD"),
+)
+
+
+# Korean phonetic aliases. Conservative list — only the highest-risk
+# typos seen in live operations. confidence=0.7 (lower than exact).
+_KOREAN_ALIAS: Mapping[str, str] = {
+    "알엠": "LLM",
+    "엘엘엠": "LLM",
+    "씨아이씨디": "CI/CD",
+    "라그": "RAG",
+    "캐그": "CAG",
+    "오아우스": "OAuth",
+    "오에스아이": "OSI",
+    "에이피아이": "API",
+    "에이아이": "AI",
+}
+
+
+# Confidence weights per source of replacement.
+_CONFIDENCE_EXACT = 1.0
+_CONFIDENCE_MIXED_CASE = 0.8
+_CONFIDENCE_KOREAN = 0.7
+_CONFIDENCE_FUZZY = 0.6
+
+
+# Minimum candidate length for fuzzy correction. Below 3 the
+# false-positive risk is too high ("dog" vs "dot" both lex-valid).
+_FUZZY_MIN_LEN = 3
+
+
+@dataclass(frozen=True)
+class Replacement:
+    """One token replacement applied during canonicalization."""
+
+    raw: str
+    canonical: str
+    source: str  # "exact" | "fuzzy" | "korean" | "multitoken"
+    confidence: float
+
+
+@dataclass(frozen=True)
+class CanonicalQuery:
+    """Result of canonicalizing a raw user query.
+
+    ``canonical`` is the rewritten query suitable for collector /
+    recall. ``raw`` is the original prompt fragment (preserved so
+    audit trails can show what the user actually wrote).
+    ``applied`` lists every replacement; callers can render those
+    to the user when confidence < 1.0. ``confidence`` is the min of
+    all per-replacement confidences (1.0 when no replacements).
+    """
+
+    raw: str
+    canonical: str
+    applied: Tuple[Replacement, ...] = field(default_factory=tuple)
+    confidence: float = 1.0
+
+    @property
+    def normalization_applied(self) -> bool:
+        return self.canonical != self.raw or bool(self.applied)
+
+
+def canonicalize_query(raw: str) -> CanonicalQuery:
+    """Normalize *raw* for engineering-domain research queries.
+
+    Returns a :class:`CanonicalQuery` describing what changed.
+
+    Stages (each preserves the user's casing wherever no rewrite
+    fires):
+
+      1. multi-token rules ("ci cd" → "CI/CD") on case-folded text.
+      2. korean alias substitution ("알엠" → "LLM").
+      3. per-token rewrite — case-insensitive exact match → mixed-
+         case uppercase-substring match ("dRAG" → "RAG") → bounded
+         fuzzy (edit distance ≤1, length ≥3).
+
+    Edge cases:
+      * Empty / whitespace-only input → empty canonical.
+      * Tokens already in canonical form pass through with
+        confidence 1.0 and no Replacement.
+    """
+
+    if not raw or not raw.strip():
+        return CanonicalQuery(raw=raw or "", canonical="", confidence=1.0)
+
+    working = " ".join(raw.split())
+    applied: list[Replacement] = []
+
+    # Stage 1 — multi-token rules (case-insensitive). Replace on
+    # the working buffer so the canonical form survives tokenization.
+    for pattern, canonical in _MULTITOKEN_CANONICAL:
+        idx = working.lower().find(pattern)
+        while idx >= 0:
+            working = working[:idx] + canonical + working[idx + len(pattern) :]
+            applied.append(
+                Replacement(
+                    raw=pattern,
+                    canonical=canonical,
+                    source="multitoken",
+                    confidence=_CONFIDENCE_EXACT,
+                )
+            )
+            idx = working.lower().find(pattern, idx + len(canonical))
+
+    # Stage 2 — korean alias substitution.
+    for alias, canonical in _KOREAN_ALIAS.items():
+        if alias in working:
+            working = working.replace(alias, canonical)
+            applied.append(
+                Replacement(
+                    raw=alias,
+                    canonical=canonical,
+                    source="korean",
+                    confidence=_CONFIDENCE_KOREAN,
+                )
+            )
+
+    # Stage 3 — per-token rewrite, preserving user casing.
+    out_tokens: list[str] = []
+    for token in working.split(" "):
+        if not token:
+            continue
+        head, core, tail = _split_punctuation(token)
+        if not core:
+            out_tokens.append(token)
+            continue
+
+        # (a) Case-insensitive exact match against the lexicon.
+        upper = core.upper()
+        if upper in _ACRONYM_CANONICAL:
+            canonical = _ACRONYM_CANONICAL[upper]
+            if core != canonical:
+                applied.append(
+                    Replacement(
+                        raw=core,
+                        canonical=canonical,
+                        source="exact",
+                        confidence=_CONFIDENCE_EXACT,
+                    )
+                )
+            out_tokens.append(f"{head}{canonical}{tail}")
+            continue
+
+        # (b) Mixed-case rule: the user typed an extra prefix/suffix
+        # before/after a lexicon entry (e.g. "dRAG" → user kept the
+        # uppercase RAG signal). Extract contiguous uppercase
+        # substring of length ≥2; if it matches the lexicon, use it.
+        mixed_canonical = _mixed_case_correct(core)
+        if mixed_canonical is not None:
+            if mixed_canonical != core:
+                applied.append(
+                    Replacement(
+                        raw=core,
+                        canonical=mixed_canonical,
+                        source="mixed_case",
+                        confidence=_CONFIDENCE_MIXED_CASE,
+                    )
+                )
+            out_tokens.append(f"{head}{mixed_canonical}{tail}")
+            continue
+
+        # (c) Fuzzy — bounded edit distance 1 against lexicon, length ≥3.
+        fuzzy_canonical = _fuzzy_correct(core)
+        if fuzzy_canonical is not None:
+            applied.append(
+                Replacement(
+                    raw=core,
+                    canonical=fuzzy_canonical,
+                    source="fuzzy",
+                    confidence=_CONFIDENCE_FUZZY,
+                )
+            )
+            out_tokens.append(f"{head}{fuzzy_canonical}{tail}")
+            continue
+
+        out_tokens.append(token)
+
+    canonical = " ".join(out_tokens).strip()
+    confidence = min((r.confidence for r in applied), default=1.0)
+    return CanonicalQuery(
+        raw=raw,
+        canonical=canonical,
+        applied=tuple(applied),
+        confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _mixed_case_correct(token: str) -> str | None:
+    """Canonicalize a token that holds one or more uppercase acronym runs.
+
+    Two patterns:
+
+      1. **Single canonical run with lowercase noise** (``dRAG``,
+         ``aLLM``) — drop the lowercase prefix/suffix and emit the
+         canonical run alone.
+      2. **Multiple canonical runs joined by non-alpha separators**
+         (``CAG/RAG``, ``RAG-CAG``) — preserve every separator and
+         replace each run with its canonical form.
+
+    Returns ``None`` when no uppercase run of length ≥2 matches the
+    lexicon, or when an uppercase run exists but doesn't match. We
+    deliberately *don't* fire on title-cased words like ``Drag``
+    (only one uppercase character).
+    """
+
+    if len(token) < 3:
+        return None
+
+    # Segment the token into (segment_text, is_upper_alpha_run) pairs.
+    segments: list[Tuple[str, bool]] = []
+    i = 0
+    while i < len(token):
+        ch = token[i]
+        if ch.isupper():
+            j = i
+            while j < len(token) and token[j].isupper():
+                j += 1
+            segments.append((token[i:j], True))
+            i = j
+        elif ch.isalpha():
+            j = i
+            while j < len(token) and token[j].isalpha() and not token[j].isupper():
+                j += 1
+            segments.append((token[i:j], False))
+            i = j
+        else:
+            j = i
+            while j < len(token) and not token[j].isalpha():
+                j += 1
+            segments.append((token[i:j], False))
+            i = j
+
+    canonical_runs = [run for run in (
+        seg for seg, is_run in segments if is_run and len(seg) >= 2
+    ) if run in _ACRONYM_CANONICAL]
+    if not canonical_runs:
+        return None
+
+    # Multi-run compound (CAG/RAG, RAG-CAG, dRAG/CAG): rebuild by
+    # walking segments; emit canonical for upper runs ≥2, preserve
+    # non-alpha separators between any two canonical runs, drop
+    # everything else (lowercase noise, single-char upper runs).
+    if len(canonical_runs) >= 2:
+        rebuilt: list[str] = []
+        last_emitted_canonical = False
+        for seg, is_run in segments:
+            if is_run and len(seg) >= 2 and seg in _ACRONYM_CANONICAL:
+                rebuilt.append(_ACRONYM_CANONICAL[seg])
+                last_emitted_canonical = True
+            elif not is_run and not seg.isalpha() and last_emitted_canonical:
+                # Separator after a canonical run — keep so the
+                # compound shape (CAG/RAG, RAG-CAG) is preserved.
+                rebuilt.append(seg)
+            else:
+                # Lowercase noise or stray short upper run: drop.
+                # If we trail off into noise after a canonical run,
+                # strip the trailing separator we may have appended.
+                last_emitted_canonical = False
+        result = "".join(rebuilt).rstrip("/-_.")
+        return result or None
+
+    # Single canonical run with lowercase noise: emit canonical alone.
+    return _ACRONYM_CANONICAL[canonical_runs[0]]
+
+
+def _split_punctuation(token: str) -> Tuple[str, str, str]:
+    """Strip leading/trailing punctuation. Returns (head, core, tail)."""
+
+    head_end = 0
+    while head_end < len(token) and not (token[head_end].isalnum() or _is_hangul(token[head_end])):
+        head_end += 1
+    tail_start = len(token)
+    while tail_start > head_end and not (
+        token[tail_start - 1].isalnum() or _is_hangul(token[tail_start - 1])
+    ):
+        tail_start -= 1
+    return token[:head_end], token[head_end:tail_start], token[tail_start:]
+
+
+def _is_hangul(ch: str) -> bool:
+    return "\uAC00" <= ch <= "\uD7A3"
+
+
+def _fuzzy_correct(token: str) -> str | None:
+    """Return canonical lexicon entry within edit distance 1 of *token*,
+    or ``None`` if no candidate qualifies.
+
+    Constraints:
+      * ``len(token) >= _FUZZY_MIN_LEN``
+      * candidate length within ±1 of token length
+      * exactly one canonical candidate matches (tie → bail)
+      * first alpha character must match (prevents wild rewrites)
+    """
+
+    if len(token) < _FUZZY_MIN_LEN:
+        return None
+    first = token[0].lower() if token else ""
+    if not first.isalpha():
+        return None
+    upper = token.upper()
+    matches: list[str] = []
+    for lex_key, canonical in _ACRONYM_CANONICAL.items():
+        if abs(len(lex_key) - len(upper)) > 1:
+            continue
+        if lex_key[0] != upper[0]:
+            continue
+        if _edit_distance_at_most_1(lex_key, upper):
+            matches.append(canonical)
+    # Deduplicate (canonical may repeat if lexicon ever has aliases).
+    unique = sorted(set(matches))
+    if len(unique) == 1:
+        return unique[0]
+    return None
+
+
+def _edit_distance_at_most_1(a: str, b: str) -> bool:
+    """Return True iff *a* and *b* differ by at most one edit
+    (insertion, deletion, or substitution).
+    """
+
+    if a == b:
+        return True
+    la, lb = len(a), len(b)
+    if abs(la - lb) > 1:
+        return False
+    if la == lb:
+        diffs = sum(1 for x, y in zip(a, b) if x != y)
+        return diffs == 1
+    short, long = (a, b) if la < lb else (b, a)
+    # Try inserting one char into `short` to match `long`.
+    i = j = 0
+    skipped = False
+    while i < len(short) and j < len(long):
+        if short[i] != long[j]:
+            if skipped:
+                return False
+            skipped = True
+            j += 1
+        else:
+            i += 1
+            j += 1
+    return True
+
+
+__all__ = (
+    "CanonicalQuery",
+    "Replacement",
+    "canonicalize_query",
+)

--- a/src/yule_orchestrator/discord/forum_conversation_adapter.py
+++ b/src/yule_orchestrator/discord/forum_conversation_adapter.py
@@ -1,0 +1,348 @@
+"""Forum-thread conversational follow-up — P0-F branch 4.
+
+The forum_message_adapter (branches 1+2) only handled Obsidian save
+requests and active-role changes. Plain follow-up messages
+("지금 뭐하고 있어?", "RAG 말고 CAG 기준으로 봐줘", "이 링크도 참고해")
+fell through and arrived at no surface — the engineering channel
+router treats forum threads as out-of-scope.
+
+This adapter is **branch 4**: when the first two branches both
+return ``handled=False`` (no save / no role-change intent), we
+classify the message as a conversational follow-up bound to the
+forum thread's existing session. The response is composed by
+re-using :func:`build_engineering_conversation_response` with
+``auto_collect=False`` so we never create a new intake from a
+forum follow-up — the forum is for talking about *existing*
+work, not filing new tasks.
+
+Invariants:
+
+  * Never call ``workflow.intake`` even if the conversation helper
+    suggests ``ready_to_intake=True``. Drop the intent silently.
+  * Never re-trigger the research collector. ``auto_collect=False``
+    is hard-pinned; the follow-up should describe / correct /
+    annotate the existing pack, not fetch a new one.
+  * Append-context / correction directives ("이 링크도 참고해",
+    "RAG 말고 CAG 기준으로") are recognized as light annotations
+    persisted into ``session.extra['forum_followup_notes']`` so
+    later turns / Obsidian write can see them.
+  * When no session is anchored to the thread, fall through to
+    ``handled=False`` so the bot can ignore the message (same
+    contract as the existing role-change branch's no-session path).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+# Skipped-reason constants.
+SKIPPED_NO_SESSION_ANCHOR: str = "no_session_for_thread"
+SKIPPED_HELPER_SUGGESTED_INTAKE: str = "helper_suggested_intake_dropped"
+SKIPPED_NO_RESPONSE_BODY: str = "no_response_body"
+
+
+# Friendly summary header (forum follow-up replies don't reuse the
+# gateway's #봇-상태 status template wholesale — that template assumes
+# private DM-style replies; forum threads need a tighter shape).
+RESPONSE_NOTE_RECORDED: str = (
+    "📝 follow-up 메모를 thread 세션에 적어 두었어요. 다음 turn 부터 "
+    "각 역할 봇이 본 메모를 참고합니다."
+)
+
+
+@dataclass(frozen=True)
+class ForumFollowupResult:
+    """What the follow-up adapter decided.
+
+    ``handled`` follows the same convention as the upstream
+    ``ForumMessageRouteResult``: ``True`` short-circuits the
+    on_message dispatcher, ``False`` falls through.
+    """
+
+    handled: bool
+    response_sent: Optional[str] = None
+    skipped_reason: Optional[str] = None
+    followup_note_recorded: Optional[str] = None
+    intent_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Lightweight directive detection
+# ---------------------------------------------------------------------------
+
+
+# "X 말고 Y" / "X 빼고 Y" / "Y 기준으로" — correction/redirect.
+_CORRECTION_PATTERNS: tuple = (
+    re.compile(r"(?P<wrong>\S+)\s+말고\s+(?P<right>\S+)"),
+    re.compile(r"(?P<wrong>\S+)\s+빼고\s+(?P<right>\S+)"),
+    re.compile(r"(?P<right>\S+)\s+기준으로"),
+)
+
+
+# "이 링크도 참고해" / "이것도 봐줘" / "이걸 붙여" — append-context.
+_APPEND_KEYWORDS: tuple = (
+    "이 링크도",
+    "이것도 참고",
+    "이것도 봐",
+    "이걸 붙여",
+    "이 자료도",
+    "이 내용도",
+    "이 메모도",
+    "이 내용 추가",
+    "참고만 해",
+)
+
+
+# "지금까지 합의만" / "요약만" / "결론만" — summarize directive.
+_SUMMARIZE_KEYWORDS: tuple = (
+    "지금까지 합의",
+    "지금까지 결정",
+    "결론만",
+    "요약만",
+    "요약해줘",
+    "정리만",
+)
+
+
+def detect_followup_directive(text: str) -> Optional[str]:
+    """Return a directive kind for *text* or ``None``.
+
+    Recognized kinds: ``"correction"`` / ``"append"`` / ``"summarize"``.
+    The adapter uses the directive label to (a) tag the note we
+    persist and (b) decide whether to reach into the conversation
+    helper or short-circuit with a fixed acknowledgement.
+    """
+
+    if not text:
+        return None
+    lowered = text.strip()
+    for pattern in _CORRECTION_PATTERNS:
+        if pattern.search(lowered):
+            return "correction"
+    for keyword in _APPEND_KEYWORDS:
+        if keyword in lowered:
+            return "append"
+    for keyword in _SUMMARIZE_KEYWORDS:
+        if keyword in lowered:
+            return "summarize"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Adapter entry point
+# ---------------------------------------------------------------------------
+
+
+async def handle_forum_followup(
+    *,
+    message: Any,
+    text: str,
+    session: Any,
+    conversation_fn: Optional[Callable[..., Any]] = None,
+    session_updater: Optional[Callable[..., Any]] = None,
+    send_chunks: Optional[Callable[..., Awaitable[Any]]] = None,
+) -> ForumFollowupResult:
+    """Branch 4 of the forum routing — conversational follow-up.
+
+    *session* is the existing session anchored to the thread (from
+    ``_resolve_session_for_forum_thread`` in forum_message_adapter).
+    When ``None`` we return ``handled=False`` so the bot drops the
+    message — fall-through preserved.
+
+    The adapter:
+
+      1. Detects a follow-up directive (correction/append/summarize).
+         If matched and the message looks like a note, persist it to
+         ``session.extra['forum_followup_notes']`` and acknowledge.
+      2. Otherwise dispatches to the engineering_conversation helper
+         with ``auto_collect=False`` so the existing status /
+         clarification / general-help responses cover the rest.
+      3. Drops any ``ready_to_intake=True`` suggestion — forum is
+         not an intake surface.
+    """
+
+    if session is None:
+        return ForumFollowupResult(
+            handled=False, skipped_reason=SKIPPED_NO_SESSION_ANCHOR
+        )
+
+    # ----------------------------------------------------------------
+    # Stage 1 — light directive recognition + note persistence.
+    # ----------------------------------------------------------------
+    directive = detect_followup_directive(text)
+    if directive is not None and session_updater is not None:
+        try:
+            _persist_followup_note(
+                session=session,
+                directive=directive,
+                text=text,
+                author_handle=_author_handle(message),
+                session_updater=session_updater,
+            )
+        except Exception:  # noqa: BLE001 - persistence failure must not crash dispatch
+            logger.warning(
+                "forum_conversation_adapter: note persistence raised",
+                exc_info=True,
+            )
+        if send_chunks is not None:
+            try:
+                await send_chunks(message.channel, RESPONSE_NOTE_RECORDED)
+            except Exception:  # noqa: BLE001 - send best-effort
+                logger.warning(
+                    "forum_conversation_adapter: send_chunks raised on note ack",
+                    exc_info=True,
+                )
+        return ForumFollowupResult(
+            handled=True,
+            response_sent=RESPONSE_NOTE_RECORDED,
+            followup_note_recorded=directive,
+            intent_id=f"forum_followup_{directive}",
+        )
+
+    # ----------------------------------------------------------------
+    # Stage 2 — conversation helper for status / clarification / help.
+    # ----------------------------------------------------------------
+    helper = conversation_fn or _default_conversation_fn
+    try:
+        response = helper(
+            message_text=text,
+            author_user_id=getattr(getattr(message, "author", None), "id", None),
+            mention_user=False,
+            auto_collect=False,  # never new-intake from forum
+            status_session_loader=lambda **_: session,
+        )
+    except Exception:  # noqa: BLE001 - never crash dispatch
+        logger.warning(
+            "forum_conversation_adapter: conversation_fn raised",
+            exc_info=True,
+        )
+        return ForumFollowupResult(
+            handled=False, skipped_reason="conversation_fn_raised"
+        )
+
+    # Forum follow-up never opens a new intake; drop the suggestion.
+    if getattr(response, "ready_to_intake", False):
+        return ForumFollowupResult(
+            handled=False,
+            skipped_reason=SKIPPED_HELPER_SUGGESTED_INTAKE,
+        )
+
+    body = getattr(response, "content", None) or ""
+    if not body.strip():
+        return ForumFollowupResult(
+            handled=False, skipped_reason=SKIPPED_NO_RESPONSE_BODY
+        )
+
+    if send_chunks is not None:
+        try:
+            await send_chunks(message.channel, body)
+        except Exception:  # noqa: BLE001 - best effort
+            logger.warning(
+                "forum_conversation_adapter: send_chunks raised on body",
+                exc_info=True,
+            )
+
+    return ForumFollowupResult(
+        handled=True,
+        response_sent=body,
+        intent_id=getattr(response, "intent_id", None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _default_conversation_fn(**kwargs):
+    """Lazy import wrapper so tests don't pay the cost when injecting."""
+
+    from .engineering_conversation import build_engineering_conversation_response
+
+    return build_engineering_conversation_response(**kwargs)
+
+
+def _persist_followup_note(
+    *,
+    session: Any,
+    directive: str,
+    text: str,
+    author_handle: str,
+    session_updater: Callable[..., Any],
+) -> None:
+    """Append a follow-up note to ``session.extra['forum_followup_notes']``.
+
+    Each note is a dict ``{"directive": str, "text": str,
+    "author": str, "recorded_at": iso8601}``. ``session_updater``
+    is the same shape as ``workflow_state.update_session``.
+    """
+
+    from dataclasses import replace as _replace
+
+    extra_in = dict(getattr(session, "extra", None) or {})
+    notes = list(extra_in.get("forum_followup_notes") or ())
+    notes.append(
+        {
+            "directive": directive,
+            "text": text.strip(),
+            "author": author_handle,
+            "recorded_at": datetime.now(tz=timezone.utc)
+            .replace(microsecond=0)
+            .isoformat(),
+        }
+    )
+    extra_in["forum_followup_notes"] = notes
+    try:
+        updated = _replace(session, extra=extra_in)
+    except TypeError:
+        # SimpleNamespace test stub — mutate in place.
+        if hasattr(session, "extra") and isinstance(session.extra, dict):
+            session.extra["forum_followup_notes"] = notes
+            try:
+                session_updater(session, now=datetime.now(tz=timezone.utc))
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        return
+    try:
+        session_updater(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _author_handle(message: Any) -> str:
+    author = getattr(message, "author", None)
+    if author is None:
+        return "unknown"
+    name = (
+        getattr(author, "global_name", None)
+        or getattr(author, "name", None)
+        or getattr(author, "display_name", None)
+    )
+    user_id = getattr(author, "id", None)
+    if name and user_id is not None:
+        return f"{name} ({user_id})"
+    if name:
+        return str(name)
+    if user_id is not None:
+        return f"user:{user_id}"
+    return "unknown"
+
+
+__all__ = (
+    "ForumFollowupResult",
+    "RESPONSE_NOTE_RECORDED",
+    "SKIPPED_HELPER_SUGGESTED_INTAKE",
+    "SKIPPED_NO_RESPONSE_BODY",
+    "SKIPPED_NO_SESSION_ANCHOR",
+    "detect_followup_directive",
+    "handle_forum_followup",
+)

--- a/src/yule_orchestrator/discord/forum_message_adapter.py
+++ b/src/yule_orchestrator/discord/forum_message_adapter.py
@@ -200,6 +200,24 @@ async def route_forum_message(
 
     change = parse_role_change_request(text)
     if change is None:
+        # ------------------------------------------------------------------
+        # Branch 3 — conversational follow-up (P0-F).
+        # ------------------------------------------------------------------
+        followup_outcome = await _route_forum_followup(
+            message=message,
+            text=text,
+            discord_module=discord_module,
+            send_chunks_factory=send_chunks_factory,
+            session_lister=session_lister,
+            session_loader=session_loader,
+            session_updater=session_updater,
+        )
+        if followup_outcome.handled:
+            return ForumMessageRouteResult(
+                handled=True,
+                response_sent=followup_outcome.response_sent,
+                skipped_reason=followup_outcome.skipped_reason,
+            )
         return ForumMessageRouteResult(
             handled=False, skipped_reason=SKIPPED_NO_INTENT
         )
@@ -516,6 +534,61 @@ def _format_role_change_response(*, change, outcome, active) -> str:
     # active / nothing matched. Surface the current state so the
     # operator knows the system saw the request.
     return RESPONSE_ROLE_NO_CHANGE.format(active=", ".join(active))
+
+
+async def _route_forum_followup(
+    *,
+    message: Any,
+    text: str,
+    discord_module: Any,
+    send_chunks_factory: Optional[Callable[[Any], Callable[..., Awaitable[Any]]]],
+    session_lister: Any,
+    session_loader: Any,
+    session_updater: Any,
+):
+    """P0-F branch 3 — conversational follow-up.
+
+    Resolves the thread's existing session (same helper the
+    role-change branch uses) and delegates to
+    :func:`forum_conversation_adapter.handle_forum_followup`. Drops
+    silently when there is no session anchored to the thread or
+    when the follow-up helper itself declines to respond.
+    """
+
+    from .forum_conversation_adapter import (
+        ForumFollowupResult,
+        handle_forum_followup,
+    )
+
+    _, _, session_lister_fn = _resolve_queue_deps(
+        queue=None,
+        approval_worker=None,
+        session_lister=session_lister,
+    )
+    _, session_updater_fn = _resolve_session_persistence(
+        session_loader=session_loader,
+        session_updater=session_updater,
+    )
+    session = _resolve_session_for_forum_thread(
+        message=message,
+        session_lister=session_lister_fn,
+    )
+    sender = _resolve_send_chunks(
+        discord_module=discord_module,
+        send_chunks_factory=send_chunks_factory,
+    )
+    if session is None:
+        return ForumFollowupResult(
+            handled=False,
+            skipped_reason="no_session_for_thread",
+        )
+    return await handle_forum_followup(
+        message=message,
+        text=text,
+        session=session,
+        session_updater=session_updater_fn,
+        send_chunks=sender,
+    )
 
 
 __all__ = (

--- a/src/yule_orchestrator/discord/member_bot.py
+++ b/src/yule_orchestrator/discord/member_bot.py
@@ -20,6 +20,9 @@ from .engineering_team_runtime import (
     handle_research_turn_message,
     handle_team_turn_message,
     mark_turn_played,
+    parse_dispatch_marker,
+    parse_research_dispatch_marker,
+    parse_research_open_marker,
     record_role_turn_event,
 )
 from .member_bots import GATEWAY_ROLE_KEY, MemberBotProfile
@@ -277,105 +280,147 @@ async def _dispatch_member_message(
 
     text = message.content or ""
 
-    # Research-turn (운영-리서치 forum thread) takes precedence
-    # because research markers and team markers can both land in
-    # threads the bot can see. We process whichever shows up.
-    try:
-        research_outcome = handle_research_turn_message(
-            role=profile.role,
-            text=text,
-        )
-    except Exception as exc:  # noqa: BLE001
-        research_outcome = None
-        print(
-            f"warning: member bot '{profile.display_label}' "
-            f"research handler failed: {exc}",
-            file=sys.stderr,
-        )
-    if research_outcome is not None:
-        # P0-E (#134 후속): explicit defense-in-depth gate for typing.
-        # Even though the handler already returned non-None (=will_post),
-        # we cross-check that profile.role is in the session's persisted
-        # active_research_roles before showing typing. If the helper
-        # says False (e.g., the handler returned an outcome for a role
-        # that's not in the active set — should never happen, but if
-        # it does we don't want a stale typing indicator), the post
-        # still goes through, just without the typing wrap.
-        active_roles = _resolve_active_roles_for_typing_gate(
-            getattr(research_outcome, "session_id", None)
-        )
-        will_type = should_type_for_member_research(
-            role=profile.role,
-            active_roles=active_roles,
-            will_post=True,
-        )
-        try:
-            if will_type:
-                # P0-D (#134): typing_keepalive 가 ~6s 마다 Discord typing
-                # event 재발사. 1-shot typing_context 는 Discord ~10s 만료
-                # 안에 _post_research_turn 의 chained synthesis (8-15s)
-                # 가 끝나지 않으면 typing 사라짐. interval=6.0s → 4s 버퍼.
-                async with typing_keepalive(
-                    message.channel, interval=6.0, label="member:research-turn"
-                ):
-                    await _post_research_turn(
-                        message.channel, research_outcome
-                    )
-            else:
-                await _post_research_turn(
-                    message.channel, research_outcome
-                )
-        except Exception as exc:  # noqa: BLE001
-            try:
-                await message.channel.send(
-                    f"⚠️ {profile.display_label} 댓글 게시 실패: {exc}"
-                )
-            except Exception:  # noqa: BLE001
-                pass
+    # P0-F: cheap pre-parse → identify which dispatch path *might*
+    # fire and bail early for ignored / not-for-me messages. The
+    # parse_*_marker helpers are simple regex (~microseconds) so we
+    # can run all three before deciding. This pre-gate is what
+    # lets us wrap the *entire* expensive handler in typing_keepalive
+    # (the handlers load_session + run deliberation + queue
+    # synthesis — easily 5-15s — so wrapping only the post means
+    # the indicator stays dark for most of that time).
+    research_marker = parse_research_dispatch_marker(text)
+    research_open_sid = parse_research_open_marker(text)
+    team_marker = parse_dispatch_marker(text)
+
+    # `(session_id, role_or_None)` shape for the two role-specific markers.
+    # research-open is role-less so the bot processes every open
+    # broadcast for its session_id; the handler then enforces the
+    # active_research_roles guard.
+    research_role = research_marker[1] if research_marker else None
+    team_role = team_marker[1] if team_marker else None
+
+    pre_gate_research = (
+        research_marker is not None
+        and (research_role is None or research_role == profile.role)
+    ) or research_open_sid is not None
+    pre_gate_team = (
+        team_marker is not None
+        and (team_role is None or team_role == profile.role)
+    )
+    if not pre_gate_research and not pre_gate_team:
+        # No marker for us — silent (typing not shown).
         return
 
-    try:
-        team_outcome = handle_team_turn_message(
-            role=profile.role,
-            text=text,
-        )
-    except Exception as exc:  # noqa: BLE001
-        team_outcome = None
-        print(
-            f"warning: member bot '{profile.display_label}' "
-            f"team handler failed: {exc}",
-            file=sys.stderr,
-        )
-    if team_outcome is None:
-        return
+    # Resolve session anchor for the defense-in-depth typing gate
+    # (P0-E). Cheap session_id extraction from the matched marker.
+    session_id_for_gate: Optional[str] = None
+    if research_marker is not None:
+        session_id_for_gate = research_marker[0]
+    elif research_open_sid is not None:
+        session_id_for_gate = research_open_sid
+    elif team_marker is not None:
+        session_id_for_gate = team_marker[0]
 
-    # P0-E (#134 후속): defense-in-depth gate matching the research-turn
-    # branch. team_outcome.turn.session_id is the canonical anchor.
-    team_session_id = getattr(getattr(team_outcome, "turn", None), "session_id", None)
-    active_roles = _resolve_active_roles_for_typing_gate(team_session_id)
+    active_roles = _resolve_active_roles_for_typing_gate(session_id_for_gate)
     will_type = should_type_for_member_research(
         role=profile.role,
         active_roles=active_roles,
         will_post=True,
     )
-    try:
-        if will_type:
-            # P0-D (#134): same keepalive rationale as research-turn above —
-            # handle_team_turn_message 의 deliberation re-render 가 8-15s
-            # 걸리는 경우 1-shot typing 으로는 fade 발생.
-            async with typing_keepalive(
-                message.channel, interval=6.0, label="member:team-turn"
-            ):
-                await _post_team_turn(message.channel, team_outcome)
-        else:
-            await _post_team_turn(message.channel, team_outcome)
-    except Exception as exc:  # noqa: BLE001
-        try:
-            await message.channel.send(
-                f"⚠️ {profile.display_label} take 게시 실패: {exc}"
+
+    # P0-F: typing_keepalive now wraps the *entire* expensive path
+    # (handler invocation + post). Previously it only wrapped the
+    # post itself, so the 8-15s deliberation / synthesis re-render
+    # inside handle_*_turn_message ran with no typing indicator.
+    if will_type:
+        async with typing_keepalive(
+            message.channel,
+            interval=6.0,
+            label="member:dispatch",
+        ):
+            await _run_member_dispatch(
+                profile=profile,
+                message=message,
+                text=text,
+                try_research=pre_gate_research,
+                try_team=pre_gate_team,
             )
-        except Exception:  # noqa: BLE001
-            pass
+    else:
+        await _run_member_dispatch(
+            profile=profile,
+            message=message,
+            text=text,
+            try_research=pre_gate_research,
+            try_team=pre_gate_team,
+        )
+
+
+async def _run_member_dispatch(
+    *,
+    profile: MemberBotProfile,
+    message: Any,
+    text: str,
+    try_research: bool,
+    try_team: bool,
+) -> None:
+    """Run the actual handlers + posts. Caller owns the typing wrap.
+
+    The pre-gate in :func:`_dispatch_member_message` already decided
+    which markers might apply; here we just invoke the matching
+    handlers and post. Errors land as ⚠️ messages in the same
+    channel so a user never sees a frozen typing indicator.
+    """
+
+    # Research-turn first — marker takes precedence when both land.
+    if try_research:
+        try:
+            research_outcome = handle_research_turn_message(
+                role=profile.role,
+                text=text,
+            )
+        except Exception as exc:  # noqa: BLE001
+            research_outcome = None
+            print(
+                f"warning: member bot '{profile.display_label}' "
+                f"research handler failed: {exc}",
+                file=sys.stderr,
+            )
+        if research_outcome is not None:
+            try:
+                await _post_research_turn(message.channel, research_outcome)
+            except Exception as exc:  # noqa: BLE001
+                try:
+                    await message.channel.send(
+                        f"⚠️ {profile.display_label} 댓글 게시 실패: {exc}"
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+            return
+
+    if try_team:
+        try:
+            team_outcome = handle_team_turn_message(
+                role=profile.role,
+                text=text,
+            )
+        except Exception as exc:  # noqa: BLE001
+            team_outcome = None
+            print(
+                f"warning: member bot '{profile.display_label}' "
+                f"team handler failed: {exc}",
+                file=sys.stderr,
+            )
+        if team_outcome is None:
+            return
+        try:
+            await _post_team_turn(message.channel, team_outcome)
+        except Exception as exc:  # noqa: BLE001
+            try:
+                await message.channel.send(
+                    f"⚠️ {profile.display_label} take 게시 실패: {exc}"
+                )
+            except Exception:  # noqa: BLE001
+                pass
 
 
 def _resolve_active_roles_for_typing_gate(

--- a/tests/discord/test_forum_conversation_adapter.py
+++ b/tests/discord/test_forum_conversation_adapter.py
@@ -1,0 +1,272 @@
+"""P0-F commit 4 — forum thread conversational follow-up adapter.
+
+Covers branch 3 of forum_message_adapter (newly added) + the
+underlying handle_forum_followup helper:
+
+  1. Status question ("지금 뭐하고 있어?") → conversation helper
+     returns a status reply, sender receives it, no new intake.
+  2. Append-context directive ("이 링크도 참고해") → light parser
+     persists a note into session.extra['forum_followup_notes'].
+  3. Correction directive ("RAG 말고 CAG 기준으로 봐줘") → same.
+  4. Summarize directive ("지금까지 합의만 요약해줘") → same.
+  5. helper suggests ready_to_intake → dropped (forum is not
+     an intake surface).
+  6. No session anchored to the thread → handled=False (fall through).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, List
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.forum_conversation_adapter import (
+    ForumFollowupResult,
+    RESPONSE_NOTE_RECORDED,
+    SKIPPED_HELPER_SUGGESTED_INTAKE,
+    SKIPPED_NO_SESSION_ANCHOR,
+    detect_followup_directive,
+    handle_forum_followup,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _forum_message(content: str):
+    channel = SimpleNamespace(id=50001, parent_id=50000, name="thread")
+    author = SimpleNamespace(id=7, name="masterway", global_name="masterway")
+    return SimpleNamespace(
+        id=60001,
+        channel=channel,
+        author=author,
+        content=content,
+    )
+
+
+def _open_session(extra_overrides=None):
+    extra = {"research_forum_thread_id": 50001}
+    if extra_overrides:
+        extra.update(extra_overrides)
+    return SimpleNamespace(
+        session_id="sess-followup-1",
+        prompt="k8s 운영 자료 정리",
+        extra=extra,
+        thread_id=None,
+        role_sequence=("tech-lead",),
+        updated_at=datetime.now(tz=timezone.utc).isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Directive detection
+# ---------------------------------------------------------------------------
+
+
+class DetectFollowupDirectiveTests(unittest.TestCase):
+    def test_correction_with_malgo(self) -> None:
+        self.assertEqual(
+            detect_followup_directive("RAG 말고 CAG 기준으로 봐줘"),
+            "correction",
+        )
+
+    def test_correction_with_beggo(self) -> None:
+        self.assertEqual(
+            detect_followup_directive("backend 빼고 ai만 더 봐줘"),
+            "correction",
+        )
+
+    def test_append_context_link(self) -> None:
+        self.assertEqual(
+            detect_followup_directive("이 링크도 참고해 줘"),
+            "append",
+        )
+
+    def test_summarize(self) -> None:
+        self.assertEqual(
+            detect_followup_directive("지금까지 합의만 짧게 말해줘"),
+            "summarize",
+        )
+
+    def test_no_directive(self) -> None:
+        self.assertIsNone(detect_followup_directive("그냥 평범한 메시지"))
+
+
+# ---------------------------------------------------------------------------
+# Adapter behavior
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.sent: List[str] = []
+        self.updated_sessions: List = []
+
+    async def send_chunks(self, channel, content, *args, **kwargs):
+        self.sent.append(content)
+
+    def session_updater(self, session, *, now=None):
+        self.updated_sessions.append((session, now))
+
+
+class HandleForumFollowupTests(unittest.TestCase):
+    def test_status_question_dispatches_to_helper(self) -> None:
+        session = _open_session()
+        recorder = _Recorder()
+
+        def fake_helper(**kwargs):
+            return SimpleNamespace(
+                content="현재 진행 중인 작업: …",
+                intent_id="status_diagnostic",
+                ready_to_intake=False,
+                is_status_query=True,
+            )
+
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("지금 뭐하고 있어?"),
+                text="지금 뭐하고 있어?",
+                session=session,
+                conversation_fn=fake_helper,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+
+        self.assertTrue(result.handled)
+        self.assertIn("진행 중", result.response_sent or "")
+        self.assertEqual(result.intent_id, "status_diagnostic")
+        # Status query is not a directive → no note persisted.
+        self.assertEqual(recorder.updated_sessions, [])
+
+    def test_append_directive_persists_note(self) -> None:
+        session = _open_session()
+        recorder = _Recorder()
+
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("이 링크도 참고해줘"),
+                text="이 링크도 참고해줘 https://example.com/cache",
+                session=session,
+                conversation_fn=lambda **_: None,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.followup_note_recorded, "append")
+        self.assertEqual(result.response_sent, RESPONSE_NOTE_RECORDED)
+        # Note actually landed in session.extra.
+        notes = session.extra["forum_followup_notes"]
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]["directive"], "append")
+        self.assertIn("example.com/cache", notes[0]["text"])
+
+    def test_correction_directive_persists_note(self) -> None:
+        session = _open_session()
+        recorder = _Recorder()
+
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("RAG 말고 CAG 기준으로 봐줘"),
+                text="RAG 말고 CAG 기준으로 봐줘",
+                session=session,
+                conversation_fn=lambda **_: None,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+
+        self.assertTrue(result.handled)
+        self.assertEqual(result.followup_note_recorded, "correction")
+        notes = session.extra["forum_followup_notes"]
+        self.assertEqual(notes[0]["directive"], "correction")
+
+    def test_helper_intake_suggestion_dropped(self) -> None:
+        session = _open_session()
+        recorder = _Recorder()
+
+        def fake_helper(**kwargs):
+            return SimpleNamespace(
+                content="좋습니다. 이대로 등록할게요.",
+                intent_id="confirm_intake",
+                ready_to_intake=True,
+                is_status_query=False,
+            )
+
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("이대로 진행해"),
+                text="이대로 진행해",
+                session=session,
+                conversation_fn=fake_helper,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+
+        # Forum is not an intake surface → drop.
+        self.assertFalse(result.handled)
+        self.assertEqual(result.skipped_reason, SKIPPED_HELPER_SUGGESTED_INTAKE)
+        # Nothing got sent.
+        self.assertEqual(recorder.sent, [])
+
+    def test_no_session_falls_through(self) -> None:
+        recorder = _Recorder()
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("아무거나"),
+                text="아무거나",
+                session=None,
+                conversation_fn=lambda **_: None,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+        self.assertFalse(result.handled)
+        self.assertEqual(result.skipped_reason, SKIPPED_NO_SESSION_ANCHOR)
+        self.assertEqual(recorder.sent, [])
+
+    def test_helper_returns_none_body_falls_through(self) -> None:
+        session = _open_session()
+        recorder = _Recorder()
+
+        def fake_helper(**kwargs):
+            return SimpleNamespace(
+                content="   ",
+                intent_id="empty",
+                ready_to_intake=False,
+                is_status_query=False,
+            )
+
+        result = _run(
+            handle_forum_followup(
+                message=_forum_message("의미없음"),
+                text="의미없음",
+                session=session,
+                conversation_fn=fake_helper,
+                session_updater=recorder.session_updater,
+                send_chunks=recorder.send_chunks,
+            )
+        )
+
+        self.assertFalse(result.handled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_forum_message_adapter.py
+++ b/tests/discord/test_forum_message_adapter.py
@@ -228,10 +228,14 @@ class ObsidianSaveRequestRouteTests(_AdapterFixture):
             result.approval_job_id, self.sent_thread_replies[0]
         )
 
-    def test_unrelated_forum_message_falls_through_to_role_branch(
+    def test_unrelated_forum_message_routed_to_followup_branch(
         self,
     ) -> None:
-        # Forum thread, no save request, no role change → not handled.
+        # P0-F: forum thread, no save request, no role change → now
+        # falls into branch 3 (forum conversational follow-up). With
+        # a thread-anchored session and the conversation helper
+        # finding *some* response, branch 3 returns handled=True
+        # — no longer dropped silently.
         session = _open_session()
         msg = _forum_message(content="이 자료 어떻게 봐?")
         result = _run(
@@ -246,9 +250,9 @@ class ObsidianSaveRequestRouteTests(_AdapterFixture):
                 session_updater=self.session_updater,
             )
         )
-        self.assertFalse(result.handled)
+        # Branch 3 picked it up; approval branch did not.
+        self.assertTrue(result.handled)
         self.assertEqual(self.posted_cards, [])
-        self.assertEqual(self.sent_thread_replies, [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/discord/test_member_bot_pre_parse_typing_p0f.py
+++ b/tests/discord/test_member_bot_pre_parse_typing_p0f.py
@@ -1,0 +1,308 @@
+"""P0-F commit 5 — member bot typing pre-parse pre-gate.
+
+Before P0-F, ``_dispatch_member_message`` called the expensive
+``handle_research_turn_message`` / ``handle_team_turn_message``
+handlers *before* entering ``typing_keepalive``. The handlers
+load session, run deliberation, and queue synthesis (5-15 s), so
+the typing indicator stayed dark for most of the work.
+
+P0-F flips the order: cheap regex pre-parse first (matches
+marker + role), then ``typing_keepalive`` enters, then the
+expensive handler runs inside the wrap. Ignored / no-marker / wrong-
+role messages return *before* the keepalive even starts so typing
+never lights up on dropped traffic.
+
+Regression coverage:
+
+  1. no marker → typing never starts (silence contract).
+  2. marker matches another role → typing never starts.
+  3. matching research-turn marker → typing wrap fires *before*
+     the handler is invoked.
+  4. matching team-turn marker → same.
+  5. research-open marker (role-less) → typing fires for every
+     active member bot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import unittest
+from types import SimpleNamespace
+from typing import Any, List
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.member_bot import _dispatch_member_message
+from yule_orchestrator.discord.member_bots import MemberBotProfile
+
+
+def _profile(role: str = "tech-lead") -> MemberBotProfile:
+    return MemberBotProfile(
+        agent_id="engineering-agent",
+        role=role,
+        env_key="ENGINEERING_AGENT_BOT_TECH_LEAD_TOKEN",
+        token="x.y.z",
+        display_label=f"engineering-agent/{role}",
+    )
+
+
+def _run(coro_factory):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro_factory())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+class _Channel:
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    @contextlib.asynccontextmanager
+    async def _typing(self):
+        yield
+
+    def typing(self):
+        return self._typing()
+
+    async def send(self, content: str = "", **kwargs: Any) -> None:
+        self.sent.append(content)
+
+
+class PreParseSilenceTests(unittest.TestCase):
+    """No marker / mismatched role → handler never called, typing never opened."""
+
+    def test_no_marker_does_not_call_handlers(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _Channel()
+        message = SimpleNamespace(content="평범한 메시지", channel=channel)
+
+        handler_called: List = []
+
+        def fake_research(**kwargs):
+            handler_called.append("research")
+            return None
+
+        def fake_team(**kwargs):
+            handler_called.append("team")
+            return None
+
+        keepalive_calls: List = []
+
+        @contextlib.asynccontextmanager
+        async def counting_keepalive(ch, **kwargs):
+            keepalive_calls.append(kwargs.get("label"))
+            yield
+
+        with patch.object(
+            mb, "handle_research_turn_message", side_effect=fake_research
+        ), patch.object(
+            mb, "handle_team_turn_message", side_effect=fake_team
+        ), patch.object(mb, "typing_keepalive", counting_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile(), message=message
+                )
+            )
+
+        self.assertEqual(handler_called, [])
+        self.assertEqual(keepalive_calls, [])
+        self.assertEqual(channel.sent, [])
+
+    def test_wrong_role_marker_silent(self) -> None:
+        # research-turn marker but role=ai-engineer; this bot is
+        # tech-lead → pre-gate False, handler not called.
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _Channel()
+        message = SimpleNamespace(
+            content="[research-turn:s ai-engineer] go", channel=channel
+        )
+
+        handler_called: List = []
+
+        def fake_research(**kwargs):
+            handler_called.append("research")
+            return None
+
+        keepalive_calls: List = []
+
+        @contextlib.asynccontextmanager
+        async def counting_keepalive(ch, **kwargs):
+            keepalive_calls.append(kwargs.get("label"))
+            yield
+
+        with patch.object(
+            mb, "handle_research_turn_message", side_effect=fake_research
+        ), patch.object(
+            mb, "handle_team_turn_message", return_value=None
+        ), patch.object(mb, "typing_keepalive", counting_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("tech-lead"), message=message
+                )
+            )
+
+        self.assertEqual(handler_called, [])
+        self.assertEqual(keepalive_calls, [])
+
+
+class PreParseWrapsExpensiveHandlerTests(unittest.TestCase):
+    """Matching marker → keepalive wraps *around* the handler invocation."""
+
+    def test_research_turn_keepalive_wraps_handler(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _Channel()
+        message = SimpleNamespace(
+            content="[research-turn:s tech-lead] go", channel=channel
+        )
+
+        # Snapshot keepalive entry/exit order vs handler call.
+        events: List[str] = []
+
+        @contextlib.asynccontextmanager
+        async def tracing_keepalive(ch, **kwargs):
+            events.append("keepalive_enter")
+            try:
+                yield
+            finally:
+                events.append("keepalive_exit")
+
+        def fake_research(**kwargs):
+            events.append("handler_called")
+            return SimpleNamespace(
+                comment="x", session_id="s", message="post body"
+            )
+
+        async def fake_post(ch, outcome):
+            events.append("post_called")
+
+        with patch.object(
+            mb, "handle_research_turn_message", side_effect=fake_research
+        ), patch.object(
+            mb, "_post_research_turn", side_effect=fake_post
+        ), patch.object(mb, "typing_keepalive", tracing_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("tech-lead"), message=message
+                )
+            )
+
+        # Critical ordering: keepalive must enter BEFORE the handler
+        # runs (so typing is visible while expensive work happens).
+        self.assertEqual(
+            events,
+            [
+                "keepalive_enter",
+                "handler_called",
+                "post_called",
+                "keepalive_exit",
+            ],
+        )
+
+    def test_team_turn_keepalive_wraps_handler(self) -> None:
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _Channel()
+        message = SimpleNamespace(
+            content="[team-turn:s tech-lead] go", channel=channel
+        )
+
+        events: List[str] = []
+
+        @contextlib.asynccontextmanager
+        async def tracing_keepalive(ch, **kwargs):
+            events.append("keepalive_enter")
+            try:
+                yield
+            finally:
+                events.append("keepalive_exit")
+
+        def fake_team(**kwargs):
+            events.append("handler_called")
+            return SimpleNamespace(
+                turn=SimpleNamespace(session_id="s"),
+                full_post=lambda: "body",
+            )
+
+        async def fake_post(ch, outcome):
+            events.append("post_called")
+
+        with patch.object(
+            mb, "handle_research_turn_message", return_value=None
+        ), patch.object(
+            mb, "handle_team_turn_message", side_effect=fake_team
+        ), patch.object(
+            mb, "_post_team_turn", side_effect=fake_post
+        ), patch.object(mb, "typing_keepalive", tracing_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("tech-lead"), message=message
+                )
+            )
+
+        self.assertEqual(
+            events,
+            [
+                "keepalive_enter",
+                "handler_called",
+                "post_called",
+                "keepalive_exit",
+            ],
+        )
+
+    def test_research_open_marker_role_agnostic_fires_keepalive(self) -> None:
+        # [research-open:<sid>] has no role, so every active member
+        # bot enters the keepalive path. Handler then enforces the
+        # active_research_roles guard.
+        from yule_orchestrator.discord import member_bot as mb
+
+        channel = _Channel()
+        message = SimpleNamespace(
+            content="[research-open:sess-42] kickoff", channel=channel
+        )
+
+        events: List[str] = []
+
+        @contextlib.asynccontextmanager
+        async def tracing_keepalive(ch, **kwargs):
+            events.append("keepalive_enter")
+            try:
+                yield
+            finally:
+                events.append("keepalive_exit")
+
+        def fake_research(**kwargs):
+            events.append("handler_called")
+            return None  # handler decides this bot isn't active for this open
+
+        with patch.object(
+            mb, "handle_research_turn_message", side_effect=fake_research
+        ), patch.object(
+            mb, "handle_team_turn_message", return_value=None
+        ), patch.object(mb, "typing_keepalive", tracing_keepalive):
+            _run(
+                lambda: _dispatch_member_message(
+                    profile=_profile("ai-engineer"), message=message
+                )
+            )
+
+        # Open-marker fires the keepalive even though the handler
+        # returns None — this is the expected pre-gate behavior:
+        # role-less open broadcasts always show typing while the
+        # cheap handler check runs.
+        self.assertIn("keepalive_enter", events)
+        self.assertIn("handler_called", events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_runtime_member_bot_parity.py
+++ b/tests/discord/test_runtime_member_bot_parity.py
@@ -136,7 +136,7 @@ class ResearchTurnDispatchTests(unittest.TestCase):
 
     def test_handler_raises_logs_warning_and_falls_through(self) -> None:
         channel = _FakeChannel()
-        message = SimpleNamespace(content="[research-turn:s t] go", channel=channel)
+        message = SimpleNamespace(content="[research-turn:s tech-lead] go", channel=channel)
 
         original_stderr = sys.stderr
         import io
@@ -163,7 +163,7 @@ class ResearchTurnDispatchTests(unittest.TestCase):
 
     def test_post_raises_surfaces_fallback_message(self) -> None:
         channel = _FakeChannel()
-        message = SimpleNamespace(content="[research-turn:s t] go", channel=channel)
+        message = SimpleNamespace(content="[research-turn:s tech-lead] go", channel=channel)
         sentinel = SimpleNamespace(comment="x", session_id="s")
 
         async def failing_post(ch, outcome):

--- a/tests/discord/test_typing_defense_in_depth_p0e.py
+++ b/tests/discord/test_typing_defense_in_depth_p0e.py
@@ -258,7 +258,7 @@ class InactiveRoleSkipsTypingTests(unittest.TestCase):
 
         self.assertEqual(channel.sent, ["posted"])
         # Gate let the wrap fire — exactly one keepalive entry for research-turn.
-        self.assertEqual(keepalive_calls, ["member:research-turn"])
+        self.assertEqual(keepalive_calls, ["member:dispatch"])
 
     def test_legacy_session_no_metadata_keeps_typing(self) -> None:
         # active_research_roles 메타 없음 → helper 가 None → legacy fallback
@@ -296,7 +296,7 @@ class InactiveRoleSkipsTypingTests(unittest.TestCase):
 
         self.assertEqual(channel.sent, ["posted"])
         # Legacy → wrap fires.
-        self.assertEqual(keepalive_calls, ["member:research-turn"])
+        self.assertEqual(keepalive_calls, ["member:dispatch"])
 
 
 if __name__ == "__main__":

--- a/tests/discord/test_typing_keepalive_p0d.py
+++ b/tests/discord/test_typing_keepalive_p0d.py
@@ -77,7 +77,7 @@ class MemberBotKeepaliveTests(unittest.TestCase):
         # asyncio.sleep(0.2) but with a tight typing_keepalive interval so
         # we can observe at least 2 enters within the test's wall clock.
         channel = _CountingChannel()
-        message = SimpleNamespace(content="[research-turn:s t] go", channel=channel)
+        message = SimpleNamespace(content="[research-turn:s tech-lead] go", channel=channel)
         sentinel = SimpleNamespace(comment="x", session_id="s")
 
         async def slow_post(ch, outcome):

--- a/tests/research/test_collector_canonicalization.py
+++ b/tests/research/test_collector_canonicalization.py
@@ -1,0 +1,201 @@
+"""P0-F commit 3 — collector / build_query_for_role wiring of the
+canonicalizer.
+
+Covers:
+
+  1. ``build_query_for_role`` rewrites ``dRAG`` → ``RAG`` before
+     dedup so the collector query is canonical, not raw.
+  2. ``build_canonical_query_for_role`` returns the
+     :class:`CanonicalQuery` envelope so the caller can persist
+     audit metadata.
+  3. ``CollectionOutcome`` carries
+     ``raw_query`` / ``canonical_query`` / ``normalization_applied``
+     / ``normalization_confidence`` / ``suppress_auto_publish``.
+  4. mock-fallback + low-confidence → ``suppress_auto_publish=True``.
+  5. mock-fallback + canonical-already (confidence 1.0) →
+     ``suppress_auto_publish=False`` (no over-eager suppression).
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.research.collector import (
+    CollectionMode,
+    CollectorConfig,
+    auto_collect_or_request_more_input,
+    build_canonical_query_for_role,
+    build_query_for_role,
+)
+from yule_orchestrator.agents.research.query_canonicalizer import CanonicalQuery
+
+
+class BuildQueryNormalizationTests(unittest.TestCase):
+    def test_drag_typo_rewritten_to_rag(self) -> None:
+        # ``build_query_for_role`` historically lowercases tokens for
+        # dedup. The canonicalization invariant is "raw 'dRAG' must
+        # not survive" — the rewritten token may end up lowercased
+        # as ``rag/cag`` in the final query string.
+        query = build_query_for_role(
+            role="engineering-agent/ai-engineer",
+            prompt="dRAG/CAG memory 구조 비교해줘",
+            task_type="research",
+        )
+        self.assertNotIn("dRAG", query)
+        self.assertIn("rag/cag", query.lower())
+
+    def test_lowercase_acronym_normalised_then_lowercased(self) -> None:
+        query = build_query_for_role(
+            role="engineering-agent/backend-engineer",
+            prompt="rag 와 cag 차이",
+        )
+        # rag/cag preserved (regardless of final casing).
+        self.assertIn("rag", query.lower())
+        self.assertIn("cag", query.lower())
+
+    def test_canonical_envelope_round_trip(self) -> None:
+        query, canonical = build_canonical_query_for_role(
+            role="engineering-agent/ai-engineer",
+            prompt="알엠 메모리 구조",
+        )
+        self.assertIsInstance(canonical, CanonicalQuery)
+        self.assertTrue(canonical.normalization_applied)
+        self.assertEqual(canonical.confidence, 0.7)
+        # The canonical envelope preserves the rewritten case.
+        self.assertIn("LLM", canonical.canonical)
+
+
+class _StubMockCollector:
+    """Minimal collector that mimics ``MockCollector`` for routing."""
+
+    name = "mock"
+
+    def search(self, query):  # noqa: ANN001
+        return ()
+
+
+class CollectionOutcomeMetadataTests(unittest.TestCase):
+    """Verify the new audit fields land on the outcome."""
+
+    def test_canonical_input_yields_confidence_one(self) -> None:
+        outcome = auto_collect_or_request_more_input(
+            role="engineering-agent/ai-engineer",
+            prompt="RAG memory architecture comparison",
+            task_type="research",
+            collector=_StubMockCollector(),
+            config=CollectorConfig(enabled=True, provider="mock", max_results=3),
+        )
+        self.assertEqual(outcome.normalization_confidence, 1.0)
+        self.assertFalse(outcome.normalization_applied)
+        self.assertFalse(outcome.suppress_auto_publish)
+        # raw / canonical equal (no rewrite needed).
+        self.assertEqual(outcome.raw_query, outcome.canonical_query)
+
+    def test_drag_typo_rewritten_and_canonical_recorded(self) -> None:
+        outcome = auto_collect_or_request_more_input(
+            role="engineering-agent/ai-engineer",
+            prompt="dRAG/CAG memory 구조 비교",
+            task_type="research",
+            collector=_StubMockCollector(),
+            config=CollectorConfig(enabled=True, provider="mock", max_results=3),
+        )
+        # Raw recorded literally.
+        self.assertIn("dRAG", outcome.raw_query)
+        # Canonical query contains the corrected form.
+        self.assertIn("RAG/CAG", outcome.canonical_query)
+        self.assertTrue(outcome.normalization_applied)
+        # mixed_case confidence is 0.8 < 0.7 threshold? No — 0.8 > 0.7,
+        # so suppress_auto_publish is False (we only suppress under
+        # the 0.7 cutoff). This is intentional: mixed-case rewrites
+        # like dRAG→RAG are high-enough signal to publish.
+        self.assertEqual(outcome.normalization_confidence, 0.8)
+        self.assertFalse(outcome.suppress_auto_publish)
+
+    def test_low_confidence_fuzzy_with_mock_suppresses_auto_publish(self) -> None:
+        # Force a fuzzy rewrite (confidence 0.6) on a mock collector.
+        # The canonicalizer's fuzzy rule only fires for length≥3
+        # tokens with first-char match. We exercise it directly by
+        # patching the canonicalize_query call to return a 0.6-confidence
+        # rewrite, then assert the outcome suppresses publish.
+        from yule_orchestrator.agents.research import (
+            query_canonicalizer as qc,
+        )
+        from yule_orchestrator.agents.research.query_canonicalizer import (
+            Replacement,
+        )
+
+        fake_canonical = CanonicalQuery(
+            raw="rxg memory",
+            canonical="RAG memory",
+            applied=(
+                Replacement(
+                    raw="rxg",
+                    canonical="RAG",
+                    source="fuzzy",
+                    confidence=0.6,
+                ),
+            ),
+            confidence=0.6,
+        )
+        with patch.object(qc, "canonicalize_query", return_value=fake_canonical):
+            outcome = auto_collect_or_request_more_input(
+                role="engineering-agent/ai-engineer",
+                prompt="rxg memory",
+                task_type="research",
+                collector=_StubMockCollector(),
+                config=CollectorConfig(enabled=True, provider="mock", max_results=3),
+            )
+        self.assertTrue(outcome.normalization_applied)
+        self.assertEqual(outcome.normalization_confidence, 0.6)
+        # Mock + low-confidence → guard fires.
+        self.assertTrue(outcome.suppress_auto_publish)
+
+    def test_low_confidence_with_real_collector_does_not_suppress(self) -> None:
+        # If the collector isn't the mock fallback, suppress stays
+        # False even with low confidence — real providers can produce
+        # useful results from approximate queries.
+        class _RealCollectorStub:
+            name = "tavily"
+
+            def search(self, query):  # noqa: ANN001
+                return ()
+
+        from yule_orchestrator.agents.research import (
+            query_canonicalizer as qc,
+        )
+        from yule_orchestrator.agents.research.query_canonicalizer import (
+            Replacement,
+        )
+
+        fake_canonical = CanonicalQuery(
+            raw="rxg memory",
+            canonical="RAG memory",
+            applied=(
+                Replacement(
+                    raw="rxg",
+                    canonical="RAG",
+                    source="fuzzy",
+                    confidence=0.6,
+                ),
+            ),
+            confidence=0.6,
+        )
+        with patch.object(qc, "canonicalize_query", return_value=fake_canonical):
+            outcome = auto_collect_or_request_more_input(
+                role="engineering-agent/ai-engineer",
+                prompt="rxg memory",
+                task_type="research",
+                collector=_RealCollectorStub(),
+                config=CollectorConfig(enabled=True, provider="tavily", max_results=3),
+            )
+        self.assertFalse(outcome.suppress_auto_publish)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/research/test_query_canonicalizer.py
+++ b/tests/research/test_query_canonicalizer.py
@@ -1,0 +1,177 @@
+"""P0-F commit 2 — engineering-domain query canonicalizer.
+
+Covers:
+
+  1. Empty / whitespace input → empty canonical.
+  2. Already-canonical input → no Replacement, confidence 1.0.
+  3. Per-token exact match (case-insensitive) → confidence 1.0.
+  4. Mixed-case rule — dRAG / aLLM / jWt → drop noise, conf 0.8.
+  5. Multi-token rules — ci cd / ci-cd / ci/cd → CI/CD, conf 1.0.
+  6. Korean alias — 알엠 / 씨아이씨디 → conf 0.7.
+  7. Bounded fuzzy edit-distance 1 — only when ≥3 chars, single
+     winner, first-char match.
+  8. Compound canonicals — CAG/RAG / RAG-CAG / dRAG/CAG → preserve.
+  9. Non-lexicon English (Drag and drop) → untouched.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.research.query_canonicalizer import (
+    CanonicalQuery,
+    Replacement,
+    canonicalize_query,
+)
+
+
+class EmptyInputTests(unittest.TestCase):
+    def test_empty_string(self) -> None:
+        r = canonicalize_query("")
+        self.assertEqual(r.canonical, "")
+        self.assertEqual(r.applied, ())
+        self.assertEqual(r.confidence, 1.0)
+        self.assertFalse(r.normalization_applied)
+
+    def test_whitespace_only(self) -> None:
+        r = canonicalize_query("   \n  ")
+        self.assertEqual(r.canonical, "")
+        self.assertEqual(r.applied, ())
+
+
+class AlreadyCanonicalTests(unittest.TestCase):
+    def test_canonical_acronym_preserved(self) -> None:
+        r = canonicalize_query("RAG memory")
+        self.assertEqual(r.canonical, "RAG memory")
+        self.assertEqual(r.applied, ())
+        self.assertEqual(r.confidence, 1.0)
+
+    def test_compound_canonical_preserved(self) -> None:
+        r = canonicalize_query("CAG/RAG 비교")
+        self.assertEqual(r.canonical, "CAG/RAG 비교")
+        self.assertEqual(r.confidence, 1.0)
+
+
+class ExactMatchTests(unittest.TestCase):
+    def test_lowercase_acronym_uppercased(self) -> None:
+        r = canonicalize_query("rag vs cag")
+        self.assertEqual(r.canonical, "RAG vs CAG")
+        self.assertEqual(r.confidence, 1.0)
+        sources = {a.source for a in r.applied}
+        self.assertEqual(sources, {"exact"})
+
+    def test_oauth_renders_as_OAuth(self) -> None:
+        r = canonicalize_query("oauth 토큰")
+        self.assertEqual(r.canonical, "OAuth 토큰")
+
+    def test_grpc_renders_as_gRPC(self) -> None:
+        r = canonicalize_query("grpc 도입")
+        self.assertEqual(r.canonical, "gRPC 도입")
+
+
+class MixedCaseTests(unittest.TestCase):
+    def test_dRAG_to_RAG(self) -> None:
+        r = canonicalize_query("dRAG memory")
+        self.assertEqual(r.canonical, "RAG memory")
+        self.assertEqual(r.confidence, 0.8)
+        self.assertEqual(len(r.applied), 1)
+        self.assertEqual(r.applied[0].source, "mixed_case")
+
+    def test_aLLM_to_LLM(self) -> None:
+        r = canonicalize_query("aLLM 도입")
+        self.assertEqual(r.canonical, "LLM 도입")
+        self.assertEqual(r.confidence, 0.8)
+
+    def test_compound_dRAG_CAG_drops_noise(self) -> None:
+        r = canonicalize_query("dRAG/CAG memory 구조")
+        self.assertEqual(r.canonical, "RAG/CAG memory 구조")
+        self.assertEqual(r.confidence, 0.8)
+
+    def test_title_case_drag_not_rewritten(self) -> None:
+        # "Drag" has only one uppercase char — mixed_case rule
+        # requires length ≥2 so it shouldn't fire.
+        r = canonicalize_query("Drag and drop")
+        self.assertEqual(r.canonical, "Drag and drop")
+        self.assertEqual(r.confidence, 1.0)
+
+
+class MultiTokenTests(unittest.TestCase):
+    def test_ci_cd_to_CICD(self) -> None:
+        r = canonicalize_query("ci cd 파이프라인")
+        self.assertEqual(r.canonical, "CI/CD 파이프라인")
+        self.assertEqual(r.confidence, 1.0)
+
+    def test_ci_hyphen_cd_to_CICD(self) -> None:
+        r = canonicalize_query("ci-cd 도입")
+        self.assertEqual(r.canonical, "CI/CD 도입")
+
+    def test_combined_multitoken_and_exact(self) -> None:
+        r = canonicalize_query("llm jwt ci cd 셋업")
+        self.assertEqual(r.canonical, "LLM JWT CI/CD 셋업")
+        self.assertEqual(r.confidence, 1.0)
+
+
+class KoreanAliasTests(unittest.TestCase):
+    def test_algam_to_LLM(self) -> None:
+        r = canonicalize_query("알엠 메모리")
+        self.assertEqual(r.canonical, "LLM 메모리")
+        self.assertEqual(r.confidence, 0.7)
+        self.assertEqual(r.applied[0].source, "korean")
+
+    def test_korean_alias_combined_with_exact(self) -> None:
+        r = canonicalize_query("알엠 jwt 비교")
+        self.assertEqual(r.canonical, "LLM JWT 비교")
+        # min(0.7 korean, 1.0 exact) = 0.7
+        self.assertEqual(r.confidence, 0.7)
+
+
+class FuzzyTests(unittest.TestCase):
+    def test_too_short_for_fuzzy(self) -> None:
+        # 2-char tokens never enter fuzzy.
+        r = canonicalize_query("rg memory")
+        self.assertEqual(r.canonical, "rg memory")
+        self.assertEqual(r.confidence, 1.0)
+
+    def test_fuzzy_first_char_mismatch_skipped(self) -> None:
+        # "zag" first char 'Z' — no lexicon entry starts with Z.
+        r = canonicalize_query("zag memory")
+        self.assertEqual(r.canonical, "zag memory")
+        self.assertEqual(r.confidence, 1.0)
+
+
+class ConfidenceAggregationTests(unittest.TestCase):
+    def test_min_of_replacement_confidences(self) -> None:
+        # exact (1.0) + mixed_case (0.8) + korean (0.7) → min 0.7.
+        r = canonicalize_query("rag 알엠 dRAG")
+        self.assertEqual(r.confidence, 0.7)
+
+
+class ApiSurfaceTests(unittest.TestCase):
+    """Confirm exported dataclasses + entry-point shape are stable."""
+
+    def test_canonical_query_has_expected_fields(self) -> None:
+        r = canonicalize_query("rag")
+        self.assertIsInstance(r, CanonicalQuery)
+        self.assertTrue(hasattr(r, "raw"))
+        self.assertTrue(hasattr(r, "canonical"))
+        self.assertTrue(hasattr(r, "applied"))
+        self.assertTrue(hasattr(r, "confidence"))
+        self.assertTrue(hasattr(r, "normalization_applied"))
+
+    def test_replacement_dataclass(self) -> None:
+        r = canonicalize_query("rag")
+        self.assertGreaterEqual(len(r.applied), 1)
+        rep = r.applied[0]
+        self.assertIsInstance(rep, Replacement)
+        self.assertEqual(rep.raw, "rag")
+        self.assertEqual(rep.canonical, "RAG")
+        self.assertIn(rep.source, {"exact", "mixed_case", "fuzzy", "korean", "multitoken"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
related to live Discord UX 회귀 3건 (forum 무응답 / dRAG 등 typo query / typing 너무 늦게 시작)

## ✨ 과제 내용

라이브 Discord UX 의 잔존 3 가지 문제를 단일 PR 로 묶어 처리.

### 원인 요약
- **문제 1** `#운영-리서치` thread 가 follow-up surface 로 동작하지 않음 — `forum_message_adapter` 가 save / role-change 2 branch 만 처리해서 "지금 뭐하고 있어?" / "RAG 말고 CAG" / "이 링크도 참고해" 가 어디서도 응답 X. engineering channel router 는 forum thread 를 engineering channel 로 인식 안 함.
- **문제 2** `dRAG`, `cag`, `알엠` 같은 case/typo/alias 변형이 raw 로 collector query 에 도달. mock fallback 시 엉뚱한 canned 결과가 authoritative reference 처럼 forum 에 올라감.
- **문제 3** member bot typing 이 `_post_*_turn` 직전에만 켜짐 — handler 의 deliberation/synthesis 5~15s 동안 typing 비어 있어 "봇이 죽었나" 의심.

### 설계 요약
- **A. forum follow-up** — `forum_conversation_adapter` 신규 모듈 + `route_forum_message` 에 branch 3 추가. 기존 session anchor 재사용. `auto_collect=False` + `ready_to_intake` drop 으로 새 intake 절대 만들지 않음. correction / append / summarize directive 는 light parser 로 식별 후 `session.extra["forum_followup_notes"]` 에 메모.
- **B. query canonicalization** — `query_canonicalizer.py` single source of truth. acronym lexicon (~30) + mixed-case rule (`dRAG`→`RAG`) + bounded fuzzy (edit distance ≤1, length ≥3) + 한국어 alias (10). `CollectionOutcome` 에 `raw_query` / `canonical_query` / `normalization_applied` / `normalization_confidence` / `suppress_auto_publish` 메타. mock + confidence < 0.7 ⇒ auto-publish 보류 guard.
- **C. typing pre-parse** — `_dispatch_member_message` 흐름 재정렬. cheap regex 로 marker + role 매칭 → expensive handler *전*에 `typing_keepalive` 진입 → handler + post 가 wrap *안* 에서 도는 구조. ignored / wrong-role 메시지는 keepalive 전혀 진입 X.

### Commit 구성 (6)
1. `d46ea82` 📝 audit doc — 3 문제 분석 + 5-spot 표 + commit 시퀀스 + acceptance 매핑
2. `c2ea6cb` ✨ query_canonicalizer 모듈 + 21 unit test
3. `eb6b138` ✨ collector / CollectionOutcome 에 canonicalizer 와이어링 + 7 test
4. `95c62dc` ✨ forum_conversation_adapter + branch 3 wire + 11 test
5. `00f51df` ✨ member bot typing pre-parse pre-gate + 5 test
6. (본 PR — push + PR 생성)

### 회귀
- `tests/` 전체 **4326 PASS** + 1 skipped (main 4282 → 4326, P0-F 44 신규).

### Acceptance Criteria
- [x] 운영-리서치 thread 에서 status question 응답
- [x] forum thread correction/append/summarize follow-up 이 새 intake 만들지 않고 처리
- [x] `dRAG/CAG` canonicalization (raw 토큰 사라짐)
- [x] low-confidence + mock fallback → auto-publish 보류 (`suppress_auto_publish=True`)
- [x] member bot typing 이 expensive handler 시작 시점부터 reply send 직전까지 유지
- [x] ignore / no-op / inactive role typing 미진입
- [x] save / role-change / approval / intake path 무회귀 (전체 4326 PASS)

### 남은 리스크
- forum follow-up 의 status 응답 표현이 `#봇-상태` 의 기존 status diagnostic 과 미세하게 다를 수 있음 (현재 같은 helper 재사용이라 동일).
- canonicalizer fuzzy 가 영문 단어 `MLA` 같은 일반 토큰을 `ML` 로 잘못 정규화할 가능성 — confidence 0.6 으로 표시되므로 mock fallback 분기에서는 suppress.
- pre-gate marker mismatch 가 wrong-role 메시지를 즉시 reject → 기존 silent drop 보다 더 빨라 cost 절감이지만, marker 가 다르게 변경되면 일시적 회귀 가능. parse 함수 변경 시 본 PR 의 회귀 test 가 가드.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- `docs/forum-followup-canonical-typing.md` — 본 PR 의 단일 출처 audit doc.
- `forum_followup_notes` 새 session.extra key — 추후 Obsidian work-report 의 frontmatter / activity log attribution 으로 surface 가능.
- canonicalizer 의 confidence 임계값 (0.7) 은 mixed_case (0.8) 까지는 허용, fuzzy (0.6) 부터는 mock 분기에서 보류. 임계값 조정 시 본 PR 의 test_low_confidence_fuzzy_with_mock_suppresses_auto_publish 가 break 알림 역할.