### PR TITLE
📃 P0-G 1차 — Governance & policy stack 8종 land (정책 SSoT 고정)

### DIFF
--- a/docs/approval-matrix.md
+++ b/docs/approval-matrix.md
@@ -47,20 +47,48 @@ action 을 추가할 때는 반드시 본 표 + `autonomy_policy._DEFAULT_LEVELS
 | **merge** | **L4** | `branch_merge` |
 | **deploy** | **L4** | `deploy` |
 
-## 3. Vault (Obsidian)
+## 3. Vault (Obsidian) — 통합 commit/push 매트릭스 (P0-G 1차 SSoT)
 
-| Action | Level | 비고 |
+본 §3 은 vault 작업의 **단일 출처 (SSoT)**. autonomy-policy.md 의 L1~L4 카탈로그가 *행동* 을 정의하고, 본 표가 *vault 작업별 mapping* 을 결정한다.
+
+핵심 원칙 (P0-G 1차 정착):
+
+- **vault commit 은 기본 자동 (L2).** `vault_research_log_commit` / `local_commit` 모두 자동. audit 는 필수.
+- **vault push 는 mode 결정.** [`docs/autonomy-policy.md`](autonomy-policy.md) §0.1 의 work mode 가 `approval_required` 면 vault remote push 도 승인 후 (L3). `autonomous_merge` 면 사용자가 인가한 범위에서 자동 가능. mode 결정은 세션 첫 응답 ask-once.
+- **코드 repo push 와 vault push 는 분리 기록.** 한 audit 묶음에 섞지 않는다. session.extra 에 `code_push_audit` / `vault_push_audit` 분리.
+- **canonical / decision finalize 는 mode 무관 L3.** 학습 미러의 SSoT 가 사용자 인지 없이 굳어지면 회귀 식별이 어려워진다.
+
+| Action | Level | mode 영향 | 비고 |
+| --- | --- | --- | --- |
+| vault 파일 읽기 | L0 | 없음 | `local_file_read` |
+| research-log 자동 저장 | L1 | 없음 | `research_log_save` |
+| agent-ops audit 자동 기록 | L1 | 없음 | `agent_ops_record` |
+| failure-postmortem 자동 작성 | L2 | 없음 | `failure_postmortem_create` |
+| self-improvement proposal | L2 | 없음 | `self_improvement_proposal` |
+| blog draft 작성 | L2 | 없음 | `blog_draft_create` |
+| vault research-log branch 자동 commit | L2 | 없음 | `vault_research_log_commit` — 로컬 commit. push 별도. |
+| **canonical knowledge 확정 저장** | **L3** | mode 무관 | `knowledge_note_finalize` — 항상 사용자 명시 승인. |
+| **decision-record 확정** | **L3** | mode 무관 | `decision_record_finalize` — 항상 사용자 명시 승인. |
+| **vault remote push** | **L3** ↔ **L2 (autonomous_merge)** | **mode 적용** | `vault_remote_push`. `approval_required` 시 L3. `autonomous_merge` + 사용자 인가 범위 시 L2 자동. audit 는 `vault_push_audit` 로 별도 기록. |
+| **vault main merge** | **L4** | mode 무관 | `branch_merge` 와 동일. mode 무관 영구 hard rail. |
+
+### 3.1 코드 repo vs vault repo 분리
+
+| 비교 | 코드 repo (예: yule-studio-agent) | vault repo (예: yule-agent-vault) |
 | --- | --- | --- |
-| vault 파일 읽기 | L0 | `local_file_read` |
-| research-log 자동 저장 | L1 | `research_log_save` |
-| agent-ops audit 자동 기록 | L1 | `agent_ops_record` |
-| failure-postmortem 자동 작성 | L2 | `failure_postmortem_create` |
-| self-improvement proposal | L2 | `self_improvement_proposal` |
-| blog draft 작성 | L2 | `blog_draft_create` |
-| vault research-log branch 자동 commit | L2 | `vault_research_log_commit` |
-| **canonical knowledge 확정 저장** | **L3** | `knowledge_note_finalize` |
-| **vault remote push** | **L3** | `vault_remote_push` |
-| **vault main merge** | **L4** | `branch_merge` 와 동일 정책 |
+| commit | L2 (`local_commit`) | L2 (`vault_research_log_commit`) |
+| feature branch push | L3 `push_to_shared_repo` | L3 `vault_remote_push` (또는 mode 적용 시 L2) |
+| main merge | L4 `branch_merge` | L4 `branch_merge` (vault 도 동일 hard rail) |
+| audit key | `session.extra["code_push_audit"]` | `session.extra["vault_push_audit"]` |
+| 회귀 test | 본 레포 `tests/` | mirror 노트는 본 레포에 land 되므로 `tests/engineering/` |
+
+### 3.2 vault repo workspace 부재 시
+
+operator 의 실제 vault repo (`yule-agent-vault`) 가 현재 workspace 에 클론되지 않은 상태에서는:
+
+- 본 레포 `notes/vault-mirror/` 에 mirror 만 land. operator 가 sync.
+- `vault_remote_push` 자체는 미실행 — 코드 land 는 P0-G 3차 (#141) scope.
+- 본 정책 (§3 표) 은 vault repo 가 존재할 때를 가정한 *contract*. 없으면 contract 만 land, write 자체는 미구현 — fake success 금지.
 
 ## 4. Runtime / Infra
 

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -17,6 +17,58 @@ A-M10 부터는 모든 행동을 다음 5 단계 자율성 사다리(autonomy la
 [`agents/lifecycle/agent_ops_log.py`](../src/yule_orchestrator/agents/lifecycle/agent_ops_log.py)
 의 `AgentOpsEntry` 로 audit 가 남는다.
 
+## 0. Work mode / topology — session-start ask-once (P0-G 1차)
+
+5-tier ladder 가 *행동 단위* 의 자율성을 결정한다면, **work mode / topology / scope 는 세션 단위** 의 운영 frame 을 결정한다. 새 coding session 이 시작될 때 gateway 가 *한 번만* 묻고 세션 메모리에 저장한다 — **반복 질문 금지**.
+
+### 0.1 mode — 머지 자율성
+
+| mode | 의미 | 상호작용 |
+| --- | --- | --- |
+| `autonomous_merge` | 사용자가 미리 인가한 범위에서 자율 merge 가능. CI green + 회귀 OK 시 self-merge. | autonomy ladder 의 L3 `branch_merge` 가 *해당 범위에서* 자동 가능. 단, L4 (main 직접 push / deploy / secret) 는 여전히 금지. |
+| `approval_required` | 모든 merge 가 사용자 명시 승인 후. | autonomy ladder 의 L3 / L4 행동은 모두 `#승인-대기` 카드. |
+
+기본 = `approval_required`. `autonomous_merge` 는 사용자가 *명시적으로* 요청한 작업에 한해서만 (예: "F1~F8 사이클 self-merge 권한 부여").
+
+### 0.2 topology — repo 구조
+
+| topology | 의미 |
+| --- | --- |
+| `single_repo` | 본 작업이 한 repo 안에서만 일어난다. |
+| `multi_repo` | 본 작업이 둘 이상 repo 에 걸친다. 외부 repo 가 들어오면 [`repo-contract-discovery`](../policies/runtime/agents/engineering-agent/repo-contract-discovery.md) 정책으로 contract 수집. |
+
+기본 = `single_repo`. `multi_repo` 진입 시 각 repo 의 RepoContract 를 세션 메모리에 보관 (`session.extra["repo_contracts"]` dict).
+
+### 0.3 scope — 변경 범위
+
+| scope | 의미 |
+| --- | --- |
+| `single_scope` | 하나의 책임 단위 (예: gateway typing fix). |
+| `full_stack_single_repo` | 같은 repo 안에서 frontend + backend 등 여러 layer 동시. |
+| `layer_scoped` | 특정 layer 안에서만 (예: backend-only / docs-only). |
+| `cross_repo_program` | 여러 repo + 여러 layer 의 프로그램. 본 scope 면 PR 분할 / 회귀 plan 이 program-level 로 올라간다. |
+
+기본 = `single_scope`. 더 큰 scope 가 필요하면 첫 응답에 한 번만 확인.
+
+### 0.4 session 메모리 contract
+
+gateway 는 첫 응답에서 다음을 묻거나 추론한다. 사용자가 묻지 않은 항목은 기본값으로 채우고 *세션 응답에 명시*. 한 세션 안에서 mode / topology / scope 가 결정되면 그 세션 안에서는 **다시 묻지 않는다**.
+
+```text
+session.extra["work_mode"] = "autonomous_merge" | "approval_required"
+session.extra["topology"]  = "single_repo" | "multi_repo"
+session.extra["scope"]     = "single_scope" | "full_stack_single_repo" |
+                              "layer_scoped" | "cross_repo_program"
+session.extra["mode_decided_at"] = iso8601 UTC
+session.extra["mode_decided_by"] = "user_explicit" | "gateway_inferred"
+```
+
+세션 중간에 mode 가 바뀌어야 하면 사용자가 명시 변경. gateway 는 추측으로 변경하지 않는다.
+
+### 0.5 5-tier ladder 와의 관계
+
+mode / topology / scope 는 *행동의 자율성 등급* 자체를 바꾸지 않는다. L3 / L4 의 hard rail (main 직접 push / deploy / secret 등) 은 mode 가 `autonomous_merge` 여도 풀리지 않는다. mode 는 **L3 의 일부 행동 (예: `branch_merge`) 을 미리 인가** 하는 역할만 한다.
+
 ## 5-tier ladder
 
 | Level | 이름 | 의미 |

