### PR TITLE
🐞 P0-J — coding bootstrap (naver-search-clone full-stack 오분류) + read-only intents (모든 요청 → research 회귀)

### DIFF
--- a/docs/p0j-coding-bootstrap-and-readonly-intents.md
+++ b/docs/p0j-coding-bootstrap-and-readonly-intents.md
@@ -1,0 +1,87 @@
+# P0-J — Coding Bootstrap + Read-only Intents (#145 + #146)
+
+> **Status:** P0-J audit doc — 두 회귀 (coding flow 오분류 + 모든 요청 → research/intake) 를 단일 PR / 8-commit 으로 해결.
+> **Issues:** #145 (coding bootstrap) + #146 (read-only intents). parent #138.
+
+## 0. 사용자 보고
+
+### Bug 1 (#145)
+
+repo + issue + 명시적 coding request 가 들어와도 gateway 가 coding 작업으로 이해 못 하고:
+1. `_suggest_task_type` 이 단일 `docker` 매칭으로 PLATFORM_INFRA 분류.
+2. `official_docs / code_context 부족` 으로 막음 ("자료 더 주세요").
+
+사례: `https://github.com/yule-studio/naver-search-clone/issues/1` — Next.js + NestJS + PostgreSQL + Docker Compose 회원가입/로그인/검색.
+
+### Bug 2 (#146)
+
+gateway 가 너무 많은 요청을 새 research / intake 처럼 처리:
+- "지금 열려 있는 세션 몇 개?" → auto-collect 수행
+- "왜 멈췄어?" → research fallback
+- "방향 수정이야" → 새 작업처럼 흐름
+
+## 1. 충돌 가능 지점 (10줄)
+
+1. `_suggest_task_type` (`engineering_conversation.py:926-932`) 의 `_TASK_TYPE_KEYWORDS` 가 단순 `in` 매칭 → `docker` 한 단어로 PLATFORM_INFRA. Next.js/NestJS/Postgres 조합 인식 불가.
+2. TASK_INTAKE_CANDIDATE 분기에서 `_maybe_run_auto_collect` 호출 → collector 가 `NEEDS_USER_INPUT` 반환 → "자료 부족" 노출. PLATFORM_INFRA 는 official_docs 요구가 더 가혹.
+3. STATUS_DIAGNOSTIC 은 이미 분리 (line 178) — 그러나 "세션 몇 개?" / "왜 멈췄어?" / "방향 수정" 같은 세분화된 intent **부재**. 모호 입력 → TASK_INTAKE_CANDIDATE fallback → auto_collect.
+4. `collector.py:1859-1893` 의 `NEEDS_USER_INPUT` mode. `user_links` 없거나 `auto_collected_count=0` 시 발화. repo URL 만 있어도 `user_supplied=True` 인정 안 됨.
+5. `session.extra["github_target"]` 는 `_persist_coding_session_context` (intake *후*) — `_maybe_run_auto_collect` 시점엔 미존재.
+6. `prepare_coding_session_context` 를 conversation 입구에서도 호출하거나 user_links 만으로 추론해야 함.
+7. 세션 list/count query 데이터 source: `agents/workflow_state.list_sessions(limit=N)` 이미 존재.
+8. `understand.py` 의 RuntimeIntent 9개 — conversation layer 의 6개와 다른 layer. 본 작업은 conversation layer 만 확장 (runtime layer 무회귀).
+9. `change_direction` / `continue_existing_work` — `session.extra` 업데이트 helper 필요. 새 intake 절대 금지.
+10. 8 commit 분할 — audit / stack lexicon / official docs seed / TaskType.FULL_STACK_APP + suggest_task_type / coding bootstrap 우회 / 신규 intent 5 + responders / hard rule (auto_collect 차단) / 통합 wiring + e2e.
+
+## 2. 신규 / 갱신 파일 매트릭스
+
+| 위치 | C/U | 책임 |
+| --- | --- | --- |
+| `docs/p0j-coding-bootstrap-and-readonly-intents.md` | C | 본 doc. |
+| `src/yule_orchestrator/agents/coding/stack_detector.py` | C | STACK_LEXICON + detect_stacks + classify_full_stack. |
+| `src/yule_orchestrator/agents/coding/official_docs_seed.py` | C | STACK_TO_DOCS + seed_official_docs. |
+| `src/yule_orchestrator/agents/messaging/dispatcher.py` | U | TaskType.FULL_STACK_APP 추가 + TASK_ROLE_SEQUENCE 매핑. |
+| `src/yule_orchestrator/discord/engineering_conversation.py` | U | `_suggest_task_type` 가 combo 우선 / 5 신규 intent 분류 + responders / hard rule (auto_collect 차단) / wire-in. |
+| `src/yule_orchestrator/agents/coding/coding_bootstrap.py` | C | should_bypass_insufficiency(text, user_links). |
+| `tests/agents/coding/test_stack_detector.py` | C | (+ 4 추가 test 파일). |
+
+## 3. 신규 conversation intents
+
+| intent | trigger 예시 | response 경로 |
+| --- | --- | --- |
+| `session_count_query` | "지금 열려 있는 세션 몇 개?" | open session count 만 |
+| `session_list_query` | "오픈 세션 목록 보여줘" | recent open sessions (id / state / updated_at / thread/PR) |
+| `blocked_reason_query` | "왜 멈췄어?" / "뭐가 막혔어?" | diagnose_session 의 signals + blocked_reason surface |
+| `continue_existing_work` | "이전 작업 이어서" / "그 세션 계속" | session 의 latest continuation_prompt 로 재개 (새 intake X) |
+| `change_direction` | "자료 추가 X, 방향 수정" / "검색 말고 로그인 먼저" | 기존 session.extra 의 prompt/scope 갱신 (새 intake X) |
+
+## 4. 신규 task_type
+
+`TaskType.FULL_STACK_APP = "full-stack-app"` — repo + 다중 stack tier (frontend + backend / backend + database / 등) 발견 + write intent 시 분류. `TASK_ROLE_SEQUENCE` 에 (tech-lead / ai-engineer / backend-engineer / frontend-engineer / devops-engineer / qa-engineer) 추가.
+
+## 5. acceptance criteria 매핑
+
+| AC (Bug 1 / 2) | 처리 commit |
+| --- | --- |
+| repo+issue+full-stack → not platform-infra | 4 |
+| repo+issue+write intent → no insufficiency follow-up | 5 |
+| stack mention → official docs seed | 3 |
+| repo/local clone → code_context bootstrap signal | 5 |
+| genuine infra → still platform-infra | 4 |
+| session count query → no auto_collect | 6 + 7 |
+| session list query → list response | 6 + 7 |
+| blocked_reason query → diagnostic | 6 + 7 |
+| continue_existing_work / change_direction → no new intake | 6 + 7 |
+| genuine new work → still intake/coding path | 8 (e2e) |
+| 기존 4559 PASS 무회귀 | 매 commit |
+
+## 6. 남은 미결정 (후속 PR)
+
+- repo 의 local clone 자동 활성화 (현재는 contract 만 활성화) — vault repo workspace 와 같은 정책으로 deferred.
+- code_context bootstrap 의 실제 컨텐츠 (실 파일 트리 / README excerpt) — repo clone 시 wire.
+
+## 7. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 — Issue #145 + #146. parent #138. |

