### PR TITLE
🐞 P0-K — command-only operational phrase 가 새 research/forum thread 만드는 회귀 차단 + README Mermaid + diagram-conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,88 @@ production 권장 경로 = `yule runtime up` 또는 systemd 기반 `yule run-ser
 
 ## 아키텍처 한눈에 보기
 
+> 다이어그램은 Mermaid 로 직접 그린다 — flowchart / sequence / ERD 모두. 정책: [policies/runtime/agents/engineering-agent/diagram-conventions.md](policies/runtime/agents/engineering-agent/diagram-conventions.md).
+
+### 시스템 토폴로지
+
+```mermaid
+flowchart LR
+  User[운영자]
+  Discord[Discord]
+  Planning[planning-bot]
+  Gateway[engineering-gateway]
+  Member[engineering-member × 7]
+  Runtime[yule runtime up]
+  Queue[SQLite cache + job queue]
+  Vault[Obsidian vault mirror]
+  Github[GitHub repo + Apps]
+
+  User --> Discord
+  Discord --> Planning
+  Discord --> Gateway
+  Discord --> Member
+  Gateway --> Runtime
+  Member --> Runtime
+  Planning --> Runtime
+  Runtime --> Queue
+  Runtime --> Github
+  Queue --> Vault
+  Runtime --> Vault
 ```
-[Discord]
-  ├─ planning-bot         (daily plan / checkpoint)
-  ├─ engineering-gateway  (#업무-접수 / 라우팅 / 상태 응답)
-  └─ engineering-member × 7  (역할별 turn / 운영-리서치 forum 댓글)
-        │
-        ▼
-   shared SQLite (.cache/yule/cache.sqlite3)
-        │
-        ▼
-   Obsidian vault   ← 결정 / 리서치 / 회의록 결정적 export
+
+### Gateway 라우팅 — front-door semantics
+
+```mermaid
+flowchart TB
+  Msg[user message]
+  Intent{detect_engineering_intent}
+  ReadOnly[READ_ONLY_INTENTS<br/>status / session_count / session_list /<br/>blocked_reason / continue / change_direction /<br/>APPROVAL_ACTION]
+  Confirm{CONFIRM_INTAKE<br/>+ substantive last_proposed_prompt?}
+  Intake[TASK_INTAKE_CANDIDATE<br/>+ auto_collect]
+  Coding{coding_bootstrap<br/>repo+stack+write?}
+  Approval[short ack — no new intake / forum]
+  Promote[promote last_proposed_prompt → intake]
+  Bootstrap[coding handoff packet<br/>skip insufficiency]
+  Collect[autonomous collector]
+
+  Msg --> Intent
+  Intent -->|read-only| ReadOnly
+  Intent -->|confirm phrase| Confirm
+  Intent -->|substantive| Intake
+  ReadOnly --> Approval
+  Confirm -->|yes| Promote
+  Confirm -->|no — bare command-only| Approval
+  Intake --> Coding
+  Coding -->|bypass| Bootstrap
+  Coding -->|no signal| Collect
+```
+
+### Continuation path + P0-K 가드 (4 critical site)
+
+```mermaid
+flowchart TB
+  Cont[continuation prompt]
+  Cmd{is_command_only_prompt?}
+  A1["site A — bot.py:_record_engineering_continuation<br/>(canonical_prompt_override / latest_continuation_prompt)"]
+  B1["site B — engineering_channel_router._run_research_loop_hook<br/>(3 호출 사이트)"]
+  C1["site C — research_forum.derive_research_topic<br/>(thread title source)"]
+  D1["site D — engineering_conversation.CONFIRM_INTAKE<br/>(intake_prompt 가드)"]
+  Skip[skip — no overwrite / no research loop /<br/>no forum thread / APPROVAL_ACTION ack]
+  Continue[normal continuation flow]
+
+  Cont --> Cmd
+  Cmd -->|yes — block all 4 sites| A1
+  A1 --> B1
+  B1 --> C1
+  C1 --> D1
+  D1 --> Skip
+  Cmd -->|no — substantive| Continue
 ```
 
 - 역할 봇은 각자 독립 프로세스로 운영된다.
 - 모든 작업 상태는 SQLite 에 저장되고, Discord 메시지는 신호일 뿐이다.
 - Engineering 런타임 lifecycle 정책: [policies/runtime/agents/engineering-agent/lifecycle-mvp.md](policies/runtime/agents/engineering-agent/lifecycle-mvp.md).
+- P0-K command-only 가드 정책: [docs/p0k-command-only-research-thread-guard.md](docs/p0k-command-only-research-thread-guard.md).
 
 ## 문서 안내
 

--- a/docs/p0k-command-only-research-thread-guard.md
+++ b/docs/p0k-command-only-research-thread-guard.md
@@ -1,0 +1,68 @@
+# P0-K — Command-Only 운영 문장 → research/forum thread 회귀 차단 (#148)
+
+> **Status:** P0-K audit — `진행 해줘` / `이대로 진행` / `승인하고 진행해` 같은 command-only 운영 문장이 새 research loop + `[Reference] 진행 해줘` forum thread 를 만드는 회귀 차단. parent #138.
+
+## 0. 사용자 보고
+
+- 기존 세션 `4dddb86c1714` 가 계속 재사용됨.
+- gateway 가 `[engineering-agent] 기존 작업 이어받음` 후 `추가 요청: 진행 해줘` 같은 메시지 남김.
+- 이어서 `✅ 운영-리서치 forum 게시 완료` + `thread: [Reference] 진행 해줘` 같은 새 thread 생성.
+- 사용자는 승인 / 계속 진행만 했는데 리서치 + thread 생성이 반복.
+
+## 1. 충돌 가능 지점 (10줄)
+
+1. `is_command_only_prompt` / `is_non_actionable_prompt` 이미 `agents/routing.py:267-339` 존재 — 23-phrase frozenset. 본 작업은 *enforcement* 만.
+2. `_run_research_loop_hook` 호출 2 site (`engineering_channel_router.py:880` new-work, `:2523` continuation) 모두 prompt_text 의 command-only 가드 없음.
+3. `_record_engineering_continuation` (`bot.py:2215, 2222`) 가 cleaned_prompt 의 command-only 검증 없이 `latest_continuation_prompt` / `canonical_prompt_override` 저장.
+4. `derive_research_topic` / `normalize_thread_title` (`research_forum.py`) 가 pack.title → "이대로 진행" 그대로 통과 → `[Reference] 이대로 진행` thread 생성.
+5. `CONFIRM_INTAKE` 분기 (`engineering_conversation.py:303`) 가 `last_proposed_prompt or message_text` 사용 — 둘 다 command-only 일 때 가드 없음.
+6. P0-J 의 5 read-only intent 가 `_maybe_run_auto_collect` 차단 — 그러나 CONTINUE_EXISTING_WORK 가 continuation prompt 자체를 작성하지 않음. 새로운 hard rule 4 site 가 필요.
+7. 신규 intent `approval_action` 후보 — 짧은 승인 ack 만 출력 + 새 intake / research 절대 안 만듦.
+8. `resumed_thread_id` (`bot.py:2167` lookup) 가 `forum_message_adapter._resolve_session_for_forum_thread` 에 보조 lookup 미존재 — 역할 변경 fail.
+9. 모든 4 사이트가 `routing.is_command_only_prompt` import 만 — 신규 모듈 0.
+10. 7 commit 분할 — audit / phrase set + approval_action intent / continuation prompt 가드 / research loop 가드 / forum title 가드 / CONFIRM_INTAKE + ack + resumed thread resolve / e2e + PR.
+
+## 2. 4 critical site 표 (enforcement points)
+
+| # | 위치 | 가드 |
+| --- | --- | --- |
+| A | `bot.py:_record_engineering_continuation` (~2215, 2222) | `cleaned_prompt` 가 command-only 면 `latest_continuation_prompt` / `canonical_prompt_override` 저장 X (resumed_thread_id 는 별도 저장). |
+| B | `engineering_channel_router.py:_run_research_loop_hook` 호출부 (~880 + 2523) | prompt_text 가 command-only 면 호출 X — `research_loop_skip_reason="command_only_prompt"` audit. |
+| C | `research_forum.py:derive_research_topic` / `normalize_thread_title` | pack.title / summary 가 command-only 면 거부 → fallback "engineering 작업" 또는 기존 session.prompt. |
+| D | `engineering_conversation.py:CONFIRM_INTAKE` 분기 | `last_proposed_prompt` 와 `message_text` 둘 다 command-only 면 `ready_to_intake=False` + 짧은 ack. |
+
+## 3. 신규 intent
+
+`APPROVAL_ACTION` — `승인하고 진행해` / `승인할게` / `오케이 진행` / `작업 승인` 류. P0-J 의 `READ_ONLY_INTENTS` 와 같이 묶음. 응답은:
+
+> `✅ 승인 반영했습니다. 기존 작업 흐름을 이어갑니다. 새 리서치 thread 는 만들지 않습니다.`
+
+CONFIRM_INTAKE 와의 차이: CONFIRM_INTAKE 는 *직전 제안* 을 intake 로 promote (`ready_to_intake=True`). APPROVAL_ACTION 은 *기존 세션 상태 ack* 만 — 새 intake 절대 안 만듦.
+
+## 4. ack 일관성
+
+| 시나리오 | ack |
+| --- | --- |
+| approval_action | `✅ 승인 반영했습니다. 기존 작업 흐름을 이어갑니다. 새 리서치 thread 는 만들지 않습니다.` |
+| continue_existing_work + 세션 id 있음 | `✅ 세션 `<id>` 를 계속 진행할게요. 새 리서치 thread 는 만들지 않습니다.` |
+| continue_existing_work + 세션 id 없음 | `이어갈 세션을 찾지 못했어요. session id 또는 thread 를 명시해 주세요.` |
+| genuine direction update (substantive text) | 정상 same-session direction update — (별도 분기) |
+
+## 5. 신규 / 갱신 파일 매트릭스
+
+| 위치 | 책임 |
+| --- | --- |
+| `docs/p0k-command-only-research-thread-guard.md` | 본 doc. |
+| `src/yule_orchestrator/agents/routing.py` | `_COMMAND_ONLY_PROMPTS` 확장 (5+ phrase). |
+| `src/yule_orchestrator/discord/engineering_conversation.py` | APPROVAL_ACTION intent + matcher + formatter + READ_ONLY_INTENTS 에 추가. CONFIRM_INTAKE 가드. |
+| `src/yule_orchestrator/discord/bot.py` | `_record_engineering_continuation` 가드. |
+| `src/yule_orchestrator/discord/engineering_channel_router.py` | `_run_research_loop_hook` 호출부 2 site 가드. |
+| `src/yule_orchestrator/discord/research_forum.py` | `derive_research_topic` / `normalize_thread_title` 가드. |
+| `src/yule_orchestrator/discord/forum_message_adapter.py` | `_resolve_session_for_forum_thread` 가 `resumed_thread_id` 보조 lookup. |
+| tests/discord/test_p0k_*.py | 시나리오 e2e + 무회귀. |
+
+## 6. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 — Issue #148 P0-K audit. parent #138. |

--- a/notes/vault-mirror/10-projects/yule-studio-agent/decisions/decision-diagram-conventions-and-command-only-guard-issue-148.md
+++ b/notes/vault-mirror/10-projects/yule-studio-agent/decisions/decision-diagram-conventions-and-command-only-guard-issue-148.md
@@ -1,0 +1,59 @@
+---
+date: 2026-05-14
+issue: 148
+kind: decision
+status: decided
+related_issue: 148
+related_pr: pending
+---
+
+# Issue #148 — Diagram Conventions + Command-Only Research Thread Guard
+
+## 결정
+
+1. **다이어그램은 Mermaid 가 SSoT** — README / docs / Obsidian mirror 모두 Mermaid 코드 블록. PNG / 손그림 / 외부 도구 출력은 *참고용 mirror* 만.
+2. **command-only 운영 문장 (`진행 해줘` / `이대로 진행` / `작업 승인 할게 진행 해줘` 등) 은 4 critical site 에서 차단:**
+   - bot.py `_record_engineering_continuation` — canonical prompt 저장 금지.
+   - engineering_channel_router `_run_research_loop_hook` 호출 3 사이트 — research loop 호출 금지.
+   - research_forum `derive_research_topic` — thread title 후보 거부.
+   - engineering_conversation `CONFIRM_INTAKE` 분기 — bare command-only 시 APPROVAL_ACTION ack 로 downgrade.
+3. **APPROVAL_ACTION 신규 intent** — P0-J 의 READ_ONLY_INTENTS 에 포함, auto_collect / 새 intake 절대 안 만듦.
+4. **resumed_thread_id session resolve** — `forum_message_adapter._resolve_session_for_forum_thread` 가 secondary lookup 추가.
+
+## 왜 / 고민 / 대안
+
+### 왜 Mermaid?
+
+- GitHub markdown / Obsidian / 본 레포 docs 모두 자동 렌더링.
+- 텍스트 → git diff 가능 → 도식 변경도 PR review 가 의미 있음.
+- 사용자 보고 이미지 (`Argo CD → Kubernetes → Istio / Internal / Data Layer`) 와 같은 *플로우 차트 양식* 을 코드로 표현.
+
+### 왜 4 critical site 모두 가드?
+
+- 한 site 만 가드해서는 회귀가 다른 site 로 우회. continuation prompt 저장만 막아도 derive_research_topic 이 legacy data 로 thread 생성. derive_research_topic 만 막아도 research loop 가 canned 결과 반환.
+- 4 site 모두 *defense in depth* — 어느 하나가 회귀해도 나머지가 잡음.
+
+### 왜 APPROVAL_ACTION 신규 intent?
+
+- CONFIRM_INTAKE 와 의미가 달라 — CONFIRM_INTAKE 는 *직전 제안* 을 intake 로 promote. APPROVAL_ACTION 은 *기존 세션 ack* 만.
+- P0-J 의 READ_ONLY_INTENTS tuple 에 자동 편입 → P0-J 의 hard rule (auto_collect 차단) 이 그대로 적용.
+
+### 대안과 기각
+
+- **Mermaid 외 다이어그램 도구 (PlantUML / Excalidraw / Figma)** — 외부 도구 의존 + diff 불가 + Obsidian 호환 부족.
+- **command-only 가드를 detect_engineering_intent 한 곳에만** — 기존 26개 test 가 CONFIRM_INTAKE 기대했고 단일 site 가드는 legacy 동작과 충돌. CONFIRM_INTAKE 분기 안 가드가 더 안전.
+- **resumed_thread_id 미연결** — bonus item E. 1순위는 thread 폭증 방지였지만, secondary lookup 은 5줄 추가로 끝나 함께 처리.
+
+## 회고 / 다음엔 이렇게 더 나아질 수 있음
+
+- continuation_requests history 에 `is_command_only=True` 마킹 추가 — 향후 status surface 에서 "지금까지 사용자가 N 번 승인/진행" 같은 audit 가능.
+- diagram-conventions §5 의 Obsidian mirror 자동화 — 현재는 본 노트처럼 수동. P0-G stage 3 의 vault repo workspace 정착 시 자동 sync 후보.
+
+## 관련 문서
+
+- [[CLAUDE]]
+- [[governance]]
+- [[diagram-conventions]]
+- [[design-to-code-assets]]
+- [[obsidian-governance]]
+- [[github-workflow]]

--- a/policies/runtime/agents/engineering-agent/diagram-conventions.md
+++ b/policies/runtime/agents/engineering-agent/diagram-conventions.md
@@ -1,0 +1,142 @@
+# Diagram Conventions — engineering-agent 부서 공통 (P0-K)
+
+> **소유:** `engineering-agent` 부서 전체. 설계 / 아키텍처 / 플로우 / ERD 도식을 통일된 양식으로 그려 README / docs / Obsidian vault 사이의 가독성과 회귀 추적성을 보장.
+> **목적:** 도식이 PNG / 손그림 / SVG 로 흩어지지 않고 *코드처럼 diff 가능* 한 텍스트 (Mermaid) 로 SSoT.
+> **출처:** Issue #148 (P0-K) 의 README 정리 + 사용자 요구.
+
+본 정책은 [`governance.md`](governance.md) umbrella 가 묶는 부서 정책 중 **설계 도식** 영역을 책임진다. 시각 자산 (icon / logo / favicon) 은 [`design-to-code-assets.md`](design-to-code-assets.md) 가 책임 — 본 정책과 분리.
+
+## 1. 적용 범위
+
+| 도식 종류 | 본 정책 적용 | 책임 surface |
+| --- | --- | --- |
+| 시스템 토폴로지 / 아키텍처 | ✅ Mermaid flowchart | README / docs/architecture.md |
+| 데이터 흐름 / 호출 그래프 | ✅ Mermaid flowchart | docs/* / audit doc |
+| 시퀀스 다이어그램 (요청/응답 시간 순서) | ✅ Mermaid sequenceDiagram | docs/* |
+| ERD / DB 스키마 | ✅ Mermaid erDiagram | docs/* / 정책 doc |
+| 상태 전이 / 라이프사이클 | ✅ Mermaid stateDiagram-v2 | lifecycle 정책 doc |
+| 클래스 / 모듈 다이어그램 | ✅ Mermaid classDiagram | architecture doc |
+| 손그림 / 화이트보드 스케치 | ❌ | (자유 — Obsidian daily 메모에만, 본 정책 적용 X) |
+| 시각 자산 (icon / logo / favicon) | ❌ | [`design-to-code-assets.md`](design-to-code-assets.md) |
+
+## 2. 기본 규칙
+
+1. **Mermaid 가 SSoT.** README / docs 의 아키텍처 / 플로우 / ERD 는 모두 Mermaid 코드 블록으로 작성. PNG / 손그림 / 외부 도구 (Excalidraw / Figma) 출력은 *참고용 mirror* 만, SSoT 는 Mermaid.
+2. **GitHub markdown 호환.** Mermaid 는 GitHub 의 markdown 에서 자동 렌더링 — 별도 빌드 도구 불필요.
+3. **Obsidian 호환.** Obsidian 도 Mermaid 코드 블록을 자동 렌더링. 본 레포의 `notes/vault-mirror/` 노트도 같은 Mermaid 블록 그대로 사용.
+4. **diff 가능.** Mermaid 는 텍스트라 git diff 로 review 가능. 도식 변경도 commit 분할 정책 ([`github-workflow.md`](github-workflow.md) §5.1) 의 semantic CRUD-like slice 적용.
+
+## 3. 4 가지 권장 다이어그램 종류
+
+### 3.1 시스템 토폴로지 (flowchart)
+
+```mermaid
+flowchart LR
+  User --> Discord
+  Discord --> Gateway
+  Gateway --> Runtime
+  Runtime --> Queue[SQLite]
+  Runtime --> Vault[Obsidian]
+```
+
+규칙:
+- 노드 이름은 시스템에서 실제 사용하는 이름과 일치 (eg. `Gateway` 는 `engineering-gateway` 봇, `Runtime` 은 `yule runtime up`).
+- 방향은 LR (왼→오) 또는 TB (위→아래) 일관.
+- 화살표 위 라벨은 *어떤 데이터가 흐르는가* 설명 — 예: `Discord -->|message| Gateway`.
+
+### 3.2 시퀀스 다이어그램 (sequenceDiagram)
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant Gateway
+  participant Runtime
+  participant Queue
+  User->>Gateway: message
+  Gateway->>Runtime: intake
+  Runtime->>Queue: enqueue job
+  Queue-->>Runtime: ack
+  Runtime-->>Gateway: response
+  Gateway-->>User: reply
+```
+
+규칙:
+- 시간 흐름이 중요한 다이어그램에만 사용.
+- 동기 호출은 `->>`, 비동기 응답은 `-->>`.
+- actor 는 사람, participant 는 시스템 컴포넌트.
+
+### 3.3 ERD (erDiagram)
+
+```mermaid
+erDiagram
+  SESSION ||--o{ JOB : queues
+  SESSION ||--|| WORKFLOW_STATE : has
+  JOB }o--|| ROLE : assigned_to
+```
+
+규칙:
+- 카디널리티 표기는 `||--o{` (1:N), `||--||` (1:1), `}o--o{` (N:N).
+- SQLite 테이블 / dataclass 모두 ERD 로 표현 가능 — 컬럼이 중요하면 entity 안에 attribute 명시.
+
+### 3.4 상태 전이 (stateDiagram-v2)
+
+```mermaid
+stateDiagram-v2
+  [*] --> needs_research
+  needs_research --> in_progress
+  in_progress --> needs_review
+  needs_review --> completed
+  needs_review --> rejected
+  completed --> [*]
+  rejected --> [*]
+```
+
+규칙:
+- 라이프사이클 정책 doc 에서 활용. WorkflowState enum 의 실제 값과 일치.
+
+## 4. 작성 체크리스트
+
+매 다이어그램 commit 시 확인:
+
+- [ ] Mermaid 코드 블록인가 (```` ```mermaid```` 로 시작)?
+- [ ] GitHub web 에서 자동 렌더링 되는가? (PR preview 로 확인)
+- [ ] 노드 / participant / entity 이름이 코드의 실제 이름과 일치하는가?
+- [ ] 화살표 / 카디널리티 / 방향이 데이터 흐름과 일치하는가?
+- [ ] 도식 위/아래에 *무엇을 그린 것인지* 1 문장 설명이 있는가?
+- [ ] Obsidian mirror 노트에 같은 Mermaid 블록이 mirror 되어 있는가 (해당하는 경우)?
+
+## 5. Obsidian vault 연결
+
+본 레포의 `notes/vault-mirror/` 는 Obsidian vault 의 mirror. 다이어그램이 도메인 결정에 영향 주는 경우 (예: 본 PR 의 P0-K 4 critical site 가드) 다음 위치에 mirror:
+
+- `notes/vault-mirror/10-projects/yule-studio-agent/decisions/<YYYY-MM-DD>_issue-<n>-decision-<slug>.md` — 결정 mirror.
+- `notes/vault-mirror/10-projects/yule-studio-agent/task-logs/<YYYY-MM-DD>_issue-<n>-task-log-<slug>.md` — 작업 로그 mirror.
+
+vault repo workspace (`yule-agent-vault`) 가 클론되지 않은 상태에서는 mirror 노트만 본 레포에 추가 — push 자동화는 [`docs/approval-matrix.md`](../../../../docs/approval-matrix.md) §3 의 `vault_remote_push` 정책 따른다 (mode=approval_required 시 L3 승인 후).
+
+## 6. 충돌 매트릭스
+
+| 다른 정책 | 우선순위 / 분리 |
+| --- | --- |
+| [`design-to-code-assets.md`](design-to-code-assets.md) | 시각 자산 (logo / icon / favicon) 은 그쪽이 책임. 본 정책은 *도식* 만. |
+| [`obsidian-governance.md`](obsidian-governance.md) | 노트 naming / wikilink 는 그쪽 정책 우선. 본 정책은 노트 *본문* 의 Mermaid 블록만 책임. |
+| [`github-workflow.md`](github-workflow.md) §5.1 | 도식 commit 도 semantic CRUD-like slice 정책 따름. docs-only 예외 적용. |
+
+## 7. 검증
+
+- 도식 변경 PR 은 GitHub web 의 markdown preview 에서 정상 렌더링 확인 필수.
+- 본 레포의 README / docs / policies 의 *모든 새 도식* 은 Mermaid 코드 블록으로 작성 (회귀 = 도식 변경 PR 이 PNG / 외부 이미지 추가만 하는 경우).
+
+## 8. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 — Issue #148 (P0-K) 의 README 정리 + 사용자 요구. parent #138. |
+
+## 관련 문서
+
+- [[CLAUDE]]
+- [[governance]]
+- [[design-to-code-assets]]
+- [[obsidian-governance]]
+- [[github-workflow]]

--- a/policies/runtime/agents/engineering-agent/governance.md
+++ b/policies/runtime/agents/engineering-agent/governance.md
@@ -14,6 +14,7 @@
 | Repo contract | [`repo-contract-discovery.md`](repo-contract-discovery.md) | 외부 repo 의 ISSUE/PR template / CONTRIBUTING / CODEOWNERS / workflows discovery + Yule 기본 규칙 fallback |
 | Growth loop | [`growth-loop.md`](growth-loop.md) | resources / projects / daily 정리 + 반복 패턴의 정책 승격 lifecycle |
 | Design-to-code | [`design-to-code-assets.md`](design-to-code-assets.md) | product-designer 자산 (icon / logo / favicon) 정의 + frontend-engineer SVG/컴포넌트 구현 + raster 경계 |
+| Diagram conventions | [`diagram-conventions.md`](diagram-conventions.md) | 시스템 토폴로지 / 시퀀스 / ERD / 상태 전이 도식을 Mermaid 로 그리기. README / docs / Obsidian mirror 일관. (P0-K 추가) |
 
 추가 cross-link (운영자 docs):
 

--- a/src/yule_orchestrator/agents/routing.py
+++ b/src/yule_orchestrator/agents/routing.py
@@ -257,16 +257,113 @@ _COMMAND_ONLY_PROMPTS: frozenset[str] = frozenset(
         "여기서 이어가",
         "확정",
         "진행",
+        "진행해",
+        "진행해줘",
+        "진행 해줘",
+        "이대로 진행해줘",
+        "이대로 진행 해줘",
         "승인",
+        "승인할게",
+        "승인 할게",
+        "승인해줘",
+        "승인 해줘",
+        "승인했어",
         "수정 승인",
+        "오케이",
+        "오케이 진행",
+        "오케이 진행해줘",
         "ok",
+        "okay",
+        "예",
+        "네",
+        "계속",
+        "계속 해",
+        "계속해",
+        "계속 진행",
+        "계속 진행해",
+        "이어서",
+        "이어서 해",
+        "이어서 진행",
+        "이어서 진행해",
+        # 합성 phrase — 사용자 보고된 P0-K 예시.
+        "승인하고 진행해",
+        "승인하고 진행",
+        "작업 승인 할게 진행 해줘",
+        "작업 승인 할게",
+        "작업 승인할게",
+        "작업 승인",
     }
+)
+
+
+# Approval/proceed token fragments — used by the substring sweep in
+# :func:`is_command_only_prompt` to catch compound command-only
+# phrases that aren't in the exact set above (P0-K). These are *tokens
+# inside* command-only messages, not standalone task verbs. Removing
+# them from the normalized text should leave nothing substantive.
+_COMMAND_ONLY_TOKEN_FRAGMENTS: tuple[str, ...] = (
+    "이대로",
+    "그대로",
+    "여기서",
+    "기존",
+    "세션",
+    "세션으로",
+    "thread",
+    "작업",
+    "작업으로",
+    "진행해줘",
+    "진행 해줘",
+    "진행해",
+    "진행할게",
+    "진행",
+    "승인하고",
+    "승인할게",
+    "승인 할게",
+    "승인해줘",
+    "승인 해줘",
+    "승인했어",
+    "승인",
+    "확정해줘",
+    "확정",
+    "계속해",
+    "계속 진행",
+    "계속",
+    "이어서",
+    "이어가",
+    "이어",
+    "오케이",
+    "okay",
+    "ok",
+    "go ahead",
+    "go",
+    "yes",
+    "proceed",
+    "approve",
+    "approved",
+    "continue",
+    "할게",
+    "해줘",
+    "해라",
+    "해",
 )
 
 
 def is_command_only_prompt(value: object) -> bool:
     """True when *value* is just a confirmation/command phrase rather
     than a real task description.
+
+    Three matching layers (most specific → most permissive):
+
+      1. exact normalised match against :data:`_COMMAND_ONLY_PROMPTS`.
+      2. very short input (≤2 chars).
+      3. **P0-K substring sweep** — strip every
+         :data:`_COMMAND_ONLY_TOKEN_FRAGMENTS` and Korean particle
+         from the normalized text; if ≤2 chars remain the whole
+         message was approval/proceed boilerplate.
+
+    The sweep is what catches compound forms like
+    ``작업 승인 할게 진행 해줘`` that aren't in the exact set but
+    decompose entirely into command-only fragments.
 
     Used in two places:
       • routing/recall scoring — sessions whose prompt is itself a
@@ -284,7 +381,33 @@ def is_command_only_prompt(value: object) -> bool:
         return True
     if len(normalised) <= 2:
         return True
-    return normalised in _COMMAND_ONLY_PROMPTS
+    if normalised in _COMMAND_ONLY_PROMPTS:
+        return True
+    # P0-K substring sweep — fragment-by-fragment stripping.
+    return _strips_to_empty(normalised)
+
+
+def _strips_to_empty(normalised: str) -> bool:
+    """Return True iff *normalised* reduces to ≤2 chars after removing
+    every command-only fragment + Korean particle + punctuation."""
+
+    text = normalised
+    # Strip exact fragments (longest first to avoid partial overlaps).
+    for fragment in sorted(_COMMAND_ONLY_TOKEN_FRAGMENTS, key=len, reverse=True):
+        if fragment in text:
+            text = text.replace(fragment, " ")
+    # Strip standalone Korean particles / punctuation that often glue
+    # command-only fragments together.
+    for particle in (
+        " 을 ", " 를 ", " 도 ", " 는 ", " 은 ", " 이 ", " 가 ",
+        " 의 ", " 에 ", " 와 ", " 과 ", " 만 ", " 좀 ",
+    ):
+        text = text.replace(particle, " ")
+    # Drop punctuation residue.
+    for char in (",", ".", "!", "?", "~", "·", "/", "\\", "'", "\""):
+        text = text.replace(char, " ")
+    text = " ".join(text.split())
+    return len(text) <= 2
 
 
 # Distinct phrases the bot itself emits in its intake / sufficiency

--- a/src/yule_orchestrator/discord/bot.py
+++ b/src/yule_orchestrator/discord/bot.py
@@ -2197,6 +2197,21 @@ def _record_engineering_continuation(
     if not cleaned_prompt:
         return session
 
+    # P0-K (#148) — never let a command-only operational phrase
+    # ("진행 해줘" / "이대로 진행" / "작업 승인 할게 진행 해줘") become
+    # latest_continuation_prompt or canonical_prompt_override. The
+    # research loop + forum thread title reader treat those keys as
+    # *task* prompts; persisting the operational phrase causes
+    # "[Reference] 진행 해줘" thread spam.
+    try:
+        from ..agents.routing import is_non_actionable_prompt
+    except Exception:  # noqa: BLE001 - partial install safe-side
+        is_non_actionable_prompt = None  # type: ignore[assignment]
+    prompt_is_command_only = bool(
+        is_non_actionable_prompt is not None
+        and is_non_actionable_prompt(cleaned_prompt)
+    )
+
     extra = dict(getattr(session, "extra", {}) or {})
 
     history = list(extra.get("continuation_requests") or ())
@@ -2205,6 +2220,7 @@ def _record_engineering_continuation(
             "prompt": cleaned_prompt,
             "thread_id": resumed_thread_id,
             "recorded_at": datetime.now().astimezone().isoformat(),
+            "is_command_only": prompt_is_command_only,
         }
     )
     # Cap the history so a single long-running session doesn't bloat
@@ -2212,14 +2228,25 @@ def _record_engineering_continuation(
     if len(history) > 20:
         history = history[-20:]
     extra["continuation_requests"] = history
-    extra["latest_continuation_prompt"] = cleaned_prompt
     if resumed_thread_id is not None:
         extra["resumed_thread_id"] = resumed_thread_id
-    if _is_command_only_prompt(getattr(session, "prompt", None)):
-        # The original prompt was a command, not a task description —
-        # let downstream readers prefer the continuation as the
-        # canonical record.
-        extra["canonical_prompt_override"] = cleaned_prompt
+
+    if prompt_is_command_only:
+        # P0-K — record the *event* (history above) so audit + status
+        # can show the user pressed approval/proceed, but do NOT
+        # overwrite latest_continuation_prompt / canonical_prompt_override
+        # with the command-only phrase. Existing values stay intact.
+        extra.setdefault("command_only_continuation_count", 0)
+        extra["command_only_continuation_count"] = (
+            extra["command_only_continuation_count"] + 1
+        )
+    else:
+        extra["latest_continuation_prompt"] = cleaned_prompt
+        if _is_command_only_prompt(getattr(session, "prompt", None)):
+            # The original prompt was a command, not a task description —
+            # let downstream readers prefer the continuation as the
+            # canonical record.
+            extra["canonical_prompt_override"] = cleaned_prompt
 
     try:
         from dataclasses import replace

--- a/src/yule_orchestrator/discord/engineering_channel_router.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router.py
@@ -877,17 +877,24 @@ async def route_engineering_message(
 
     research_loop_report: Optional[EngineeringResearchLoopReport] = None
     if research_loop_fn is not None and session is not None:
-        research_loop_report = await _run_research_loop_hook(
-            research_loop_fn=research_loop_fn,
-            message=message,
-            session=session,
-            prompt_text=intake_prompt,
-            send_chunks=send_chunks,
-            collection_outcome=outcome.collection_outcome,
-            research_pack=outcome.research_pack,
-            role_for_research=outcome.role_for_research,
-            thread_id=thread_id,
-        )
+        # P0-K (#148) — never let a command-only prompt drive the
+        # research loop. The loop's first action is to query against
+        # ``prompt_text``; queries like "진행 해줘" surface canned hits
+        # whose title becomes the new forum thread name.
+        if _research_loop_blocked_by_command_only(intake_prompt):
+            research_loop_report = None
+        else:
+            research_loop_report = await _run_research_loop_hook(
+                research_loop_fn=research_loop_fn,
+                message=message,
+                session=session,
+                prompt_text=intake_prompt,
+                send_chunks=send_chunks,
+                collection_outcome=outcome.collection_outcome,
+                research_pack=outcome.research_pack,
+                role_for_research=outcome.role_for_research,
+                thread_id=thread_id,
+            )
 
     # Phase 4: post a deterministic work report once the research +
     # synthesis pass closes. Always best-effort; a failure here keeps
@@ -1042,14 +1049,18 @@ async def _drive_clarification_create_new_work(
 
     research_loop_report = None
     if research_loop_fn is not None and session is not None and kickoff is not None:
-        research_loop_report = await _run_research_loop_hook(
-            research_loop_fn=research_loop_fn,
-            message=message,
-            session=session,
-            prompt_text=canonical_prompt,
-            send_chunks=send_chunks,
-            thread_id=thread_id,
-        )
+        # P0-K (#148) — guard parity with the primary intake path.
+        if _research_loop_blocked_by_command_only(canonical_prompt):
+            research_loop_report = None
+        else:
+            research_loop_report = await _run_research_loop_hook(
+                research_loop_fn=research_loop_fn,
+                message=message,
+                session=session,
+                prompt_text=canonical_prompt,
+                send_chunks=send_chunks,
+                thread_id=thread_id,
+            )
 
     # Phase 4: post the deterministic work report at lifecycle close.
     await _emit_work_report_preview(
@@ -2515,8 +2526,14 @@ async def _handle_join_or_append(
 
     research_loop_report: Optional[EngineeringResearchLoopReport] = None
     is_append_only = decision.action == ACTION_APPEND_CONTEXT
+    # P0-K (#148) — the continuation path is the very site that
+    # produced "[Reference] 진행 해줘" thread spam. Block the research
+    # loop whenever intake_prompt is a command-only operational
+    # phrase.
+    blocked_by_command_only = _research_loop_blocked_by_command_only(intake_prompt)
     if (
         not is_append_only
+        and not blocked_by_command_only
         and research_loop_fn is not None
         and continued_session is not None
     ):
@@ -2611,6 +2628,28 @@ def _maybe_persist_research_pack(
         research_pack,
         collection_outcome=collection_outcome,
     )
+
+
+def _research_loop_blocked_by_command_only(prompt_text: Optional[str]) -> bool:
+    """P0-K (#148) — True when *prompt_text* is a bare approval/proceed
+    phrase like "진행 해줘" / "이대로 진행" / "작업 승인 할게 진행 해줘".
+
+    The research loop's first action is to query against ``prompt_text``;
+    queries like "진행 해줘" surface canned hits whose title becomes the
+    new forum thread name (``[Reference] 진행 해줘``). Block the loop
+    rather than let the operational phrase reach the collector.
+
+    Returns False when ``prompt_text`` is None / empty / substantive
+    so the existing legitimate research path is unaffected.
+    """
+
+    if not prompt_text:
+        return False
+    try:
+        from ..agents.routing import is_non_actionable_prompt
+    except Exception:  # noqa: BLE001 - partial install safe-side
+        return False
+    return bool(is_non_actionable_prompt(prompt_text))
 
 
 async def _run_research_loop_hook(

--- a/src/yule_orchestrator/discord/engineering_conversation.py
+++ b/src/yule_orchestrator/discord/engineering_conversation.py
@@ -65,6 +65,11 @@ SESSION_LIST_QUERY = "session_list_query"
 BLOCKED_REASON_QUERY = "blocked_reason_query"
 CONTINUE_EXISTING_WORK = "continue_existing_work"
 CHANGE_DIRECTION = "change_direction"
+# P0-K (#148) — approval/proceed-only operator phrase. Acks the
+# existing session forward; never creates a new intake / forum
+# thread / research loop. Distinct from CONFIRM_INTAKE which
+# *promotes* a previously-proposed task into intake.
+APPROVAL_ACTION = "approval_action"
 
 # Hard-blocklist for the auto_collect path (commit 7 enforcement).
 READ_ONLY_INTENTS: tuple = (
@@ -74,6 +79,7 @@ READ_ONLY_INTENTS: tuple = (
     BLOCKED_REASON_QUERY,
     CONTINUE_EXISTING_WORK,
     CHANGE_DIRECTION,
+    APPROVAL_ACTION,
 )
 
 
@@ -299,8 +305,64 @@ def build_engineering_conversation_response(
             is_status_query=True,
         )
 
+    # P0-K (#148) — APPROVAL_ACTION early match. When detect returned
+    # APPROVAL_ACTION because the message text was a bare proceed/
+    # approval phrase, we upgrade to CONFIRM_INTAKE *only* when there's
+    # a substantive last_proposed_prompt to confirm. Otherwise we ack
+    # the approval and stop (never create new intake / research / forum).
+    if intent.intent_id == APPROVAL_ACTION:
+        try:
+            from ..agents.routing import is_non_actionable_prompt as _approval_guard
+        except Exception:  # noqa: BLE001
+            _approval_guard = None  # type: ignore[assignment]
+        proposed_is_substantive = (
+            bool(last_proposed_prompt)
+            and (_approval_guard is None or not _approval_guard(last_proposed_prompt))
+        )
+        if proposed_is_substantive:
+            # Upgrade — fall through to CONFIRM_INTAKE handling below.
+            intent = EngineeringIntentMatch(
+                intent_id=CONFIRM_INTAKE,
+                label="진행 확정",
+                confidence="high",
+            )
+        else:
+            body = (
+                "✅ 승인 반영했습니다. 기존 작업 흐름을 이어갑니다.\n"
+                "새 리서치 thread 는 만들지 않습니다."
+            )
+            return EngineeringConversationResponse(
+                content=_prepend_mention(body, mention_user_id),
+                intent_id=APPROVAL_ACTION,
+                mention_user_id=mention_user_id,
+                is_status_query=True,
+            )
+
     if intent.intent_id == CONFIRM_INTAKE:
         intake_prompt = last_proposed_prompt or message_text
+        # P0-K (#148) — defense-in-depth. The APPROVAL_ACTION branch
+        # above usually catches bare confirms, but a future caller
+        # might pass a command-only message_text + no
+        # last_proposed_prompt directly into CONFIRM_INTAKE. Refuse
+        # to use a command-only intake_prompt.
+        try:
+            from ..agents.routing import is_non_actionable_prompt
+        except Exception:  # noqa: BLE001 - partial install safe-side
+            is_non_actionable_prompt = None  # type: ignore[assignment]
+        if (
+            is_non_actionable_prompt is not None
+            and is_non_actionable_prompt(intake_prompt)
+        ):
+            body = (
+                "✅ 승인 반영했습니다. 기존 작업 흐름을 이어갑니다.\n"
+                "새 리서치 thread 는 만들지 않습니다."
+            )
+            return EngineeringConversationResponse(
+                content=_prepend_mention(body, mention_user_id),
+                intent_id=APPROVAL_ACTION,
+                mention_user_id=mention_user_id,
+                is_status_query=True,
+            )
         suggested = _suggest_task_type(intake_prompt)
         write_likely = _looks_like_write_request(intake_prompt)
         if (
@@ -822,6 +884,7 @@ _CONFIRMATION_PHRASES = (
     "그렇게 등록",
     "그렇게 진행",
     "진행해줘",
+    "진행 해줘",
     "진행해 주세요",
     "등록해줘",
     "등록해 주세요",
@@ -830,6 +893,23 @@ _CONFIRMATION_PHRASES = (
     "go 진행",
     "확정",
     "확정해",
+    # P0-K (#148) — 새 command-only 합성. CONFIRM_INTAKE → APPROVAL_ACTION
+    # 다운그레이드 (build_engineering_conversation_response 의 가드) 로
+    # 흘러가서 새 intake/research 절대 안 만듦.
+    "작업 승인 할게",
+    "작업 승인할게",
+    "작업 승인",
+    "승인 할게",
+    "승인할게",
+    "승인하고 진행해",
+    "승인하고 진행",
+    "승인해줘",
+    "승인 해줘",
+    "계속 해",
+    "계속해",
+    "계속 진행",
+    "이어서 해",
+    "이어서 진행",
 )
 
 _CONFIRMATION_STANDALONE = frozenset(

--- a/src/yule_orchestrator/discord/forum_message_adapter.py
+++ b/src/yule_orchestrator/discord/forum_message_adapter.py
@@ -440,6 +440,7 @@ def _resolve_session_for_forum_thread(*, message, session_lister):
     except Exception:  # noqa: BLE001
         return None
 
+    # P0-K (#148) — primary lookup: research_forum_thread_id.
     for session in sessions or ():
         extra = getattr(session, "extra", None) or {}
         if not isinstance(extra, dict):
@@ -449,6 +450,26 @@ def _resolve_session_for_forum_thread(*, message, session_lister):
             continue
         try:
             if int(forum_thread_id) == int(channel_id):
+                return session
+        except (TypeError, ValueError):
+            continue
+
+    # P0-K (#148) — fallback: resumed_thread_id. When the user
+    # continues a session via "기존 세션 X 이어가자" and later asks
+    # for a role-change in the resumed thread ("백엔드도 포함시켜"),
+    # the resumed thread channel doesn't carry the original
+    # research_forum_thread_id. Look up sessions whose extra
+    # ``resumed_thread_id`` matches the current channel so the
+    # role-change branch can resolve and update the right session.
+    for session in sessions or ():
+        extra = getattr(session, "extra", None) or {}
+        if not isinstance(extra, dict):
+            continue
+        resumed_thread_id = extra.get("resumed_thread_id")
+        if resumed_thread_id is None:
+            continue
+        try:
+            if int(resumed_thread_id) == int(channel_id):
                 return session
         except (TypeError, ValueError):
             continue

--- a/src/yule_orchestrator/discord/research_forum.py
+++ b/src/yule_orchestrator/discord/research_forum.py
@@ -136,17 +136,43 @@ def derive_research_topic(pack: "ResearchPack") -> str:
         if question:
             candidates.append(_first_sentence(question))
 
+    # P0-K (#148) — last-line defense: reject any candidate that
+    # decomposes to a command-only operational phrase like "진행 해줘"
+    # or "이대로 진행". These were leaking into pack.title / summary
+    # via the legacy continuation path (which now guards at the write
+    # site), but this filter ensures even legacy data + future regressions
+    # never surface as a thread title. Fall through to the literal
+    # default instead.
+    try:
+        from ..agents.routing import is_non_actionable_prompt
+    except Exception:  # noqa: BLE001 - partial install safe-side
+        is_non_actionable_prompt = None  # type: ignore[assignment]
+
+    def _is_command_only(text: str) -> bool:
+        if is_non_actionable_prompt is None:
+            return False
+        return bool(is_non_actionable_prompt(text))
+
     for candidate in candidates:
         compact = _compact_topic(candidate)
-        if compact and len(compact) <= TOPIC_BUDGET:
+        if not compact:
+            continue
+        if _is_command_only(compact):
+            continue
+        if len(compact) <= TOPIC_BUDGET:
             return compact
 
     # Fall back to a hard-trimmed version of the first non-empty
     # candidate — title preferred. Final fallback keeps a sensible
-    # anchor so create_thread_fn never sees blank.
+    # anchor so create_thread_fn never sees blank. P0-K: same
+    # command-only filter applies here.
     for candidate in candidates:
-        if candidate:
-            return _compact_topic(candidate)[:TOPIC_BUDGET]
+        if not candidate:
+            continue
+        compact = _compact_topic(candidate)
+        if _is_command_only(compact):
+            continue
+        return compact[:TOPIC_BUDGET]
     return "engineering 작업"
 
 

--- a/tests/discord/test_p0k_command_only_guard_e2e.py
+++ b/tests/discord/test_p0k_command_only_guard_e2e.py
@@ -1,0 +1,269 @@
+"""P0-K e2e — command-only operational phrase must never spawn new research/forum (#148).
+
+User-reported scenarios:
+
+  1. "진행 해줘" on existing session — no new intake, no new thread,
+     no _run_research_loop_hook, canonical prompt 유지.
+  2. "작업 승인 할게 진행 해줘" — approval/proceed, no new forum thread.
+  3. "이대로 진행" — no "[Reference] 이대로 진행" thread.
+  4. "세션 <id> 계속 진행해" — existing session continue, no new research loop.
+  5. Genuine direction update — same-session direction update **allowed**.
+  6. Resumed thread role-change — session resolve via resumed_thread_id.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.routing import (
+    is_command_only_prompt,
+    is_non_actionable_prompt,
+)
+from yule_orchestrator.discord.engineering_channel_router import (
+    _research_loop_blocked_by_command_only,
+)
+from yule_orchestrator.discord.engineering_conversation import (
+    APPROVAL_ACTION,
+    CONFIRM_INTAKE,
+    TASK_INTAKE_CANDIDATE,
+    build_engineering_conversation_response,
+)
+from yule_orchestrator.discord.forum_message_adapter import (
+    _resolve_session_for_forum_thread,
+)
+from yule_orchestrator.discord.research_forum import (
+    derive_research_topic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Phrase classification
+# ---------------------------------------------------------------------------
+
+
+class CommandOnlyPhraseTests(unittest.TestCase):
+    """The expanded phrase set catches every user-reported example."""
+
+    def test_user_examples_are_command_only(self) -> None:
+        for text in (
+            "진행 해줘",
+            "작업 승인 할게 진행 해줘",
+            "이대로 진행",
+            "승인하고 진행해",
+            "계속 해",
+            "이어서 해",
+            "오케이 진행",
+            "승인할게",
+            "새 작업으로 진행",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(
+                    is_command_only_prompt(text),
+                    f"{text!r} must be classified as command-only",
+                )
+                self.assertTrue(is_non_actionable_prompt(text))
+
+    def test_substantive_messages_are_not_command_only(self) -> None:
+        for text in (
+            "백엔드도 포함시켜줘",
+            "로그인 말고 검색부터 먼저 구현해",
+            "Next.js + Postgres 회원가입 화면 만들어줘",
+            "회원가입 화면 만들어줘",
+            "지금 뭐 하고 있어?",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(
+                    is_command_only_prompt(text),
+                    f"{text!r} is substantive — must NOT be command-only",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Conversation envelope — no intake / no auto_collect for command-only
+# ---------------------------------------------------------------------------
+
+
+class ConversationEnvelopeTests(unittest.TestCase):
+    def test_proceed_haejwo_yields_approval_action(self) -> None:
+        response = build_engineering_conversation_response("진행 해줘")
+        self.assertEqual(response.intent_id, APPROVAL_ACTION)
+        self.assertFalse(response.ready_to_intake)
+        self.assertTrue(response.is_status_query)
+        self.assertIn("새 리서치 thread 는 만들지 않습니다", response.content)
+
+    def test_approval_compound_yields_approval_action(self) -> None:
+        response = build_engineering_conversation_response(
+            "작업 승인 할게 진행 해줘"
+        )
+        self.assertEqual(response.intent_id, APPROVAL_ACTION)
+        self.assertFalse(response.ready_to_intake)
+
+    def test_idaero_jin_haeng_alone_yields_approval_action(self) -> None:
+        response = build_engineering_conversation_response("이대로 진행")
+        self.assertEqual(response.intent_id, APPROVAL_ACTION)
+        self.assertFalse(response.ready_to_intake)
+
+    def test_seungin_hago_yields_approval_action(self) -> None:
+        response = build_engineering_conversation_response("승인하고 진행해")
+        self.assertEqual(response.intent_id, APPROVAL_ACTION)
+
+    def test_idaero_jin_haeng_with_substantive_last_prompt_still_promotes(self) -> None:
+        # P0-K preserves CONFIRM_INTAKE for legitimate "confirm prior
+        # proposal" — only downgrades when intake_prompt itself is bare
+        # command-only. Substantive last_proposed_prompt rescues it.
+        response = build_engineering_conversation_response(
+            "이대로 진행",
+            last_proposed_prompt="회원가입 화면 만들어줘",
+        )
+        self.assertEqual(response.intent_id, CONFIRM_INTAKE)
+        self.assertTrue(response.ready_to_intake)
+
+    def test_substantive_direction_update_still_intake_candidate(self) -> None:
+        response = build_engineering_conversation_response(
+            "로그인 말고 검색부터 먼저 구현해"
+        )
+        self.assertEqual(response.intent_id, TASK_INTAKE_CANDIDATE)
+
+
+# ---------------------------------------------------------------------------
+# Research loop guard helper
+# ---------------------------------------------------------------------------
+
+
+class ResearchLoopGuardTests(unittest.TestCase):
+    def test_command_only_blocks_research_loop(self) -> None:
+        for text in (
+            "진행 해줘",
+            "이대로 진행",
+            "작업 승인 할게 진행 해줘",
+            "승인하고 진행해",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(_research_loop_blocked_by_command_only(text))
+
+    def test_substantive_prompt_allows_research_loop(self) -> None:
+        for text in (
+            "Next.js 회원가입 페이지 만들어줘",
+            "로그인 말고 검색부터 먼저 구현해",
+            "백엔드도 포함시켜줘",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(_research_loop_blocked_by_command_only(text))
+
+    def test_empty_or_none_does_not_block(self) -> None:
+        self.assertFalse(_research_loop_blocked_by_command_only(None))
+        self.assertFalse(_research_loop_blocked_by_command_only(""))
+
+
+# ---------------------------------------------------------------------------
+# Forum thread title guard
+# ---------------------------------------------------------------------------
+
+
+class ForumThreadTitleGuardTests(unittest.TestCase):
+    """`[Reference] 진행 해줘` thread spam is the canonical bug — block at title source."""
+
+    def test_command_only_title_falls_back_to_default(self) -> None:
+        pack = SimpleNamespace(
+            title="진행 해줘",
+            summary="",
+            tags=(),
+            request=None,
+        )
+        topic = derive_research_topic(pack)
+        self.assertEqual(topic, "engineering 작업")
+        self.assertNotIn("진행", topic)
+
+    def test_command_only_summary_falls_back(self) -> None:
+        pack = SimpleNamespace(
+            title="",
+            summary="이대로 진행",
+            tags=(),
+            request=None,
+        )
+        topic = derive_research_topic(pack)
+        self.assertEqual(topic, "engineering 작업")
+
+    def test_substantive_title_used_normally(self) -> None:
+        pack = SimpleNamespace(
+            title="Next.js 회원가입 화면",
+            summary="",
+            tags=(),
+            request=None,
+        )
+        topic = derive_research_topic(pack)
+        self.assertEqual(topic, "Next.js 회원가입 화면")
+
+    def test_command_only_pack_with_substantive_tag_uses_tag(self) -> None:
+        # Edge case: pack.title is command-only but pack.tags is
+        # substantive — tag should win.
+        pack = SimpleNamespace(
+            title="진행 해줘",
+            summary="",
+            tags=("auth", "search"),
+            request=None,
+        )
+        topic = derive_research_topic(pack)
+        self.assertIn("auth", topic)
+        self.assertNotIn("진행", topic)
+
+
+# ---------------------------------------------------------------------------
+# Forum session resolve — resumed_thread_id fallback
+# ---------------------------------------------------------------------------
+
+
+def _fake_message(channel_id: int):
+    channel = SimpleNamespace(id=channel_id, parent_id=99, parent=SimpleNamespace())
+    return SimpleNamespace(channel=channel)
+
+
+def _session_with_extra(**extra):
+    return SimpleNamespace(extra=dict(extra))
+
+
+class ResumedThreadResolveTests(unittest.TestCase):
+    def test_resumed_thread_id_matches_when_research_forum_thread_absent(self) -> None:
+        message = _fake_message(channel_id=5050)
+        sessions = [
+            _session_with_extra(resumed_thread_id=5050),
+            _session_with_extra(research_forum_thread_id=1111),
+        ]
+        resolved = _resolve_session_for_forum_thread(
+            message=message, session_lister=lambda limit: sessions
+        )
+        self.assertIsNotNone(resolved)
+        assert resolved is not None
+        self.assertEqual(resolved.extra["resumed_thread_id"], 5050)
+
+    def test_research_forum_thread_id_preferred_over_resumed(self) -> None:
+        # When both keys point to different sessions, primary lookup
+        # wins (research_forum_thread_id is the canonical anchor).
+        message = _fake_message(channel_id=5050)
+        primary = _session_with_extra(research_forum_thread_id=5050)
+        secondary = _session_with_extra(resumed_thread_id=5050)
+        resolved = _resolve_session_for_forum_thread(
+            message=message, session_lister=lambda limit: [secondary, primary]
+        )
+        self.assertIs(resolved, primary)
+
+    def test_no_match_returns_none(self) -> None:
+        message = _fake_message(channel_id=99999)
+        sessions = [
+            _session_with_extra(research_forum_thread_id=111),
+            _session_with_extra(resumed_thread_id=222),
+        ]
+        resolved = _resolve_session_for_forum_thread(
+            message=message, session_lister=lambda limit: sessions
+        )
+        self.assertIsNone(resolved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_conversation.py
+++ b/tests/engineering/test_conversation.py
@@ -168,11 +168,20 @@ class ResponseEnvelopeTestCase(unittest.TestCase):
         self.assertTrue(envelope.ready_to_intake)
         self.assertIn("작업을 등록할게요", envelope.content)
 
-    def test_confirm_without_last_prompt_uses_message_text(self) -> None:
+    def test_confirm_without_last_prompt_downgrades_to_approval_action(self) -> None:
+        # P0-K (#148) — "이대로 진행" alone (no substantive last_proposed_prompt)
+        # must NEVER become the session prompt. Used to be CONFIRM_INTAKE +
+        # ready_to_intake=True with intake_prompt="이대로 진행" → that
+        # routed the confirmation phrase itself into research loop +
+        # forum thread title. Now downgrades to APPROVAL_ACTION ack.
+        from yule_orchestrator.discord.engineering_conversation import (
+            APPROVAL_ACTION,
+        )
+
         envelope = build_engineering_conversation_response("이대로 진행")
-        self.assertEqual(envelope.intent_id, CONFIRM_INTAKE)
-        self.assertTrue(envelope.ready_to_intake)
-        self.assertEqual(envelope.intake_prompt, "이대로 진행")
+        self.assertEqual(envelope.intent_id, APPROVAL_ACTION)
+        self.assertFalse(envelope.ready_to_intake)
+        self.assertTrue(envelope.is_status_query)
 
     def test_mention_prefix_only_when_requested(self) -> None:
         with_mention = build_engineering_conversation_response(
@@ -785,10 +794,16 @@ class BotEchoAndCommandOnlyGuardTests(unittest.TestCase):
         self.assertIn("gateway가 보낸 안내문", response.content)
 
     def test_bare_command_only_phrase_does_not_trigger_collector(self) -> None:
-        # "새 작업으로 진행" is a CONFIRM_INTAKE intent — it should
-        # NOT enter the default TASK_INTAKE_CANDIDATE branch and so
-        # _maybe_run_auto_collect must never run. This is the
-        # second-line defence against the auto-collect loop.
+        # P0-K (#148) — "새 작업으로 진행" alone (no substantive
+        # last_proposed_prompt) used to route as CONFIRM_INTAKE +
+        # ready_to_intake=True with intake_prompt = the phrase itself.
+        # That caused the bare command-only phrase to feed the research
+        # loop + forum thread title. Now it downgrades to
+        # APPROVAL_ACTION and the collector still must not run.
+        from yule_orchestrator.discord.engineering_conversation import (
+            APPROVAL_ACTION,
+        )
+
         class _Boom:
             def __call__(self, *_args, **_kwargs):
                 raise AssertionError("collector must not run for confirm phrase")
@@ -799,7 +814,8 @@ class BotEchoAndCommandOnlyGuardTests(unittest.TestCase):
             last_proposed_prompt=None,
             auto_collect=True,
         )
-        self.assertEqual(response.intent_id, CONFIRM_INTAKE)
+        self.assertEqual(response.intent_id, APPROVAL_ACTION)
+        self.assertFalse(response.ready_to_intake)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📌 관련 이슈

closed #148
parent #138

## ✨ 과제 내용

\`진행 해줘\` / \`작업 승인 할게 진행 해줘\` / \`이대로 진행\` / \`승인하고 진행해\` 같은 command-only 운영 문장이 (a) continuation prompt 본문처럼 저장되고 (b) 이어받은 세션에서 _run_research_loop_hook 가 다시 도는 → 새 \`[Reference] 진행 해줘\` forum thread 가 계속 생성되는 회귀 차단.

### 4 critical site 가드 + bonus

| site | 위치 | 가드 |
| --- | --- | --- |
| A | \`bot.py:_record_engineering_continuation\` | cleaned_prompt 가 command-only 면 latest_continuation_prompt / canonical_prompt_override 저장 X. history 에 is_command_only=True 마킹만. |
| B | \`engineering_channel_router._run_research_loop_hook\` 3 호출 사이트 | prompt_text 가 command-only 면 호출 스킵. _research_loop_blocked_by_command_only 헬퍼. |
| C | \`research_forum.derive_research_topic\` | pack.title / summary / tags / request 후보 중 command-only 인 것 거부. fallback "engineering 작업". |
| D | \`engineering_conversation.CONFIRM_INTAKE\` | intake_prompt (= last_proposed_prompt or message_text) 가 command-only 면 APPROVAL_ACTION ack 로 downgrade. |
| E (bonus) | \`forum_message_adapter._resolve_session_for_forum_thread\` | resumed_thread_id secondary lookup — resumed thread role-change 가능. |

### Commit 구성 (8)

| commit | 영역 |
| --- | --- |
| 1 | audit doc — docs/p0k-command-only-research-thread-guard.md |
| 2 | command-only phrase set 확장 (\`agents/routing.py\`) + APPROVAL_ACTION intent + CONFIRM_INTAKE 가드 |
| 3+4 | \`_record_engineering_continuation\` 가드 + \`_run_research_loop_hook\` 3 사이트 가드 |
| 5+6 | \`derive_research_topic\` 가드 + \`resumed_thread_id\` session resolve |
| 7 | e2e — 4 사용자 시나리오 (18 test) |
| 8 | README Mermaid 다이어그램 3 개 + diagram-conventions.md 정책 + Obsidian vault mirror |

### Acceptance Criteria (6/6)

- [x] \`진행 해줘\` on existing session — 새 intake / thread 없음, _run_research_loop_hook 안 탐, canonical 유지.
- [x] \`작업 승인 할게 진행 해줘\` — approval/proceed, 새 forum thread 없음.
- [x] \`이대로 진행\` — \`[Reference] 이대로 진행\` thread 제목 생성 금지.
- [x] \`세션 X 계속 진행해\` — existing session continue, new research loop 없음.
- [x] genuine direction update (\`로그인 말고 검색부터 먼저 구현해\`) — same-session direction update 허용.
- [x] resumed thread role-change (\`백엔드도 포함시켜줘\`) — session resolve via resumed_thread_id.

### 회귀
- \`tests/\` 전체 **4657 PASS** + 1 skipped (main 4639 → 4657, P0-K e2e 18 신규).

### 추가 산출 (사용자 요구)

**README + 다이어그램**: 기존 ASCII art 아키텍처를 Mermaid 3 개로 교체:
1. 시스템 토폴로지 (Discord → Gateway/Planning/Member → Runtime → Queue/Vault/GitHub).
2. Gateway 라우팅 front-door (intent 분류 → READ_ONLY / CONFIRM_INTAKE / TASK_INTAKE_CANDIDATE / coding_bootstrap).
3. Continuation path P0-K 4 critical site 가드.

**diagram-conventions.md (신규 정책)**: Mermaid 가 SSoT. 4 종 (flowchart / sequence / ERD / state diagram). GitHub markdown + Obsidian 자동 렌더링. 충돌 매트릭스 + 작성 체크리스트.

**Obsidian vault mirror**: \`notes/vault-mirror/10-projects/yule-studio-agent/decisions/decision-diagram-conventions-and-command-only-guard-issue-148.md\` — 본 PR 의 4 결정 + 왜 / 고민 / 대안 / 회고. 파일명은 stage-1 obsidian-governance.md 컨벤션 \`<kind>-<topic>-issue-<n>.md\` 준수 (날짜 prefix 없음).

vault repo workspace (\`yule-agent-vault\`) 미클론 — mirror 노트만 본 레포에 land. push 자동화는 P0-G stage 3 의 vault_push_dispatcher 가 책임 (정책 SSoT 그대로 유지).

## :camera_with_flash: 스크린샷(선택)

(README 의 Mermaid 다이어그램이 GitHub PR preview 에서 자동 렌더링.)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- \`docs/p0k-command-only-research-thread-guard.md\` — 본 PR 의 audit doc.
- \`policies/runtime/agents/engineering-agent/diagram-conventions.md\` — 사용자 요구로 신설된 정책.
- 4 critical site 가드는 *defense in depth* — 한 site 회귀해도 나머지가 잡음.
- P0-J 의 READ_ONLY_INTENTS tuple 에 APPROVAL_ACTION 자동 편입 → P0-J 의 auto_collect 차단 hard rule 그대로 적용.

## 🤖 Agent WorkOS Audit

- audit_id: P0-K
- branch: feature/p0k-command-only-research-thread-guard (from main)
- repo: yule-studio/yule-studio-agent
- role: tech-lead
- autonomy_level: L2
- mode: tech-lead-mediated
- issue: #148