--- a/docs/autonomy-policy.md
+++ b/docs/autonomy-policy.md
@@ -247,6 +247,8 @@ A-M10c 추가:
 
 ## 관련 문서
 
-- [approval-matrix.md](approval-matrix.md) — action × level 매트릭스 표
+- [approval-matrix.md](approval-matrix.md) — action × level 매트릭스 표 (vault 통합 §3 P0-G SSoT 포함)
 - [engineering.md](engineering.md) — engineering-agent 전체 아키텍처
 - [operations.md](operations.md) — runtime / supervisor / heartbeat
+- [`policies/runtime/agents/engineering-agent/obsidian-governance.md`](../policies/runtime/agents/engineering-agent/obsidian-governance.md) §0 — GitHub vs Obsidian role separation (P0-G 1차)
+- [`policies/runtime/agents/engineering-agent/repo-contract-discovery.md`](../policies/runtime/agents/engineering-agent/repo-contract-discovery.md) — 외부 repo 의 자체 컨벤션 우선 적용 (multi_repo topology 시)

--- a/policies/runtime/agents/engineering-agent/design-to-code-assets.md
+++ b/policies/runtime/agents/engineering-agent/design-to-code-assets.md
@@ -1,0 +1,128 @@
+# Design-to-Code Asset — engineering-agent 부서 공통 (P0-G)
+
+> **소유:** `engineering-agent` 부서 전체. *icon / logo / favicon* 등 시각 자산을 `product-designer` 가 의미 / 형태 / 컬러 / 비율 / 용도로 정의하고 `frontend-engineer` 가 SVG / 컴포넌트로 구현하는 hand-off 정책.
+> **목적:** 같은 자산이 surface 마다 다른 형태로 흩어지거나, 디자이너 의도가 코드 구현 단계에서 사라지는 회귀 차단.
+> **출처:** Issue #139 (parent #138) — P0-G 1차.
+
+본 정책은 [`write-ownership.md`](write-ownership.md) §5 의 7 역할 surface 매트릭스 중 `product-designer` ↔ `frontend-engineer` 협업 surface 의 *자산 영역* 만 책임.
+
+## 1. 적용 범위
+
+| 자산 종류 | 본 정책 적용? | 비고 |
+| --- | --- | --- |
+| **logo** (브랜드 / 제품 로고) | ✅ | SVG source-of-truth |
+| **favicon** (브라우저 탭 / 앱) | ✅ | SVG source + PNG export 매트릭스 |
+| **icon** (UI inline icon set) | ✅ | SVG component (React/Vue 등) |
+| **illustration** (히어로 이미지 등) | 부분 | 단순 = SVG. 복잡 = raster (PNG/WebP) — 본 정책 §4 의 경계 |
+| **photography / 실사** | ❌ | raster 전용. 본 정책 적용 X |
+| **screenshot / mock-up** | ❌ | raster 전용. 본 정책 적용 X |
+
+## 2. product-designer 의 책임 — 자산 정의
+
+자산이 신규로 등장하면 `product-designer` 가 *코드 작성 전에* 다음 5 차원을 정의한다.
+
+### 2.1 의미 (semantic)
+
+- 자산이 *무엇을 의미하는가*. 어떤 컨텍스트에서 사용되는가.
+- naming convention: `<surface>-<intent>-<modifier?>`. 예: `logo-primary` / `icon-status-success` / `favicon-light`.
+
+### 2.2 형태 (form)
+
+- 윤곽 / stroke / 곡률.
+- viewBox 의 기본 (예: 24×24, 48×48). 일관된 viewBox 가 inline 사용성을 결정.
+- stroke vs fill — 어느 쪽이 source 인지 명시.
+
+### 2.3 컬러 (color)
+
+- 사용 가능한 컬러 토큰 (디자인 시스템 token 이름). hex 직접 박지 않는다.
+- light / dark theme 동시 정의. theme 별 별도 자산이면 그것도 명시.
+
+### 2.4 비율 (proportion)
+
+- 권장 표시 크기 (예: header 16 / 24 / 32, app 192 / 512 등).
+- aspect ratio 고정 여부. 자르거나 늘릴 수 있는가.
+
+### 2.5 용도 (usage)
+
+- 허용 surface: header / nav / button / favicon / og-image 등.
+- 금지 surface: 디자이너가 명시한 사용 금지 컨텍스트 (예: "favicon 으로 logo-primary 사용 금지 — favicon-light 만").
+- 접근성 — alt text / aria-label 의 기본 권장 문구.
+
+위 5 차원은 *디자인 소스* (Figma / Sketch 등) 의 metadata 로 1 차 land. 본 레포에 mirror 가 land 될 때는:
+
+- `notes/vault-mirror/.../resources/design/<asset-name>.md` 에 5 차원 명세 노트로 mirror.
+- 또는 `assets/design/<asset-name>.md` (실제 자산 코드 옆) 의 README 로 cross-link.
+
+## 3. frontend-engineer 의 책임 — 자산 구현
+
+`product-designer` 의 5 차원이 land 된 *후에* `frontend-engineer` 가 코드로 구현한다.
+
+### 3.1 SVG source-of-truth
+
+- icon / logo / favicon 의 **source-of-truth 는 SVG**. 다른 포맷은 export.
+- SVG source 는 `assets/icons/` / `assets/logos/` 등 권한이 명확한 폴더에 land. 한 자산 = 한 파일.
+- viewBox / stroke / fill / aria-label 모두 §2 의 5 차원과 정확히 일치 (회귀 test).
+
+### 3.2 컴포넌트 wrapping
+
+- React / Vue 등 프레임워크 컴포넌트로 wrapping 할 때 *디자인 토큰을 prop 으로 받게*. 컴포넌트 내부에서 hex / 직접 컬러 박지 않는다.
+- `<Icon name="status-success" />` 처럼 name 기반 lookup 이 권장. 자산 file path 를 caller 가 알 필요 없다.
+
+### 3.3 raster export 매트릭스
+
+favicon / og-image 등 raster 가 필요한 곳:
+
+| 자산 | raster 포맷 | 크기 | 빌드 시점 |
+| --- | --- | --- | --- |
+| favicon | PNG | 16 / 32 / 48 / 192 / 512 | build 시점 자동 export (스크립트) |
+| apple-touch-icon | PNG | 180 | 같음 |
+| og-image | PNG / WebP | 1200×630 | 같음 |
+| social card | PNG | 800×420 | 같음 |
+
+raster 는 *항상 SVG 에서 자동 생성*. raster 를 source 로 쓰지 않는다 (회귀 test).
+
+## 4. SVG vs raster 경계
+
+| 조건 | 선택 |
+| --- | --- |
+| 단색 / 평면 아이콘 | SVG |
+| 그라데이션 / 부드러운 컬러 전환 | SVG |
+| 실사 사진 / 텍스처 | raster |
+| 복잡한 illustration (수십 개 path / 그라데이션 다단계) | raster 또는 SVG — 디자이너 판단 |
+| 5KB 이하 표현 가능 | SVG 권장 |
+| > 50KB 의 SVG | raster 검토 |
+
+경계가 모호한 경우 — `product-designer` 가 §2.5 (용도) 에 SVG / raster 선택 근거 명시.
+
+## 5. 충돌 매트릭스 — 다른 정책과의 관계
+
+| 다른 정책 | 충돌 가능성 | 해소 |
+| --- | --- | --- |
+| [`write-ownership.md`](write-ownership.md) §5 product-designer surface | 본 정책이 5 차원을 추가 정의 — write-ownership 의 *role-owned* 카테고리에 자산 명세 노트 / SVG source 포함 | 본 정책이 우선. |
+| [`obsidian-governance.md`](obsidian-governance.md) §2 naming | mirror 노트의 naming convention 은 obsidian 정책 그대로 (`YYYY-MM-DD_issue-<n>-<kind>-<slug>.md`) | obsidian 정책 우선. 본 정책은 *내부 구조* 만 책임. |
+| [`growth-loop.md`](growth-loop.md) §1 resources | 재사용 가능한 자산 노트는 `20-resources/design/` 에 land | growth-loop 정책 우선. |
+| 외부 repo 의 design 컨벤션 ([`repo-contract-discovery.md`](repo-contract-discovery.md)) | 외부 repo 가 별도 design system 사용 시 | 외부 repo 의 컨벤션 우선. 본 정책은 본 레포 / yule 제품군에 한정. |
+
+## 6. 본 정책의 코드 land 단계
+
+- 본 commit 은 정책 SSoT 만 land.
+- 실제 자산 폴더 구조 (`assets/icons/` / `assets/logos/`) 의 신설 + raster export 자동화 스크립트 + `<Icon>` 컴포넌트는 P0-G 3차 (#141) scope (vault repo / design repo workspace 확인 후 결정).
+- 본 레포 (`yule-studio-agent`) 가 *현재* engineering-agent backend 위주라 frontend 자산 의 production code 가 부재. 자산 코드는 frontend 가 생기는 시점에 본 정책에 따라 land — fake success 금지.
+
+## 7. 검증
+
+`tests/engineering/test_policy_stack_completeness.py` (P0-G commit 7 신설) 가 본 정책 파일 존재 + §2 5 차원 / §3 SVG source-of-truth / §4 SVG vs raster 경계 키워드를 lint.
+
+## 8. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 (Issue #139 — P0-G stage 1 정책 8종 1차 land. parent #138.) |
+
+## 관련 문서
+
+- [[CLAUDE]]
+- [[governance]]
+- [[write-ownership]]
+- [[obsidian-governance]]
+- [[growth-loop]]

--- a/policies/runtime/agents/engineering-agent/github-workflow.md
+++ b/policies/runtime/agents/engineering-agent/github-workflow.md
@@ -141,17 +141,54 @@ issue 진행 코멘트는 **5 섹션 모두 필수**.
 
 ## 5. 커밋 분할 + GitHub Apps + push
 
-### 5.1 커밋 분할
+### 5.1 커밋 / PR 분할 — semantic CRUD-like slices (P0-G refine)
 
-- 1 PR 안에 **최소 3 commit, 권장 5 commit** 의 논리 단위 분할.
-- 모든 변경을 1 commit 으로 뭉치는 것 금지.
-- 분할 기준 (예시):
-  1. 선행 산출물 분석 / Obsidian 노트
-  2. 첫 정책 layer (Obsidian / wikilink / naming)
-  3. 두 번째 정책 layer (write ownership / authoring)
-  4. 세 번째 정책 layer (GitHub workflow / docs)
-  5. 정책 회귀 test
+PR / 커밋 분할의 *목적* 은 literal CRUD 4 분할 강제가 아니라 **리뷰어가 5분 안에 목적을 설명 가능 + 롤백이 독립 가능 + 테스트 포인트가 한 덩어리** 인 단위로 자르는 것이다.
+
+기본 원칙 (한 PR / 한 commit 모두 적용):
+
+1. **한 PR = 한 책임.** 한 PR 안에 의도가 다른 변경이 섞이지 않는다.
+2. **5분 룰.** 리뷰어가 PR title + body §✨ 만 보고 5 분 안에 목적을 설명 가능해야 한다. 안 되면 분할.
+3. **롤백 독립.** revert 했을 때 다른 의도 변경까지 같이 되돌아가면 안 된다.
+4. **테스트 포인트가 한 덩어리.** 한 PR 의 변경은 단일 acceptance / regression test 묶음으로 보호 가능해야 한다.
+
+**Semantic slice 분류 — C / R / U / D + 예외 4 종.**
+
+| 분류 | 의미 | 대표 예시 |
+| --- | --- | --- |
+| **C** (Create / Construct) | 새 구조·새 기능·새 정책 신설 | 신규 모듈 / 신규 정책 파일 / 신규 dataclass / 신규 worker. |
+| **R** (Read / Reveal) | 조회 / 진단 / 가시화 / 계측 | 신규 status command / 신규 metric / observability surface / 새 audit log shape. |
+| **U** (Update / Upgrade) | 기존 동작·기존 정책 업데이트 | 정책 §X.Y 의 규칙 갱신 / 기존 endpoint contract 강화 / 기존 surface 의 표현 정정. |
+| **D** (Delete / Decommission) | 제거 / 정리 / deprecated / cleanup | 더 이상 쓰이지 않는 helper 제거 / dead-flag drop / 정책 supersede. |
+
+**예외 4 종.** 다음은 본 정책의 5분 룰 / 한 PR = 한 책임 을 *지키되 분류 강제 X*:
+
+- **hotfix.** 인시던트 / live 회귀의 즉시 차단. 분류 표기 무관. PR title 에 `hotfix:` prefix 명시.
+- **docs-only.** 정책 / docs 만 land. 분류 강제 안 함. 단, 같은 PR 에 코드 변경이 함께 들어가면 분할.
+- **test-only.** 회귀 test 만 추가. 코드 동작 변경 없음. 분류 강제 안 함.
+- **tiny config fix.** ≤ 10 줄, 단일 env / config 정정. 분류 강제 안 함. PR body §✨ 에 "tiny config" 한 줄.
+
+**한 PR 안의 commit 분할.**
+
+- 한 PR 안에 **최소 3 commit, 권장 5 commit** 의 논리 단위 분할.
+- 모든 변경을 1 commit 으로 뭉치는 것 금지 (예외 4 종은 예외).
+- 분할 기준 (정책 PR 의 예시):
+  1. C — 선행 산출물 분석 / Obsidian 노트 / audit doc
+  2. C — 첫 정책 layer (예: Obsidian / wikilink / naming)
+  3. C / U — 두 번째 정책 layer (write ownership / authoring)
+  4. C / U — 세 번째 정책 layer (GitHub workflow / docs)
+  5. C — 정책 회귀 test
+- 코드 PR 의 예시:
+  1. C — 신규 모듈 (pure unit)
+  2. U — 기존 caller 의 wire-in
+  3. C — 회귀 test
 - 커밋 메시지 = [`policies/reference/COMMIT_CONVENTION.md`](../../../reference/COMMIT_CONVENTION.md) 의 한국어 3 섹션 (`변경 이유` / `주요 변경 사항` / `비고`) 엄격 준수. 비어 있는 섹션은 `- 없음` 한 줄.
+
+**PR 사이즈 가이드.**
+
+- 정책 PR: doc 만이면 5~8 commit, code 동반이면 7~10.
+- 코드 PR: 단일 책임이면 3~6 commit. 그 이상 필요하면 **PR 분할 검토**.
+- 단일 PR 의 diff 가 **> 800 줄 (test 제외)** 이면 분할 권장 — 리뷰어 5분 룰 위반.
 
 ### 5.2 GitHub Apps 우선 사용
 
@@ -174,10 +211,11 @@ issue 진행 코멘트는 **5 섹션 모두 필수**.
 - §2 PR 4 섹션 + Audit 헤딩 존재
 - §3 실재 label 표 / 추천 label 표 모두 존재
 - §4 progress 5 섹션 모두 본문에 명시
-- §5 커밋 분할 / push 정책 키워드 존재
+- §5 커밋 분할 / push 정책 키워드 존재 + §5.1 의 semantic CRUD-like slice 표 존재
 
 ## 7. 변경 이력
 
 | 일자 | 변경 |
 | --- | --- |
 | 2026-05-08 | 초안 (Issue #69 — D-69-10 ~ D-69-14 결정 반영. PR template fix `a19b718` 결과 활용.) |
+| 2026-05-14 | P0-G 1차 (Issue #139 / parent #138) — §5.1 을 semantic CRUD-like slices 로 refine. C/R/U/D + 예외 4 종 (hotfix / docs-only / test-only / tiny config). 5 분 룰 / 롤백 독립 / 테스트 포인트 한 덩어리 원칙 명시. PR 사이즈 가이드 (800 줄) 추가. |

--- a/policies/runtime/agents/engineering-agent/governance.md
+++ b/policies/runtime/agents/engineering-agent/governance.md
@@ -4,13 +4,21 @@
 > **목적:** Obsidian / write ownership / GitHub workflow 의 부서 공통 정책을 한 곳에서 cross-link 한다.
 > **출처:** Issue #69 (parent #20). 통합 입력 = 완료된 #25 / #48 / #59. 14 개 결정 (D-69-1 ~ D-69-14).
 
-본 문서는 *umbrella* — 실제 정책 본문은 다음 3 문서가 책임진다.
+본 문서는 *umbrella* — 실제 정책 본문은 다음 6 문서가 책임진다 (P0-G 1차 land 에서 3 → 6 으로 확장).
 
 | layer | 문서 | 책임 영역 |
 | --- | --- | --- |
-| Obsidian | [`obsidian-governance.md`](obsidian-governance.md) | 노트 naming / `## 관련 문서` 강제 / wikilink 정확성 / cross-link 정책 |
+| Obsidian | [`obsidian-governance.md`](obsidian-governance.md) | 노트 naming / `## 관련 문서` 강제 / wikilink 정확성 / cross-link 정책 + (P0-G) GitHub-실행기록 vs Obsidian-학습미러 role separation |
 | Write ownership | [`write-ownership.md`](write-ownership.md) | 3-mode authoring (`role-owned` / `tech-lead-mediated` / `gateway-mediated`) + 결정 트리 + 7 역할 surface 매트릭스 |
-| GitHub workflow | [`github-workflow.md`](github-workflow.md) | issue / PR template / label / progress comment / 커밋 분할 / GitHub Apps / push 정책 |
+| GitHub workflow | [`github-workflow.md`](github-workflow.md) | issue / PR template / label / progress comment / 커밋 분할 (semantic CRUD-like slices) / GitHub Apps / push 정책 |
+| Repo contract | [`repo-contract-discovery.md`](repo-contract-discovery.md) | 외부 repo 의 ISSUE/PR template / CONTRIBUTING / CODEOWNERS / workflows discovery + Yule 기본 규칙 fallback |
+| Growth loop | [`growth-loop.md`](growth-loop.md) | resources / projects / daily 정리 + 반복 패턴의 정책 승격 lifecycle |
+| Design-to-code | [`design-to-code-assets.md`](design-to-code-assets.md) | product-designer 자산 (icon / logo / favicon) 정의 + frontend-engineer SVG/컴포넌트 구현 + raster 경계 |
+
+추가 cross-link (운영자 docs):
+
+- [`docs/autonomy-policy.md`](../../../../docs/autonomy-policy.md) — work mode / topology / scope (session-start ask-once) + 5-tier autonomy ladder.
+- [`docs/approval-matrix.md`](../../../../docs/approval-matrix.md) — 통합 vault commit/push gating 매트릭스.
 
 ## 1. 부서 governance 의 4 원칙
 
@@ -94,6 +102,17 @@ surface 별 최종 author subject:
 
 위 항목은 사용자 명시 승인이 있어도 **본 정책 자체로는 풀리지 않는다** — 별도의 hard-rail 변경 PR + 사용자 결정이 필요.
 
+## 6.5 P0-G — 외부 repo 작업 + 자산 정책 + 학습 미러 정착 (2026-05-14)
+
+본 umbrella 가 묶는 정책이 3 → 6 으로 확장되며 다음 책임이 추가된다:
+
+- **외부 repo 작업** — [`repo-contract-discovery.md`](repo-contract-discovery.md) 가 외부 repo 의 자체 규칙 (issue/PR template, CONTRIBUTING, CODEOWNERS, workflows) 을 수집해 우선 적용한다. 본 레포 (`yule-studio-agent`) 자체에는 적용 안 됨.
+- **PR splitting (semantic CRUD-like slices)** — [`github-workflow.md`](github-workflow.md) §5.1 가 literal CRUD 4 분할 강제가 아닌 *semantic slice* 분류 (C/R/U/D + 예외 4 종) 로 정착.
+- **GitHub vs Obsidian role separation** — GitHub = 실행 기록, Obsidian = 학습/판단/회고 미러. 두 surface 는 backlink 로 연결되지만 책임이 다르다. [`obsidian-governance.md`](obsidian-governance.md) §0 / §10 + 본 umbrella §4 가 책임.
+- **Vault commit/push 통합** — [`docs/approval-matrix.md`](../../../../docs/approval-matrix.md) §3 (Vault) 가 vault commit (L2 auto) vs vault push (L3 approval) 단일 SSoT 표로 정착. 코드 repo push 와 vault push 는 분리 기록.
+- **Growth loop** — [`growth-loop.md`](growth-loop.md) 가 resources / projects / daily 의 3-구조 lifecycle 정의. 같은 아쉬움/실수가 반복되면 *개인 메모 → 정책 승격* 가이드.
+- **Design-to-code asset** — [`design-to-code-assets.md`](design-to-code-assets.md) 가 product-designer 의 의미/형태/컬러/비율 정의 → frontend-engineer 의 SVG/컴포넌트 구현 분리. raster 와 SVG source-of-truth 경계.
+
 ## 7. 검증
 
 | 검증 | 위치 |
@@ -110,3 +129,4 @@ surface 별 최종 author subject:
 | 일자 | 변경 |
 | --- | --- |
 | 2026-05-08 | 초안 (Issue #69 — D-69-1 ~ D-69-14 통합. #25/#48/#59 산출물을 부서 governance 로 정착.) |
+| 2026-05-14 | P0-G 1차 (Issue #139 / parent #138) — umbrella 가 묶는 정책 3 → 6 으로 확장 (repo-contract-discovery / growth-loop / design-to-code-assets 신설). §6.5 변경 요약 추가. |

--- a/policies/runtime/agents/engineering-agent/growth-loop.md
+++ b/policies/runtime/agents/engineering-agent/growth-loop.md
@@ -1,0 +1,84 @@
+# Growth Loop — engineering-agent 부서 공통 (P0-G)
+
+> **소유:** `engineering-agent` 부서 전체. 학습 / 회고 / 재사용 가능한 패턴이 *Obsidian 메모* 에서 *정책 SSoT* 로 승격되는 라이프사이클 정의.
+> **목적:** 같은 아쉬움 / 같은 실수 / 같은 패턴이 반복되는데 매번 ad-hoc 으로 해결되는 회귀 차단. 반복 = 신호. 신호 = 정책 승격 후보.
+> **출처:** Issue #139 (parent #138) — P0-G 1차.
+
+본 정책은 [`obsidian-governance.md`](obsidian-governance.md) §0 (GitHub vs Obsidian role separation) 의 *학습 미러* 영역을 책임진다.
+
+## 1. 3-구조 lifecycle
+
+Obsidian vault 의 *모든* 메모는 다음 3 구조 중 한 곳에 속한다 (PARA 의 영향 + Yule 운영 특수성):
+
+| 구조 | 의미 | 위치 (vault mirror) | 예시 |
+| --- | --- | --- | --- |
+| **resources** | 재사용 가능한 reference / 외부 자료 / 일반화된 학습 | `20-resources/` | 외부 repo / docs / PR 의 학습 정리. RAG vs CAG memory 구조 노트. |
+| **projects** | 진행 중인 프로젝트 단위 기록 — issue / PR / decision / task-log | `10-projects/<project>/` | 본 레포의 issue #139 task-log. |
+| **daily** | 그 날의 짧은 기록 — 아쉬움 / 회고 / off-the-cuff 생각 | `00-daily/YYYY-MM-DD.md` | 2026-05-14 의 daily 메모. |
+
+(folder root prefix `00-` / `10-` / `20-` / `30-` 등 의 정확한 path 는 [`obsidian-memory.md`](obsidian-memory.md) 의 v0 contract 가 SSoT. 본 정책은 *역할 분담* 만 책임.)
+
+## 2. 흐름 — daily / projects / resources 간 이동
+
+1. **daily 가 시작점.** 새 생각 / 회고 / 아쉬움은 daily 에 먼저 쓴다. 임계값 (정책 § 4) 을 넘지 않는 한 다른 위치로 옮기지 않는다.
+2. **projects 로 promote** — daily 의 메모가 *특정 issue / PR / decision* 에 직접 묶이면 projects 폴더의 해당 issue 노트로 이동 (full content 또는 wikilink). daily 노트는 backlink 유지.
+3. **resources 로 promote** — projects 의 학습 / 패턴 / 외부 자료가 *다른 프로젝트에도 재사용 가능* 하면 resources 로 추출. projects 노트는 backlink 유지.
+
+승격은 **항상 위 방향만** — resources → projects → daily 방향으로 *되돌리지* 않는다. 만약 resources 의 노트가 오래되어 사라져야 하면 [`obsidian-governance.md`](obsidian-governance.md) §7 backlink 정책에 따라 supersede 표기.
+
+## 3. 재사용 신호 — 정책 승격 후보 식별
+
+다음 신호가 *둘 이상* 동시에 잡히면 *개인 메모* 단계를 넘어 **정책 SSoT 로 승격 검토**:
+
+| 신호 | 어디서 감지 |
+| --- | --- |
+| 같은 아쉬움 / 같은 실수가 daily 에 3 회 이상 반복 | grep `## 아쉬움` / `## 회고` 키워드. |
+| 동일 패턴이 projects 노트의 §회고 / §결정 에 등장 | 다른 issue 의 노트인데 결정이 거의 같음. |
+| PR review 에서 같은 reviewer feedback 이 반복 | GitHub PR review API / Obsidian 의 PR review 노트. |
+| failure-postmortem 의 root cause 가 동일 | `agent-ops/postmortems/` 의 5 건 중 2 회 이상 같은 cause. |
+| 외부 repo 작업 시 같은 RepoContract 결정이 반복 | [`repo-contract-discovery.md`](repo-contract-discovery.md) 의 fallback hit 가 자주 발생. |
+
+**최소 2 신호** 가 잡혀야 승격 검토. 한 가지만으로는 패턴이라고 단정하지 않는다.
+
+## 4. 정책 승격 워크플로
+
+신호가 잡힌 후의 *명시적 단계*:
+
+1. **회고 / decision 노트 작성** — `projects/<project>/decisions/` 또는 `resources/patterns/` 에 신호의 근거를 정리. 신호 출처 (어느 daily / 어느 PR / 어느 postmortem) 를 모두 인용.
+2. **정책 SSoT 후보 식별** — 본 레포의 어느 정책 문서가 이 패턴을 안에 박을지 결정 (예: 외부 repo 패턴 → `repo-contract-discovery.md`, 머지 흐름 패턴 → `github-workflow.md`).
+3. **정책 PR 작성** — 정책 PR 은 *대부분 docs-only* (예외 4 종 중 하나 — [`github-workflow.md`](github-workflow.md) §5.1) 라 C/R/U/D 분류 강제 없음. 단 회귀 test 는 동행 권장.
+4. **승급 audit 기록** — 정책이 land 되면 originating Obsidian 노트의 frontmatter / 본문에 "정책 #PR-N 으로 승격" backlink. 같은 패턴이 다시 daily 에 등장하면 운영자가 즉시 "정책 §X.Y 참조" 로 답할 수 있어야 한다.
+
+## 5. 승격 안 함 — 개인 메모로 남기는 케이스
+
+다음은 정책으로 *승격하지 않는다*. 학습 미러는 운영 규칙이 아니어도 가치가 있다.
+
+- 일회성 회고 / 단발성 아쉬움 (반복 X).
+- 사용자의 *취향* / *선호* (mode 결정 같은 운영 결정은 예외 — [`docs/autonomy-policy.md`](../../../../docs/autonomy-policy.md) §0 가 책임).
+- 검증되지 않은 가설 / 실험 진행 중 메모.
+- 보안 / credential / secret — 어느 surface 든 SSoT 로 박지 않는다.
+
+## 6. 본 정책의 코드 land 단계
+
+본 정책 자체는 *문서* 가 SSoT. 코드 자동화는 후속:
+
+- **승격 신호 감지 자동 helper** — `agents/lifecycle/self_improvement.py` (이미 존재, M10c) 가 *failed_retryable 누적 / 동일 topic 중복 approval / 빈 hydration / stale heartbeat* 신호를 잡는다. 본 정책이 추가한 5 신호 (daily 반복 / PR review 반복 등) 의 감지 wiring 은 #140 stage 2 scope.
+- **정책 PR template 보조** — 정책 승급용 PR template (Audit 블록 + 신호 출처) 은 stage 2 의 후속 작업.
+
+## 7. 검증
+
+`tests/engineering/test_policy_stack_completeness.py` (P0-G commit 7 신설) 가 본 정책 파일 존재 + §1 3-구조 / §2 흐름 / §3 신호 / §4 승급 워크플로 키워드를 lint.
+
+## 8. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 (Issue #139 — P0-G stage 1 정책 8종 1차 land. parent #138.) |
+
+## 관련 문서
+
+- [[CLAUDE]]
+- [[governance]]
+- [[obsidian-governance]]
+- [[obsidian-memory]]
+- [[repo-contract-discovery]]

--- a/policies/runtime/agents/engineering-agent/obsidian-governance.md
+++ b/policies/runtime/agents/engineering-agent/obsidian-governance.md
@@ -6,6 +6,40 @@
 
 본 정책은 `policies/runtime/agents/engineering-agent/obsidian-memory.md` (v0 contract) 의 *상위 운영 규칙* 이다. v0 contract 가 정의한 path / frontmatter 는 그대로 유지되며, 본 정책은 *어떻게 노트를 서로 연결할지* 만 추가한다.
 
+## 0. GitHub vs Obsidian — role separation (P0-G 1차)
+
+본 부서가 두 surface 를 함께 쓰는 이유:
+
+- **GitHub = 실행 기록.** issue / PR / merge / tag / CI / deploy 의 *기록* 이 일어나는 곳. *지금 무엇이 머지됐는지* 가 정답. 의사 결정의 산출물 (코드 / 정책 / 회귀 test) 이 SSoT 로 박힌다.
+- **Obsidian = 학습 / 판단 / 회고 미러.** 같은 사건을 *해상도가 다른* 시점에서 다시 기록 — 왜 그렇게 결정했는지 / 무엇이 어려웠는지 / 어떤 패턴이 반복되는지. *결정의 맥락* 이 사는 곳.
+
+두 surface 는 backlink 로 연결되지만 **책임이 다르다.** 같은 정보를 두 surface 에 *동일하게* 쓰지 않는다. 같은 사건을 *다른 해상도로* 쓴다.
+
+### 0.1 어디에 무엇을 쓰는가
+
+| 정보 종류 | GitHub | Obsidian |
+| --- | --- | --- |
+| 작업의 *목적* (왜 이 PR 을 만드는가) | issue body §어떤 기능, PR body §✨ | research/decision 노트의 §변경 이유 |
+| 작업의 *결과* (무엇이 머지됐는지) | PR title / merged sha / CI / tag | task-log 노트의 §어떻게 했는가 |
+| 결정의 *맥락* (왜 그 결정인가) | issue / PR 의 짧은 설명 | decision 노트의 §고민 / §대안 / §회고 |
+| 반복 패턴 / 학습 | 안 씀 (PR 본문이 부적합) | resource / pattern 노트 — [`growth-loop.md`](growth-loop.md) 참조 |
+| audit (실패 / 재시도 / dedup) | 일부 progress comment | `agent-ops` 노트 / `failure-postmortem` |
+| secret / credential | **절대 금지** (모든 surface) | **절대 금지** |
+
+### 0.2 backlink contract
+
+- **GitHub → Obsidian.** issue / PR 의 progress comment 가 *모든* 관련 Obsidian 노트 path 를 §4 (Obsidian 노트 경로) 에 명시. 노트 basename 은 [`obsidian-memory.md`](obsidian-memory.md) 의 v0 contract 와 본 정책 §2 의 컨벤션을 따른다.
+- **Obsidian → GitHub.** 노트의 frontmatter / 본문에 GitHub issue 번호 / PR URL 을 backlink. 본 정책 §3 의 `## 관련 문서` 가 wikilink 만 책임; PR URL 등 외부 link 는 본문 §어떻게 했는가 또는 §회고 에 명시.
+- backlink 는 **양방향** 이어야 학습 미러가 의미를 가진다. PR 만 있고 Obsidian 노트가 없으면 = 학습 누락. Obsidian 노트만 있고 PR 이 없으면 = 실행 누락 (또는 정책 변경 only PR — 명시 필요).
+
+### 0.3 Obsidian repo workspace 부재 시
+
+본 레포 (`yule-studio-agent`) 의 `notes/vault-mirror/` 는 *Obsidian 의 mirror* 다. 실제 vault repo (operator 의 `yule-agent-vault`) 가 현재 workspace 에 클론되어 있지 않으면:
+
+- mirror 노트 자체는 본 레포 안에서 land. 운영자가 vault repo 로 sync.
+- mirror write 자체를 코드로 자동화하는 작업은 vault repo workspace 가용성 확인 후 (P0-G 3차 / #141 scope).
+- 본 commit / 본 정책 land 시점에는 mirror 노트 path 정책만 정의 — vault remote push 자체는 본 정책의 책임 아님 (그건 [`docs/approval-matrix.md`](../../../../docs/approval-matrix.md) §3 + [`docs/autonomy-policy.md`](../../../../docs/autonomy-policy.md) L3 `vault_remote_push` 가 책임).
+
 ## 1. 적용 범위
 
 - 모든 신규 / 수정 노트 (research / decision / task-log / report / reference / meeting / knowledge).
@@ -113,3 +147,4 @@ backlink 는 **추가만**. 기존 링크 / 문구는 보존.
 | 일자 | 변경 |
 | --- | --- |
 | 2026-05-08 | 초안 (Issue #69 — D-69-6 ~ D-69-9 결정 반영) |
+| 2026-05-14 | P0-G 1차 (Issue #139 / parent #138) — §0 신설: GitHub=실행기록 / Obsidian=학습미러 role separation 명시. 어디에 무엇을 쓰는가 표 + 양방향 backlink contract + vault workspace 부재 대응. |

--- a/policies/runtime/agents/engineering-agent/repo-contract-discovery.md
+++ b/policies/runtime/agents/engineering-agent/repo-contract-discovery.md
@@ -1,0 +1,109 @@
+# Repo Contract Discovery — engineering-agent 부서 공통 (P0-G)
+
+> **소유:** `engineering-agent` 부서 전체. 외부 repo (본 레포 외) 에서 코딩 작업을 받으면 그 repo 자체의 운영 규칙을 먼저 수집한 뒤 작업을 시작한다.
+> **목적:** "Yule 기본 규칙" 을 다른 repo 에 강제 적용해 사용자가 원치 않는 산출물을 만드는 회귀를 막는다.
+> **출처:** Issue #139 (parent #138) — 정책 8 종 1차 land.
+
+본 정책은 [`governance.md`](governance.md) umbrella 가 묶는 부서 정책 중 **외부 repo 표면** 을 책임진다. 외부 repo 가 자체 규칙을 갖고 있으면 그 규칙이 우선. 없으면 Yule 기본 규칙 (본 레포의 [`github-workflow.md`](github-workflow.md), [`obsidian-governance.md`](obsidian-governance.md)) fallback.
+
+## 1. 적용 범위
+
+- 외부 repo 의 issue / PR / branch / commit 작업 직전 (작업 첫 commit 또는 첫 PR draft 직전).
+- 본 레포 (`yule-studio-agent`) 자체에는 적용되지 않는다 — 본 레포는 SSoT.
+- vault repo 가 있다면 (vault repo 도 외부 repo 로 취급) 동일 정책 적용.
+
+## 2. RepoContract — discovery 결과 표현
+
+수집 결과는 단일 dataclass-shape 으로 표현한다 (코드 land 는 stage 2 / #140 의 scope).
+
+```text
+RepoContract:
+  owner: str                            # GitHub owner
+  repo: str                             # GitHub repo name
+  primary_branch: str                   # 보통 "main" / "master"
+  issue_templates: tuple[Path, ...]     # .github/ISSUE_TEMPLATE/*
+  pr_templates:    tuple[Path, ...]     # .github/PULL_REQUEST_TEMPLATE*
+  contributing:   Optional[Path]        # CONTRIBUTING.md / .github/CONTRIBUTING.md
+  readme:         Optional[Path]        # README*.md (root)
+  codeowners:     Optional[Path]        # CODEOWNERS / .github/CODEOWNERS / docs/CODEOWNERS
+  workflows:      tuple[Path, ...]      # .github/workflows/*.yml
+  branch_protection_hint: Optional[str] # 워크플로 파일 / docs 에서 발견한 보호 규칙
+  branch_strategy: Optional[str]        # "git-flow" / "trunk-based" / "github-flow" / "custom"
+  commit_convention: Optional[str]      # CONTRIBUTING / commitlint / .gitmessage 에서 발견
+  ssot_paths: tuple[Path, ...]          # 위 파일들이 발견된 path 목록
+  fallback: bool                        # 위 contract 가 거의 없을 때 True
+```
+
+`fallback=True` 면 Yule 기본 규칙으로 작업하지만, **PR body 의 §📚 레퍼런스** 섹션에 "이 repo 에 자체 컨벤션이 없어 Yule 기본 규칙 사용 — 운영자 검토 요청" 한 줄을 명시.
+
+## 3. 수집 우선순위
+
+다음 순서로 탐색하고, 발견되는 즉시 `RepoContract` 의 해당 필드를 채운다. 모든 path 는 *해당 repo 의 base sha 기준*.
+
+| 우선순위 | 경로 / 패턴 | 채워지는 필드 |
+| --- | --- | --- |
+| 1 | `.github/ISSUE_TEMPLATE/*.md`, `.github/ISSUE_TEMPLATE.md` | `issue_templates` |
+| 2 | `.github/PULL_REQUEST_TEMPLATE*`, `PULL_REQUEST_TEMPLATE.md` | `pr_templates` |
+| 3 | `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, `docs/CONTRIBUTING.md` | `contributing`, 종속적으로 `branch_strategy` / `commit_convention` |
+| 4 | `README*.md` (repo root) | `readme`. branch strategy / merge 정책 hint 추출. |
+| 5 | `CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS` | `codeowners` |
+| 6 | `.github/workflows/*.yml` | `workflows`. CI/CD 정책 + 보호 branch 신호 추출. |
+| 7 | `.git-flow.cfg`, `.gitmessage`, `commitlint.config.*`, `.github/branch-rules.md` 등 | `branch_strategy`, `commit_convention` 보강 |
+| 8 | repo 의 GitHub Settings API (branch protection) — 권한 있을 때만 | `branch_protection_hint` |
+
+> **권한 부재 시:** GitHub Settings API 에 접근 불가능하면 `branch_protection_hint=None` 으로 두고, PR body 에 "branch protection 미확인" 명시. 추측 금지.
+
+## 4. 우선순위 규칙 — repo vs Yule 기본
+
+| 조건 | 따라야 할 규칙 |
+| --- | --- |
+| issue template 발견 | repo template 그대로 |
+| PR template 발견 | repo template 그대로. Yule 의 PR body 4 섹션은 *추가 정보 nested* 로만 사용. |
+| CONTRIBUTING 의 branch strategy 발견 | repo strategy 우선 |
+| commit convention 발견 (CONTRIBUTING / commitlint / gitmessage) | repo convention 우선. Yule 의 한국어 3 섹션은 *비고* 로만 추가 가능. |
+| CODEOWNERS 발견 | review 요청 시 그 owner 자동 mention |
+| workflows 파일 발견 | CI 가 통과하지 못하면 머지하지 않음 (Yule 의 5-step merge gate 와 OR 가 아닌 AND) |
+| 위 모두 없음 → `fallback=True` | Yule 기본 규칙 적용. PR 에 명시. |
+
+본 표는 [`github-workflow.md`](github-workflow.md) §1~§5 와 충돌 시 **본 표가 외부 repo 에 한해 우선**. 본 레포 작업에는 영향 없음.
+
+## 5. 산출물 위치
+
+`RepoContract` 가 채워지면 다음 두 surface 에 기록:
+
+1. **GitHub issue progress comment** — `### 0. Repo Contract` 섹션으로 1 회 명시 (해당 issue 의 첫 progress comment 만).
+2. **세션 메모리** — `session.extra["repo_contract"]` 에 dict 로 round-trip. 추후 동일 repo 의 후속 issue 시 재사용.
+
+## 6. discovery 가 실패할 수 있는 경우 + 대응
+
+| 실패 모드 | 대응 |
+| --- | --- |
+| repo 접근 권한 없음 (private + token 없음) | 작업 중단. progress comment 에 "권한 없음" 명시 + 사용자에게 token 요청. fake success 금지. |
+| `.github/` 미존재 | `fallback=True` 로 진행. PR body 에 명시. |
+| 충돌하는 컨벤션 (예: README 와 CONTRIBUTING 이 다름) | CONTRIBUTING 이 우선. README 의 다른 hint 는 PR body 의 §📚 에 메모. |
+| repo 의 default branch 가 `master` | primary_branch 그대로 따름. Yule 의 "main fallback" 가정 금지. |
+
+## 7. 본 정책의 코드 land 단계
+
+본 정책 자체는 *문서* 가 SSoT. 코드는 후속 (#140 stage 2) 가 land:
+
+- `agents/git/repo_contract.py` (예정) — `RepoContract` dataclass + GitHub Apps + 로컬 git 클론 두 backend 모두 지원.
+- `agents/engineering_conversation` → 세션 시작 시 RepoContract 수집 helper 호출.
+- `policies/runtime/agents/engineering-agent/github-workflow.md` 의 PR body 가 RepoContract 결과를 PR Audit 블록에 surface.
+
+## 8. 검증
+
+`tests/engineering/test_policy_stack_completeness.py` (본 PR 신설) 가 본 정책 파일 존재 + 핵심 섹션 (§3 우선순위, §4 우선순위 규칙) 키워드를 lint.
+
+## 9. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 (Issue #139 — P0-G stage 1 정책 8종 1차 land. parent #138.) |
+
+## 관련 문서
+
+- [[CLAUDE]]
+- [[governance]]
+- [[github-workflow]]
+- [[obsidian-governance]]

--- a/tests/engineering/test_policy_stack_completeness.py
+++ b/tests/engineering/test_policy_stack_completeness.py
@@ -1,0 +1,345 @@
+"""P0-G commit 7 — 정책 stack 완전성 회귀 test.
+
+본 test 는 P0-G 1차 (#139, parent #138) 가 land 한 8 종 정책 + 운영자
+docs 의 *존재* 와 *핵심 섹션 키워드* 를 lint-style 로 검증한다. 정책이
+silent regression 으로 사라지거나 핵심 표 / 섹션이 삭제되는 것을 막는다.
+
+기존 ``test_engineering_agent_governance_doc.py`` 는 4 정책 (governance /
+obsidian-governance / write-ownership / github-workflow) + 운영자 docs +
+vault mirror 3 노트를 검증한다. 본 test 는 그 외 P0-G 신설 / 갱신 항목을
+추가로 보호한다 — 중복 없이.
+
+검사 대상:
+  * policies/runtime/agents/engineering-agent/repo-contract-discovery.md  (P0-G 신설)
+  * policies/runtime/agents/engineering-agent/growth-loop.md              (P0-G 신설)
+  * policies/runtime/agents/engineering-agent/design-to-code-assets.md    (P0-G 신설)
+  * policies/runtime/agents/engineering-agent/github-workflow.md §5.1     (P0-G refine — C/R/U/D)
+  * policies/runtime/agents/engineering-agent/obsidian-governance.md §0    (P0-G — GitHub vs Obsidian role separation)
+  * policies/runtime/agents/engineering-agent/governance.md §6.5           (P0-G — umbrella 6 layer)
+  * docs/autonomy-policy.md §0                                              (P0-G — work mode/topology/scope ask-once)
+  * docs/approval-matrix.md §3                                              (P0-G — vault commit/push SSoT)
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_POLICY_DIR = _REPO_ROOT / "policies" / "runtime" / "agents" / "engineering-agent"
+_DOCS_DIR = _REPO_ROOT / "docs"
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# New policies — repo contract discovery / growth loop / design-to-code assets
+# ---------------------------------------------------------------------------
+
+
+class RepoContractDiscoveryDocTests(unittest.TestCase):
+    """``repo-contract-discovery.md`` is the SSoT for external repo conventions."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "repo-contract-discovery.md"
+        self.text = _read(self.path)
+
+    def test_file_exists(self) -> None:
+        self.assertTrue(self.path.is_file(), self.path)
+
+    def test_repo_contract_dataclass_shape_present(self) -> None:
+        for needle in (
+            "RepoContract",
+            "issue_templates",
+            "pr_templates",
+            "contributing",
+            "codeowners",
+            "workflows",
+            "branch_strategy",
+            "fallback",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_priority_order_present(self) -> None:
+        # §3 priority — ensure top 4 sources are still listed.
+        for needle in (
+            "ISSUE_TEMPLATE",
+            "PULL_REQUEST_TEMPLATE",
+            "CONTRIBUTING.md",
+            "CODEOWNERS",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_yule_fallback_rule_present(self) -> None:
+        self.assertIn("자체 규칙을 갖고 있으면 그 규칙이 우선", self.text)
+        self.assertIn("fallback", self.text)
+
+    def test_no_permission_no_fake_success(self) -> None:
+        # §6 — fake success forbidden when repo access fails.
+        self.assertIn("fake success 금지", self.text)
+
+
+class GrowthLoopDocTests(unittest.TestCase):
+    """``growth-loop.md`` defines daily / projects / resources lifecycle."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "growth-loop.md"
+        self.text = _read(self.path)
+
+    def test_file_exists(self) -> None:
+        self.assertTrue(self.path.is_file(), self.path)
+
+    def test_three_buckets_present(self) -> None:
+        for needle in ("resources", "projects", "daily"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_promotion_flow_direction(self) -> None:
+        # daily → projects → resources. The doc must reject reverse promotion.
+        self.assertIn("daily", self.text)
+        self.assertIn("승격", self.text)
+        self.assertIn("위 방향만", self.text)
+
+    def test_signals_for_promotion_present(self) -> None:
+        # §3 — at least 2 of the 5 signals (daily 반복 / PR review 반복 /
+        # postmortem root cause / repo-contract fallback / projects 같은 결정).
+        signal_count = sum(
+            1
+            for needle in (
+                "daily",
+                "PR review",
+                "postmortem",
+                "fallback",
+                "projects",
+            )
+            if needle in self.text
+        )
+        self.assertGreaterEqual(signal_count, 4, "growth loop signal coverage")
+
+
+class DesignToCodeAssetDocTests(unittest.TestCase):
+    """``design-to-code-assets.md`` defines designer→engineer hand-off."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "design-to-code-assets.md"
+        self.text = _read(self.path)
+
+    def test_file_exists(self) -> None:
+        self.assertTrue(self.path.is_file(), self.path)
+
+    def test_five_dimensions_present(self) -> None:
+        for needle in ("의미", "형태", "컬러", "비율", "용도"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_svg_source_of_truth_present(self) -> None:
+        self.assertIn("SVG", self.text)
+        self.assertIn("source-of-truth", self.text)
+
+    def test_raster_boundary_present(self) -> None:
+        # §4 SVG vs raster boundary
+        for needle in ("그라데이션", "실사", "raster"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_conflict_matrix_present(self) -> None:
+        # §5 충돌 매트릭스
+        self.assertIn("write-ownership", self.text)
+        self.assertIn("obsidian-governance", self.text)
+        self.assertIn("growth-loop", self.text)
+
+
+# ---------------------------------------------------------------------------
+# Updated policies — github-workflow §5.1 / obsidian-governance §0 /
+# governance §6.5 / docs/autonomy-policy.md §0 / docs/approval-matrix.md §3
+# ---------------------------------------------------------------------------
+
+
+class GithubWorkflowSemanticSliceTests(unittest.TestCase):
+    """``github-workflow.md`` §5.1 refines PR splitting to semantic CRUD-like slices."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "github-workflow.md"
+        self.text = _read(self.path)
+
+    def test_semantic_crud_classes_present(self) -> None:
+        for needle in ("Create", "Read", "Update", "Delete"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_exceptions_present(self) -> None:
+        for needle in ("hotfix", "docs-only", "test-only", "tiny config"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_five_minute_rule_present(self) -> None:
+        self.assertIn("5분", self.text)
+        self.assertIn("롤백 독립", self.text)
+
+    def test_pr_size_guide_present(self) -> None:
+        self.assertIn("800 줄", self.text)
+
+
+class ObsidianGovernanceRoleSeparationTests(unittest.TestCase):
+    """``obsidian-governance.md`` §0 — GitHub vs Obsidian role separation."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "obsidian-governance.md"
+        self.text = _read(self.path)
+
+    def test_role_separation_section_present(self) -> None:
+        self.assertIn("## 0. GitHub vs Obsidian", self.text)
+
+    def test_execution_record_vs_learning_mirror(self) -> None:
+        self.assertIn("실행 기록", self.text)
+        self.assertIn("학습", self.text)
+
+    def test_bidirectional_backlink(self) -> None:
+        self.assertIn("양방향", self.text)
+        self.assertIn("backlink", self.text)
+
+    def test_vault_repo_absent_fallback(self) -> None:
+        # When vault repo workspace 없음 — mirror only, write 자동화는 deferred.
+        self.assertIn("vault repo", self.text)
+        self.assertIn("workspace", self.text)
+        self.assertIn("#141", self.text)
+
+
+class GovernanceUmbrellaExtensionTests(unittest.TestCase):
+    """``governance.md`` umbrella now cross-links 6 layers (was 3)."""
+
+    def setUp(self) -> None:
+        self.path = _POLICY_DIR / "governance.md"
+        self.text = _read(self.path)
+
+    def test_six_layers_cross_linked(self) -> None:
+        for needle in (
+            "obsidian-governance.md",
+            "write-ownership.md",
+            "github-workflow.md",
+            "repo-contract-discovery.md",
+            "growth-loop.md",
+            "design-to-code-assets.md",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_p0g_section_present(self) -> None:
+        self.assertIn("P0-G", self.text)
+
+    def test_operator_docs_cross_link(self) -> None:
+        # autonomy-policy.md / approval-matrix.md cross-link.
+        self.assertIn("autonomy-policy.md", self.text)
+        self.assertIn("approval-matrix.md", self.text)
+
+
+class AutonomyPolicyAskOnceTests(unittest.TestCase):
+    """``docs/autonomy-policy.md`` §0 — work mode / topology / scope ask-once."""
+
+    def setUp(self) -> None:
+        self.path = _DOCS_DIR / "autonomy-policy.md"
+        self.text = _read(self.path)
+
+    def test_section_zero_present(self) -> None:
+        self.assertIn("## 0. Work mode", self.text)
+
+    def test_work_mode_values_present(self) -> None:
+        for needle in ("autonomous_merge", "approval_required"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_topology_values_present(self) -> None:
+        for needle in ("single_repo", "multi_repo"):
+            self.assertIn(needle, self.text, needle)
+
+    def test_scope_values_present(self) -> None:
+        for needle in (
+            "single_scope",
+            "full_stack_single_repo",
+            "layer_scoped",
+            "cross_repo_program",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_ask_once_contract(self) -> None:
+        self.assertIn("다시 묻지 않는다", self.text)
+
+    def test_session_memory_keys_documented(self) -> None:
+        for key in (
+            "work_mode",
+            "topology",
+            "scope",
+            "mode_decided_at",
+            "mode_decided_by",
+        ):
+            self.assertIn(key, self.text, key)
+
+
+class ApprovalMatrixVaultSsotTests(unittest.TestCase):
+    """``docs/approval-matrix.md`` §3 — vault commit/push 통합 SSoT."""
+
+    def setUp(self) -> None:
+        self.path = _DOCS_DIR / "approval-matrix.md"
+        self.text = _read(self.path)
+
+    def test_section_three_marker(self) -> None:
+        # The P0-G refine adds "통합 commit/push 매트릭스 (P0-G 1차 SSoT)".
+        self.assertIn("통합 commit/push", self.text)
+        self.assertIn("SSoT", self.text)
+
+    def test_vault_commit_l2_present(self) -> None:
+        # L2 자동 commit
+        self.assertIn("vault_research_log_commit", self.text)
+        self.assertIn("L2", self.text)
+
+    def test_vault_push_mode_branching(self) -> None:
+        # vault_remote_push 가 mode 에 따라 L3 ↔ L2 분기.
+        self.assertIn("vault_remote_push", self.text)
+        self.assertIn("autonomous_merge", self.text)
+        self.assertIn("approval_required", self.text)
+
+    def test_code_vs_vault_push_separation(self) -> None:
+        # §3.1 코드 repo vs vault repo 분리표.
+        self.assertIn("code_push_audit", self.text)
+        self.assertIn("vault_push_audit", self.text)
+
+    def test_no_workspace_no_fake_success(self) -> None:
+        # §3.2 vault repo workspace 부재 시 fake success 금지.
+        self.assertIn("fake success 금지", self.text)
+
+
+# ---------------------------------------------------------------------------
+# Completeness — required policy doc presence check
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_POLICY_FILES = (
+    # 4 base layers (covered by test_engineering_agent_governance_doc.py too,
+    # but listed here so the P0-G stack list is auditable in one place).
+    _POLICY_DIR / "governance.md",
+    _POLICY_DIR / "obsidian-governance.md",
+    _POLICY_DIR / "write-ownership.md",
+    _POLICY_DIR / "github-workflow.md",
+    # 3 P0-G new policies.
+    _POLICY_DIR / "repo-contract-discovery.md",
+    _POLICY_DIR / "growth-loop.md",
+    _POLICY_DIR / "design-to-code-assets.md",
+    # 2 operator docs (P0-G touched).
+    _DOCS_DIR / "autonomy-policy.md",
+    _DOCS_DIR / "approval-matrix.md",
+)
+
+
+class RequiredPolicyDocsExistTests(unittest.TestCase):
+    """All 9 policy-stack docs must exist. Missing any = test fail."""
+
+    def test_all_required_policy_docs_present(self) -> None:
+        missing = [p for p in _REQUIRED_POLICY_FILES if not p.is_file()]
+        self.assertEqual(missing, [], f"missing policy docs: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈

closed #139
parent #138

## ✨ 과제 내용

기능보다 정책을 먼저 고정. 사용자가 명시한 8 가지 정책 영역을 본 레포 SSoT 로 land. 기존 문서가 있으면 update, 같은 의미의 새 doc 중복 생성 금지.

### 어떤 기존 문서를 갱신했는가

| 문서 | 변경 |
| --- | --- |
| `policies/runtime/agents/engineering-agent/governance.md` | umbrella 가 묶는 layer 표 3 → 6 으로 확장. §6.5 P0-G 변경 요약 신설. 변경 이력 추가. |
| `policies/runtime/agents/engineering-agent/github-workflow.md` | §5.1 PR splitting 을 semantic CRUD-like slices (C/R/U/D + 예외 4종) 로 refine. 5분 룰 / 800줄 PR 가이드 추가. |
| `policies/runtime/agents/engineering-agent/obsidian-governance.md` | §0 신설: GitHub=실행기록 / Obsidian=학습미러 role separation + 양방향 backlink contract + vault repo 부재 대응. |
| `docs/autonomy-policy.md` | §0 신설: work mode (autonomous_merge / approval_required) + topology (single/multi repo) + scope (single/full_stack/layer/cross_repo) 의 session-start ask-once + session.extra 5 key contract. |
| `docs/approval-matrix.md` | §3 (Vault) 가 통합 SSoT 로 강화: vault commit L2 / vault push 가 mode 에 따라 L3 ↔ L2 분기 / code push 와 vault push 분리 audit / §3.1 코드 vs vault 분리표 + §3.2 vault repo 부재 대응. |

### 새로 만든 정책

| 신규 문서 | 영역 |
| --- | --- |
| `policies/runtime/agents/engineering-agent/repo-contract-discovery.md` | 외부 repo 의 ISSUE/PR template / CONTRIBUTING / CODEOWNERS / workflows discovery + Yule 기본 규칙 fallback. RepoContract dataclass shape. fake success 금지. |
| `policies/runtime/agents/engineering-agent/growth-loop.md` | resources / projects / daily 3-구조 lifecycle + 반복 패턴 5 신호 → 정책 SSoT 승급 4 단계. |
| `policies/runtime/agents/engineering-agent/design-to-code-assets.md` | product-designer 의 5 차원 (의미/형태/컬러/비율/용도) → frontend-engineer 의 SVG source-of-truth + raster export 매트릭스 + SVG/raster 경계 + 충돌 매트릭스. |

### 충돌하던 규칙을 어떻게 정리했는가

| 충돌 | 해소 |
| --- | --- |
| vault commit/push 정책이 `docs/autonomy-policy.md` (5-tier ladder) + `docs/approval-matrix.md` 두 곳에 흩어져 있음 | `docs/approval-matrix.md` §3 을 **SSoT 로 강화**. autonomy-policy.md 는 5-tier 카탈로그만 유지, 매핑은 approval-matrix 가 책임. cross-link 정착. |
| autonomy ladder 의 `branch_merge` (L4) 와 사용자 명시 `autonomous_merge` 권한이 어디서 만나는지 불명확 | autonomy-policy.md §0.5 + approval-matrix.md §3 의 mode 영향 column 으로 정리. `autonomous_merge` mode 는 *L3 의 일부 행동을 인가* 만, L4 hard rail (main 직접 push / deploy / secret) 은 영구. |
| Obsidian 노트 폴더 구조 (`00-`/`10-`/`20-`) 가 `obsidian-memory.md` (v0 contract) 와 신규 `growth-loop.md` 두 곳에 산재 가능 | growth-loop.md 가 *역할 분담* 만 책임, path SSoT 는 obsidian-memory.md 명시. second source of truth 회피. |
| design asset 의 5 차원 정의가 write-ownership.md §5 product-designer surface 와 어떻게 묶이는지 | design-to-code-assets.md §5 충돌 매트릭스에 명시. 5 차원 정의는 본 정책 우선, naming convention 은 obsidian 정책 우선. |

### 추가한 테스트

- `tests/engineering/test_policy_stack_completeness.py` (신규, 8 TestCase / 37 test):
  - 신규 3 정책 (repo-contract / growth-loop / design-to-code) 의 핵심 섹션 lint.
  - github-workflow §5.1 의 C/R/U/D + 예외 4종 + 5분 룰 + 800줄 가이드 검증.
  - obsidian-governance §0 의 실행기록 vs 학습미러 + 양방향 backlink + vault repo 부재 대응.
  - governance.md umbrella 의 6 layer cross-link + 운영자 docs cross-link.
  - autonomy-policy §0 의 mode/topology/scope 값 + session 메모리 5 key + 다시 묻지 않는다 contract.
  - approval-matrix §3 의 통합 SSoT 마커 + L2 commit / mode 분기 push / code/vault audit key 분리.
  - `RequiredPolicyDocsExistTests`: 9 정책 docs 의 file 존재 1-shot 검증.

### 남은 미결정 사항

- mode 결정의 코드 wiring (gateway 가 세션 첫 응답에 ask-once) — **#140 stage 2** scope.
- RepoContract 의 코드 (`agents/git/repo_contract.py`) — **#140 stage 2** scope.
- semantic CRUD-like slice 의 PR lint CI check — **#140 stage 2** scope.
- vault repo workspace 실제 발견 시 mirror write 자동화 — **#141 stage 3** scope.
- design asset 의 실제 SVG source 폴더 (`assets/icons/` / `assets/logos/`) + raster export 스크립트 + `<Icon>` 컴포넌트 — **#141 stage 3** scope (frontend production code 가 생기는 시점).
- growth-loop 의 5 신호 자동 감지 (`self_improvement.py` 확장) — **#140 stage 2** scope.

### Commit 구성 (7)

1. `225d2ac` 📃 정책 umbrella 확장 + Repo contract discovery 신설 (NEW)
2. `c02cdc7` 📃 PR splitting 정책 → semantic CRUD-like slices (C/R/U/D + 예외 4종) refine
3. `7c7a4c8` 📃 Work mode / topology / scope 의 session-start ask-once 정책
4. `868a20a` 📃 GitHub vs Obsidian role separation + Vault commit/push 통합 SSoT
5. `a8e2f78` 📃 Growth loop policy 신설 (resources / projects / daily lifecycle)
6. `847f1a2` 📃 Design-to-code asset policy 신설
7. `1f16661` ✅ 필수 정책 문서 누락 감지 governance test 신설 (37 test)

### 회귀

- `tests/` 전체 **4363 PASS** + 1 skipped (main 4326 → 4363, P0-G 37 신규).

## :camera_with_flash: 스크린샷(선택)

- (없음 — doc-only PR)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 본 PR 은 *정책 SSoT* 만 land. 코드 변경 0. 모든 정책의 코드 land 는 #140 stage 2 (기능) / #141 stage 3 (vault mirror + design asset 실 구현) 의 scope.
- second source of truth 회피 원칙 — 충돌하던 정책은 한 SSoT 로 모으고 다른 곳은 cross-link 만.
- Obsidian vault repo (`yule-agent-vault`) workspace 가 현재 클론되어 있지 않으므로 mirror write 자체는 *코드로 자동화* 하지 않음. mirror contract / path / routing 만 문서화 — fake success 금지.