--- a/src/yule_orchestrator/agents/coding/coding_bootstrap.py
+++ b/src/yule_orchestrator/agents/coding/coding_bootstrap.py
@@ -1,0 +1,233 @@
+"""Coding bootstrap pre-check — P0-J (#145).
+
+The collector's ``NEEDS_USER_INPUT`` mode tells the gateway to ask
+the user for more material ("자료 부족"). For coding requests the
+heuristic is too aggressive: if the user pasted a GitHub repo URL +
+an issue + clearly described what to build (e.g. "Next.js+NestJS+
+Postgres+Docker Compose 회원가입/로그인/검색"), there *is* anchor
+material — just not in the form the legacy collector recognizes.
+
+This module gives the gateway a **bypass decision**: when the
+request carries (a) a GitHub repo target, (b) a clear write intent,
+and (c) ≥1 recognized engineering stack, the gateway treats the
+combination as a *code_context bootstrap pending* signal and
+proceeds with coding handoff *without* surfacing "자료 더 주세요".
+
+The local repo clone is optional — repo target *alone* (issue or
+repo root) is enough to register the bootstrap signal. The actual
+clone / file tree extraction wires in P0-J 후속 (the
+``vault repo workspace`` follow-up referenced in stage-1 §6).
+
+The decision is **read-only**. Returns a :class:`CodingBootstrap`
+that the caller persists into ``session.extra`` and uses to gate
+the insufficiency surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+# Status codes — stable identifiers.
+STATUS_BYPASS = "bypass_insufficiency"
+STATUS_REQUIRES_USER_INPUT = "requires_user_input"
+STATUS_NOT_CODING_REQUEST = "not_coding_request"
+
+STATUSES = (
+    STATUS_BYPASS,
+    STATUS_REQUIRES_USER_INPUT,
+    STATUS_NOT_CODING_REQUEST,
+)
+
+
+@dataclass(frozen=True)
+class CodingBootstrap:
+    """Outcome of :func:`evaluate_coding_bootstrap`.
+
+    ``status``                  — one of the STATUS_* constants.
+    ``bypass_insufficiency``    — True when gateway should NOT
+                                  surface "자료 부족" follow-up.
+    ``code_context_pending``    — True when repo target + write
+                                  intent + stack ≥1 → workspace
+                                  bootstrap is "pending" (work to
+                                  happen when local clone wires).
+    ``seeded_docs``             — list of canonical stack names
+                                  whose official docs are seeded.
+    ``reason``                  — short Korean status text.
+    ``has_github_repo``         — True when github_target kind ∈
+                                  (repo/issue/pull_request).
+    ``stacks_mentioned``        — tuple of canonical stack names.
+    ``write_intent``            — True when the message has write
+                                  / build / implement verbs.
+    """
+
+    status: str
+    bypass_insufficiency: bool
+    code_context_pending: bool
+    seeded_docs: Tuple[str, ...] = field(default_factory=tuple)
+    reason: Optional[str] = None
+    has_github_repo: bool = False
+    stacks_mentioned: Tuple[str, ...] = ()
+    write_intent: bool = False
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            "status": self.status,
+            "bypass_insufficiency": self.bypass_insufficiency,
+            "code_context_pending": self.code_context_pending,
+            "seeded_docs": list(self.seeded_docs),
+            "reason": self.reason,
+            "has_github_repo": self.has_github_repo,
+            "stacks_mentioned": list(self.stacks_mentioned),
+            "write_intent": self.write_intent,
+        }
+
+    def status_summary_line(self) -> str:
+        """One-line summary for the status diagnostic surface."""
+
+        if self.status == STATUS_BYPASS:
+            seed_count = len(self.seeded_docs)
+            return (
+                f"🚀 coding bootstrap: insufficiency 우회 — "
+                f"repo target + {len(self.stacks_mentioned)} stacks + write intent "
+                f"(+{seed_count} docs seeded)"
+            )
+        if self.status == STATUS_REQUIRES_USER_INPUT:
+            return "📝 coding bootstrap: 추가 정보 필요 — anchor 미충분"
+        return "ℹ️ coding bootstrap: 코딩 요청 아님"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_coding_bootstrap(
+    *,
+    message_text: str,
+    user_links: Sequence[str] = (),
+    existing_extra: Optional[Mapping[str, Any]] = None,
+) -> CodingBootstrap:
+    """Decide whether to bypass the collector's insufficiency surface.
+
+    Three outcomes:
+
+      * **bypass** — github_target is a repo/issue/PR + ≥1
+        recognized stack + write intent.
+      * **requires_user_input** — partial signals (e.g. repo URL
+        but no write intent; or write intent but no repo).
+      * **not_coding_request** — neither stack nor write intent —
+        the message is not a coding request at all.
+    """
+
+    extra_in = dict(existing_extra or {})
+
+    has_github_repo = _has_github_repo(extra_in, user_links)
+
+    # Stack detection — defer import to keep module isolated.
+    try:
+        from .stack_detector import detect_stacks, has_write_intent
+        from .official_docs_seed import seed_official_docs
+    except Exception:  # noqa: BLE001 - partial install fallback
+        return CodingBootstrap(
+            status=STATUS_REQUIRES_USER_INPUT,
+            bypass_insufficiency=False,
+            code_context_pending=False,
+            reason="stack_detector_unavailable",
+        )
+
+    detection = detect_stacks(message_text or "")
+    write_intent = has_write_intent(message_text or "")
+
+    if not detection.has_any and not write_intent:
+        return CodingBootstrap(
+            status=STATUS_NOT_CODING_REQUEST,
+            bypass_insufficiency=False,
+            code_context_pending=False,
+            reason="no_stack_no_write_intent",
+            has_github_repo=has_github_repo,
+        )
+
+    # Bypass when all 3 signals are present.
+    if has_github_repo and detection.has_any and write_intent:
+        seeded = seed_official_docs(detection.stacks)
+        return CodingBootstrap(
+            status=STATUS_BYPASS,
+            bypass_insufficiency=True,
+            code_context_pending=True,
+            seeded_docs=tuple(s.canonical for s in seeded),
+            reason=(
+                "repo target + stack mention + write intent — "
+                "coding bootstrap 활성, insufficiency 우회"
+            ),
+            has_github_repo=True,
+            stacks_mentioned=detection.stacks,
+            write_intent=True,
+        )
+
+    return CodingBootstrap(
+        status=STATUS_REQUIRES_USER_INPUT,
+        bypass_insufficiency=False,
+        code_context_pending=False,
+        reason=_partial_signal_reason(
+            has_github_repo=has_github_repo,
+            has_stacks=detection.has_any,
+            write_intent=write_intent,
+        ),
+        has_github_repo=has_github_repo,
+        stacks_mentioned=detection.stacks,
+        write_intent=write_intent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _has_github_repo(
+    extra: Mapping[str, Any], user_links: Sequence[str]
+) -> bool:
+    """Return True when extra OR user_links carries a GitHub repo/issue/PR target."""
+
+    github_target = extra.get("github_target")
+    if isinstance(github_target, Mapping) and github_target:
+        kind = str(github_target.get("kind") or "")
+        if kind in ("repo", "issue", "pull_request"):
+            return True
+    # Fall back to scanning user_links — defer parser import.
+    try:
+        from ..git.github_url import parse_github_targets
+    except Exception:  # noqa: BLE001
+        return False
+    targets = parse_github_targets(user_links or ())
+    for t in targets:
+        if t.kind in ("repo", "issue", "pull_request"):
+            return True
+    return False
+
+
+def _partial_signal_reason(
+    *, has_github_repo: bool, has_stacks: bool, write_intent: bool
+) -> str:
+    missing: list[str] = []
+    if not has_github_repo:
+        missing.append("repo target")
+    if not has_stacks:
+        missing.append("stack mention")
+    if not write_intent:
+        missing.append("write intent")
+    if missing:
+        return "anchor 부족: " + ", ".join(missing)
+    return "unknown"
+
+
+__all__ = (
+    "CodingBootstrap",
+    "STATUSES",
+    "STATUS_BYPASS",
+    "STATUS_NOT_CODING_REQUEST",
+    "STATUS_REQUIRES_USER_INPUT",
+    "evaluate_coding_bootstrap",
+)

--- a/src/yule_orchestrator/agents/coding/official_docs_seed.py
+++ b/src/yule_orchestrator/agents/coding/official_docs_seed.py
@@ -1,0 +1,369 @@
+"""Official docs seed for detected engineering stacks — P0-J (#145).
+
+When the user's coding request mentions a stack (Next.js / NestJS /
+PostgreSQL / Docker Compose / ...), seed the official documentation
+URL as a ResearchSource-shaped reference so the gateway can answer
+"official_docs 부족" by *itself* instead of asking the user.
+
+The mapping is intentionally narrow — only first-party canonical
+docs. If a stack has multiple canonical sources (e.g. Next.js docs
+vs App Router docs), we pick the top-level entry. No third-party
+tutorials, no Stack Overflow.
+
+This module is **pure / network-free** — it produces seed metadata
+(title / url / source_type). The actual web fetch is the collector
+loop's responsibility; the seed lets the gateway short-circuit
+"NEEDS_USER_INPUT" when stack mentions are present.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class OfficialDocsSource:
+    """Seed entry for the collector / status surface.
+
+    Shape matches the ``ResearchSource`` used elsewhere — title,
+    url, domain, snippet, source_type. The caller composes the
+    actual ``ResearchSource`` when persisting; this dataclass
+    keeps the seed table independent of the heavier import.
+    """
+
+    canonical: str  # stack canonical name (matches stack_detector)
+    title: str
+    url: str
+    domain: str
+    snippet: str
+    source_type: str = "official_docs"
+
+
+# Mapping by canonical stack name from
+# ``agents.coding.stack_detector._LEXICON``. Keep entries narrow —
+# top-level entry per stack.
+_DOCS: Mapping[str, OfficialDocsSource] = {
+    # Frontend
+    "Next.js": OfficialDocsSource(
+        canonical="Next.js",
+        title="Next.js — Official Docs",
+        url="https://nextjs.org/docs",
+        domain="nextjs.org",
+        snippet="The official Next.js documentation — App Router, Pages Router, deployment, data fetching.",
+    ),
+    "React": OfficialDocsSource(
+        canonical="React",
+        title="React — Reference",
+        url="https://react.dev/reference/react",
+        domain="react.dev",
+        snippet="Official React reference for hooks, components, and APIs.",
+    ),
+    "Vue": OfficialDocsSource(
+        canonical="Vue",
+        title="Vue.js — Guide",
+        url="https://vuejs.org/guide/introduction.html",
+        domain="vuejs.org",
+        snippet="Official Vue 3 guide.",
+    ),
+    "Svelte": OfficialDocsSource(
+        canonical="Svelte",
+        title="Svelte — Tutorial / Docs",
+        url="https://svelte.dev/docs",
+        domain="svelte.dev",
+        snippet="Official Svelte / SvelteKit docs.",
+    ),
+    "Tailwind": OfficialDocsSource(
+        canonical="Tailwind",
+        title="Tailwind CSS — Docs",
+        url="https://tailwindcss.com/docs",
+        domain="tailwindcss.com",
+        snippet="Official Tailwind CSS installation, configuration, utility reference.",
+    ),
+    "Vite": OfficialDocsSource(
+        canonical="Vite",
+        title="Vite — Guide",
+        url="https://vitejs.dev/guide/",
+        domain="vitejs.dev",
+        snippet="Official Vite build tool guide.",
+    ),
+    "Angular": OfficialDocsSource(
+        canonical="Angular",
+        title="Angular — Docs",
+        url="https://angular.dev/overview",
+        domain="angular.dev",
+        snippet="Official Angular docs (v17+).",
+    ),
+    # Backend
+    "NestJS": OfficialDocsSource(
+        canonical="NestJS",
+        title="NestJS — Documentation",
+        url="https://docs.nestjs.com",
+        domain="docs.nestjs.com",
+        snippet="Official NestJS framework documentation — modules, providers, controllers, auth, TypeORM/Prisma.",
+    ),
+    "Express": OfficialDocsSource(
+        canonical="Express",
+        title="Express.js — Guide",
+        url="https://expressjs.com/en/guide/routing.html",
+        domain="expressjs.com",
+        snippet="Express.js official guide (routing / middleware / error handling).",
+    ),
+    "FastAPI": OfficialDocsSource(
+        canonical="FastAPI",
+        title="FastAPI — Documentation",
+        url="https://fastapi.tiangolo.com",
+        domain="fastapi.tiangolo.com",
+        snippet="Official FastAPI documentation.",
+    ),
+    "Django": OfficialDocsSource(
+        canonical="Django",
+        title="Django — Documentation",
+        url="https://docs.djangoproject.com/en/stable/",
+        domain="docs.djangoproject.com",
+        snippet="Official Django documentation.",
+    ),
+    "Flask": OfficialDocsSource(
+        canonical="Flask",
+        title="Flask — Documentation",
+        url="https://flask.palletsprojects.com",
+        domain="flask.palletsprojects.com",
+        snippet="Official Flask documentation.",
+    ),
+    "Spring Boot": OfficialDocsSource(
+        canonical="Spring Boot",
+        title="Spring Boot — Reference",
+        url="https://docs.spring.io/spring-boot/docs/current/reference/html/",
+        domain="docs.spring.io",
+        snippet="Official Spring Boot reference documentation.",
+    ),
+    "Rails": OfficialDocsSource(
+        canonical="Rails",
+        title="Ruby on Rails — Guides",
+        url="https://guides.rubyonrails.org",
+        domain="guides.rubyonrails.org",
+        snippet="Official Ruby on Rails guides.",
+    ),
+    "Node.js": OfficialDocsSource(
+        canonical="Node.js",
+        title="Node.js — Docs",
+        url="https://nodejs.org/docs/latest/api/",
+        domain="nodejs.org",
+        snippet="Official Node.js API documentation.",
+    ),
+    # Database
+    "PostgreSQL": OfficialDocsSource(
+        canonical="PostgreSQL",
+        title="PostgreSQL — Documentation",
+        url="https://www.postgresql.org/docs/current/",
+        domain="postgresql.org",
+        snippet="Official PostgreSQL documentation — SQL syntax, indexing, replication.",
+    ),
+    "MySQL": OfficialDocsSource(
+        canonical="MySQL",
+        title="MySQL — Reference Manual",
+        url="https://dev.mysql.com/doc/refman/8.0/en/",
+        domain="dev.mysql.com",
+        snippet="Official MySQL reference manual.",
+    ),
+    "MongoDB": OfficialDocsSource(
+        canonical="MongoDB",
+        title="MongoDB — Manual",
+        url="https://www.mongodb.com/docs/manual/",
+        domain="mongodb.com",
+        snippet="Official MongoDB manual.",
+    ),
+    "SQLite": OfficialDocsSource(
+        canonical="SQLite",
+        title="SQLite — Documentation",
+        url="https://sqlite.org/docs.html",
+        domain="sqlite.org",
+        snippet="Official SQLite documentation.",
+    ),
+    "Prisma": OfficialDocsSource(
+        canonical="Prisma",
+        title="Prisma — Documentation",
+        url="https://www.prisma.io/docs",
+        domain="prisma.io",
+        snippet="Official Prisma ORM documentation.",
+    ),
+    "TypeORM": OfficialDocsSource(
+        canonical="TypeORM",
+        title="TypeORM — Documentation",
+        url="https://typeorm.io",
+        domain="typeorm.io",
+        snippet="Official TypeORM documentation.",
+    ),
+    # Infra
+    "Docker": OfficialDocsSource(
+        canonical="Docker",
+        title="Docker — Documentation",
+        url="https://docs.docker.com",
+        domain="docs.docker.com",
+        snippet="Official Docker documentation.",
+    ),
+    "Docker Compose": OfficialDocsSource(
+        canonical="Docker Compose",
+        title="Docker Compose — Overview",
+        url="https://docs.docker.com/compose/",
+        domain="docs.docker.com",
+        snippet="Official Docker Compose docs — multi-container apps, services, networks, volumes.",
+    ),
+    "Kubernetes": OfficialDocsSource(
+        canonical="Kubernetes",
+        title="Kubernetes — Documentation",
+        url="https://kubernetes.io/docs/home/",
+        domain="kubernetes.io",
+        snippet="Official Kubernetes documentation.",
+    ),
+    "Terraform": OfficialDocsSource(
+        canonical="Terraform",
+        title="Terraform — Documentation",
+        url="https://developer.hashicorp.com/terraform/docs",
+        domain="developer.hashicorp.com",
+        snippet="Official Terraform documentation.",
+    ),
+    "GitHub Actions": OfficialDocsSource(
+        canonical="GitHub Actions",
+        title="GitHub Actions — Documentation",
+        url="https://docs.github.com/en/actions",
+        domain="docs.github.com",
+        snippet="Official GitHub Actions documentation.",
+    ),
+    "Vercel": OfficialDocsSource(
+        canonical="Vercel",
+        title="Vercel — Documentation",
+        url="https://vercel.com/docs",
+        domain="vercel.com",
+        snippet="Official Vercel platform docs.",
+    ),
+    # Cache / Queue / Testing
+    "Redis": OfficialDocsSource(
+        canonical="Redis",
+        title="Redis — Documentation",
+        url="https://redis.io/docs/",
+        domain="redis.io",
+        snippet="Official Redis docs — data structures, persistence, replication.",
+    ),
+    "RabbitMQ": OfficialDocsSource(
+        canonical="RabbitMQ",
+        title="RabbitMQ — Documentation",
+        url="https://www.rabbitmq.com/documentation.html",
+        domain="rabbitmq.com",
+        snippet="Official RabbitMQ documentation.",
+    ),
+    "Kafka": OfficialDocsSource(
+        canonical="Kafka",
+        title="Apache Kafka — Documentation",
+        url="https://kafka.apache.org/documentation/",
+        domain="kafka.apache.org",
+        snippet="Official Apache Kafka documentation.",
+    ),
+    "Jest": OfficialDocsSource(
+        canonical="Jest",
+        title="Jest — Documentation",
+        url="https://jestjs.io/docs/getting-started",
+        domain="jestjs.io",
+        snippet="Official Jest testing framework docs.",
+    ),
+    "Vitest": OfficialDocsSource(
+        canonical="Vitest",
+        title="Vitest — Guide",
+        url="https://vitest.dev/guide/",
+        domain="vitest.dev",
+        snippet="Official Vitest guide.",
+    ),
+    "pytest": OfficialDocsSource(
+        canonical="pytest",
+        title="pytest — Documentation",
+        url="https://docs.pytest.org/en/stable/",
+        domain="docs.pytest.org",
+        snippet="Official pytest documentation.",
+    ),
+    "Cypress": OfficialDocsSource(
+        canonical="Cypress",
+        title="Cypress — Documentation",
+        url="https://docs.cypress.io",
+        domain="docs.cypress.io",
+        snippet="Official Cypress E2E testing docs.",
+    ),
+    "Playwright": OfficialDocsSource(
+        canonical="Playwright",
+        title="Playwright — Documentation",
+        url="https://playwright.dev/docs/intro",
+        domain="playwright.dev",
+        snippet="Official Playwright docs.",
+    ),
+    # Auth
+    "JWT": OfficialDocsSource(
+        canonical="JWT",
+        title="JWT — Introduction (jwt.io)",
+        url="https://jwt.io/introduction",
+        domain="jwt.io",
+        snippet="JSON Web Tokens introduction.",
+    ),
+    "OAuth": OfficialDocsSource(
+        canonical="OAuth",
+        title="OAuth 2.0 — RFC 6749",
+        url="https://datatracker.ietf.org/doc/html/rfc6749",
+        domain="datatracker.ietf.org",
+        snippet="The OAuth 2.0 Authorization Framework (RFC 6749).",
+    ),
+    "Auth0": OfficialDocsSource(
+        canonical="Auth0",
+        title="Auth0 — Documentation",
+        url="https://auth0.com/docs",
+        domain="auth0.com",
+        snippet="Official Auth0 documentation.",
+    ),
+    "NextAuth": OfficialDocsSource(
+        canonical="NextAuth",
+        title="NextAuth.js — Documentation",
+        url="https://next-auth.js.org/getting-started/introduction",
+        domain="next-auth.js.org",
+        snippet="Official NextAuth.js documentation.",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def seed_official_docs(
+    detected_stacks: Sequence[str],
+) -> Tuple[OfficialDocsSource, ...]:
+    """Return docs entries for *detected_stacks*.
+
+    *detected_stacks* matches canonical names from
+    :func:`stack_detector.detect_stacks`. Unknown canonicals are
+    silently skipped (no fake docs). Order preserved.
+    """
+
+    if not detected_stacks:
+        return ()
+    out: list[OfficialDocsSource] = []
+    seen: set = set()
+    for canonical in detected_stacks:
+        if canonical in seen:
+            continue
+        entry = _DOCS.get(canonical)
+        if entry is None:
+            continue
+        seen.add(canonical)
+        out.append(entry)
+    return tuple(out)
+
+
+def known_canonicals() -> Tuple[str, ...]:
+    """For tests / debugging — list of stacks with an official docs entry."""
+
+    return tuple(_DOCS.keys())
+
+
+__all__ = (
+    "OfficialDocsSource",
+    "known_canonicals",
+    "seed_official_docs",
+)

--- a/src/yule_orchestrator/agents/coding/stack_detector.py
+++ b/src/yule_orchestrator/agents/coding/stack_detector.py
@@ -1,0 +1,280 @@
+"""Engineering tech-stack detector — P0-J (#145).
+
+When a user pastes a coding request like "Next.js + NestJS + PostgreSQL
++ Docker Compose 회원가입/로그인/검색", the previous
+``_suggest_task_type`` matched on the single word "docker" and
+classified the request as ``platform-infra``. That blocked the
+gateway with the "official_docs / code_context 부족" insufficiency
+gate even though the user clearly described a coding-capable
+full-stack app.
+
+This module recognises engineering stacks across multiple **tiers**
+(frontend / backend / database / infra-tool / cache / queue /
+testing) so the caller can:
+
+  1. classify a request as **full-stack** when ≥2 distinct tiers
+     are mentioned (commit 4 wires this into ``_suggest_task_type``),
+  2. seed official-docs URLs per detected stack (commit 3),
+  3. surface the detected stack list in the gateway status surface
+     and the coding handoff packet.
+
+The detector is **pure / network-free**. It uses case-insensitive
+substring matching against a curated lexicon. Each stack carries its
+*tier* + its *canonical display name* so callers don't have to
+re-derive.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Tuple
+
+
+# Tier constants — used by ``classify_full_stack`` to decide whether
+# enough distinct tiers were mentioned.
+TIER_FRONTEND = "frontend"
+TIER_BACKEND = "backend"
+TIER_DATABASE = "database"
+TIER_INFRA = "infra"
+TIER_CACHE = "cache"
+TIER_QUEUE = "queue"
+TIER_TESTING = "testing"
+TIER_AUTH = "auth"
+
+TIERS = (
+    TIER_FRONTEND,
+    TIER_BACKEND,
+    TIER_DATABASE,
+    TIER_INFRA,
+    TIER_CACHE,
+    TIER_QUEUE,
+    TIER_TESTING,
+    TIER_AUTH,
+)
+
+
+@dataclass(frozen=True)
+class StackEntry:
+    """One row in the stack lexicon — display name, tier, match aliases."""
+
+    canonical: str
+    tier: str
+    aliases: Tuple[str, ...]
+
+
+# Curated engineering lexicon. Each entry's aliases are matched as
+# **whole tokens or known compounds** so "docker" alone fires the
+# infra tier but the combo logic (commit 4) still allows the request
+# to be classified as full-stack when other tiers are also present.
+_LEXICON: Tuple[StackEntry, ...] = (
+    # --- Frontend ----------------------------------------------------------
+    StackEntry("Next.js", TIER_FRONTEND, ("next.js", "nextjs", "next js")),
+    StackEntry("React", TIER_FRONTEND, ("react", "리액트")),
+    StackEntry("Vue", TIER_FRONTEND, ("vue.js", "vuejs", "vue")),
+    StackEntry("Svelte", TIER_FRONTEND, ("svelte", "sveltekit")),
+    StackEntry("Tailwind", TIER_FRONTEND, ("tailwind", "tailwindcss")),
+    StackEntry("Vite", TIER_FRONTEND, ("vite", "vitejs")),
+    StackEntry("Angular", TIER_FRONTEND, ("angular",)),
+    # --- Backend -----------------------------------------------------------
+    StackEntry("NestJS", TIER_BACKEND, ("nest.js", "nestjs", "nest js")),
+    StackEntry("Express", TIER_BACKEND, ("express.js", "expressjs", "express ")),
+    StackEntry("FastAPI", TIER_BACKEND, ("fastapi", "fast api")),
+    StackEntry("Django", TIER_BACKEND, ("django",)),
+    StackEntry("Flask", TIER_BACKEND, ("flask",)),
+    StackEntry("Spring Boot", TIER_BACKEND, ("spring boot", "springboot", "spring-boot")),
+    StackEntry("Rails", TIER_BACKEND, ("rails", "ruby on rails")),
+    StackEntry("Gin", TIER_BACKEND, ("gin ", "gin-gonic")),
+    StackEntry("Node.js", TIER_BACKEND, ("node.js", "nodejs", "node js")),
+    # --- Database ----------------------------------------------------------
+    StackEntry("PostgreSQL", TIER_DATABASE, ("postgresql", "postgres", "psql")),
+    StackEntry("MySQL", TIER_DATABASE, ("mysql", "mariadb")),
+    StackEntry("MongoDB", TIER_DATABASE, ("mongodb", "mongo")),
+    StackEntry("SQLite", TIER_DATABASE, ("sqlite",)),
+    StackEntry("Prisma", TIER_DATABASE, ("prisma",)),  # ORM but binds DB tier
+    StackEntry("TypeORM", TIER_DATABASE, ("typeorm",)),
+    StackEntry("DynamoDB", TIER_DATABASE, ("dynamodb",)),
+    # --- Infra -------------------------------------------------------------
+    StackEntry("Docker", TIER_INFRA, ("docker",)),
+    StackEntry("Docker Compose", TIER_INFRA, ("docker compose", "docker-compose")),
+    StackEntry("Kubernetes", TIER_INFRA, ("kubernetes", "k8s")),
+    StackEntry("Terraform", TIER_INFRA, ("terraform",)),
+    StackEntry("GitHub Actions", TIER_INFRA, ("github actions", "github-actions")),
+    StackEntry("Vercel", TIER_INFRA, ("vercel",)),
+    StackEntry("Netlify", TIER_INFRA, ("netlify",)),
+    StackEntry("AWS", TIER_INFRA, ("aws ", " aws", "amazon web services")),
+    # --- Cache -------------------------------------------------------------
+    StackEntry("Redis", TIER_CACHE, ("redis",)),
+    StackEntry("Memcached", TIER_CACHE, ("memcached",)),
+    # --- Queue -------------------------------------------------------------
+    StackEntry("RabbitMQ", TIER_QUEUE, ("rabbitmq",)),
+    StackEntry("Kafka", TIER_QUEUE, ("kafka",)),
+    StackEntry("SQS", TIER_QUEUE, ("sqs ", "amazon sqs")),
+    # --- Testing -----------------------------------------------------------
+    StackEntry("Jest", TIER_TESTING, ("jest",)),
+    StackEntry("Vitest", TIER_TESTING, ("vitest",)),
+    StackEntry("pytest", TIER_TESTING, ("pytest",)),
+    StackEntry("Cypress", TIER_TESTING, ("cypress",)),
+    StackEntry("Playwright", TIER_TESTING, ("playwright",)),
+    # --- Auth --------------------------------------------------------------
+    StackEntry("JWT", TIER_AUTH, ("jwt ", "jwt token", " jwt")),
+    StackEntry("OAuth", TIER_AUTH, ("oauth", "oauth2", "oauth 2")),
+    StackEntry("Auth0", TIER_AUTH, ("auth0",)),
+    StackEntry("Clerk", TIER_AUTH, ("clerk",)),
+    StackEntry("NextAuth", TIER_AUTH, ("nextauth", "next-auth")),
+)
+
+
+@dataclass(frozen=True)
+class StackDetection:
+    """Output of :func:`detect_stacks`.
+
+    ``stacks`` is the ordered tuple of canonical names we found.
+    ``tiers_present`` is the set of tier identifiers covered.
+    ``mentioned_aliases`` is the raw alias substring that matched —
+    useful for surfacing back to the user ("Next.js detected via
+    'next.js'") or seeding queries.
+    """
+
+    stacks: Tuple[str, ...]
+    tiers_present: Tuple[str, ...]
+    mentioned_aliases: Mapping[str, str]  # canonical → alias-as-matched
+
+    @property
+    def has_any(self) -> bool:
+        return bool(self.stacks)
+
+    @property
+    def is_full_stack(self) -> bool:
+        """≥2 distinct tiers among (frontend / backend / database / cache / queue / auth)
+        — i.e. genuine *application* stack, not pure infra.
+        """
+
+        app_tiers = {
+            TIER_FRONTEND,
+            TIER_BACKEND,
+            TIER_DATABASE,
+            TIER_CACHE,
+            TIER_QUEUE,
+            TIER_AUTH,
+        }
+        return len(set(self.tiers_present) & app_tiers) >= 2
+
+    @property
+    def is_infra_only(self) -> bool:
+        """All matched stacks are infra-tier (deploy / terraform / k8s).
+        Used to keep PLATFORM_INFRA classification for genuine infra
+        requests like "GitHub Actions만 셋업" or "terraform module만".
+        """
+
+        if not self.tiers_present:
+            return False
+        return all(tier == TIER_INFRA for tier in self.tiers_present)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def detect_stacks(text: str) -> StackDetection:
+    """Scan *text* for engineering stack mentions.
+
+    Returns :class:`StackDetection`. Empty input → no detections.
+    Match is case-insensitive whole-or-substring; punctuation
+    boundaries are honored so "Docker." still matches "docker".
+    """
+
+    if not text:
+        return StackDetection((), (), {})
+    lowered = text.lower()
+    found: list[Tuple[str, str, str]] = []  # (canonical, tier, matched alias)
+    seen_canonical: set = set()
+    for entry in _LEXICON:
+        for alias in entry.aliases:
+            normalized_alias = alias.lower()
+            if normalized_alias in lowered:
+                if entry.canonical not in seen_canonical:
+                    seen_canonical.add(entry.canonical)
+                    found.append((entry.canonical, entry.tier, alias.strip()))
+                break
+    stacks = tuple(name for name, _, _ in found)
+    tiers = tuple(_unique_preserve(tier for _, tier, _ in found))
+    mentioned = {name: alias for name, _, alias in found}
+    return StackDetection(stacks=stacks, tiers_present=tiers, mentioned_aliases=mentioned)
+
+
+def classify_full_stack(text: str) -> bool:
+    """Convenience wrapper for the gateway's task-type hint.
+
+    True iff the message mentions ≥2 distinct *application* tiers
+    (frontend / backend / database / cache / queue / auth). Pure
+    infra mentions never trip this.
+    """
+
+    return detect_stacks(text).is_full_stack
+
+
+def has_write_intent(text: str) -> bool:
+    """Heuristic — does the message describe a *write/implement* request?
+
+    Looks for build-verbs (만들 / 구현 / 작성 / build / implement /
+    setup / 세팅 / 셋업 / scaffold / spin up) and excludes pure
+    review verbs (검토 / 분석 / 리뷰 / 어떻게 생각).
+    """
+
+    if not text:
+        return False
+    lowered = text.lower()
+    review_signals = ("검토", "분석", "review", "리뷰", "어떻게 생각", "조사")
+    if any(signal in lowered for signal in review_signals):
+        return False
+    write_signals = (
+        "만들",
+        "구현",
+        "작성",
+        "build",
+        "implement",
+        "scaffold",
+        "spin up",
+        "set up",
+        "setup",
+        "셋업",
+        "세팅",
+        "개발",
+        "create",
+    )
+    return any(signal in lowered for signal in write_signals)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _unique_preserve(seq) -> list:
+    seen: set = set()
+    out: list = []
+    for item in seq:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+__all__ = (
+    "StackDetection",
+    "StackEntry",
+    "TIERS",
+    "TIER_AUTH",
+    "TIER_BACKEND",
+    "TIER_CACHE",
+    "TIER_DATABASE",
+    "TIER_FRONTEND",
+    "TIER_INFRA",
+    "TIER_QUEUE",
+    "TIER_TESTING",
+    "classify_full_stack",
+    "detect_stacks",
+    "has_write_intent",
+)

--- a/src/yule_orchestrator/agents/messaging/dispatcher.py
+++ b/src/yule_orchestrator/agents/messaging/dispatcher.py
@@ -140,6 +140,11 @@ TASK_EXECUTOR_ROLE: Mapping[TaskType, str] = {
     TaskType.EMAIL_CAMPAIGN: "frontend-engineer",
     TaskType.QA_TEST: "qa-engineer",
     TaskType.PLATFORM_INFRA: "backend-engineer",
+    # P0-J (#145): full-stack-app 의 default executor 는 backend-engineer
+    # (스키마 + auth + API 가 보통 첫 implementation 이며, frontend 는
+    # 두 번째 implementation 라운드로 이어진다). 필요 시 tech-lead 가
+    # 작업 분배 시점에 override 가능.
+    TaskType.FULL_STACK_APP: "backend-engineer",
     TaskType.UNKNOWN: "tech-lead",
 }
 

--- a/src/yule_orchestrator/agents/messaging/dispatcher.py
+++ b/src/yule_orchestrator/agents/messaging/dispatcher.py
@@ -21,6 +21,11 @@ from .registry import ParticipantsPool
 class TaskType(str, Enum):
     BACKEND_FEATURE = "backend-feature"
     FRONTEND_FEATURE = "frontend-feature"
+    # P0-J (#145) — Next.js+NestJS+Postgres+Docker Compose 같은 full-stack
+    # 요청을 Docker 한 단어로 platform-infra 분류하던 회귀 차단용. 다중
+    # application tier (frontend+backend+database 등) 동시 발견 + write
+    # intent 시 분류.
+    FULL_STACK_APP = "full-stack-app"
     LANDING_PAGE = "landing-page"
     ONBOARDING_FLOW = "onboarding-flow"
     VISUAL_POLISH = "visual-polish"
@@ -102,6 +107,15 @@ TASK_ROLE_SEQUENCE: Mapping[TaskType, Sequence[str]] = {
         "backend-engineer",
         "qa-engineer",
         "devops-engineer",
+    ),
+    TaskType.FULL_STACK_APP: (
+        "tech-lead",
+        "ai-engineer",
+        "product-designer",
+        "backend-engineer",
+        "frontend-engineer",
+        "devops-engineer",
+        "qa-engineer",
     ),
     TaskType.UNKNOWN: (
         "tech-lead",

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -374,14 +374,47 @@ def build_engineering_conversation_response(
             collection_outcome=collection,
         )
 
+    # P0-J (#145) — coding bootstrap bypass. When the user has a GitHub
+    # repo target + stack mention + write intent, the collector's
+    # "자료 부족" surface is wrong (the *anchor* material is the repo
+    # itself). Replace the NEEDS_USER_INPUT body with a bootstrap
+    # acknowledgement so the gateway proceeds to coding handoff.
+    bootstrap_outcome = None
+    try:
+        from ..agents.coding.coding_bootstrap import (
+            STATUS_BYPASS,
+            evaluate_coding_bootstrap,
+        )
+
+        bootstrap_outcome = evaluate_coding_bootstrap(
+            message_text=message_text,
+            user_links=user_links,
+        )
+    except Exception:  # noqa: BLE001 - partial install fallback
+        bootstrap_outcome = None
+
     # default: TASK_INTAKE_CANDIDATE
     if collection is not None:
-        body = _format_intake_with_collection(
-            message_text=message_text,
-            suggested_task_type=suggested,
-            write_likely=write_likely,
-            collection=collection,
-        )
+        # P0-J: if collector reported NEEDS_USER_INPUT but bootstrap
+        # says bypass, swap the body to the bootstrap announcement.
+        collection_mode = getattr(getattr(collection, "mode", None), "value", "")
+        if (
+            collection_mode == "needs_user_input"
+            and bootstrap_outcome is not None
+            and bootstrap_outcome.status == STATUS_BYPASS
+        ):
+            body = _format_coding_bootstrap_body(
+                message_text=message_text,
+                bootstrap=bootstrap_outcome,
+                suggested_task_type=suggested,
+            )
+        else:
+            body = _format_intake_with_collection(
+                message_text=message_text,
+                suggested_task_type=suggested,
+                write_likely=write_likely,
+                collection=collection,
+            )
     else:
         body = _format_intake_candidate_question(
             message_text=message_text,
@@ -550,6 +583,44 @@ def _maybe_run_auto_collect(
         )
     except Exception:  # noqa: BLE001
         return None
+
+
+def _format_coding_bootstrap_body(
+    *,
+    message_text: str,
+    bootstrap: Any,
+    suggested_task_type: Optional[str],
+) -> str:
+    """P0-J (#145) — replace 'NEEDS_USER_INPUT' surface with bootstrap ack.
+
+    When the gateway has repo + stack + write intent, the autonomous
+    collector's "자료 부족" follow-up is wrong: the *anchor* is the
+    repo itself. This body explains what the gateway will do next
+    (seed docs + coding handoff) so the user knows we're proceeding,
+    not stalling.
+    """
+
+    topic = _summarize_topic(message_text)
+    stacks = ", ".join(getattr(bootstrap, "stacks_mentioned", ()) or ())
+    seeded = ", ".join(getattr(bootstrap, "seeded_docs", ()) or ())
+    task_label = (
+        _pretty_task_type(suggested_task_type) if suggested_task_type else None
+    )
+    paragraphs: list[str] = [
+        "🚀 coding bootstrap 활성 — repo target + stack mention + write intent 조합으로 "
+        "추가 자료 요청 없이 coding handoff 로 진행합니다.",
+        f"이번 요청은 “{topic}” 으로 이해했고,"
+        + (f" `{task_label}` 작업으로 분류했어요." if task_label else ""),
+    ]
+    if stacks:
+        paragraphs.append(f"📚 감지된 스택: {stacks}")
+    if seeded:
+        paragraphs.append(f"📖 official docs 자동 seed: {seeded}")
+    paragraphs.append(
+        "코드 컨텍스트는 repo target 으로부터 부트스트랩될 예정입니다. "
+        "다른 자료가 필요해지면 그때 다시 알려주세요."
+    )
+    return "\n\n".join(paragraphs)
 
 
 def _format_collection_announcement(collection: Any) -> str:

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -225,6 +225,80 @@ def build_engineering_conversation_response(
             is_status_query=True,
         )
 
+    # P0-J (#146) — read-only intents hard rule. NEVER call
+    # _maybe_run_auto_collect / NEVER set ready_to_intake=True.
+    if intent.intent_id == SESSION_COUNT_QUERY:
+        body = format_session_count_response()
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=SESSION_COUNT_QUERY,
+            mention_user_id=mention_user_id,
+            is_status_query=True,
+        )
+
+    if intent.intent_id == SESSION_LIST_QUERY:
+        body = format_session_list_response()
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=SESSION_LIST_QUERY,
+            mention_user_id=mention_user_id,
+            is_status_query=True,
+        )
+
+    if intent.intent_id == BLOCKED_REASON_QUERY:
+        session = None
+        if callable(status_session_loader):
+            try:
+                try:
+                    session = status_session_loader(message_text=message_text)
+                except TypeError:
+                    session = status_session_loader()
+            except Exception:  # noqa: BLE001 - loader failure must not crash
+                session = None
+        body = format_blocked_reason_response(session)
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=BLOCKED_REASON_QUERY,
+            mention_user_id=mention_user_id,
+            is_status_query=True,
+        )
+
+    if intent.intent_id == CONTINUE_EXISTING_WORK:
+        session = None
+        if callable(status_session_loader):
+            try:
+                try:
+                    session = status_session_loader(message_text=message_text)
+                except TypeError:
+                    session = status_session_loader()
+            except Exception:  # noqa: BLE001
+                session = None
+        body = format_continue_existing_response(session)
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=CONTINUE_EXISTING_WORK,
+            mention_user_id=mention_user_id,
+            is_status_query=True,
+        )
+
+    if intent.intent_id == CHANGE_DIRECTION:
+        session = None
+        if callable(status_session_loader):
+            try:
+                try:
+                    session = status_session_loader(message_text=message_text)
+                except TypeError:
+                    session = status_session_loader()
+            except Exception:  # noqa: BLE001
+                session = None
+        body = format_change_direction_response(session, user_text=message_text)
+        return EngineeringConversationResponse(
+            content=_prepend_mention(body, mention_user_id),
+            intent_id=CHANGE_DIRECTION,
+            mention_user_id=mention_user_id,
+            is_status_query=True,
+        )
+
     if intent.intent_id == CONFIRM_INTAKE:
         intake_prompt = last_proposed_prompt or message_text
         suggested = _suggest_task_type(intake_prompt)

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -908,9 +908,14 @@ _TASK_TYPE_KEYWORDS: tuple[tuple[TaskType, tuple[str, ...]], ...] = (
     ),
     (TaskType.LANDING_PAGE, ("landing", "랜딩", "marketing page", "히어로")),
     (TaskType.QA_TEST, ("regression", "회귀", "qa", "test plan", "테스트 시나리오")),
+    # P0-J (#145): PLATFORM_INFRA 키워드에서 단독으로 흔히 등장하는 "docker"
+    # 제거. Docker / Docker Compose / K8s 가 *full-stack 요청 안에서* 언급되면
+    # 본 매칭 전에 stack_detector 의 is_full_stack 가 우선해 FULL_STACK_APP 분류.
+    # 본 platform-infra 매칭은 deploy/terraform/github actions 같은 *genuine
+    # infra* 신호만 남김.
     (
         TaskType.PLATFORM_INFRA,
-        ("infra", "deploy", "ci ", " ci", "docker", "k8s", "terraform", "github action"),
+        ("infra", "deploy", "ci ", " ci", "terraform", "github action"),
     ),
     (
         TaskType.FRONTEND_FEATURE,
@@ -924,7 +929,39 @@ _TASK_TYPE_KEYWORDS: tuple[tuple[TaskType, tuple[str, ...]], ...] = (
 
 
 def _suggest_task_type(message_text: str) -> Optional[str]:
+    """Classify task type — P0-J (#145) refined.
+
+    Order:
+
+      1. **Stack detector** — if message mentions ≥2 distinct
+         application tiers (frontend / backend / database / cache /
+         queue / auth) → ``full-stack-app``. This precedes the
+         keyword table so "Docker Compose + Next.js + NestJS +
+         Postgres" never falls into ``platform-infra``.
+      2. **Stack detector — pure infra** — when *only* infra tier is
+         detected (terraform / k8s / github actions / docker alone)
+         → ``platform-infra``. Keeps the existing classification for
+         genuine infra requests.
+      3. **Keyword table** — legacy fallback for short messages.
+      4. None.
+    """
+
     normalized = _normalize(message_text)
+    if not normalized:
+        return None
+
+    try:
+        from ..agents.coding.stack_detector import detect_stacks
+    except Exception:  # noqa: BLE001 - partial install fallback
+        detect_stacks = None  # type: ignore[assignment]
+
+    if detect_stacks is not None:
+        detection = detect_stacks(message_text)
+        if detection.is_full_stack:
+            return TaskType.FULL_STACK_APP.value
+        if detection.is_infra_only:
+            return TaskType.PLATFORM_INFRA.value
+
     for task_type, keywords in _TASK_TYPE_KEYWORDS:
         for keyword in keywords:
             if keyword in normalized:
@@ -1795,6 +1832,10 @@ _REQUIRED_SOURCE_TYPES_BY_TASK_TYPE: Mapping[str, tuple[str, ...]] = {
     TaskType.BACKEND_FEATURE.value: (SOURCE_TYPE_OFFICIAL_DOCS, SOURCE_TYPE_GITHUB_ISSUE),
     TaskType.QA_TEST.value: (SOURCE_TYPE_GITHUB_ISSUE, SOURCE_TYPE_CODE_CONTEXT),
     TaskType.PLATFORM_INFRA.value: (SOURCE_TYPE_OFFICIAL_DOCS, SOURCE_TYPE_CODE_CONTEXT),
+    # P0-J (#145): full-stack 앱은 docs + code context 둘 다 권장하지만
+    # github_target / write intent 가 있으면 commit 5 의 coding bootstrap
+    # 우회가 insufficiency 를 막아줌. 본 표는 정보 제공용.
+    TaskType.FULL_STACK_APP.value: (SOURCE_TYPE_OFFICIAL_DOCS, SOURCE_TYPE_CODE_CONTEXT),
 }
 
 

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -56,6 +56,25 @@ NEEDS_CLARIFICATION = "needs_clarification"
 CONFIRM_INTAKE = "confirm_intake"
 SPLIT_TASK_PROPOSAL = "split_task_proposal"
 STATUS_DIAGNOSTIC = "status_diagnostic"
+# P0-J (#146) — read-only intents. STATUS/SESSION_*/BLOCKED_REASON/
+# CONTINUE/CHANGE_DIRECTION 류는 절대 _maybe_run_auto_collect 호출 금지
+# (hard rule). commit 7 의 build_engineering_conversation_response
+# 라우팅 분기가 이 상수들을 hard-blocklist 로 사용.
+SESSION_COUNT_QUERY = "session_count_query"
+SESSION_LIST_QUERY = "session_list_query"
+BLOCKED_REASON_QUERY = "blocked_reason_query"
+CONTINUE_EXISTING_WORK = "continue_existing_work"
+CHANGE_DIRECTION = "change_direction"
+
+# Hard-blocklist for the auto_collect path (commit 7 enforcement).
+READ_ONLY_INTENTS: tuple = (
+    STATUS_DIAGNOSTIC,
+    SESSION_COUNT_QUERY,
+    SESSION_LIST_QUERY,
+    BLOCKED_REASON_QUERY,
+    CONTINUE_EXISTING_WORK,
+    CHANGE_DIRECTION,
+)
 
 
 @dataclass(frozen=True)
@@ -538,6 +557,41 @@ def detect_engineering_intent(message_text: str) -> EngineeringIntentMatch:
             confidence="high",
         )
 
+    # P0-J (#146) — read-only intent precedence. session_count /
+    # session_list / blocked_reason / continue_existing_work /
+    # change_direction 은 STATUS_DIAGNOSTIC 보다 먼저 매칭해 절대
+    # auto_collect 경로로 흘러가지 않게 한다.
+    if _is_session_count_query(normalized):
+        return EngineeringIntentMatch(
+            intent_id=SESSION_COUNT_QUERY,
+            label="세션 개수 질의",
+            confidence="high",
+        )
+    if _is_session_list_query(normalized):
+        return EngineeringIntentMatch(
+            intent_id=SESSION_LIST_QUERY,
+            label="세션 목록 질의",
+            confidence="high",
+        )
+    if _is_blocked_reason_query(normalized):
+        return EngineeringIntentMatch(
+            intent_id=BLOCKED_REASON_QUERY,
+            label="막힘 원인 질의",
+            confidence="high",
+        )
+    if _is_change_direction(normalized):
+        return EngineeringIntentMatch(
+            intent_id=CHANGE_DIRECTION,
+            label="방향 수정",
+            confidence="high",
+        )
+    if _is_continue_existing_work(normalized):
+        return EngineeringIntentMatch(
+            intent_id=CONTINUE_EXISTING_WORK,
+            label="기존 작업 이어가기",
+            confidence="high",
+        )
+
     # Status / diagnostic intent must be checked BEFORE confirmation.
     # "왜 안 됐어?", "운영 리서치는 안 열어?", "지금 뭐 하는 중?" must
     # NOT be promoted to a new intake or read as a go-ahead.
@@ -799,6 +853,115 @@ def _is_status_diagnostic(normalized: str) -> bool:
     return any(phrase in normalized for phrase in _STATUS_DIAGNOSTIC_PHRASES)
 
 
+# ---------------------------------------------------------------------------
+# P0-J (#146) read-only intent matchers
+# ---------------------------------------------------------------------------
+
+
+_SESSION_COUNT_PHRASES = (
+    "세션 몇 개",
+    "세션 몇개",
+    "세션 작업들 몇",
+    "세션들 몇",
+    "열린 작업 몇 개",
+    "열린 작업 몇개",
+    "열린 작업들 몇",
+    "오픈 세션 몇",
+    "open session count",
+    "how many open sessions",
+    "현재 세션 수",
+    "활성 세션 수",
+    "진행 중인 세션 몇",
+    "진행 중인 세션이 몇",
+)
+
+_SESSION_LIST_PHRASES = (
+    "세션 목록",
+    "세션 리스트",
+    "오픈 세션 뭐",
+    "오픈 세션 뭐뭐",
+    "열린 세션 목록",
+    "열린 작업 목록",
+    "진행 중인 세션 목록",
+    "open session list",
+    "list open sessions",
+    "세션 다 보여줘",
+    "열린 작업 보여줘",
+)
+
+_BLOCKED_REASON_PHRASES = (
+    "왜 멈췄",
+    "왜 멈춰",
+    "뭐가 막혔",
+    "뭐가 막혀",
+    "왜 안 됐",
+    "왜 안돼",
+    "왜 안 돼",
+    "왜 안되",
+    "왜 막혔",
+    "왜 막혀",
+    "어디서 막혔",
+    "stuck",
+    "blocked",
+    "blocking",
+    "왜 진행 안",
+    "왜 진척 안",
+)
+
+_CONTINUE_EXISTING_PHRASES = (
+    "이전 작업 이어",
+    "이어서 해",
+    "이어서 진행",
+    "이어서 작업",
+    "그 세션 계속",
+    "그 작업 계속",
+    "계속 진행해",
+    "continue existing",
+    "resume session",
+    "기존 세션 이어",
+    "그 세션 이어",
+    "원래 작업 이어",
+)
+
+_CHANGE_DIRECTION_PHRASES = (
+    "방향 수정",
+    "방향 바꿔",
+    "방향 변경",
+    "직진 말고",
+    "리서치 말고 구현",
+    "검색 말고",
+    "조사 말고 구현",
+    "자료 추가가 아니라 방향",
+    "자료 추가 아니라 방향",
+    "그쪽 말고",
+    "방향 틀어",
+    "redirect",
+    "change direction",
+    "pivot",
+    "다른 쪽으로",
+)
+
+
+def _is_session_count_query(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _SESSION_COUNT_PHRASES)
+
+
+def _is_session_list_query(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _SESSION_LIST_PHRASES)
+
+
+def _is_blocked_reason_query(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _BLOCKED_REASON_PHRASES)
+
+
+def _is_continue_existing_work(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _CONTINUE_EXISTING_PHRASES)
+
+
+def _is_change_direction(normalized: str) -> bool:
+    return any(phrase in normalized for phrase in _CHANGE_DIRECTION_PHRASES)
+
+
 _GENERAL_HELP_PHRASES = (
     "engineering-agent",
     "엔지니어링 에이전트",
@@ -972,6 +1135,184 @@ def _suggest_task_type(message_text: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 # Response body formatters
 # ---------------------------------------------------------------------------
+
+
+def _open_states_set() -> set:
+    """States considered 'open' for session count/list responses."""
+
+    return {"new", "queued", "in_progress", "needs_research", "awaiting_review"}
+
+
+def format_session_count_response(session_lister=None) -> str:
+    """Render a count-only answer for the session_count_query intent.
+
+    *session_lister* is the injected ``list_sessions``-style callable
+    (production: ``agents.workflow_state.list_sessions``). Returns
+    a single-line Korean answer.
+    """
+
+    sessions = _safe_list_sessions(session_lister)
+    if sessions is None:
+        return "ℹ️ 세션 카운트를 조회할 수 없어요 (workflow state 미연결)."
+    open_set = _open_states_set()
+    open_count = sum(
+        1
+        for s in sessions
+        if _coerce_str(getattr(getattr(s, "state", None), "value", getattr(s, "state", None)))
+        in open_set
+    )
+    total = len(sessions)
+    return f"현재 열려 있는 engineering-agent 세션은 **{open_count}개** 입니다 (전체 캐시 {total}개)."
+
+
+def format_session_list_response(
+    session_lister=None, *, limit: int = 10
+) -> str:
+    """Render a list of open sessions for the session_list_query intent.
+
+    Shows id / state / task_type / updated_at + thread/PR if present.
+    """
+
+    sessions = _safe_list_sessions(session_lister)
+    if sessions is None:
+        return "ℹ️ 세션 목록을 조회할 수 없어요 (workflow state 미연결)."
+    open_set = _open_states_set()
+    rows: list[str] = []
+    for s in sessions:
+        state_value = _coerce_str(
+            getattr(getattr(s, "state", None), "value", getattr(s, "state", None))
+        )
+        if state_value not in open_set:
+            continue
+        sid = _coerce_str(getattr(s, "session_id", None)) or "?"
+        task = _coerce_str(getattr(s, "task_type", None)) or "?"
+        updated = _coerce_str(getattr(s, "updated_at", None)) or ""
+        extra = getattr(s, "extra", None) or {}
+        thread_id = (
+            extra.get("research_forum_thread_id")
+            or extra.get("forum_thread_id")
+            or getattr(s, "thread_id", None)
+        )
+        pr_n = extra.get("pull_request_number")
+        anchors: list[str] = []
+        if thread_id is not None:
+            anchors.append(f"thread `{thread_id}`")
+        if pr_n is not None:
+            anchors.append(f"PR #{pr_n}")
+        anchor_text = (" · " + " · ".join(anchors)) if anchors else ""
+        rows.append(
+            f"- `{sid}` · {state_value} · {task} · {updated}{anchor_text}"
+        )
+        if len(rows) >= limit:
+            break
+    if not rows:
+        return "현재 열려 있는 engineering-agent 세션이 없어요."
+    return "현재 열려 있는 engineering-agent 세션 목록:\n\n" + "\n".join(rows)
+
+
+def format_blocked_reason_response(
+    session: Optional[Any] = None,
+) -> str:
+    """Surface the blocked reason / signals for the active session.
+
+    Reuses ``diagnose_session`` to derive signals + tracking blocked
+    reason. When no session is provided, returns a hint to specify.
+    """
+
+    if session is None:
+        return (
+            "현재 채널에 매칭되는 열린 세션이 없어 막힘 원인을 특정할 수 없어요.\n"
+            "확인할 session id 를 알려주시거나, 이어갈 thread 안에서 다시 말씀해 주세요."
+        )
+    try:
+        from ..agents.lifecycle.session_status import diagnose_session
+
+        report = diagnose_session(session)
+    except Exception:  # noqa: BLE001
+        report = None
+
+    sid = _coerce_str(getattr(session, "session_id", None)) or "?"
+    lines: list[str] = [f"세션 `{sid}` 의 막힘 원인 진단:"]
+
+    blocked_reason = None
+    extra = getattr(session, "extra", None) or {}
+    if isinstance(extra, Mapping):
+        blocked_reason = _coerce_str(extra.get("tracking_blocked_reason"))
+    if blocked_reason:
+        lines.append(f"- tracking blocked: {blocked_reason}")
+    if report is not None and getattr(report, "signals", None):
+        for signal in report.signals[:5]:
+            code = getattr(signal, "code", "?")
+            title = getattr(signal, "title", "")
+            detail = getattr(signal, "detail", "")
+            severity = getattr(signal, "severity", "?")
+            tail = f" — {detail}" if detail else ""
+            lines.append(f"- [{severity}] {code}: {title}{tail}")
+    if len(lines) == 1:
+        lines.append("- 감지된 막힘 신호가 없어요. 상태는 정상 흐름으로 보여요.")
+    return "\n".join(lines)
+
+
+def format_continue_existing_response(session: Optional[Any] = None) -> str:
+    """Ack continue_existing_work — do NOT create a new intake."""
+
+    if session is None:
+        return (
+            "이어갈 세션을 찾지 못했어요. session id 또는 thread 를 명시해 주세요. "
+            "(새 세션을 만들지 않고 기존 세션 위에서 진행합니다.)"
+        )
+    sid = _coerce_str(getattr(session, "session_id", None)) or "?"
+    state = _coerce_str(
+        getattr(getattr(session, "state", None), "value", getattr(session, "state", None))
+    ) or "?"
+    return (
+        f"✅ 세션 `{sid}` 을 이어서 진행할게요. (state: {state})\n"
+        "새 intake / research thread 를 만들지 않습니다."
+    )
+
+
+def format_change_direction_response(
+    session: Optional[Any] = None,
+    *,
+    user_text: str = "",
+) -> str:
+    """Ack change_direction — same session update, no new intake."""
+
+    sid = _coerce_str(getattr(session, "session_id", None)) if session else None
+    head = "✅ 방향 수정 신호를 받았어요."
+    sid_line = f" 세션 `{sid}` 위에서 진행 방향을 갱신합니다." if sid else ""
+    note = (
+        f"\n새 받아온 방향 메모: {user_text.strip()[:200]}" if user_text else ""
+    )
+    return (
+        f"{head}{sid_line}\n"
+        "새 intake / research thread 를 만들지 않고 기존 세션의 prompt/scope 만 "
+        "업데이트합니다." + note
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals — list_sessions helper
+# ---------------------------------------------------------------------------
+
+
+def _safe_list_sessions(lister):
+    """Call the injected lister; return None on failure (caller surfaces hint)."""
+
+    if lister is None:
+        try:
+            from ..agents.workflow_state import list_sessions as _list
+
+            lister = _list
+        except Exception:  # noqa: BLE001
+            return None
+    try:
+        try:
+            return tuple(lister(limit=100))
+        except TypeError:
+            return tuple(lister())
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _format_general_help() -> str:

--- a/tests/agents/coding/test_coding_bootstrap.py
+++ b/tests/agents/coding/test_coding_bootstrap.py
@@ -1,0 +1,162 @@
+"""P0-J commit 5 — coding bootstrap insufficiency-bypass tests."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.coding_bootstrap import (
+    CodingBootstrap,
+    STATUS_BYPASS,
+    STATUS_NOT_CODING_REQUEST,
+    STATUS_REQUIRES_USER_INPUT,
+    evaluate_coding_bootstrap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bypass — naver-search-clone scenario
+# ---------------------------------------------------------------------------
+
+
+class BypassScenarioTests(unittest.TestCase):
+    def test_naver_search_clone_via_user_links(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text=(
+                "Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+                "회원가입/로그인/검색 앱 구현해줘"
+            ),
+            user_links=(
+                "https://github.com/yule-studio/naver-search-clone/issues/1",
+            ),
+        )
+        self.assertEqual(result.status, STATUS_BYPASS)
+        self.assertTrue(result.bypass_insufficiency)
+        self.assertTrue(result.code_context_pending)
+        self.assertTrue(result.has_github_repo)
+        self.assertTrue(result.write_intent)
+        self.assertIn("Next.js", result.stacks_mentioned)
+        # At least 4 docs seeded (Next.js / NestJS / Postgres / Docker Compose).
+        self.assertGreaterEqual(len(result.seeded_docs), 4)
+
+    def test_bypass_via_extra_github_target(self) -> None:
+        # When the gateway already parsed github_target into session.extra
+        # (P0-H stage 2 wiring), bootstrap reads from there.
+        result = evaluate_coding_bootstrap(
+            message_text="Next.js + Postgres 회원가입 화면 만들어줘",
+            user_links=(),
+            existing_extra={
+                "github_target": {
+                    "kind": "issue",
+                    "owner": "foo",
+                    "repo": "bar",
+                    "number": 1,
+                }
+            },
+        )
+        self.assertEqual(result.status, STATUS_BYPASS)
+        self.assertTrue(result.bypass_insufficiency)
+
+
+# ---------------------------------------------------------------------------
+# Requires user input — partial signals
+# ---------------------------------------------------------------------------
+
+
+class PartialSignalTests(unittest.TestCase):
+    def test_repo_without_stack(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text="이거 구현해줘",  # write intent but no stack
+            user_links=("https://github.com/foo/bar/issues/1",),
+        )
+        self.assertEqual(result.status, STATUS_REQUIRES_USER_INPUT)
+        self.assertFalse(result.bypass_insufficiency)
+        self.assertIn("stack mention", result.reason or "")
+
+    def test_stack_without_repo(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text="Next.js + Postgres 만들어줘",
+            user_links=(),
+        )
+        self.assertEqual(result.status, STATUS_REQUIRES_USER_INPUT)
+        self.assertIn("repo target", result.reason or "")
+
+    def test_stack_and_repo_without_write_intent(self) -> None:
+        # No write verb — likely a review request, not a build request.
+        result = evaluate_coding_bootstrap(
+            message_text="Next.js + Postgres 코드 검토해줘",
+            user_links=("https://github.com/foo/bar/issues/1",),
+        )
+        self.assertEqual(result.status, STATUS_REQUIRES_USER_INPUT)
+        self.assertIn("write intent", result.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Not a coding request
+# ---------------------------------------------------------------------------
+
+
+class NotCodingRequestTests(unittest.TestCase):
+    def test_pure_status_question(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text="지금 뭐하고 있어?",
+            user_links=(),
+        )
+        self.assertEqual(result.status, STATUS_NOT_CODING_REQUEST)
+        self.assertFalse(result.bypass_insufficiency)
+
+    def test_empty_message(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text="",
+            user_links=(),
+        )
+        self.assertEqual(result.status, STATUS_NOT_CODING_REQUEST)
+
+
+# ---------------------------------------------------------------------------
+# Summary line + round trip
+# ---------------------------------------------------------------------------
+
+
+class SummaryLineTests(unittest.TestCase):
+    def test_bypass_summary(self) -> None:
+        result = CodingBootstrap(
+            status=STATUS_BYPASS,
+            bypass_insufficiency=True,
+            code_context_pending=True,
+            stacks_mentioned=("Next.js", "Postgres"),
+            seeded_docs=("Next.js", "PostgreSQL"),
+        )
+        line = result.status_summary_line()
+        self.assertIn("🚀", line)
+        self.assertIn("우회", line)
+        self.assertIn("2 stacks", line)
+
+    def test_requires_user_input_summary(self) -> None:
+        result = CodingBootstrap(
+            status=STATUS_REQUIRES_USER_INPUT,
+            bypass_insufficiency=False,
+            code_context_pending=False,
+        )
+        self.assertIn("📝", result.status_summary_line())
+
+
+class RoundTripTests(unittest.TestCase):
+    def test_to_dict_includes_all_signals(self) -> None:
+        result = evaluate_coding_bootstrap(
+            message_text="Next.js + Postgres 만들어줘",
+            user_links=("https://github.com/foo/bar/issues/1",),
+        )
+        payload = result.to_dict()
+        self.assertEqual(payload["status"], STATUS_BYPASS)
+        self.assertTrue(payload["bypass_insufficiency"])
+        self.assertTrue(payload["code_context_pending"])
+        self.assertGreaterEqual(len(payload["seeded_docs"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/coding/test_official_docs_seed.py
+++ b/tests/agents/coding/test_official_docs_seed.py
@@ -1,0 +1,144 @@
+"""P0-J commit 3 — official docs seed tests."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.official_docs_seed import (
+    OfficialDocsSource,
+    known_canonicals,
+    seed_official_docs,
+)
+from yule_orchestrator.agents.coding.stack_detector import detect_stacks
+
+
+# ---------------------------------------------------------------------------
+# Core seed entries — naver-search-clone scenario
+# ---------------------------------------------------------------------------
+
+
+class NaverSearchCloneSeedTests(unittest.TestCase):
+    def test_full_stack_detection_seeds_core_docs(self) -> None:
+        text = "Next.js + NestJS + PostgreSQL + Docker Compose 회원가입/로그인/검색"
+        detected = detect_stacks(text)
+        seeds = seed_official_docs(detected.stacks)
+        canonicals = {s.canonical for s in seeds}
+        # Core 4 stacks must all be seeded. (Docker alias also fires
+        # inside "Docker Compose" — that's expected; both seeds are
+        # informative for the gateway.)
+        for required in ("Next.js", "NestJS", "PostgreSQL", "Docker Compose"):
+            self.assertIn(required, canonicals, required)
+        self.assertGreaterEqual(len(seeds), 4)
+
+    def test_nextjs_url_pinned(self) -> None:
+        seeds = seed_official_docs(("Next.js",))
+        self.assertEqual(seeds[0].url, "https://nextjs.org/docs")
+
+    def test_nestjs_url_pinned(self) -> None:
+        seeds = seed_official_docs(("NestJS",))
+        self.assertEqual(seeds[0].url, "https://docs.nestjs.com")
+
+    def test_postgresql_url_pinned(self) -> None:
+        seeds = seed_official_docs(("PostgreSQL",))
+        self.assertEqual(seeds[0].url, "https://www.postgresql.org/docs/current/")
+
+    def test_docker_compose_url_pinned(self) -> None:
+        seeds = seed_official_docs(("Docker Compose",))
+        self.assertEqual(seeds[0].url, "https://docs.docker.com/compose/")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — empty / unknown / dedup
+# ---------------------------------------------------------------------------
+
+
+class SeedEdgeCaseTests(unittest.TestCase):
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(seed_official_docs(()), ())
+
+    def test_unknown_canonical_silently_skipped(self) -> None:
+        seeds = seed_official_docs(("NotAStack", "Next.js"))
+        self.assertEqual(len(seeds), 1)
+        self.assertEqual(seeds[0].canonical, "Next.js")
+
+    def test_duplicate_canonical_deduped(self) -> None:
+        seeds = seed_official_docs(("Next.js", "Next.js"))
+        self.assertEqual(len(seeds), 1)
+
+    def test_order_preserved(self) -> None:
+        seeds = seed_official_docs(("PostgreSQL", "Next.js", "Docker"))
+        self.assertEqual(
+            [s.canonical for s in seeds],
+            ["PostgreSQL", "Next.js", "Docker"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lexicon coverage
+# ---------------------------------------------------------------------------
+
+
+class LexiconCoverageTests(unittest.TestCase):
+    """Most lexicon entries should have a docs seed (>= 30 covered)."""
+
+    def test_minimum_canonical_count(self) -> None:
+        # As of P0-J: 37 canonicals.
+        self.assertGreaterEqual(len(known_canonicals()), 30)
+
+    def test_core_stacks_all_present(self) -> None:
+        core = (
+            "Next.js",
+            "NestJS",
+            "PostgreSQL",
+            "Docker",
+            "Docker Compose",
+            "React",
+            "FastAPI",
+            "Django",
+            "Kubernetes",
+            "GitHub Actions",
+            "Redis",
+            "JWT",
+            "OAuth",
+        )
+        canonicals = set(known_canonicals())
+        for name in core:
+            self.assertIn(name, canonicals, name)
+
+    def test_all_urls_start_with_https(self) -> None:
+        seeds = seed_official_docs(known_canonicals())
+        for entry in seeds:
+            self.assertTrue(
+                entry.url.startswith("https://"),
+                f"{entry.canonical} url not https: {entry.url}",
+            )
+
+    def test_all_entries_have_source_type_official_docs(self) -> None:
+        seeds = seed_official_docs(known_canonicals())
+        for entry in seeds:
+            self.assertEqual(entry.source_type, "official_docs")
+
+
+# ---------------------------------------------------------------------------
+# OfficialDocsSource shape
+# ---------------------------------------------------------------------------
+
+
+class SourceShapeTests(unittest.TestCase):
+    def test_all_required_fields(self) -> None:
+        seed = seed_official_docs(("Next.js",))[0]
+        self.assertIsInstance(seed, OfficialDocsSource)
+        self.assertTrue(seed.canonical)
+        self.assertTrue(seed.title)
+        self.assertTrue(seed.url)
+        self.assertTrue(seed.domain)
+        self.assertTrue(seed.snippet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/coding/test_stack_detector.py
+++ b/tests/agents/coding/test_stack_detector.py
@@ -1,0 +1,147 @@
+"""P0-J commit 2 — stack lexicon + full-stack detector tests."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.stack_detector import (
+    StackDetection,
+    TIER_AUTH,
+    TIER_BACKEND,
+    TIER_DATABASE,
+    TIER_FRONTEND,
+    TIER_INFRA,
+    classify_full_stack,
+    detect_stacks,
+    has_write_intent,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_stacks
+# ---------------------------------------------------------------------------
+
+
+class DetectStacksTests(unittest.TestCase):
+    def test_empty_input(self) -> None:
+        d = detect_stacks("")
+        self.assertEqual(d.stacks, ())
+        self.assertFalse(d.has_any)
+        self.assertFalse(d.is_full_stack)
+
+    def test_naver_search_clone_full_stack_scenario(self) -> None:
+        text = (
+            "Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+            "회원가입/로그인/검색 앱 구현"
+        )
+        d = detect_stacks(text)
+        self.assertIn("Next.js", d.stacks)
+        self.assertIn("NestJS", d.stacks)
+        self.assertIn("PostgreSQL", d.stacks)
+        self.assertIn("Docker Compose", d.stacks)
+        # Distinct application tiers — frontend / backend / database.
+        self.assertIn(TIER_FRONTEND, d.tiers_present)
+        self.assertIn(TIER_BACKEND, d.tiers_present)
+        self.assertIn(TIER_DATABASE, d.tiers_present)
+        self.assertIn(TIER_INFRA, d.tiers_present)
+        self.assertTrue(d.is_full_stack)
+        # Critical: NOT infra-only — has frontend + backend + db too.
+        self.assertFalse(d.is_infra_only)
+
+    def test_pure_infra_request_classified_correctly(self) -> None:
+        d = detect_stacks("terraform module + github actions only")
+        self.assertIn("Terraform", d.stacks)
+        self.assertIn("GitHub Actions", d.stacks)
+        self.assertTrue(d.is_infra_only)
+        self.assertFalse(d.is_full_stack)
+
+    def test_docker_alone_is_infra_only(self) -> None:
+        d = detect_stacks("docker 컨테이너 설정")
+        self.assertEqual(d.stacks, ("Docker",))
+        self.assertTrue(d.is_infra_only)
+        self.assertFalse(d.is_full_stack)
+
+    def test_react_only_is_not_full_stack(self) -> None:
+        d = detect_stacks("React 컴포넌트 리팩터링")
+        self.assertEqual(d.stacks, ("React",))
+        self.assertFalse(d.is_full_stack)
+
+    def test_react_plus_postgres_is_full_stack(self) -> None:
+        d = detect_stacks("React 화면 + PostgreSQL 스키마")
+        self.assertTrue(d.is_full_stack)
+
+
+# ---------------------------------------------------------------------------
+# Alias matching
+# ---------------------------------------------------------------------------
+
+
+class AliasMatchingTests(unittest.TestCase):
+    def test_nextjs_alias_variants(self) -> None:
+        for alias in ("Next.js", "nextjs", "next js"):
+            d = detect_stacks(alias)
+            self.assertEqual(d.stacks, ("Next.js",))
+
+    def test_nestjs_alias_variants(self) -> None:
+        for alias in ("Nest.js", "NestJS", "nest js"):
+            d = detect_stacks(alias)
+            self.assertEqual(d.stacks, ("NestJS",))
+
+    def test_postgresql_alias_variants(self) -> None:
+        for alias in ("PostgreSQL", "postgres", "psql"):
+            d = detect_stacks(alias)
+            self.assertEqual(d.stacks, ("PostgreSQL",))
+
+    def test_docker_compose_alias_variants(self) -> None:
+        for alias in ("Docker Compose", "docker-compose"):
+            d = detect_stacks(alias)
+            self.assertIn("Docker Compose", d.stacks)
+
+
+# ---------------------------------------------------------------------------
+# classify_full_stack convenience
+# ---------------------------------------------------------------------------
+
+
+class ClassifyFullStackTests(unittest.TestCase):
+    def test_full_stack_combo_true(self) -> None:
+        self.assertTrue(
+            classify_full_stack(
+                "Next.js + NestJS + PostgreSQL + Docker Compose 회원가입/로그인"
+            )
+        )
+
+    def test_infra_only_false(self) -> None:
+        self.assertFalse(classify_full_stack("docker compose stack 만"))
+
+    def test_single_tier_false(self) -> None:
+        self.assertFalse(classify_full_stack("React 화면만"))
+
+
+# ---------------------------------------------------------------------------
+# has_write_intent
+# ---------------------------------------------------------------------------
+
+
+class HasWriteIntentTests(unittest.TestCase):
+    def test_build_korean(self) -> None:
+        self.assertTrue(has_write_intent("회원가입 화면 만들어줘"))
+
+    def test_implement_english(self) -> None:
+        self.assertTrue(has_write_intent("implement the search endpoint"))
+
+    def test_review_intent_excluded(self) -> None:
+        self.assertFalse(has_write_intent("이 코드 검토해줘"))
+
+    def test_review_overrides_build_keyword(self) -> None:
+        # "리뷰" 가 명시되면 write_intent 가 아님 (defense-in-depth)
+        self.assertFalse(has_write_intent("만들어진 거 리뷰해줘"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_readonly_intents_p0j.py
+++ b/tests/discord/test_readonly_intents_p0j.py
@@ -1,0 +1,223 @@
+"""P0-J commit 7 — read-only intent hard-rule regression (#146).
+
+Verifies that the 5 new intents (session_count / session_list /
+blocked_reason / continue_existing_work / change_direction):
+
+  * are classified correctly;
+  * skip the auto_collect path entirely;
+  * never emit ``ready_to_intake=True``;
+  * never create a new research/intake.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.discord.engineering_conversation import (
+    BLOCKED_REASON_QUERY,
+    CHANGE_DIRECTION,
+    CONTINUE_EXISTING_WORK,
+    READ_ONLY_INTENTS,
+    SESSION_COUNT_QUERY,
+    SESSION_LIST_QUERY,
+    STATUS_DIAGNOSTIC,
+    build_engineering_conversation_response,
+    detect_engineering_intent,
+)
+
+
+# ---------------------------------------------------------------------------
+# Intent classification
+# ---------------------------------------------------------------------------
+
+
+class IntentClassificationTests(unittest.TestCase):
+    def test_session_count_phrases(self) -> None:
+        for text in (
+            "지금 열려 있는 세션 작업들 몇 개 있어?",
+            "열린 작업 몇 개야?",
+            "오픈 세션 몇개 있어",
+            "활성 세션 수 알려줘",
+            "how many open sessions",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    detect_engineering_intent(text).intent_id,
+                    SESSION_COUNT_QUERY,
+                )
+
+    def test_session_list_phrases(self) -> None:
+        for text in (
+            "오픈 세션 뭐뭐 있어?",
+            "현재 진행 중인 세션 목록 보여줘",
+            "세션 리스트 보여줘",
+            "list open sessions",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    detect_engineering_intent(text).intent_id,
+                    SESSION_LIST_QUERY,
+                )
+
+    def test_blocked_reason_phrases(self) -> None:
+        for text in (
+            "왜 멈췄어?",
+            "뭐가 막혔어?",
+            "왜 안 됐어?",
+            "stuck",
+            "왜 진행 안 되고 있어?",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    detect_engineering_intent(text).intent_id,
+                    BLOCKED_REASON_QUERY,
+                )
+
+    def test_continue_existing_work_phrases(self) -> None:
+        for text in (
+            "이전 작업 이어서 해줘",
+            "그 세션 계속 진행해",
+            "기존 세션 이어가자",
+            "resume session please",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    detect_engineering_intent(text).intent_id,
+                    CONTINUE_EXISTING_WORK,
+                )
+
+    def test_change_direction_phrases(self) -> None:
+        for text in (
+            "자료 추가가 아니라 방향 수정이야",
+            "검색 말고 로그인부터 먼저 해",
+            "리서치 말고 구현으로 넘겨",
+            "그쪽 말고 다른 쪽으로",
+            "pivot 해줘",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    detect_engineering_intent(text).intent_id,
+                    CHANGE_DIRECTION,
+                )
+
+    def test_read_only_intents_constant_complete(self) -> None:
+        self.assertIn(STATUS_DIAGNOSTIC, READ_ONLY_INTENTS)
+        self.assertIn(SESSION_COUNT_QUERY, READ_ONLY_INTENTS)
+        self.assertIn(SESSION_LIST_QUERY, READ_ONLY_INTENTS)
+        self.assertIn(BLOCKED_REASON_QUERY, READ_ONLY_INTENTS)
+        self.assertIn(CONTINUE_EXISTING_WORK, READ_ONLY_INTENTS)
+        self.assertIn(CHANGE_DIRECTION, READ_ONLY_INTENTS)
+
+
+# ---------------------------------------------------------------------------
+# Hard rule — no auto_collect / no intake for read-only intents
+# ---------------------------------------------------------------------------
+
+
+class NoAutoCollectHardRuleTests(unittest.TestCase):
+    """Read-only intents must NEVER call _maybe_run_auto_collect."""
+
+    def _assert_no_collect_called(self, text: str) -> None:
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect"
+        ) as mock_collect:
+            response = build_engineering_conversation_response(text)
+        # Hard rule: auto_collect must not have been called.
+        self.assertEqual(
+            mock_collect.call_count,
+            0,
+            f"auto_collect fired for {text!r} (intent={response.intent_id})",
+        )
+        # Read-only intent: never create new intake.
+        self.assertFalse(response.ready_to_intake)
+        # Read-only intent: is_status_query=True so router short-circuits.
+        self.assertTrue(response.is_status_query)
+        # Intent matches one of READ_ONLY_INTENTS.
+        self.assertIn(response.intent_id, READ_ONLY_INTENTS)
+
+    def test_session_count_query_no_auto_collect(self) -> None:
+        self._assert_no_collect_called(
+            "지금 열려 있는 세션 작업들 몇 개 있어?"
+        )
+
+    def test_session_list_query_no_auto_collect(self) -> None:
+        self._assert_no_collect_called("오픈 세션 뭐뭐 있어?")
+
+    def test_blocked_reason_query_no_auto_collect(self) -> None:
+        self._assert_no_collect_called("왜 멈췄어?")
+
+    def test_continue_existing_work_no_auto_collect(self) -> None:
+        self._assert_no_collect_called("이전 작업 이어서 진행")
+
+    def test_change_direction_no_auto_collect(self) -> None:
+        self._assert_no_collect_called(
+            "자료 추가가 아니라 방향 수정이야"
+        )
+
+    def test_status_diagnostic_no_auto_collect(self) -> None:
+        # Sanity — existing STATUS_DIAGNOSTIC stays in the blocklist.
+        self._assert_no_collect_called("지금 뭐 하는 중이야?")
+
+
+# ---------------------------------------------------------------------------
+# Genuine new work still uses auto_collect (no false negatives)
+# ---------------------------------------------------------------------------
+
+
+class GenuineNewWorkStillRunsCollectTests(unittest.TestCase):
+    """An actual substantive new request must still go through intake/coding path."""
+
+    def test_intake_candidate_still_runs_auto_collect(self) -> None:
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect",
+            return_value=None,
+        ) as mock_collect:
+            response = build_engineering_conversation_response(
+                "회원가입 페이지 만들어줘 — Next.js + Postgres 로",
+                user_links=("https://github.com/foo/bar/issues/1",),
+            )
+        # auto_collect was called (or attempted).
+        self.assertGreaterEqual(mock_collect.call_count, 1)
+        # NOT read-only.
+        self.assertNotIn(response.intent_id, READ_ONLY_INTENTS)
+
+
+# ---------------------------------------------------------------------------
+# Response body sanity
+# ---------------------------------------------------------------------------
+
+
+class ResponseBodySanityTests(unittest.TestCase):
+    def test_session_count_response_includes_count_phrase(self) -> None:
+        response = build_engineering_conversation_response(
+            "지금 열려 있는 세션 몇 개?"
+        )
+        self.assertIn("세션", response.content)
+
+    def test_blocked_reason_with_no_session_yields_hint(self) -> None:
+        response = build_engineering_conversation_response("왜 멈췄어?")
+        self.assertIn("막힘", response.content)
+
+    def test_continue_existing_with_no_session_yields_hint(self) -> None:
+        response = build_engineering_conversation_response(
+            "이전 작업 이어서 해"
+        )
+        # Hint about new intake not being created.
+        self.assertIn("새 세션을 만들지 않고", response.content)
+
+    def test_change_direction_acknowledges_without_new_intake(self) -> None:
+        response = build_engineering_conversation_response(
+            "리서치 말고 구현으로 넘겨"
+        )
+        self.assertIn("새 intake", response.content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_status_diagnostic.py
+++ b/tests/discord/test_status_diagnostic.py
@@ -54,12 +54,13 @@ def _session(**overrides: Any) -> WorkflowSession:
 
 class StatusDiagnosticIntentDetectionTests(unittest.TestCase):
     def test_detects_korean_research_status_questions(self) -> None:
+        # P0-J (#146): "왜 안 됐어?" / "왜 멈췄어" / "뭐가 막혔어" 는 더
+        # 구체적인 BLOCKED_REASON_QUERY intent 로 분리됨. 본 test 는
+        # 그 외 status_diagnostic 케이스만 보호.
         cases = (
             "운영 리서치는 안 열어?",
             "운영-리서치는 왜 안 열렸어?",
             "리서치 왜 실패했어?",
-            "왜 안 됐어?",
-            "왜 멈췄어",
             "지금 뭐 하는 중이야?",
             "현재 상태 알려줘",
             "진행 상황 어떻게 되고 있어?",
@@ -73,14 +74,14 @@ class StatusDiagnosticIntentDetectionTests(unittest.TestCase):
 
     def test_detects_expanded_phrases_added_in_polish(self) -> None:
         # New phrasings the user asked us to cover; each must NOT be
-        # promoted to a new intake or read as a confirm phrase.
+        # promoted to a new intake or read as a confirm phrase. P0-J
+        # (#146): "뭐가 막혔어" / "왜 안 열렸어" 류는 BLOCKED_REASON_QUERY
+        # 로 더 구체화 — 별도 test 에서 검증.
         cases = (
             "어떻게 됐어?",
             "어떻게 되고 있어?",
             "진행상황 좀",
             "어디까지 갔어?",
-            "뭐가 막혔어",
-            "왜 안 열렸어",
             "운영-리서치 왜 안 열려",
             "상태 체크 좀",
             "다시 한번 확인해줘",
@@ -334,8 +335,11 @@ class BuildResponseStatusQueryTests(unittest.TestCase):
         self.assertIn("열린 engineering-agent 세션이 보이지 않아요", response.content)
 
     def test_status_query_with_no_loader_falls_back_to_no_session(self) -> None:
+        # P0-J (#146): "왜 안 됐어?" 는 BLOCKED_REASON_QUERY 로 분리됨.
+        # 본 test 는 status_diagnostic 분기 자체 — pure status phrase 로
+        # 유지하면서 loader 없을 때 fall-back 동작 검증.
         response = build_engineering_conversation_response(
-            "왜 안 됐어?",
+            "지금 뭐 하는 중이야?",
             status_session_loader=None,
         )
         self.assertTrue(response.is_status_query)

--- a/tests/engineering/test_naver_search_clone_e2e_p0j.py
+++ b/tests/engineering/test_naver_search_clone_e2e_p0j.py
@@ -1,0 +1,203 @@
+"""P0-J commit 8 — naver-search-clone e2e scenario (#145).
+
+End-to-end: when the user pastes the exact bug-report message —
+``Next.js + NestJS + PostgreSQL + Docker Compose 회원가입/로그인/검색
+앱 구현해줘`` with a GitHub issue URL — the gateway must:
+
+  1. classify task as `full-stack-app` (NOT platform-infra).
+  2. NOT surface the "자료 부족" insufficiency follow-up.
+  3. seed official docs for Next.js / NestJS / PostgreSQL / Docker Compose.
+  4. emit a coding-bootstrap acknowledgement that proceeds to handoff.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.coding_bootstrap import (
+    STATUS_BYPASS,
+    evaluate_coding_bootstrap,
+)
+from yule_orchestrator.agents.coding.official_docs_seed import (
+    seed_official_docs,
+)
+from yule_orchestrator.agents.coding.stack_detector import (
+    detect_stacks,
+    has_write_intent,
+)
+from yule_orchestrator.discord.engineering_conversation import (
+    TASK_INTAKE_CANDIDATE,
+    _suggest_task_type,
+    build_engineering_conversation_response,
+)
+
+
+NAVER_SEARCH_CLONE_TEXT = (
+    "Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+    "회원가입/로그인/검색 앱 구현해줘"
+)
+ISSUE_URL = "https://github.com/yule-studio/naver-search-clone/issues/1"
+
+
+# ---------------------------------------------------------------------------
+# Per-component checks
+# ---------------------------------------------------------------------------
+
+
+class StackDetectionTests(unittest.TestCase):
+    def test_full_stack_detected(self) -> None:
+        detection = detect_stacks(NAVER_SEARCH_CLONE_TEXT)
+        self.assertTrue(detection.is_full_stack)
+        self.assertFalse(detection.is_infra_only)
+        for required in ("Next.js", "NestJS", "PostgreSQL", "Docker Compose"):
+            self.assertIn(required, detection.stacks)
+
+    def test_write_intent_detected(self) -> None:
+        self.assertTrue(has_write_intent(NAVER_SEARCH_CLONE_TEXT))
+
+
+class SuggestTaskTypeTests(unittest.TestCase):
+    def test_classified_as_full_stack_app(self) -> None:
+        task_type = _suggest_task_type(NAVER_SEARCH_CLONE_TEXT)
+        self.assertEqual(task_type, "full-stack-app")
+        self.assertNotEqual(task_type, "platform-infra")
+
+
+class CodingBootstrapTests(unittest.TestCase):
+    def test_bypass_status_with_issue_url(self) -> None:
+        outcome = evaluate_coding_bootstrap(
+            message_text=NAVER_SEARCH_CLONE_TEXT,
+            user_links=(ISSUE_URL,),
+        )
+        self.assertEqual(outcome.status, STATUS_BYPASS)
+        self.assertTrue(outcome.bypass_insufficiency)
+        self.assertTrue(outcome.code_context_pending)
+        # All four core stack docs seeded.
+        self.assertGreaterEqual(len(outcome.seeded_docs), 4)
+
+
+class OfficialDocsSeedTests(unittest.TestCase):
+    def test_core_4_docs_seeded(self) -> None:
+        seeds = seed_official_docs(
+            ("Next.js", "NestJS", "PostgreSQL", "Docker Compose")
+        )
+        urls = {s.url for s in seeds}
+        self.assertIn("https://nextjs.org/docs", urls)
+        self.assertIn("https://docs.nestjs.com", urls)
+        self.assertIn("https://www.postgresql.org/docs/current/", urls)
+        self.assertIn("https://docs.docker.com/compose/", urls)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end conversation layer behavior
+# ---------------------------------------------------------------------------
+
+
+class NaverSearchCloneEndToEndTests(unittest.TestCase):
+    """The bug-report scenario, simulated through the conversation layer."""
+
+    def test_response_is_task_intake_candidate_not_platform_infra(self) -> None:
+        # We don't need a real collector — the conversation layer must
+        # NOT trip the platform-infra classification path or the
+        # NEEDS_USER_INPUT surface.
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect",
+            return_value=None,
+        ):
+            response = build_engineering_conversation_response(
+                NAVER_SEARCH_CLONE_TEXT,
+                user_links=(ISSUE_URL,),
+            )
+        # Intent is the coding intake path, not status / clarification.
+        self.assertEqual(response.intent_id, TASK_INTAKE_CANDIDATE)
+        # Suggested task type is full-stack-app.
+        self.assertEqual(response.suggested_task_type, "full-stack-app")
+        # Write intent detected.
+        self.assertTrue(response.write_likely)
+        # intake_prompt preserved.
+        self.assertEqual(response.intake_prompt, NAVER_SEARCH_CLONE_TEXT)
+
+    def test_bootstrap_body_replaces_needs_user_input_surface(self) -> None:
+        # Simulate the collector returning NEEDS_USER_INPUT (the legacy
+        # path that triggers "자료 부족"). Bootstrap must bypass it.
+        from types import SimpleNamespace
+
+        fake_collection = SimpleNamespace(
+            mode=SimpleNamespace(value="needs_user_input"),
+            user_prompt="관련 자료를 더 보내주세요.",
+            auto_collected_count=0,
+            collector_name="mock",
+            query="naver search clone",
+            pack=None,
+        )
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect",
+            return_value=fake_collection,
+        ):
+            response = build_engineering_conversation_response(
+                NAVER_SEARCH_CLONE_TEXT,
+                user_links=(ISSUE_URL,),
+            )
+        # Bootstrap body must be in the content; legacy "자료 부족" must not.
+        self.assertIn("coding bootstrap", response.content)
+        self.assertIn("📚", response.content)  # stack detection emoji
+        self.assertNotIn("자료가 조금 더 필요해요", response.content)
+        self.assertNotIn("자동 수집이 비어 있어서", response.content)
+
+    def test_user_provided_collection_still_uses_legacy_body(self) -> None:
+        # When the collector succeeds (AUTO_COLLECTED), the legacy body
+        # is used — bootstrap doesn't override.
+        from types import SimpleNamespace
+
+        fake_collection = SimpleNamespace(
+            mode=SimpleNamespace(value="auto_collected"),
+            user_prompt=None,
+            auto_collected_count=3,
+            collector_name="mock",
+            query="naver search clone",
+            pack=None,
+        )
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect",
+            return_value=fake_collection,
+        ):
+            response = build_engineering_conversation_response(
+                NAVER_SEARCH_CLONE_TEXT,
+                user_links=(ISSUE_URL,),
+            )
+        # Legacy auto_collected greeting present.
+        self.assertIn("1차 자료를 모아볼게요", response.content)
+
+    def test_no_repo_url_falls_back_to_legacy_collection_path(self) -> None:
+        # Without a repo URL, bootstrap status != BYPASS → legacy body wins.
+        from types import SimpleNamespace
+
+        fake_collection = SimpleNamespace(
+            mode=SimpleNamespace(value="needs_user_input"),
+            user_prompt="관련 자료를 더 보내주세요.",
+            auto_collected_count=0,
+            collector_name="mock",
+            query="x",
+            pack=None,
+        )
+        with patch(
+            "yule_orchestrator.discord.engineering_conversation._maybe_run_auto_collect",
+            return_value=fake_collection,
+        ):
+            response = build_engineering_conversation_response(
+                NAVER_SEARCH_CLONE_TEXT,
+                user_links=(),  # no repo URL
+            )
+        # Legacy NEEDS_USER_INPUT body shown — bootstrap bypass NOT applied.
+        self.assertNotIn("coding bootstrap", response.content)
+        self.assertIn("자료", response.content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_suggest_task_type_p0j.py
+++ b/tests/engineering/test_suggest_task_type_p0j.py
@@ -1,0 +1,112 @@
+"""P0-J commit 4 — _suggest_task_type combo 우선 회귀 (#145)."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.messaging.dispatcher import (
+    TASK_ROLE_SEQUENCE,
+    TaskType,
+)
+from yule_orchestrator.discord.engineering_conversation import (
+    _suggest_task_type,
+)
+
+
+# ---------------------------------------------------------------------------
+# Full-stack combo precedence
+# ---------------------------------------------------------------------------
+
+
+class FullStackComboPrecedenceTests(unittest.TestCase):
+    def test_naver_search_clone_classified_as_full_stack_app(self) -> None:
+        """Critical fix — was returning platform-infra due to "docker"."""
+
+        text = (
+            "Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+            "회원가입/로그인/검색 앱 구현해줘"
+        )
+        result = _suggest_task_type(text)
+        self.assertEqual(result, "full-stack-app")
+        # Negative check — explicitly NOT platform-infra.
+        self.assertNotEqual(result, "platform-infra")
+
+    def test_react_plus_postgres_full_stack(self) -> None:
+        result = _suggest_task_type("React 화면 + PostgreSQL 스키마 묶어줘")
+        self.assertEqual(result, "full-stack-app")
+
+    def test_full_stack_app_role_sequence_present(self) -> None:
+        # Constructor wiring — TaskType.FULL_STACK_APP must have a sequence.
+        self.assertIn(TaskType.FULL_STACK_APP, TASK_ROLE_SEQUENCE)
+        seq = TASK_ROLE_SEQUENCE[TaskType.FULL_STACK_APP]
+        # tech-lead always opens; full-stack should include both front+back+devops.
+        self.assertEqual(seq[0], "tech-lead")
+        for role in ("backend-engineer", "frontend-engineer", "devops-engineer"):
+            self.assertIn(role, seq)
+
+
+# ---------------------------------------------------------------------------
+# Pure infra still classified as platform-infra
+# ---------------------------------------------------------------------------
+
+
+class PureInfraStillPlatformInfraTests(unittest.TestCase):
+    def test_terraform_only(self) -> None:
+        result = _suggest_task_type("terraform module 만들어줘")
+        self.assertEqual(result, "platform-infra")
+
+    def test_github_actions_only(self) -> None:
+        result = _suggest_task_type("github actions workflow 만들어줘")
+        self.assertEqual(result, "platform-infra")
+
+    def test_k8s_only(self) -> None:
+        result = _suggest_task_type("k8s manifest 만들어줘")
+        self.assertEqual(result, "platform-infra")
+
+    def test_docker_only(self) -> None:
+        # Docker 단독은 infra-only로 분류 — full-stack 신호 없으면 그대로.
+        result = _suggest_task_type("docker 이미지 빌드")
+        self.assertEqual(result, "platform-infra")
+
+    def test_deploy_keyword(self) -> None:
+        result = _suggest_task_type("deploy script 만들어줘")
+        self.assertEqual(result, "platform-infra")
+
+
+# ---------------------------------------------------------------------------
+# Other classifications unchanged (regression)
+# ---------------------------------------------------------------------------
+
+
+class ExistingClassificationsTests(unittest.TestCase):
+    def test_landing_page(self) -> None:
+        result = _suggest_task_type("랜딩 페이지 디자인")
+        self.assertEqual(result, "landing-page")
+
+    def test_qa_test(self) -> None:
+        result = _suggest_task_type("회귀 test plan 작성")
+        self.assertEqual(result, "qa-test")
+
+    def test_frontend_feature_keyword(self) -> None:
+        # frontend keyword alone (no full stack)
+        result = _suggest_task_type("frontend 컴포넌트 분리")
+        self.assertEqual(result, "frontend-feature")
+
+    def test_backend_feature_keyword(self) -> None:
+        result = _suggest_task_type("backend api schema")
+        # backend + api triggers; could also be full-stack (api+schema=database)
+        # so just check it's NOT platform-infra and IS coding-capable.
+        self.assertIn(result, ("backend-feature", "full-stack-app"))
+
+    def test_no_signal_returns_none(self) -> None:
+        result = _suggest_task_type("그냥 잡담")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈

closed #145 (coding bootstrap)
closed #146 (read-only intents)
parent #138

## ✨ 과제 내용

두 사용자 보고를 단일 PR / 8-commit 으로 해결.

### Bug 1 (#145) — naver-search-clone 시나리오

repo + issue + 명시적 coding request 가 들어와도 gateway 가:
1. `_suggest_task_type` 이 단일 \`docker\` 키워드로 PLATFORM_INFRA 분류.
2. \`official_docs / code_context 부족\` 으로 "자료 더 주세요" 응답.

**Fix**: stack lexicon detector + FULL_STACK_APP task_type + official docs seed + coding bootstrap 우회.

### Bug 2 (#146) — gateway 가 모든 요청을 새 research/intake 로 처리

- "지금 열려 있는 세션 작업들 몇 개?" → auto-collect 수행
- "왜 멈췄어?" → research fallback 위험
- "방향 수정이야" → 새 작업처럼 흐름

**Fix**: 5 신규 read-only intent + hard rule (auto_collect 차단).

### Commit 구성 (8)

| commit | 영역 | 결과 |
| --- | --- | --- |
| 1 | audit doc | docs/p0j-coding-bootstrap-and-readonly-intents.md — 10줄 충돌 + 8-commit 계획 |
| 2 | stack detector | agents/coding/stack_detector.py — 45+ lexicon, 8 tier, is_full_stack/is_infra_only |
| 3 | official docs seed | agents/coding/official_docs_seed.py — 37 stack → docs URL canonical mapping |
| 4 | FULL_STACK_APP + suggest_task_type | TaskType.FULL_STACK_APP + stack_detector 우선 분류 |
| 5 | coding bootstrap | agents/coding/coding_bootstrap.py — repo + stack + write intent → bypass insufficiency |
| 6 | 5 read-only intent + responders | session_count / session_list / blocked_reason / continue / change_direction |
| 7 | hard rule — auto_collect 차단 | READ_ONLY_INTENTS 분기에서 _maybe_run_auto_collect 호출 X |
| 8 | wire-in + naver-search-clone e2e | _format_coding_bootstrap_body + 9 e2e test |

### Acceptance Criteria (11/11)

#### Bug 1
- [x] repo+issue+full-stack coding request → \`platform-infra\` 오분류 X (commit 4 + 8 e2e)
- [x] repo+issue+write intent → insufficiency follow-up 없음 (commit 5 + 8 wire)
- [x] stack mention → official docs seed 자동 생성 (commit 3 — 37 stack URL)
- [x] repo/local clone → code_context bootstrap signal (commit 5 — code_context_pending)
- [x] genuine infra request (\`deploy\` / \`terraform\` / \`k8s\` / \`github actions only\`) → 여전히 platform-infra (commit 4)

#### Bug 2
- [x] session count query → auto_collect 없음, 개수만 (commit 6+7, NoAutoCollectHardRuleTests)
- [x] session list query → auto_collect 없음, 목록 응답 (동일)
- [x] blocked_reason query → auto_collect 없음, diagnostic 응답 (동일)
- [x] continue_existing_work phrase → 기존 session continuation (no new intake)
- [x] change_direction phrase → same session update (no new intake)
- [x] genuine new work request → 여전히 intake/coding path (GenuineNewWorkStillRunsCollectTests)

#### 회귀
- [x] 기존 4559 PASS 무회귀 (실제 **4639 PASS** + 1 skipped, P0-J 신규 80)

### 신규 모듈 (5)

1. \`agents/coding/stack_detector.py\` — 45+ engineering stack lexicon, 8 tier.
2. \`agents/coding/official_docs_seed.py\` — 37 stack → canonical docs URL.
3. \`agents/coding/coding_bootstrap.py\` — repo + stack + write intent insufficiency bypass.
4. \`docs/p0j-coding-bootstrap-and-readonly-intents.md\` — audit doc.
5. (engineering_conversation 의 5 신규 intent + responders + helper 는 기존 모듈 확장.)

### 신규 test 80 개 분포

- \`test_stack_detector.py\` — 17 test (detection / aliasing / classify_full_stack / write intent).
- \`test_official_docs_seed.py\` — 14 test (naver-search-clone seed / edge / coverage / shape).
- \`test_suggest_task_type_p0j.py\` — 13 test (full-stack precedence / pure infra / no regression).
- \`test_coding_bootstrap.py\` — 10 test (bypass / partial signals / not coding / summary / round-trip).
- \`test_readonly_intents_p0j.py\` — 17 test (intent classification / no-auto-collect hard rule / genuine new work still runs collect / response body sanity).
- \`test_naver_search_clone_e2e_p0j.py\` — 9 test (per-component + end-to-end conversation layer).

## :camera_with_flash: 스크린샷(선택)

(없음 — 백엔드 conversation 로직 PR)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- \`docs/p0j-coding-bootstrap-and-readonly-intents.md\` — 본 PR 의 audit doc / 8-commit single source of truth.
- naver-search-clone 시나리오 ("Next.js + NestJS + PostgreSQL + Docker Compose 회원가입/로그인/검색") 가 \`test_naver_search_clone_e2e_p0j.py\` 에서 *end-to-end* 보호.
- Docker 가 stack lexicon 의 infra-tier 로 등록돼 있지만 *application tier* 와 함께 발견되면 is_full_stack=True 가 우선. genuine infra (terraform / github actions / k8s 단독) 는 그대로 platform-infra 유지.
- 5 read-only intent 모두 is_status_query=True 로 마킹 — router (engineering_channel_router) 가 short-circuit, intake_fn / kickoff_fn 호출 안 함.

## 🤖 Agent WorkOS Audit

- audit_id: P0-J
- branch: feature/p0j-coding-bootstrap-and-readonly-intents (from main)
- repo: yule-studio/yule-studio-agent
- role: tech-lead (cross-role coding flow + conversation routing 통합)
- autonomy_level: L2 (정책 land 후 회귀 fix, 회귀 test 동행)
- mode: tech-lead-mediated
- issues: #145 + #146