### PR TITLE
♻️ engineering_channel_router 3316줄 분해 phase 1 (P0-P step 1-6)

### DIFF
--- a/docs/p0p-engineering-channel-router-decomposition.md
+++ b/docs/p0p-engineering-channel-router-decomposition.md
@@ -1,0 +1,192 @@
+# P0-P — engineering_channel_router.py 모듈 분해 (3316줄 → 11 책임 단위)
+
+> **Status:** behavior-preserving refactor. 동작 변화 0 + 향후 gateway bugfix 가 쉬워지는 구조.
+> **Parent:** #138 (engineering_conversation monolith — closed). 같은 패턴 (audit → package facade → step-wise extraction → `_legacy` 제거) 을 router 에 재적용.
+
+## 0. 충돌 가능 지점 (10줄)
+
+1. `engineering_channel_router.py` 3316줄 — gateway orchestration 의 모든 책임 한 파일.
+2. 외부 import 가 많음 — `bot.py` 가 `route_engineering_message` 와 dataclass 들 (`EngineeringConversationOutcome`, `EngineeringThreadKickoff`, `EngineeringThreadContinuation`, `EngineeringResearchLoopReport`, `EngineeringRouteResult`, `EngineeringRouteContext`) 를 직접 import. 테스트 fixture 도 동일.
+3. 내부 helper 60+ 개 — 책임이 entangled: 한 함수가 routing decision 만들고 동시에 session 영속화 하고 forum 게시까지 호출.
+4. P0-K / P0-M / P0-N1-5 가드가 router 안 여러 사이트에 흩어져 있음 (`_research_loop_blocked_by_command_only` 3 call site, `is_non_actionable_prompt` firewall 4 call site, clarification create branch 1 site). 분해 시 모든 가드의 동등 보존이 hard rule.
+5. 11 모듈 분해: `models` / `utils` / `intent_detection` / `session_persistence` / `coding_gate` / `obsidian_gate` / `research_loop` / `reporting` / `runtime_preflight` / `clarification` (이미 분리됨) / `main`.
+6. Python import 시스템: `engineering_channel_router.py` → `engineering_channel_router/__init__.py` 전환은 transparent. 외부 28 import 무회귀.
+7. 매 commit 후 전체 pytest (현재 4672 PASS + 1 skipped) 유지 — drift 없어야 머지 가능.
+8. 향후 bugfix 가 쉬워지는 지점:
+   - 새 routing precedence 추가 — `main.py` 하나만.
+   - 새 gate 추가 (예: vault export gate) — 같은 패턴으로 `*_gate.py` 한 파일.
+   - session.extra 키 추가 — `session_persistence.py` 한 곳.
+   - research loop guard 변경 — `research_loop.py` 한 곳.
+   - clarification cache 정책 변경 — 이미 `engineering/clarification.py` 단독.
+9. behavior-preserving — 어떤 분기 / 어떤 가드도 변경 없이 이동만.
+10. 12 commit 분할: audit / 패키지 facade / 10 모듈 단계 추출 / 최종 정리. 모듈별 작아서 회귀 분석 쉽게.
+
+## 1. 책임 단위 분해
+
+| 모듈 | 책임 | 핵심 symbol | 의존 |
+| --- | --- | --- | --- |
+| `models.py` | dataclass + type alias | `EngineeringRouteContext`, `EngineeringConversationOutcome`, `EngineeringThreadKickoff`, `EngineeringThreadContinuation`, `EngineeringResearchLoopReport`, `EngineeringRouteResult` + 7 type alias | leaf |
+| `utils.py` | env coercion + message parsing + async helper | `_optional_*` (str/int/bool), `_optional_*_env`, `_safe_int`, `_normalize_channel_name`, `extract_user_links_from_message`, `extract_message_attachments`, `_attach_recall_coverage`, `_maybe_await` | leaf |
+| `intent_detection.py` | 메시지 위치 / confirmation / continuation 신호 | `is_engineering_channel`, `detect_confirmation_signal`, `should_continue_existing_thread`, `should_start_new_thread`, `_CONFIRMATION_KEYWORDS` | models |
+| `session_persistence.py` | session.extra mutation + load helpers | `_persist_role_selection`, `_persist_lifecycle_mode`, `_persist_coding_session_context`, `_persist_extra_keys`, `_persist_thread_id`, `_persist_coding_proposal`, `_persist_coding_job`, `_load_session_by_id`, `_most_recent_session`, `_is_terminal`, `_work_report_to_dict`, `_record_persistence_failure`, `_proposal_to_dict`, `_proposal_from_dict` | models, utils |
+| `coding_gate.py` | "수정 권한 제안" / "수정 승인" 처리 | `_run_coding_authorization_gate`, `_find_session_with_pending_coding_proposal`, `_find_latest_open_session` + `_CODING_*` re-export | models, session_persistence, utils |
+| `obsidian_gate.py` | "저장 승인" / "이대로 저장" + preview | `_run_obsidian_approval_gate`, `_run_obsidian_preview_branch`, `_can_save_to_obsidian`, `_find_session_with_pending_proposal` | models, session_persistence, utils |
+| `research_loop.py` | research_loop hook + P0-K command-only 가드 + forum status persistence | `_research_loop_blocked_by_command_only`, `_run_research_loop_hook`, `_maybe_persist_research_pack`, `persist_research_forum_status`, `_format_member_bots_forum_status`, `make_default_research_loop` | models, session_persistence, utils |
+| `reporting.py` | work_report preview + clarification display + outcome coercion | `_emit_work_report_preview`, `_format_clarification_message`, `_coerce_outcome`, `_coerce_research_loop_report` | models, session_persistence |
+| `runtime_preflight.py` | runtime intent / recall short-circuit | `_run_runtime_preflight`, `_handle_join_or_append`, `_thread_id_for_runtime`, `_observation_for_runtime`, `_format_runtime_preflight_clarification`, `_PREFLIGHT_SHORT_CIRCUIT_INTENTS` | models, session_persistence, research_loop, reporting, utils, clarification |
+| `engineering/clarification.py` (외부 — 이미 분리됨) | clarification cache + TTL (P0-N4) + 선택 helper | `GATEWAY_CLARIFICATION_CONTEXT`, `remember_clarification_candidates`, `recall_clarification_canonical_prompt`, `try_select_candidate`, `looks_like_new_work_selection`, `clear_clarification_context` | — |
+| `main.py` (= `__init__.py` 의 entry 부분) | `route_engineering_message` 메인 + clarification CREATE 분기 | `route_engineering_message`, `_drive_clarification_create_new_work`, `_handle_clarification_selection` | 모든 위 모듈 |
+
+## 2. 의존 그래프
+
+```mermaid
+flowchart TD
+  models --> intent_detection
+  models --> session_persistence
+  models --> coding_gate
+  models --> obsidian_gate
+  models --> research_loop
+  models --> reporting
+  models --> runtime_preflight
+  models --> main
+  utils --> intent_detection
+  utils --> session_persistence
+  utils --> coding_gate
+  utils --> obsidian_gate
+  utils --> research_loop
+  utils --> runtime_preflight
+  utils --> main
+  session_persistence --> coding_gate
+  session_persistence --> obsidian_gate
+  session_persistence --> research_loop
+  session_persistence --> reporting
+  session_persistence --> runtime_preflight
+  session_persistence --> main
+  research_loop --> runtime_preflight
+  research_loop --> main
+  reporting --> runtime_preflight
+  reporting --> main
+  intent_detection --> main
+  coding_gate --> main
+  obsidian_gate --> main
+  runtime_preflight --> main
+  clarification[engineering.clarification] --> runtime_preflight
+  clarification --> main
+```
+
+`main.py` 가 final stage — 모든 sub-module 을 import 하지만 어디서도 import 되지 않음. 순환 없음.
+
+## 3. facade `__init__.py`
+
+```python
+"""engineering_channel_router — package facade (behavior-preserving)."""
+
+from .models import (
+    EngineeringConversationOutcome,
+    EngineeringResearchLoopReport,
+    EngineeringRouteContext,
+    EngineeringRouteResult,
+    EngineeringThreadContinuation,
+    EngineeringThreadKickoff,
+    # 7 type aliases
+)
+from .intent_detection import (
+    detect_confirmation_signal,
+    is_engineering_channel,
+    should_continue_existing_thread,
+    should_start_new_thread,
+)
+from .research_loop import (
+    _research_loop_blocked_by_command_only,
+    make_default_research_loop,
+    persist_research_forum_status,
+)
+from .main import (
+    route_engineering_message,
+)
+
+# Backward-compat re-exports the legacy module owned:
+from .session_persistence import (
+    _load_session_by_id,
+    _most_recent_session,
+)
+from .reporting import (
+    _coerce_outcome,
+)
+from .runtime_preflight import (
+    _handle_join_or_append,
+    _run_runtime_preflight,
+)
+# clarification cache symbols stay imported from .engineering.clarification
+# (already extracted in P0-N4) — re-exposed here under the historical
+# underscored aliases for tests that monkey-patch the router directly.
+from ..engineering.clarification import (
+    GATEWAY_CLARIFICATION_CONTEXT as _GATEWAY_CLARIFICATION_CONTEXT,
+    clarification_context_key as _clarification_context_key,
+    clear_clarification_context as _clear_clarification_context,
+    recall_clarification_candidates as _recall_clarification_candidates,
+    recall_clarification_canonical_prompt as _recall_clarification_canonical_prompt,
+    remember_clarification_candidates as _remember_clarification_candidates,
+    try_select_candidate as _try_select_candidate,
+    looks_like_new_work_selection as _looks_like_new_work_selection,
+)
+
+__all__ = (
+    # public dataclasses
+    "EngineeringConversationOutcome", "EngineeringResearchLoopReport",
+    "EngineeringRouteContext", "EngineeringRouteResult",
+    "EngineeringThreadContinuation", "EngineeringThreadKickoff",
+    # public functions
+    "route_engineering_message", "is_engineering_channel",
+    "detect_confirmation_signal", "should_continue_existing_thread",
+    "should_start_new_thread", "make_default_research_loop",
+    "persist_research_forum_status",
+)
+```
+
+## 4. 변경 외부 surface 0
+
+`from yule_orchestrator.discord.engineering_channel_router import X` 형태의 외부 import 전부 무회귀. `bot.py` / `commands.py` / `supervisor.py` / 테스트 fixture 모두 그대로 동작.
+
+## 5. 회귀 보호
+
+- 매 commit 후 `pytest tests -q` 4672 PASS + 1 skipped 유지.
+- 동작 변경 0 — phrase / matcher / 라우팅 우선순위 / 가드 모두 그대로.
+- 특히 P0-K / P0-M / P0-N 가드의 *동등 보존* 가 절대 룰:
+  - `_research_loop_blocked_by_command_only` 호출 3 사이트
+  - `is_non_actionable_prompt(intake_prompt)` firewall 4 사이트
+  - `_drive_clarification_create_new_work` 우선순위 (runtime preflight 보다 위)
+  - `_emit_work_report_preview(canonical_prompt=...)` 가 항상 actionable prompt 받음
+  - clarification cache TTL evict 가 read 경로 단일 진입점 거침
+
+## 6. 이후 bugfix 가 쉬워지는 지점
+
+1. **새 routing precedence** — `main.py` 의 `route_engineering_message` 만.
+2. **새 gate 추가** — `<name>_gate.py` 한 파일 + `main.py` 에 한 줄 hook.
+3. **session.extra 키 추가** — `session_persistence.py` 한 곳.
+4. **research loop guard 변경** — `research_loop.py` 한 곳 (`_research_loop_blocked_by_command_only` 정책).
+5. **work report payload 수정** — `reporting.py` + `session_persistence._work_report_to_dict`.
+6. **import 경로** — `from yule_orchestrator.discord.engineering_channel_router import X` 그대로 유지. 내부 모듈 직접 import (`from yule_orchestrator.discord.engineering_channel_router.research_loop import _run_research_loop_hook`) 도 지원.
+
+## 7. 추출 순서 (12 commit)
+
+| Step | 내용 | 위험도 |
+| --- | --- | --- |
+| 1 | audit doc (이 문서) | 0 |
+| 2 | `git mv` + `__init__.py` facade + `_legacy.py` shim | low |
+| 3 | `models.py` (leaf) | low |
+| 4 | `utils.py` (leaf) | low |
+| 5 | `intent_detection.py` (models 만 의존) | low |
+| 6 | `session_persistence.py` (모든 mutation 의 single source) | medium |
+| 7 | `coding_gate.py` (session_persistence 의존) | medium |
+| 8 | `obsidian_gate.py` (session_persistence 의존) | medium |
+| 9 | `research_loop.py` (P0-K 가드 + research_loop hook + forum status) | high |
+| 10 | `reporting.py` (coerce + work_report preview + clarification display) | medium |
+| 11 | `runtime_preflight.py` (모든 위 모듈 의존, `_handle_join_or_append` 동반) | high |
+| 12 | `main.py` 에 entry 남기고 `_legacy.py` 제거, 최종 회귀 + PR | high |
+
+## 8. 변경 이력
+
+| 일자 | 변경 |
+| --- | --- |
+| 2026-05-14 | 초안 — P0-P behavior-preserving refactor. parent #138 / P0-L 패턴 재사용. |

--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -49,6 +49,14 @@ from .models import (  # noqa: F401 — facade re-export
     ThreadContinuationFn,
     ThreadKickoffFn,
 )
+# Env + coercion + message parsing + recall coverage live in .utils (P0-P step 4).
+from .utils import (  # noqa: F401 — facade re-export
+    _attach_recall_coverage,
+    _maybe_await,
+    _optional_bool_env,
+    extract_message_attachments,
+    extract_user_links_from_message,
+)
 
 from ._legacy import *  # noqa: F401,F403 — facade re-export
 from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis

--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -1,0 +1,76 @@
+"""Engineering channel router — package facade (P0-P decomposition).
+
+Historical monolith (``engineering_channel_router.py``, 3316 lines)
+is being split into 11 responsibility-aligned modules per the audit at
+``docs/p0p-engineering-channel-router-decomposition.md``. Each module
+owns one slice of the gateway orchestration:
+
+  * :mod:`.models`              — dataclasses + type aliases.
+  * :mod:`.utils`               — env coercion + message parsing + async helpers.
+  * :mod:`.intent_detection`    — channel + confirmation + continuation signals.
+  * :mod:`.session_persistence` — session.extra mutations + load helpers.
+  * :mod:`.coding_gate`         — "수정 권한 제안" / "수정 승인" handler.
+  * :mod:`.obsidian_gate`       — "저장 승인" / "이대로 저장" handler.
+  * :mod:`.research_loop`       — P0-K command-only guard + research_loop hook
+                                    + forum status persistence.
+  * :mod:`.reporting`           — work_report preview + clarification display
+                                    + outcome coercion.
+  * :mod:`.runtime_preflight`   — runtime intent + recall short-circuit.
+  * :mod:`..engineering.clarification` (already extracted in P0-N4) —
+                                    clarification cache + TTL + selection.
+  * :mod:`.main`                — `route_engineering_message` orchestration
+                                    + clarification CREATE driver.
+
+This ``__init__.py`` is the **thin facade** — re-exports the public API
+so ``from yule_orchestrator.discord.engineering_channel_router import X``
+keeps working for every external import site (bot.py, commands.py,
+supervisor.py, all test fixtures) without source changes.
+"""
+
+from __future__ import annotations
+
+# Until commits 3-12 fully extract each module, re-export everything
+# from the legacy single-file body so existing callers (and tests) keep
+# working verbatim. Subsequent commits replace these wildcard imports
+# with explicit per-module imports as content moves out of ``_legacy``.
+from ._legacy import *  # noqa: F401,F403 — facade re-export
+from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis
+    EngineeringConversationOutcome,
+    EngineeringResearchLoopReport,
+    EngineeringRouteContext,
+    EngineeringRouteResult,
+    EngineeringThreadContinuation,
+    EngineeringThreadKickoff,
+    _GATEWAY_CLARIFICATION_CONTEXT,
+    _attach_recall_coverage,
+    _can_save_to_obsidian,
+    _clarification_context_key,
+    _clear_clarification_context,
+    _coerce_outcome,
+    _emit_work_report_preview,
+    _extract_session_id_from_router_text,
+    _handle_clarification_selection,
+    _handle_join_or_append,
+    _looks_like_new_work_selection,
+    _maybe_await,
+    _optional_bool_env,
+    _persist_lifecycle_mode,
+    _persist_thread_id,
+    _recall_clarification_candidates,
+    _recall_clarification_canonical_prompt,
+    _remember_clarification_candidates,
+    _research_loop_blocked_by_command_only,
+    _run_research_loop_hook,
+    _run_runtime_preflight,
+    _try_select_candidate,
+    detect_confirmation_signal,
+    extract_message_attachments,
+    is_coding_approval_phrase,
+    is_coding_proposal_request,
+    is_engineering_channel,
+    make_default_research_loop,
+    persist_research_forum_status,
+    route_engineering_message,
+    should_continue_existing_thread,
+    should_start_new_thread,
+)

--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -65,6 +65,13 @@ from .intent_detection import (  # noqa: F401 — facade re-export
     should_continue_existing_thread,
     should_start_new_thread,
 )
+# session.extra mutations + load helpers live in .session_persistence (P0-P step 6).
+from .session_persistence import (  # noqa: F401 — facade re-export
+    _load_session_by_id,
+    _most_recent_session,
+    _persist_lifecycle_mode,
+    _persist_thread_id,
+)
 
 from ._legacy import *  # noqa: F401,F403 — facade re-export
 from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis

--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -57,6 +57,14 @@ from .utils import (  # noqa: F401 — facade re-export
     extract_message_attachments,
     extract_user_links_from_message,
 )
+# Channel + confirmation + continuation predicates live in .intent_detection
+# (P0-P step 5).
+from .intent_detection import (  # noqa: F401 — facade re-export
+    detect_confirmation_signal,
+    is_engineering_channel,
+    should_continue_existing_thread,
+    should_start_new_thread,
+)
 
 from ._legacy import *  # noqa: F401,F403 — facade re-export
 from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis

--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -33,14 +33,25 @@ from __future__ import annotations
 # from the legacy single-file body so existing callers (and tests) keep
 # working verbatim. Subsequent commits replace these wildcard imports
 # with explicit per-module imports as content moves out of ``_legacy``.
-from ._legacy import *  # noqa: F401,F403 — facade re-export
-from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis
+# Canonical dataclasses + type aliases live in .models (P0-P step 3).
+from .models import (  # noqa: F401 — facade re-export
+    ConversationFn,
     EngineeringConversationOutcome,
     EngineeringResearchLoopReport,
     EngineeringRouteContext,
     EngineeringRouteResult,
     EngineeringThreadContinuation,
     EngineeringThreadKickoff,
+    ExtractPromptFn,
+    IntakeFn,
+    ResearchLoopFn,
+    SendChunksFn,
+    ThreadContinuationFn,
+    ThreadKickoffFn,
+)
+
+from ._legacy import *  # noqa: F401,F403 — facade re-export
+from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis
     _GATEWAY_CLARIFICATION_CONTEXT,
     _attach_recall_coverage,
     _can_save_to_obsidian,

--- a/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
@@ -1012,254 +1012,37 @@ def _find_latest_open_session(
     return _most_recent_session(open_sessions)
 
 
-def _is_terminal(session: Any) -> bool:
-    state = getattr(session, "state", None)
-    state_value = getattr(state, "value", state)
-    return str(state_value).lower() in {"completed", "rejected"}
+# P0-P step 6: session.extra mutations + load helpers extracted to .session_persistence.
+from .session_persistence import (  # noqa: E402,F401 — re-export for back-compat
+    _is_terminal,
+    _load_session_by_id,
+    _most_recent_session,
+    _persist_coding_job,
+    _persist_coding_proposal,
+    _persist_coding_session_context,
+    _persist_extra_keys,
+    _persist_lifecycle_mode,
+    _persist_role_selection,
+    _persist_thread_id,
+    _proposal_from_dict,
+    _proposal_to_dict,
+    _record_persistence_failure,
+    _work_report_to_dict,
+)
 
 
-def _persist_coding_proposal(
-    session: Any,
-    proposal: CodingAuthorizationProposal,
-) -> Any:
-    """Stash a fresh proposal under ``session.extra['coding_proposal']``."""
-
-    return _persist_extra_keys(
-        session,
-        {
-            "coding_proposal": _proposal_to_dict(proposal),
-            "coding_job": None,  # supersedes any prior pending job copy
-        },
-    )
 
 
-def _persist_coding_job(session: Any, job_payload: Mapping[str, object]) -> Any:
-    """Replace any pending proposal with the approved coding job payload."""
-
-    return _persist_extra_keys(
-        session,
-        {
-            "coding_job": dict(job_payload),
-            "coding_proposal": None,  # consumed
-        },
-    )
 
 
-def _persist_role_selection(
-    session: Any,
-    canonical_prompt: str,
-) -> Any:
-    """Run :func:`role_selection.recommend_active_roles` against
-    *canonical_prompt* and stash the result on ``session.extra``.
-
-    Best-effort: import or persistence failures simply skip — the
-    legacy "all roles" fallback path remains operational. Used right
-    after intake so the work-report builder + research scoping see a
-    populated ``active_research_roles`` from turn one.
-    """
-
-    if session is None:
-        return session
-    try:
-        from ...agents.lifecycle.role_selection import (
-            apply_role_selection_to_extra,
-            recommend_active_roles,
-        )
-    except Exception:  # noqa: BLE001
-        return session
-    try:
-        hint_sequence = tuple(getattr(session, "role_sequence", ()) or ())
-    except Exception:  # noqa: BLE001
-        hint_sequence = ()
-    try:
-        selection = recommend_active_roles(
-            user_prompt=canonical_prompt or "",
-            hint_role_sequence=hint_sequence,
-        )
-    except Exception:  # noqa: BLE001
-        return session
-    try:
-        existing = dict(getattr(session, "extra", {}) or {})
-    except Exception:  # noqa: BLE001
-        existing = {}
-    merged = apply_role_selection_to_extra(existing, selection)
-    # Only forward the four selection-specific keys to _persist_extra_keys
-    # so we don't accidentally rewrite unrelated extras with stale copies.
-    selection_updates = {
-        key: merged[key]
-        for key in (
-            "active_research_roles",
-            "excluded_research_roles",
-            "role_selection_source",
-            "role_selection_reasons",
-        )
-        if key in merged
-    }
-    if not selection_updates:
-        return session
-    return _persist_extra_keys(session, selection_updates)
 
 
-def _persist_coding_session_context(
-    session: Any,
-    *,
-    message_text: str,
-    user_links: Sequence[str] = (),
-) -> Any:
-    """P0-H stage 2 + P0-I stage 3 — store gateway-prepared coding session context.
-
-    Calls :func:`prepare_coding_session_context` to compute the
-    work_mode / topology / scope / github_target / repo_contract /
-    coding_handoff_packet extras for *session*, then merges them in.
-    Additionally (P0-I) runs the **tracking enforcement validator** and
-    stores the result for the status surface to display.
-
-    Ask-once contract: if the session already has work_mode set, the
-    helper does not re-prompt and does not overwrite.
-
-    Best-effort — any failure leaves the session untouched so partial
-    install / missing gh CLI never blocks intake.
-    """
-
-    if session is None:
-        return session
-    try:
-        from ...agents.coding.coding_session_context import (
-            prepare_coding_session_context,
-        )
-    except Exception:  # noqa: BLE001 - partial install fallback
-        return session
-
-    try:
-        existing_extra = dict(getattr(session, "extra", None) or {})
-    except Exception:  # noqa: BLE001
-        existing_extra = {}
-
-    try:
-        context = prepare_coding_session_context(
-            message_text=message_text or "",
-            user_links=tuple(user_links or ()),
-            existing_extra=existing_extra,
-            existing_session_id=getattr(session, "session_id", None),
-            # discover_contract=False until vault/workspace clone wiring lands.
-            # The contract still records its own fallback line in extras.
-        )
-    except Exception:  # noqa: BLE001
-        return session
-
-    extras_update = dict(context.extras_update or {})
-
-    # P0-I stage 3 — tracking enforcement validation. Run it against
-    # the *post-update* extras so the validator sees github_target /
-    # work_mode / handoff packet that this very call just persisted.
-    try:
-        from ...agents.coding.tracking_enforcement import (
-            validate_tracking_chain,
-        )
-
-        post_update_extra = dict(existing_extra)
-        post_update_extra.update(extras_update)
-        tracking = validate_tracking_chain(post_update_extra)
-        extras_update["tracking_validation"] = dict(tracking.to_dict())
-        if tracking.blocked and tracking.blocked_reason:
-            extras_update["tracking_blocked_reason"] = tracking.blocked_reason
-    except Exception:  # noqa: BLE001
-        pass
-
-    if not extras_update:
-        return session
-    return _persist_extra_keys(session, extras_update)
 
 
-def _persist_lifecycle_mode(session: Any, canonical_prompt: str) -> Any:
-    """Mark *session* as research-only when the prompt signals that.
-
-    Live regression: the gateway used to advertise an executor role
-    ("실행 후보 backend-engineer") even on a request like "오늘은 코드
-    수정 없이 자료 수집이 목표야". Phase 2 fixes that by stashing the
-    lifecycle mode at intake so every downstream consumer (work_report
-    builder, status diagnostic, member-bot research path) reads the
-    same answer.
-
-    The session.extra layout matches the spec's bullet 5:
-        lifecycle_mode: "research_only" | "implementation"
-        executor_role:  null when research-only
-        research_leads: list[str]   roles leading the investigation
-
-    Best-effort — any import or persistence failure leaves the session
-    untouched so a partial agent layout cannot block intake.
-    """
-
-    if session is None:
-        return session
-    try:
-        from ...agents.coding.authorization import (
-            LIFECYCLE_MODE_IMPLEMENTATION,
-            LIFECYCLE_MODE_RESEARCH_ONLY,
-            recommend_authorization,
-        )
-    except Exception:  # noqa: BLE001
-        return session
-
-    try:
-        proposal = recommend_authorization(user_request=canonical_prompt or "")
-    except Exception:  # noqa: BLE001
-        return session
-
-    if proposal.lifecycle_mode == LIFECYCLE_MODE_RESEARCH_ONLY:
-        updates = {
-            "lifecycle_mode": LIFECYCLE_MODE_RESEARCH_ONLY,
-            "executor_role": None,
-            "research_leads": list(proposal.research_leads),
-        }
-    else:
-        updates = {
-            "lifecycle_mode": LIFECYCLE_MODE_IMPLEMENTATION,
-        }
-    return _persist_extra_keys(session, updates)
 
 
-def _work_report_to_dict(report: Any) -> dict:
-    """Serialise a :class:`agents.reports.work_report.WorkReport` into a plain
-    JSON-friendly dict so the workflow store can persist it under
-    ``session.extra['work_report']``."""
 
-    return {
-        "session_id": getattr(report, "session_id", None),
-        "title": getattr(report, "title", "") or "",
-        "canonical_prompt": getattr(report, "canonical_prompt", "") or "",
-        "executive_summary": getattr(report, "executive_summary", "") or "",
-        "research_summary": getattr(report, "research_summary", "") or "",
-        "tech_lead_recommendation": getattr(
-            report, "tech_lead_recommendation", ""
-        )
-        or "",
-        "role_decisions": dict(getattr(report, "role_decisions", {}) or {}),
-        "risks": list(getattr(report, "risks", ()) or ()),
-        "proposed_next_steps": list(
-            getattr(report, "proposed_next_steps", ()) or ()
-        ),
-        "requires_code_change": bool(
-            getattr(report, "requires_code_change", False)
-        ),
-        "recommended_executor_role": getattr(
-            report, "recommended_executor_role", None
-        ),
-        "approval_request": getattr(report, "approval_request", None),
-        "participants": list(getattr(report, "participants", ()) or ()),
-        "reference_count": int(getattr(report, "reference_count", 0) or 0),
-        "research_stop_reason": getattr(report, "research_stop_reason", None),
-        "under_covered_roles": list(
-            getattr(report, "under_covered_roles", ()) or ()
-        ),
-        # Phase 3 status gate fields.
-        "status": getattr(report, "status", "interim"),
-        "missing_roles": list(getattr(report, "missing_roles", ()) or ()),
-        "has_research_pack": bool(
-            getattr(report, "has_research_pack", False)
-        ),
-        "has_synthesis": bool(getattr(report, "has_synthesis", False)),
-    }
+
 
 
 async def _emit_work_report_preview(
@@ -1337,156 +1120,14 @@ async def _emit_work_report_preview(
             pass
 
 
-def _persist_extra_keys(session: Any, updates: Mapping[str, object]) -> Any:
-    """Merge *updates* into ``session.extra`` and persist via ``update_session``.
-
-    Always mutates the live ``extra`` dict when one is present, so test
-    fixtures using mutable dataclass stubs observe the new keys without
-    having to capture the returned session. Production WorkflowSession
-    is frozen — for that path we rely on ``dataclasses.replace`` +
-    ``update_session`` to land the change in SQLite.
-
-    Stabilisation Phase 1: persistence failures used to be silently
-    swallowed, which made live debugging impossible. We now stamp a
-    ``persistence_error`` entry on the session's live extra dict (when
-    available) so the status diagnostic + supervisor can surface
-    "왜 저장이 안 됐어?" without having to grep logs. The user-visible
-    reply chain is still kept intact (no exception leaks past this
-    helper).
-    """
-
-    try:
-        from dataclasses import replace as _dc_replace
-        from datetime import datetime as _dt
-
-        from ...agents.workflow_state import update_session
-    except Exception as exc:  # noqa: BLE001
-        _record_persistence_failure(
-            session,
-            step="import update_session",
-            reason=str(exc),
-            updates=updates,
-        )
-        return session
-
-    # Try in-place mutation first so test stubs (plain dataclasses with
-    # a regular dict ``extra``) observe the change directly. Production
-    # WorkflowSession holds an immutable mapping; this no-ops there.
-    live = getattr(session, "extra", None)
-    if isinstance(live, dict):
-        for key, value in updates.items():
-            live[key] = value
-
-    existing = dict(getattr(session, "extra", {}) or {})
-    merged = {**existing, **dict(updates)}
-    try:
-        updated = _dc_replace(session, extra=merged)
-    except TypeError:
-        # Non-dataclass stub — in-place mutation above already covered it.
-        return session
-    try:
-        update_session(updated, now=_dt.now().astimezone())
-    except Exception as exc:  # noqa: BLE001
-        _record_persistence_failure(
-            updated,
-            step="update_session",
-            reason=str(exc),
-            updates=updates,
-        )
-    return updated
 
 
-def _record_persistence_failure(
-    session: Any,
-    *,
-    step: str,
-    reason: str,
-    updates: Mapping[str, object],
-) -> None:
-    """Stamp a persistence failure note on the live ``session.extra``.
-
-    Best-effort — the session.extra mutation is wrapped so even
-    pathological stubs never raise out of this helper. The note keeps
-    the offending step + reason + the keys that were being written so
-    the diagnostic responder can show the operator exactly which
-    update silently failed during the live MVP loop.
-    """
-
-    if session is None:
-        return
-    try:
-        live = getattr(session, "extra", None)
-        if isinstance(live, dict):
-            live["persistence_error"] = {
-                "step": step,
-                "reason": reason,
-                "keys": sorted(str(k) for k in (updates or {}).keys()),
-            }
-    except Exception:  # noqa: BLE001
-        return
 
 
-def _persist_thread_id(
-    session: Any,
-    thread_id: Optional[int],
-) -> Any:
-    """Write the Discord work-thread id back to ``session.thread_id``.
-
-    MVP closure refactor: delegates to
-    :func:`agents.lifecycle.persistence.persist_thread_link` so the
-    router and any other caller (member-bot, supervisor cleanup)
-    follow the same persistence contract — including the structured
-    ``persistence_error`` stamp on failure. Behaviour is identical to
-    the prior inline implementation; only the import/replace
-    sequence is consolidated upstream.
-    """
-
-    from ...agents.lifecycle.persistence import persist_thread_link
-
-    result = persist_thread_link(session, thread_id)
-    return result.session
 
 
-def _proposal_to_dict(proposal: CodingAuthorizationProposal) -> Mapping[str, object]:
-    return {
-        "session_id": proposal.session_id,
-        "user_request": proposal.user_request,
-        "executor_role": proposal.executor_role,
-        "review_roles": list(proposal.review_roles),
-        "participant_roles": list(proposal.participant_roles),
-        "write_scope": list(proposal.write_scope),
-        "forbidden_scope": list(proposal.forbidden_scope),
-        "reason": proposal.reason,
-        "safety_rules": list(proposal.safety_rules),
-        "approval_required": bool(proposal.approval_required),
-        "metadata": dict(proposal.metadata),
-        "lifecycle_mode": proposal.lifecycle_mode,
-        "research_leads": list(proposal.research_leads),
-    }
 
 
-def _proposal_from_dict(payload: Mapping[str, object]) -> CodingAuthorizationProposal:
-    lifecycle_mode = str(payload.get("lifecycle_mode") or "implementation")
-    raw_executor = payload.get("executor_role")
-    if lifecycle_mode == "research_only":
-        executor_role = str(raw_executor or "")
-    else:
-        executor_role = str(raw_executor or "tech-lead")
-    return CodingAuthorizationProposal(
-        session_id=payload.get("session_id"),
-        user_request=str(payload.get("user_request") or ""),
-        executor_role=executor_role,
-        review_roles=tuple(payload.get("review_roles") or ()),
-        participant_roles=tuple(payload.get("participant_roles") or ()),
-        write_scope=tuple(payload.get("write_scope") or ()),
-        forbidden_scope=tuple(payload.get("forbidden_scope") or ()),
-        reason=str(payload.get("reason") or ""),
-        safety_rules=tuple(payload.get("safety_rules") or ()),
-        approval_required=bool(payload.get("approval_required", True)),
-        metadata=dict(payload.get("metadata") or {}),
-        lifecycle_mode=lifecycle_mode,
-        research_leads=tuple(payload.get("research_leads") or ()),
-    )
 
 
 async def _run_coding_authorization_gate(
@@ -1895,40 +1536,8 @@ def _find_session_with_pending_proposal(
     return _most_recent_session(candidates_with_proposal)
 
 
-def _load_session_by_id(
-    list_sessions_fn: Callable[..., Sequence[Any]],
-    session_id: Optional[str],
-) -> Optional[Any]:
-    if not session_id:
-        return None
-    try:
-        try:
-            sessions = list_sessions_fn(limit=50)
-        except TypeError:
-            sessions = list_sessions_fn()
-    except Exception:  # noqa: BLE001
-        return None
-    for session in sessions or ():
-        if getattr(session, "session_id", None) == session_id:
-            return session
-    return None
 
 
-def _most_recent_session(sessions: Sequence[Any]) -> Optional[Any]:
-    if not sessions:
-        return None
-
-    def _sort_key(s: Any):
-        ts = getattr(s, "updated_at", None)
-        if ts is None:
-            return (0, 0)
-        try:
-            epoch = ts.timestamp()
-        except Exception:  # noqa: BLE001
-            epoch = 0
-        return (1, epoch)
-
-    return max(sessions, key=_sort_key)
 
 
 async def _run_runtime_preflight(

--- a/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
@@ -67,35 +67,6 @@ from ...agents.runtime import (
     make_recall_fn,
 )
 
-
-# Single-source confirmation lexicon; the engineering conversation layer
-# may also detect intent and pre-set ``confirmed=True`` itself, in which
-# case the router trusts that signal.
-_CONFIRMATION_KEYWORDS: tuple[str, ...] = (
-    "확정",
-    "진행",
-    "시작해",
-    "시작하자",
-    "시작할게",
-    "시작합시다",
-    "고고",
-    "ㄱㄱ",
-    "ㄱㄱㄱ",
-    "맞아 진행",
-    "그대로 진행",
-    "그대로 가",
-    "오케이 진행",
-    "오케 진행",
-    "go ahead",
-    "let's go",
-    "lets go",
-    "kick off",
-    "kickoff",
-    "proceed",
-    "approve and start",
-)
-
-
 # P0-P step 3: dataclasses + type aliases extracted to .models.
 from .models import (  # noqa: E402,F401 — re-export for back-compat
     ConversationFn,
@@ -114,105 +85,15 @@ from .models import (  # noqa: E402,F401 — re-export for back-compat
 )
 
 
-def is_engineering_channel(
-    *,
-    message: Any,
-    route_context: EngineeringRouteContext,
-) -> bool:
-    if not route_context.configured:
-        return False
-
-    channel = getattr(message, "channel", None)
-    if channel is None:
-        return False
-
-    channel_id = getattr(channel, "id", None)
-    parent = getattr(channel, "parent", None)
-    parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
-    channel_name = _normalize_channel_name(getattr(channel, "name", None))
-    parent_name = _normalize_channel_name(getattr(parent, "name", None))
-
-    target_id = route_context.intake_channel_id
-    target_name = _normalize_channel_name(route_context.intake_channel_name)
-
-    if target_id is not None:
-        if channel_id is not None and channel_id == target_id:
-            return True
-        if parent_id is not None and parent_id == target_id:
-            return True
-    if target_name:
-        if channel_name == target_name:
-            return True
-        if parent_name == target_name:
-            return True
-    return False
-
-
-def detect_confirmation_signal(text: str) -> bool:
-    """Heuristic confirmation detector used when the conversation layer
-    does not pre-classify intent.  Matches Korean and English go-ahead
-    phrases conservatively — short ack words like ``yes``/``네`` are
-    excluded so casual chat isn't promoted to a workflow intake."""
-
-    if not text:
-        return False
-    normalized = " ".join(text.lower().split())
-    if not normalized:
-        return False
-    return any(keyword in normalized for keyword in _CONFIRMATION_KEYWORDS)
-
-
-def should_continue_existing_thread(*texts: str) -> bool:
-    """True when the user asked to reuse an existing workflow thread/session."""
-
-    normalized = " ".join(
-        " ".join(str(text or "").lower().split()) for text in texts
-    )
-    if not normalized.strip():
-        return False
-    continuation_signals = (
-        "새로 등록하지 말고",
-        "새로 만들지 말고",
-        "새 스레드 만들지",
-        "새 thread 만들지",
-        "새로운 스레드",
-        "새 thread",
-        "기존 스레드",
-        "기존 thread",
-        "열려 있는 스레드",
-        "열려있는 스레드",
-        "열려 있는 thread",
-        "열려있는 thread",
-        "이어가",
-        "이어 가",
-        "이어서",
-        "continue existing",
-        "reuse thread",
-        "same thread",
-        "do not create a new thread",
-        "don't create a new thread",
-    )
-    return any(signal in normalized for signal in continuation_signals)
-
-
-def should_start_new_thread(text: str) -> bool:
-    """True when the latest user turn explicitly overrides continuation."""
-
-    normalized = " ".join(str(text or "").lower().split())
-    if not normalized:
-        return False
-    force_new_signals = (
-        "새 작업으로 진행",
-        "새 작업으로 시작",
-        "새로 등록해",
-        "새로 등록",
-        "새 스레드로",
-        "새 thread로",
-        "새 세션으로",
-        "new thread",
-        "new session",
-    )
-    return any(signal in normalized for signal in force_new_signals)
+# P0-P step 5: channel + confirmation + continuation predicates
+# extracted to .intent_detection.
+from .intent_detection import (  # noqa: E402,F401 — re-export for back-compat
+    _CONFIRMATION_KEYWORDS,
+    detect_confirmation_signal,
+    is_engineering_channel,
+    should_continue_existing_thread,
+    should_start_new_thread,
+)
 
 
 async def route_engineering_message(

--- a/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
@@ -96,166 +96,22 @@ _CONFIRMATION_KEYWORDS: tuple[str, ...] = (
 )
 
 
-@dataclass(frozen=True)
-class EngineeringRouteContext:
-    """Where the engineering intake channel lives.
-
-    Both ``intake_channel_id`` and ``intake_channel_name`` are optional
-    individually — if either one matches the message channel (or its
-    parent, for a thread), the message is treated as engineering.
-
-    F16 (issue #128) added ``prefer_recall_first_gateway`` — an opt-in
-    flag that, when set, lets the router call ``decide_gateway`` (the
-    new 7-action recall-first decision) for **any** intent. While off
-    (default), the router keeps the legacy preflight short-circuit
-    behaviour so all pre-F16 contracts hold. The coverage scorer is
-    attached to recall results unconditionally — it is **derived**
-    metadata and changes no existing behaviour, but lets observability
-    and future routing tap into it without re-running recall.
-    """
-
-    intake_channel_id: Optional[int] = None
-    intake_channel_name: Optional[str] = None
-    prefer_recall_first_gateway: bool = False
-
-    @property
-    def configured(self) -> bool:
-        return self.intake_channel_id is not None or bool(
-            _normalize_channel_name(self.intake_channel_name)
-        )
-
-    @classmethod
-    def from_env(cls) -> "EngineeringRouteContext":
-        return cls(
-            intake_channel_id=_optional_int_env("DISCORD_ENGINEERING_INTAKE_CHANNEL_ID"),
-            intake_channel_name=_optional_string_env(
-                "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME"
-            ),
-            prefer_recall_first_gateway=_optional_bool_env(
-                "YULE_GATEWAY_RECALL_FIRST_ENABLED", default=False
-            ),
-        )
-
-
-@dataclass(frozen=True)
-class EngineeringConversationOutcome:
-    """The shape returned by the engineering free-conversation layer.
-
-    ``confirmed=True`` means the user just expressed intent to start
-    a real intake; ``intake_prompt`` is the canonicalised request for
-    the workflow.  The conversation layer is free to omit those fields
-    — the router falls back to a keyword-based confirmation check on
-    the original user text.
-
-    ``research_pack`` and ``collection_outcome`` carry the autonomous
-    research collector's result through to the research-loop hook
-    (forum publisher / deliberation kickoff). ``role_for_research``
-    lets the conversation layer signal which role profile drove the
-    collection so downstream code can render labels accordingly.
-    """
-
-    content: str
-    confirmed: bool = False
-    intake_prompt: Optional[str] = None
-    write_requested: bool = False
-    thread_topic: Optional[str] = None
-    research_pack: Any = None
-    collection_outcome: Any = None
-    role_for_research: Optional[str] = None
-    # When True the conversation already answered a status/diagnostic
-    # question. The router must NOT route to intake/decide/auto_collect
-    # — the user wasn't filing new work, they were asking what's going
-    # on with existing work.
-    is_status_query: bool = False
-
-
-@dataclass(frozen=True)
-class EngineeringThreadKickoff:
-    """Result of creating a working thread and posting kickoff."""
-
-    thread_id: Optional[int] = None
-    message: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class EngineeringThreadContinuation:
-    """Result of continuing an already-open workflow thread."""
-
-    session: Any
-    thread_id: Optional[int] = None
-    message: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class EngineeringResearchLoopReport:
-    """What the research loop hook reported back to the router.
-
-    ``follow_up_message`` is sent to the user when the loop decided the
-    research pack is too thin (e.g. no URL, no attachment for a
-    landing-page task). ``forum_status_message`` is the operator-facing
-    summary line ("운영-리서치 forum thread 게시: …") posted after a
-    successful publish. ``error`` is filled when the hook itself raised;
-    callers display it as a `⚠️` line and continue.
-    """
-
-    follow_up_message: Optional[str] = None
-    forum_status_message: Optional[str] = None
-    forum_thread_id: Optional[int] = None
-    forum_thread_url: Optional[str] = None
-    insufficient: bool = False
-    error: Optional[str] = None
-    # member-bots vs gateway publication mode signal — populated by the
-    # research-loop hook from the publication outcome so status /
-    # diagnostic responses can describe the live setup correctly.
-    forum_comment_mode: Optional[str] = None
-    # member-bots mode only: did the gateway successfully post the
-    # ``[research-open:<session_id>]`` open-call directive that each
-    # member bot is supposed to react to? ``None`` in gateway mode.
-    kickoff_posted: Optional[bool] = None
-    # member-bots mode only: stringified error from the open-call
-    # directive post when ``kickoff_posted`` is False; otherwise None.
-    kickoff_error: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class EngineeringRouteResult:
-    """What the router did with one Discord message.
-
-    ``handled=False`` means this message is *not* an engineering channel
-    message; the bot should fall through to its planning conversation
-    path.  ``handled=True`` means the router has already replied (and
-    optionally created an intake/thread), so the bot must not double-reply.
-    """
-
-    handled: bool
-    conversation_message: Optional[str] = None
-    intake_message: Optional[str] = None
-    kickoff_message: Optional[str] = None
-    session_id: Optional[str] = None
-    thread_id: Optional[int] = None
-    research_loop_report: Optional[EngineeringResearchLoopReport] = None
-    error: Optional[str] = None
-    routing_decision: Optional[EngineeringRoutingDecision] = None
-
-
-SendChunksFn = Callable[[Any, str], Awaitable[None]]
-ExtractPromptFn = Callable[..., str]
-ConversationFn = Callable[..., Union[
+# P0-P step 3: dataclasses + type aliases extracted to .models.
+from .models import (  # noqa: E402,F401 — re-export for back-compat
+    ConversationFn,
     EngineeringConversationOutcome,
-    Awaitable[EngineeringConversationOutcome],
-    str,
-    Awaitable[str],
-]]
-IntakeFn = Callable[..., Any]
-ThreadKickoffFn = Callable[..., Awaitable[EngineeringThreadKickoff]]
-ThreadContinuationFn = Callable[..., Union[
-    Optional[EngineeringThreadContinuation],
-    Awaitable[Optional[EngineeringThreadContinuation]],
-]]
-ResearchLoopFn = Callable[..., Union[
     EngineeringResearchLoopReport,
-    Awaitable[EngineeringResearchLoopReport],
-]]
+    EngineeringRouteContext,
+    EngineeringRouteResult,
+    EngineeringThreadContinuation,
+    EngineeringThreadKickoff,
+    ExtractPromptFn,
+    IntakeFn,
+    ResearchLoopFn,
+    SendChunksFn,
+    ThreadContinuationFn,
+    ThreadKickoffFn,
+)
 
 
 def is_engineering_channel(

--- a/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
@@ -2997,20 +2997,8 @@ def _coerce_research_loop_report(raw: Any) -> EngineeringResearchLoopReport:
     )
 
 
-def _optional_str(value: Any) -> Optional[str]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _safe_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+# P0-P step 4: value coercion helpers extracted to .utils.
+from .utils import _optional_str, _safe_int  # noqa: E402,F401 — re-export
 
 
 def _coerce_outcome(
@@ -3062,111 +3050,14 @@ def _coerce_outcome(
     )
 
 
-async def _maybe_await(value: Any) -> Any:
-    if hasattr(value, "__await__"):
-        return await value
-    return value
-
-
-def extract_user_links_from_message(
-    message: Any,
-    prompt_text: Optional[str] = None,
-) -> tuple[str, ...]:
-    """Pull URLs out of the user's message body.
-
-    Lazily delegates to :func:`research_collector.extract_urls` so we get
-    the same regex + dedup the collector uses internally. Returns an empty
-    tuple if the helper isn't importable (e.g. during a partial install).
-    """
-
-    text = (prompt_text or getattr(message, "content", "") or "")
-    if not text:
-        return ()
-    try:
-        from ...agents.research.collector import extract_urls
-    except Exception:  # noqa: BLE001
-        return ()
-    return tuple(extract_urls(text))
-
-
-def extract_message_attachments(message: Any) -> tuple[Any, ...]:
-    """Return the message's attachments as a stable tuple, discord.py-agnostic.
-
-    discord.py exposes ``message.attachments`` as a list of ``Attachment``
-    objects, but tests pass plain dataclasses or dicts. We accept any iterable
-    and drop ``None`` entries so the engineering conversation layer can rely
-    on a clean sequence regardless of the Discord shape.
-    """
-
-    raw = getattr(message, "attachments", None)
-    if raw is None:
-        return ()
-    if isinstance(raw, (list, tuple)):
-        return tuple(item for item in raw if item is not None)
-    try:
-        return tuple(item for item in raw if item is not None)
-    except TypeError:
-        return ()
-
-
-def _normalize_channel_name(value: object | None) -> str:
-    if value is None:
-        return ""
-    return str(value).strip().lstrip("#").lower()
-
-
-def _optional_int_env(name: str) -> Optional[int]:
-    raw = os.environ.get(name)
-    if raw is None or not raw.strip():
-        return None
-    value = raw.strip()
-    try:
-        return int(value)
-    except ValueError as exc:
-        raise ValueError(
-            f"{name} must be an integer value, got: {value!r}"
-        ) from exc
-
-
-def _optional_string_env(name: str) -> Optional[str]:
-    raw = os.environ.get(name)
-    if raw is None:
-        return None
-    value = raw.strip()
-    return value or None
-
-
-def _optional_bool_env(name: str, *, default: bool = False) -> bool:
-    """Parse a boolean envvar — empty/unset returns ``default``.
-
-    Accepted truthy values: ``"true"``, ``"1"``, ``"yes"``, ``"on"``
-    (case-insensitive). Anything else is treated as the default. Used
-    by F16 ``EngineeringRouteContext.prefer_recall_first_gateway`` so
-    operators can opt into the recall-first gateway path without code
-    changes.
-    """
-
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    value = raw.strip().lower()
-    if not value:
-        return default
-    return value in {"true", "1", "yes", "on"}
-
-
-def _attach_recall_coverage(recall: RuntimeRecallResult) -> RuntimeRecallResult:
-    """F16 — replace ``recall`` with a copy whose ``coverage`` is scored.
-
-    The scorer is **defensive**: any failure (None, malformed hits)
-    degrades to ``RecallCoverage(level=low, stale=True)``. Legacy
-    callers that ignore ``coverage`` see no behaviour change.
-    """
-
-    try:
-        coverage = compute_recall_coverage(recall)
-    except Exception:  # noqa: BLE001
-        coverage = RecallCoverage(
-            level="low", stale=True, sources=(), reason="scorer raised"
-        )
-    return replace(recall, coverage=coverage)
+# P0-P step 4: async + message-parsing + env + recall coverage extracted to .utils.
+from .utils import (  # noqa: E402,F401 — re-export for back-compat
+    _attach_recall_coverage,
+    _maybe_await,
+    _normalize_channel_name,
+    _optional_bool_env,
+    _optional_int_env,
+    _optional_string_env,
+    extract_message_attachments,
+    extract_user_links_from_message,
+)

--- a/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/_legacy.py
@@ -17,16 +17,16 @@ import os
 from dataclasses import dataclass, replace
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 
-from ..agents.coding.authorization import (
+from ...agents.coding.authorization import (
     CodingAuthorizationProposal,
     format_authorization_message,
     recommend_authorization,
 )
-from ..agents.coding.job import (
+from ...agents.coding.job import (
     STATUS_READY,
     build_coding_job_from_proposal,
 )
-from ..agents.obsidian.approval import (
+from ...agents.obsidian.approval import (
     ObsidianApprovalError,
     build_save_proposal,
     execute_pending_proposal,
@@ -35,8 +35,8 @@ from ..agents.obsidian.approval import (
     is_obsidian_save_request,
     store_pending_proposal,
 )
-from ..agents.research.persistence import persist_research_artifacts
-from ..agents.routing import (
+from ...agents.research.persistence import persist_research_artifacts
+from ...agents.routing import (
     ACTION_APPEND_CONTEXT,
     ACTION_ASK,
     ACTION_CREATE,
@@ -49,7 +49,7 @@ from ..agents.routing import (
     is_non_actionable_prompt,
     list_open_sessions,
 )
-from ..agents.runtime import (
+from ...agents.runtime import (
     ACTION_APPEND_CONTEXT as RUNTIME_ACTION_APPEND_CONTEXT,
     ACTION_ASK_CLARIFICATION as RUNTIME_ACTION_ASK_CLARIFICATION,
     ACTION_JOIN_SESSION as RUNTIME_ACTION_JOIN_SESSION,
@@ -447,7 +447,7 @@ async def route_engineering_message(
         explicit_session_id = _explicit_session_request(prompt_text)
         if explicit_session_id:
             try:
-                from ..agents.workflow_state import load_session as _load_session
+                from ...agents.workflow_state import load_session as _load_session
                 target_session = _load_session(explicit_session_id)
             except Exception:  # noqa: BLE001 - lookup failures fall through to legacy flow
                 target_session = None
@@ -586,7 +586,7 @@ async def route_engineering_message(
     # typing_keepalive 가 ~6s 마다 typing event 재발사 → 첫 visible
     # reply (send_chunks) 까지 끊김 없이 유지. ignored / non-actionable /
     # bot-echo 분기는 본 라인 *전*에 이미 return 했으므로 silence 보존.
-    from .typing_indicator import typing_keepalive
+    from ..typing_indicator import typing_keepalive
 
     async with typing_keepalive(
         getattr(message, "channel", None),
@@ -969,7 +969,7 @@ _PREFLIGHT_SHORT_CIRCUIT_INTENTS = frozenset(
 # stays focused on flow orchestration. The router-prefixed (``_``)
 # names below are kept as aliases so existing tests / callers that
 # import from ``engineering_channel_router`` keep working.
-from .engineering.clarification import (
+from ..engineering.clarification import (
     GATEWAY_CLARIFICATION_CONTEXT as _GATEWAY_CLARIFICATION_CONTEXT,
     clarification_context_key as _clarification_context_key,
     clear_clarification_context as _clear_clarification_context,
@@ -1156,7 +1156,7 @@ async def _handle_clarification_selection(
 # the historical underscore-prefixed names so existing tests / callers
 # (e.g. ``engineering_channel_router.is_coding_approval_phrase``) keep
 # working.
-from .engineering.phrase_detect import (
+from ..engineering.phrase_detect import (
     CODING_APPROVAL_PHRASES as _CODING_APPROVAL_PHRASES,
     CODING_PROPOSAL_REQUEST_PHRASES as _CODING_PROPOSAL_REQUEST_PHRASES,
     CONTINUATION_RESEARCH_KEYWORDS as _CONTINUATION_RESEARCH_KEYWORDS,
@@ -1324,7 +1324,7 @@ def _persist_role_selection(
     if session is None:
         return session
     try:
-        from ..agents.lifecycle.role_selection import (
+        from ...agents.lifecycle.role_selection import (
             apply_role_selection_to_extra,
             recommend_active_roles,
         )
@@ -1387,7 +1387,7 @@ def _persist_coding_session_context(
     if session is None:
         return session
     try:
-        from ..agents.coding.coding_session_context import (
+        from ...agents.coding.coding_session_context import (
             prepare_coding_session_context,
         )
     except Exception:  # noqa: BLE001 - partial install fallback
@@ -1416,7 +1416,7 @@ def _persist_coding_session_context(
     # the *post-update* extras so the validator sees github_target /
     # work_mode / handoff packet that this very call just persisted.
     try:
-        from ..agents.coding.tracking_enforcement import (
+        from ...agents.coding.tracking_enforcement import (
             validate_tracking_chain,
         )
 
@@ -1456,7 +1456,7 @@ def _persist_lifecycle_mode(session: Any, canonical_prompt: str) -> Any:
     if session is None:
         return session
     try:
-        from ..agents.coding.authorization import (
+        from ...agents.coding.authorization import (
             LIFECYCLE_MODE_IMPLEMENTATION,
             LIFECYCLE_MODE_RESEARCH_ONLY,
             recommend_authorization,
@@ -1549,7 +1549,7 @@ async def _emit_work_report_preview(
     if session is None:
         return
     try:
-        from ..agents.reports.work_report import (
+        from ...agents.reports.work_report import (
             build_work_report,
             format_work_report_markdown,
         )
@@ -1622,7 +1622,7 @@ def _persist_extra_keys(session: Any, updates: Mapping[str, object]) -> Any:
         from dataclasses import replace as _dc_replace
         from datetime import datetime as _dt
 
-        from ..agents.workflow_state import update_session
+        from ...agents.workflow_state import update_session
     except Exception as exc:  # noqa: BLE001
         _record_persistence_failure(
             session,
@@ -1704,7 +1704,7 @@ def _persist_thread_id(
     sequence is consolidated upstream.
     """
 
-    from ..agents.lifecycle.persistence import persist_thread_link
+    from ...agents.lifecycle.persistence import persist_thread_link
 
     result = persist_thread_link(session, thread_id)
     return result.session
@@ -1882,7 +1882,7 @@ async def _run_coding_authorization_gate(
 # share one canonical implementation. The router-private alias is
 # kept for backward compat with internal callers (and the runtime
 # preflight ``_explicit_session_id`` substring check).
-from ..agents.lifecycle.resolver import (
+from ...agents.lifecycle.resolver import (
     _EXPLICIT_SESSION_ID_RE as _EXPLICIT_SESSION_ID_RE,
     extract_explicit_session_id as _extract_session_id_from_router_text,
 )
@@ -1905,7 +1905,7 @@ def _can_save_to_obsidian(session: Any) -> tuple[bool, Optional[str]]:
     # helper so the router, work_report builder, and Discord status
     # diagnostic all share one set of "can we save?" rules. The block
     # reasons stay identical to keep operator-visible messages stable.
-    from ..agents.lifecycle.status import can_write_obsidian_record
+    from ...agents.lifecycle.status import can_write_obsidian_record
 
     return can_write_obsidian_record(session)
 
@@ -1956,7 +1956,7 @@ async def _run_obsidian_approval_gate(
     candidate: Optional[Any] = None
     if explicit_id:
         try:
-            from ..agents.workflow_state import load_session as _load_session
+            from ...agents.workflow_state import load_session as _load_session
 
             candidate = _load_session(explicit_id)
         except Exception:  # noqa: BLE001 - lookup failure falls through
@@ -2438,7 +2438,7 @@ def _observation_for_runtime(input_: RuntimeInput):
     runtime loop's default observe (keeps the router's import surface
     small)."""
 
-    from ..agents.runtime.models import RuntimeObservation
+    from ...agents.runtime.models import RuntimeObservation
 
     text = input_.message_text or ""
     return RuntimeObservation(
@@ -2516,7 +2516,7 @@ async def _handle_join_or_append(
     # P0-E (#134 후속): JOIN/APPEND 의 thread lookup + resume 도 long-running
     # path (Discord API 조회 + 세션 hydration). conversation_fn wrap 과 동일
     # 6s interval 로 typing 유지 — 끊김 race 방지.
-    from .typing_indicator import typing_keepalive
+    from ..typing_indicator import typing_keepalive
 
     async with typing_keepalive(
         getattr(message, "channel", None),
@@ -2667,7 +2667,7 @@ def _research_loop_blocked_by_command_only(prompt_text: Optional[str]) -> bool:
     if not prompt_text:
         return False
     try:
-        from ..agents.routing import is_non_actionable_prompt
+        from ...agents.routing import is_non_actionable_prompt
     except Exception:  # noqa: BLE001 - partial install safe-side
         return False
     return bool(is_non_actionable_prompt(prompt_text))
@@ -2716,8 +2716,8 @@ async def _run_research_loop_hook(
     # user saw long silent gaps. Wrap the work in ``typing_keepalive``
     # so "입력 중..." stays visible from the moment we start collecting
     # until the loop returns a follow-up message (or an error).
-    from .typing_indicator import typing_keepalive
-    from ..agents.job_queue import (
+    from ..typing_indicator import typing_keepalive
+    from ...agents.job_queue import (
         HeartbeatStore,
         JobQueue,
         ResearchWorker,
@@ -2840,7 +2840,7 @@ def persist_research_forum_status(
     # Behaviour is identical; the helper covers the dataclass replace,
     # in-place test-stub fallback, structured persistence_error stamp,
     # and stale-error cleanup that this function used to inline.
-    from ..agents.lifecycle.persistence import persist_research_forum_link
+    from ...agents.lifecycle.persistence import persist_research_forum_link
 
     open_call_posted = report.kickoff_posted if report.forum_comment_mode == "member-bots" else None
     open_call_error = report.kickoff_error if report.forum_comment_mode == "member-bots" else None
@@ -2916,7 +2916,7 @@ async def make_default_research_loop(
     # without depending on env state.
     if forum_comment_mode is None:
         try:
-            from ..agents.research.collector import resolve_forum_comment_mode
+            from ...agents.research.collector import resolve_forum_comment_mode
         except Exception:  # noqa: BLE001
             forum_comment_mode = "member-bots"
         else:
@@ -2958,7 +2958,7 @@ async def make_default_research_loop(
             and session is not None
         ):
             try:
-                from .engineering_team_runtime import research_open_call_directive
+                from ..engineering_team_runtime import research_open_call_directive
             except Exception:  # noqa: BLE001
                 kickoff = None
             else:
@@ -2972,7 +2972,7 @@ async def make_default_research_loop(
                     "추가 조사하고, 필요한 take를 독립적으로 남깁니다.\n\n"
                     f"{kickoff}"
                 )
-                from .research_forum import chunk_for_discord_message
+                from ..research_forum import chunk_for_discord_message
                 pieces = chunk_for_discord_message(kickoff_message) or (
                     kickoff_message,
                 )
@@ -3041,7 +3041,7 @@ async def make_default_research_loop(
                 synthesis_text = _optional_str(
                     getattr(deliberation_result, "synthesis_text", None)
                 )
-                from .research_forum import chunk_for_discord_message
+                from ..research_forum import chunk_for_discord_message
                 try:
                     for record in rendered:
                         text = _optional_str(getattr(record, "rendered", None))
@@ -3227,7 +3227,7 @@ def extract_user_links_from_message(
     if not text:
         return ()
     try:
-        from ..agents.research.collector import extract_urls
+        from ...agents.research.collector import extract_urls
     except Exception:  # noqa: BLE001
         return ()
     return tuple(extract_urls(text))

--- a/src/yule_orchestrator/discord/engineering_channel_router/intent_detection.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/intent_detection.py
@@ -1,0 +1,161 @@
+"""engineering_channel_router — channel + confirmation + continuation signals.
+
+Three predicates the main route consults before any orchestration:
+
+- :func:`is_engineering_channel` — message location check against the
+  configured intake channel (id or name, including parent-thread match).
+- :func:`detect_confirmation_signal` — keyword-based "go ahead" detector
+  used when the conversation layer didn't pre-classify ``confirmed``.
+- :func:`should_continue_existing_thread` /
+  :func:`should_start_new_thread` — keyword pairs that read explicit
+  "이어가 / 새 작업으로 진행" overrides in the user's last turn.
+
+``_CONFIRMATION_KEYWORDS`` is the single-source lexicon; the
+conversation layer's intent classifier owns its own broader phrase set
+(intent_detection.py inside ``engineering_conversation``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import EngineeringRouteContext
+from .utils import _normalize_channel_name
+
+
+# Single-source confirmation lexicon; the engineering conversation layer
+# may also detect intent and pre-set ``confirmed=True`` itself, in which
+# case the router trusts that signal.
+_CONFIRMATION_KEYWORDS: tuple[str, ...] = (
+    "확정",
+    "진행",
+    "시작해",
+    "시작하자",
+    "시작할게",
+    "시작합시다",
+    "고고",
+    "ㄱㄱ",
+    "ㄱㄱㄱ",
+    "맞아 진행",
+    "그대로 진행",
+    "그대로 가",
+    "오케이 진행",
+    "오케 진행",
+    "go ahead",
+    "let's go",
+    "lets go",
+    "kick off",
+    "kickoff",
+    "proceed",
+    "approve and start",
+)
+
+
+def is_engineering_channel(
+    *,
+    message: Any,
+    route_context: EngineeringRouteContext,
+) -> bool:
+    if not route_context.configured:
+        return False
+
+    channel = getattr(message, "channel", None)
+    if channel is None:
+        return False
+
+    channel_id = getattr(channel, "id", None)
+    parent = getattr(channel, "parent", None)
+    parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
+    channel_name = _normalize_channel_name(getattr(channel, "name", None))
+    parent_name = _normalize_channel_name(getattr(parent, "name", None))
+
+    target_id = route_context.intake_channel_id
+    target_name = _normalize_channel_name(route_context.intake_channel_name)
+
+    if target_id is not None:
+        if channel_id is not None and channel_id == target_id:
+            return True
+        if parent_id is not None and parent_id == target_id:
+            return True
+    if target_name:
+        if channel_name == target_name:
+            return True
+        if parent_name == target_name:
+            return True
+    return False
+
+
+def detect_confirmation_signal(text: str) -> bool:
+    """Heuristic confirmation detector used when the conversation layer
+    does not pre-classify intent.  Matches Korean and English go-ahead
+    phrases conservatively — short ack words like ``yes``/``네`` are
+    excluded so casual chat isn't promoted to a workflow intake."""
+
+    if not text:
+        return False
+    normalized = " ".join(text.lower().split())
+    if not normalized:
+        return False
+    return any(keyword in normalized for keyword in _CONFIRMATION_KEYWORDS)
+
+
+def should_continue_existing_thread(*texts: str) -> bool:
+    """True when the user asked to reuse an existing workflow thread/session."""
+
+    normalized = " ".join(
+        " ".join(str(text or "").lower().split()) for text in texts
+    )
+    if not normalized.strip():
+        return False
+    continuation_signals = (
+        "새로 등록하지 말고",
+        "새로 만들지 말고",
+        "새 스레드 만들지",
+        "새 thread 만들지",
+        "새로운 스레드",
+        "새 thread",
+        "기존 스레드",
+        "기존 thread",
+        "열려 있는 스레드",
+        "열려있는 스레드",
+        "열려 있는 thread",
+        "열려있는 thread",
+        "이어가",
+        "이어 가",
+        "이어서",
+        "continue existing",
+        "reuse thread",
+        "same thread",
+        "do not create a new thread",
+        "don't create a new thread",
+    )
+    return any(signal in normalized for signal in continuation_signals)
+
+
+def should_start_new_thread(text: str) -> bool:
+    """True when the latest user turn explicitly overrides continuation."""
+
+    normalized = " ".join(str(text or "").lower().split())
+    if not normalized:
+        return False
+    force_new_signals = (
+        "새 작업으로 진행",
+        "새 작업으로 시작",
+        "새로 등록해",
+        "새로 등록",
+        "새 스레드로",
+        "새 thread로",
+        "새 세션으로",
+        "new thread",
+        "new session",
+    )
+    return any(signal in normalized for signal in force_new_signals)
+
+
+__all__ = (
+    "_CONFIRMATION_KEYWORDS",
+    "detect_confirmation_signal",
+    "is_engineering_channel",
+    "should_continue_existing_thread",
+    "should_start_new_thread",
+)

--- a/src/yule_orchestrator/discord/engineering_channel_router/models.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/models.py
@@ -1,0 +1,218 @@
+"""engineering_channel_router — dataclasses + type aliases (leaf module).
+
+Six frozen dataclasses + seven Callable aliases form the contract
+between the router and every adapter that drives it (bot.py / commands /
+test fixtures). No in-package dependencies — every other router module
+imports symbols from here.
+
+- :class:`EngineeringRouteContext` — intake channel identity + opt-in
+  recall-first flag.
+- :class:`EngineeringConversationOutcome` — what the conversation
+  layer returns to the router.
+- :class:`EngineeringThreadKickoff` — thread creation result.
+- :class:`EngineeringThreadContinuation` — thread resumption result.
+- :class:`EngineeringResearchLoopReport` — research loop hook result
+  (forum publish status + member-bots open-call signals).
+- :class:`EngineeringRouteResult` — final router output handed back to
+  the bot event loop.
+
+Type aliases name the long ``Callable[..., ...]`` types every gateway
+injection seam uses (intake_fn, conversation_fn, thread_kickoff_fn,
+thread_continuation_fn, research_loop_fn, send_chunks, extract_prompt).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional, Union
+
+from ...agents.routing import EngineeringRoutingDecision
+
+
+@dataclass(frozen=True)
+class EngineeringRouteContext:
+    """Where the engineering intake channel lives.
+
+    Both ``intake_channel_id`` and ``intake_channel_name`` are optional
+    individually — if either one matches the message channel (or its
+    parent, for a thread), the message is treated as engineering.
+
+    F16 (issue #128) added ``prefer_recall_first_gateway`` — an opt-in
+    flag that, when set, lets the router call ``decide_gateway`` (the
+    new 7-action recall-first decision) for **any** intent. While off
+    (default), the router keeps the legacy preflight short-circuit
+    behaviour so all pre-F16 contracts hold. The coverage scorer is
+    attached to recall results unconditionally — it is **derived**
+    metadata and changes no existing behaviour, but lets observability
+    and future routing tap into it without re-running recall.
+    """
+
+    intake_channel_id: Optional[int] = None
+    intake_channel_name: Optional[str] = None
+    prefer_recall_first_gateway: bool = False
+
+    @property
+    def configured(self) -> bool:
+        # Lazy import to avoid a circular dep with utils (which will be
+        # extracted in P0-P step 4). Keeps models a true leaf module.
+        from ._legacy import _normalize_channel_name
+
+        return self.intake_channel_id is not None or bool(
+            _normalize_channel_name(self.intake_channel_name)
+        )
+
+    @classmethod
+    def from_env(cls) -> "EngineeringRouteContext":
+        from ._legacy import (
+            _optional_bool_env,
+            _optional_int_env,
+            _optional_string_env,
+        )
+
+        return cls(
+            intake_channel_id=_optional_int_env("DISCORD_ENGINEERING_INTAKE_CHANNEL_ID"),
+            intake_channel_name=_optional_string_env(
+                "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME"
+            ),
+            prefer_recall_first_gateway=_optional_bool_env(
+                "YULE_GATEWAY_RECALL_FIRST_ENABLED", default=False
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class EngineeringConversationOutcome:
+    """The shape returned by the engineering free-conversation layer.
+
+    ``confirmed=True`` means the user just expressed intent to start
+    a real intake; ``intake_prompt`` is the canonicalised request for
+    the workflow.  The conversation layer is free to omit those fields
+    — the router falls back to a keyword-based confirmation check on
+    the original user text.
+
+    ``research_pack`` and ``collection_outcome`` carry the autonomous
+    research collector's result through to the research-loop hook
+    (forum publisher / deliberation kickoff). ``role_for_research``
+    lets the conversation layer signal which role profile drove the
+    collection so downstream code can render labels accordingly.
+    """
+
+    content: str
+    confirmed: bool = False
+    intake_prompt: Optional[str] = None
+    write_requested: bool = False
+    thread_topic: Optional[str] = None
+    research_pack: Any = None
+    collection_outcome: Any = None
+    role_for_research: Optional[str] = None
+    # When True the conversation already answered a status/diagnostic
+    # question. The router must NOT route to intake/decide/auto_collect
+    # — the user wasn't filing new work, they were asking what's going
+    # on with existing work.
+    is_status_query: bool = False
+
+
+@dataclass(frozen=True)
+class EngineeringThreadKickoff:
+    """Result of creating a working thread and posting kickoff."""
+
+    thread_id: Optional[int] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EngineeringThreadContinuation:
+    """Result of continuing an already-open workflow thread."""
+
+    session: Any
+    thread_id: Optional[int] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EngineeringResearchLoopReport:
+    """What the research loop hook reported back to the router.
+
+    ``follow_up_message`` is sent to the user when the loop decided the
+    research pack is too thin (e.g. no URL, no attachment for a
+    landing-page task). ``forum_status_message`` is the operator-facing
+    summary line ("운영-리서치 forum thread 게시: …") posted after a
+    successful publish. ``error`` is filled when the hook itself raised;
+    callers display it as a `⚠️` line and continue.
+    """
+
+    follow_up_message: Optional[str] = None
+    forum_status_message: Optional[str] = None
+    forum_thread_id: Optional[int] = None
+    forum_thread_url: Optional[str] = None
+    insufficient: bool = False
+    error: Optional[str] = None
+    # member-bots vs gateway publication mode signal — populated by the
+    # research-loop hook from the publication outcome so status /
+    # diagnostic responses can describe the live setup correctly.
+    forum_comment_mode: Optional[str] = None
+    # member-bots mode only: did the gateway successfully post the
+    # ``[research-open:<session_id>]`` open-call directive that each
+    # member bot is supposed to react to? ``None`` in gateway mode.
+    kickoff_posted: Optional[bool] = None
+    # member-bots mode only: stringified error from the open-call
+    # directive post when ``kickoff_posted`` is False; otherwise None.
+    kickoff_error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EngineeringRouteResult:
+    """What the router did with one Discord message.
+
+    ``handled=False`` means this message is *not* an engineering channel
+    message; the bot should fall through to its planning conversation
+    path.  ``handled=True`` means the router has already replied (and
+    optionally created an intake/thread), so the bot must not double-reply.
+    """
+
+    handled: bool
+    conversation_message: Optional[str] = None
+    intake_message: Optional[str] = None
+    kickoff_message: Optional[str] = None
+    session_id: Optional[str] = None
+    thread_id: Optional[int] = None
+    research_loop_report: Optional[EngineeringResearchLoopReport] = None
+    error: Optional[str] = None
+    routing_decision: Optional[EngineeringRoutingDecision] = None
+
+
+SendChunksFn = Callable[[Any, str], Awaitable[None]]
+ExtractPromptFn = Callable[..., str]
+ConversationFn = Callable[..., Union[
+    EngineeringConversationOutcome,
+    Awaitable[EngineeringConversationOutcome],
+    str,
+    Awaitable[str],
+]]
+IntakeFn = Callable[..., Any]
+ThreadKickoffFn = Callable[..., Awaitable[EngineeringThreadKickoff]]
+ThreadContinuationFn = Callable[..., Union[
+    Optional[EngineeringThreadContinuation],
+    Awaitable[Optional[EngineeringThreadContinuation]],
+]]
+ResearchLoopFn = Callable[..., Union[
+    EngineeringResearchLoopReport,
+    Awaitable[EngineeringResearchLoopReport],
+]]
+
+
+__all__ = (
+    "EngineeringConversationOutcome",
+    "EngineeringResearchLoopReport",
+    "EngineeringRouteContext",
+    "EngineeringRouteResult",
+    "EngineeringThreadContinuation",
+    "EngineeringThreadKickoff",
+    "ConversationFn",
+    "ExtractPromptFn",
+    "IntakeFn",
+    "ResearchLoopFn",
+    "SendChunksFn",
+    "ThreadContinuationFn",
+    "ThreadKickoffFn",
+)

--- a/src/yule_orchestrator/discord/engineering_channel_router/models.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/models.py
@@ -53,9 +53,10 @@ class EngineeringRouteContext:
 
     @property
     def configured(self) -> bool:
-        # Lazy import to avoid a circular dep with utils (which will be
-        # extracted in P0-P step 4). Keeps models a true leaf module.
-        from ._legacy import _normalize_channel_name
+        # Lazy import: ``utils`` is a sibling leaf module; importing at
+        # method call time keeps ``models`` itself fully leaf so other
+        # router modules can import it without dragging utils.
+        from .utils import _normalize_channel_name
 
         return self.intake_channel_id is not None or bool(
             _normalize_channel_name(self.intake_channel_name)
@@ -63,7 +64,7 @@ class EngineeringRouteContext:
 
     @classmethod
     def from_env(cls) -> "EngineeringRouteContext":
-        from ._legacy import (
+        from .utils import (
             _optional_bool_env,
             _optional_int_env,
             _optional_string_env,

--- a/src/yule_orchestrator/discord/engineering_channel_router/session_persistence.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/session_persistence.py
@@ -1,0 +1,472 @@
+"""engineering_channel_router — session.extra mutations + load helpers.
+
+Every gate / hook that needs to write to ``session.extra`` or look up a
+session by id / recency flows through this module. Keeping the single
+write surface here means future schema additions (new ``session.extra``
+keys, new audit log shapes) have one canonical edit site.
+
+Owned helpers (organised by what they touch on ``session.extra``):
+
+* lifecycle bookkeeping — :func:`_persist_role_selection`,
+  :func:`_persist_lifecycle_mode`, :func:`_persist_coding_session_context`,
+  :func:`_persist_extra_keys`, :func:`_persist_thread_id`,
+  :func:`_record_persistence_failure`, :func:`_is_terminal`.
+* coding flow — :func:`_persist_coding_proposal`, :func:`_persist_coding_job`,
+  :func:`_proposal_to_dict`, :func:`_proposal_from_dict`.
+* reporting — :func:`_work_report_to_dict` (used by the work-report
+  preview at lifecycle close).
+* session lookup — :func:`_load_session_by_id`, :func:`_most_recent_session`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence
+
+from ...agents.coding.authorization import (
+    CodingAuthorizationProposal,
+)
+
+
+def _is_terminal(session: Any) -> bool:
+    state = getattr(session, "state", None)
+    state_value = getattr(state, "value", state)
+    return str(state_value).lower() in {"completed", "rejected"}
+
+def _persist_coding_proposal(
+    session: Any,
+    proposal: CodingAuthorizationProposal,
+) -> Any:
+    """Stash a fresh proposal under ``session.extra['coding_proposal']``."""
+
+    return _persist_extra_keys(
+        session,
+        {
+            "coding_proposal": _proposal_to_dict(proposal),
+            "coding_job": None,  # supersedes any prior pending job copy
+        },
+    )
+
+def _persist_coding_job(session: Any, job_payload: Mapping[str, object]) -> Any:
+    """Replace any pending proposal with the approved coding job payload."""
+
+    return _persist_extra_keys(
+        session,
+        {
+            "coding_job": dict(job_payload),
+            "coding_proposal": None,  # consumed
+        },
+    )
+
+def _persist_role_selection(
+    session: Any,
+    canonical_prompt: str,
+) -> Any:
+    """Run :func:`role_selection.recommend_active_roles` against
+    *canonical_prompt* and stash the result on ``session.extra``.
+
+    Best-effort: import or persistence failures simply skip — the
+    legacy "all roles" fallback path remains operational. Used right
+    after intake so the work-report builder + research scoping see a
+    populated ``active_research_roles`` from turn one.
+    """
+
+    if session is None:
+        return session
+    try:
+        from ...agents.lifecycle.role_selection import (
+            apply_role_selection_to_extra,
+            recommend_active_roles,
+        )
+    except Exception:  # noqa: BLE001
+        return session
+    try:
+        hint_sequence = tuple(getattr(session, "role_sequence", ()) or ())
+    except Exception:  # noqa: BLE001
+        hint_sequence = ()
+    try:
+        selection = recommend_active_roles(
+            user_prompt=canonical_prompt or "",
+            hint_role_sequence=hint_sequence,
+        )
+    except Exception:  # noqa: BLE001
+        return session
+    try:
+        existing = dict(getattr(session, "extra", {}) or {})
+    except Exception:  # noqa: BLE001
+        existing = {}
+    merged = apply_role_selection_to_extra(existing, selection)
+    # Only forward the four selection-specific keys to _persist_extra_keys
+    # so we don't accidentally rewrite unrelated extras with stale copies.
+    selection_updates = {
+        key: merged[key]
+        for key in (
+            "active_research_roles",
+            "excluded_research_roles",
+            "role_selection_source",
+            "role_selection_reasons",
+        )
+        if key in merged
+    }
+    if not selection_updates:
+        return session
+    return _persist_extra_keys(session, selection_updates)
+
+def _persist_coding_session_context(
+    session: Any,
+    *,
+    message_text: str,
+    user_links: Sequence[str] = (),
+) -> Any:
+    """P0-H stage 2 + P0-I stage 3 — store gateway-prepared coding session context.
+
+    Calls :func:`prepare_coding_session_context` to compute the
+    work_mode / topology / scope / github_target / repo_contract /
+    coding_handoff_packet extras for *session*, then merges them in.
+    Additionally (P0-I) runs the **tracking enforcement validator** and
+    stores the result for the status surface to display.
+
+    Ask-once contract: if the session already has work_mode set, the
+    helper does not re-prompt and does not overwrite.
+
+    Best-effort — any failure leaves the session untouched so partial
+    install / missing gh CLI never blocks intake.
+    """
+
+    if session is None:
+        return session
+    try:
+        from ...agents.coding.coding_session_context import (
+            prepare_coding_session_context,
+        )
+    except Exception:  # noqa: BLE001 - partial install fallback
+        return session
+
+    try:
+        existing_extra = dict(getattr(session, "extra", None) or {})
+    except Exception:  # noqa: BLE001
+        existing_extra = {}
+
+    try:
+        context = prepare_coding_session_context(
+            message_text=message_text or "",
+            user_links=tuple(user_links or ()),
+            existing_extra=existing_extra,
+            existing_session_id=getattr(session, "session_id", None),
+            # discover_contract=False until vault/workspace clone wiring lands.
+            # The contract still records its own fallback line in extras.
+        )
+    except Exception:  # noqa: BLE001
+        return session
+
+    extras_update = dict(context.extras_update or {})
+
+    # P0-I stage 3 — tracking enforcement validation. Run it against
+    # the *post-update* extras so the validator sees github_target /
+    # work_mode / handoff packet that this very call just persisted.
+    try:
+        from ...agents.coding.tracking_enforcement import (
+            validate_tracking_chain,
+        )
+
+        post_update_extra = dict(existing_extra)
+        post_update_extra.update(extras_update)
+        tracking = validate_tracking_chain(post_update_extra)
+        extras_update["tracking_validation"] = dict(tracking.to_dict())
+        if tracking.blocked and tracking.blocked_reason:
+            extras_update["tracking_blocked_reason"] = tracking.blocked_reason
+    except Exception:  # noqa: BLE001
+        pass
+
+    if not extras_update:
+        return session
+    return _persist_extra_keys(session, extras_update)
+
+def _persist_lifecycle_mode(session: Any, canonical_prompt: str) -> Any:
+    """Mark *session* as research-only when the prompt signals that.
+
+    Live regression: the gateway used to advertise an executor role
+    ("실행 후보 backend-engineer") even on a request like "오늘은 코드
+    수정 없이 자료 수집이 목표야". Phase 2 fixes that by stashing the
+    lifecycle mode at intake so every downstream consumer (work_report
+    builder, status diagnostic, member-bot research path) reads the
+    same answer.
+
+    The session.extra layout matches the spec's bullet 5:
+        lifecycle_mode: "research_only" | "implementation"
+        executor_role:  null when research-only
+        research_leads: list[str]   roles leading the investigation
+
+    Best-effort — any import or persistence failure leaves the session
+    untouched so a partial agent layout cannot block intake.
+    """
+
+    if session is None:
+        return session
+    try:
+        from ...agents.coding.authorization import (
+            LIFECYCLE_MODE_IMPLEMENTATION,
+            LIFECYCLE_MODE_RESEARCH_ONLY,
+            recommend_authorization,
+        )
+    except Exception:  # noqa: BLE001
+        return session
+
+    try:
+        proposal = recommend_authorization(user_request=canonical_prompt or "")
+    except Exception:  # noqa: BLE001
+        return session
+
+    if proposal.lifecycle_mode == LIFECYCLE_MODE_RESEARCH_ONLY:
+        updates = {
+            "lifecycle_mode": LIFECYCLE_MODE_RESEARCH_ONLY,
+            "executor_role": None,
+            "research_leads": list(proposal.research_leads),
+        }
+    else:
+        updates = {
+            "lifecycle_mode": LIFECYCLE_MODE_IMPLEMENTATION,
+        }
+    return _persist_extra_keys(session, updates)
+
+def _work_report_to_dict(report: Any) -> dict:
+    """Serialise a :class:`agents.reports.work_report.WorkReport` into a plain
+    JSON-friendly dict so the workflow store can persist it under
+    ``session.extra['work_report']``."""
+
+    return {
+        "session_id": getattr(report, "session_id", None),
+        "title": getattr(report, "title", "") or "",
+        "canonical_prompt": getattr(report, "canonical_prompt", "") or "",
+        "executive_summary": getattr(report, "executive_summary", "") or "",
+        "research_summary": getattr(report, "research_summary", "") or "",
+        "tech_lead_recommendation": getattr(
+            report, "tech_lead_recommendation", ""
+        )
+        or "",
+        "role_decisions": dict(getattr(report, "role_decisions", {}) or {}),
+        "risks": list(getattr(report, "risks", ()) or ()),
+        "proposed_next_steps": list(
+            getattr(report, "proposed_next_steps", ()) or ()
+        ),
+        "requires_code_change": bool(
+            getattr(report, "requires_code_change", False)
+        ),
+        "recommended_executor_role": getattr(
+            report, "recommended_executor_role", None
+        ),
+        "approval_request": getattr(report, "approval_request", None),
+        "participants": list(getattr(report, "participants", ()) or ()),
+        "reference_count": int(getattr(report, "reference_count", 0) or 0),
+        "research_stop_reason": getattr(report, "research_stop_reason", None),
+        "under_covered_roles": list(
+            getattr(report, "under_covered_roles", ()) or ()
+        ),
+        # Phase 3 status gate fields.
+        "status": getattr(report, "status", "interim"),
+        "missing_roles": list(getattr(report, "missing_roles", ()) or ()),
+        "has_research_pack": bool(
+            getattr(report, "has_research_pack", False)
+        ),
+        "has_synthesis": bool(getattr(report, "has_synthesis", False)),
+    }
+
+def _persist_extra_keys(session: Any, updates: Mapping[str, object]) -> Any:
+    """Merge *updates* into ``session.extra`` and persist via ``update_session``.
+
+    Always mutates the live ``extra`` dict when one is present, so test
+    fixtures using mutable dataclass stubs observe the new keys without
+    having to capture the returned session. Production WorkflowSession
+    is frozen — for that path we rely on ``dataclasses.replace`` +
+    ``update_session`` to land the change in SQLite.
+
+    Stabilisation Phase 1: persistence failures used to be silently
+    swallowed, which made live debugging impossible. We now stamp a
+    ``persistence_error`` entry on the session's live extra dict (when
+    available) so the status diagnostic + supervisor can surface
+    "왜 저장이 안 됐어?" without having to grep logs. The user-visible
+    reply chain is still kept intact (no exception leaks past this
+    helper).
+    """
+
+    try:
+        from dataclasses import replace as _dc_replace
+        from datetime import datetime as _dt
+
+        from ...agents.workflow_state import update_session
+    except Exception as exc:  # noqa: BLE001
+        _record_persistence_failure(
+            session,
+            step="import update_session",
+            reason=str(exc),
+            updates=updates,
+        )
+        return session
+
+    # Try in-place mutation first so test stubs (plain dataclasses with
+    # a regular dict ``extra``) observe the change directly. Production
+    # WorkflowSession holds an immutable mapping; this no-ops there.
+    live = getattr(session, "extra", None)
+    if isinstance(live, dict):
+        for key, value in updates.items():
+            live[key] = value
+
+    existing = dict(getattr(session, "extra", {}) or {})
+    merged = {**existing, **dict(updates)}
+    try:
+        updated = _dc_replace(session, extra=merged)
+    except TypeError:
+        # Non-dataclass stub — in-place mutation above already covered it.
+        return session
+    try:
+        update_session(updated, now=_dt.now().astimezone())
+    except Exception as exc:  # noqa: BLE001
+        _record_persistence_failure(
+            updated,
+            step="update_session",
+            reason=str(exc),
+            updates=updates,
+        )
+    return updated
+
+def _record_persistence_failure(
+    session: Any,
+    *,
+    step: str,
+    reason: str,
+    updates: Mapping[str, object],
+) -> None:
+    """Stamp a persistence failure note on the live ``session.extra``.
+
+    Best-effort — the session.extra mutation is wrapped so even
+    pathological stubs never raise out of this helper. The note keeps
+    the offending step + reason + the keys that were being written so
+    the diagnostic responder can show the operator exactly which
+    update silently failed during the live MVP loop.
+    """
+
+    if session is None:
+        return
+    try:
+        live = getattr(session, "extra", None)
+        if isinstance(live, dict):
+            live["persistence_error"] = {
+                "step": step,
+                "reason": reason,
+                "keys": sorted(str(k) for k in (updates or {}).keys()),
+            }
+    except Exception:  # noqa: BLE001
+        return
+
+def _persist_thread_id(
+    session: Any,
+    thread_id: Optional[int],
+) -> Any:
+    """Write the Discord work-thread id back to ``session.thread_id``.
+
+    MVP closure refactor: delegates to
+    :func:`agents.lifecycle.persistence.persist_thread_link` so the
+    router and any other caller (member-bot, supervisor cleanup)
+    follow the same persistence contract — including the structured
+    ``persistence_error`` stamp on failure. Behaviour is identical to
+    the prior inline implementation; only the import/replace
+    sequence is consolidated upstream.
+    """
+
+    from ...agents.lifecycle.persistence import persist_thread_link
+
+    result = persist_thread_link(session, thread_id)
+    return result.session
+
+def _proposal_to_dict(proposal: CodingAuthorizationProposal) -> Mapping[str, object]:
+    return {
+        "session_id": proposal.session_id,
+        "user_request": proposal.user_request,
+        "executor_role": proposal.executor_role,
+        "review_roles": list(proposal.review_roles),
+        "participant_roles": list(proposal.participant_roles),
+        "write_scope": list(proposal.write_scope),
+        "forbidden_scope": list(proposal.forbidden_scope),
+        "reason": proposal.reason,
+        "safety_rules": list(proposal.safety_rules),
+        "approval_required": bool(proposal.approval_required),
+        "metadata": dict(proposal.metadata),
+        "lifecycle_mode": proposal.lifecycle_mode,
+        "research_leads": list(proposal.research_leads),
+    }
+
+def _proposal_from_dict(payload: Mapping[str, object]) -> CodingAuthorizationProposal:
+    lifecycle_mode = str(payload.get("lifecycle_mode") or "implementation")
+    raw_executor = payload.get("executor_role")
+    if lifecycle_mode == "research_only":
+        executor_role = str(raw_executor or "")
+    else:
+        executor_role = str(raw_executor or "tech-lead")
+    return CodingAuthorizationProposal(
+        session_id=payload.get("session_id"),
+        user_request=str(payload.get("user_request") or ""),
+        executor_role=executor_role,
+        review_roles=tuple(payload.get("review_roles") or ()),
+        participant_roles=tuple(payload.get("participant_roles") or ()),
+        write_scope=tuple(payload.get("write_scope") or ()),
+        forbidden_scope=tuple(payload.get("forbidden_scope") or ()),
+        reason=str(payload.get("reason") or ""),
+        safety_rules=tuple(payload.get("safety_rules") or ()),
+        approval_required=bool(payload.get("approval_required", True)),
+        metadata=dict(payload.get("metadata") or {}),
+        lifecycle_mode=lifecycle_mode,
+        research_leads=tuple(payload.get("research_leads") or ()),
+    )
+
+def _load_session_by_id(
+    list_sessions_fn: Callable[..., Sequence[Any]],
+    session_id: Optional[str],
+) -> Optional[Any]:
+    if not session_id:
+        return None
+    try:
+        try:
+            sessions = list_sessions_fn(limit=50)
+        except TypeError:
+            sessions = list_sessions_fn()
+    except Exception:  # noqa: BLE001
+        return None
+    for session in sessions or ():
+        if getattr(session, "session_id", None) == session_id:
+            return session
+    return None
+
+def _most_recent_session(sessions: Sequence[Any]) -> Optional[Any]:
+    if not sessions:
+        return None
+
+    def _sort_key(s: Any):
+        ts = getattr(s, "updated_at", None)
+        if ts is None:
+            return (0, 0)
+        try:
+            epoch = ts.timestamp()
+        except Exception:  # noqa: BLE001
+            epoch = 0
+        return (1, epoch)
+
+    return max(sessions, key=_sort_key)
+
+
+
+__all__ = (
+    "_is_terminal",
+    "_persist_coding_proposal",
+    "_persist_coding_job",
+    "_persist_role_selection",
+    "_persist_coding_session_context",
+    "_persist_lifecycle_mode",
+    "_work_report_to_dict",
+    "_persist_extra_keys",
+    "_record_persistence_failure",
+    "_persist_thread_id",
+    "_proposal_to_dict",
+    "_proposal_from_dict",
+    "_load_session_by_id",
+    "_most_recent_session",
+)

--- a/src/yule_orchestrator/discord/engineering_channel_router/utils.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/utils.py
@@ -1,0 +1,188 @@
+"""engineering_channel_router — env coercion + message parsing + async helpers.
+
+Pure leaf module (no router-internal deps). Collects the type/env/value
+coercion primitives plus the discord.py-agnostic message readers
+(``extract_user_links_from_message``, ``extract_message_attachments``)
+and the ``_maybe_await`` async-or-not helper every gateway hook uses.
+
+Also hosts the F16 ``_attach_recall_coverage`` derived-metadata helper
+because it sits between the runtime recall and the routing layer — no
+business decisions, just enrichment.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from typing import Any, Optional
+
+from ...agents.runtime import (
+    RecallCoverage,
+    RuntimeRecallResult,
+    compute_recall_coverage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Value coercion
+# ---------------------------------------------------------------------------
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_channel_name(value: object | None) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lstrip("#").lower()
+
+
+# ---------------------------------------------------------------------------
+# Env readers
+# ---------------------------------------------------------------------------
+
+
+def _optional_int_env(name: str) -> Optional[int]:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    value = raw.strip()
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be an integer value, got: {value!r}"
+        ) from exc
+
+
+def _optional_string_env(name: str) -> Optional[str]:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None
+
+
+def _optional_bool_env(name: str, *, default: bool = False) -> bool:
+    """Parse a boolean envvar — empty/unset returns ``default``.
+
+    Accepted truthy values: ``"true"``, ``"1"``, ``"yes"``, ``"on"``
+    (case-insensitive). Anything else is treated as the default. Used
+    by F16 ``EngineeringRouteContext.prefer_recall_first_gateway`` so
+    operators can opt into the recall-first gateway path without code
+    changes.
+    """
+
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if not value:
+        return default
+    return value in {"true", "1", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Message parsing (discord.py-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def extract_user_links_from_message(
+    message: Any,
+    prompt_text: Optional[str] = None,
+) -> tuple[str, ...]:
+    """Pull URLs out of the user's message body.
+
+    Lazily delegates to :func:`research_collector.extract_urls` so we get
+    the same regex + dedup the collector uses internally. Returns an empty
+    tuple if the helper isn't importable (e.g. during a partial install).
+    """
+
+    text = (prompt_text or getattr(message, "content", "") or "")
+    if not text:
+        return ()
+    try:
+        from ...agents.research.collector import extract_urls
+    except Exception:  # noqa: BLE001
+        return ()
+    return tuple(extract_urls(text))
+
+
+def extract_message_attachments(message: Any) -> tuple[Any, ...]:
+    """Return the message's attachments as a stable tuple, discord.py-agnostic.
+
+    discord.py exposes ``message.attachments`` as a list of ``Attachment``
+    objects, but tests pass plain dataclasses or dicts. We accept any iterable
+    and drop ``None`` entries so the engineering conversation layer can rely
+    on a clean sequence regardless of the Discord shape.
+    """
+
+    raw = getattr(message, "attachments", None)
+    if raw is None:
+        return ()
+    if isinstance(raw, (list, tuple)):
+        return tuple(item for item in raw if item is not None)
+    try:
+        return tuple(item for item in raw if item is not None)
+    except TypeError:
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# Async helper
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+# ---------------------------------------------------------------------------
+# F16 recall coverage enrichment
+# ---------------------------------------------------------------------------
+
+
+def _attach_recall_coverage(recall: RuntimeRecallResult) -> RuntimeRecallResult:
+    """F16 — replace ``recall`` with a copy whose ``coverage`` is scored.
+
+    The scorer is **defensive**: any failure (None, malformed hits)
+    degrades to ``RecallCoverage(level=low, stale=True)``. Legacy
+    callers that ignore ``coverage`` see no behaviour change.
+    """
+
+    try:
+        coverage = compute_recall_coverage(recall)
+    except Exception:  # noqa: BLE001
+        coverage = RecallCoverage(
+            level="low", stale=True, sources=(), reason="scorer raised"
+        )
+    return replace(recall, coverage=coverage)
+
+
+__all__ = (
+    "_attach_recall_coverage",
+    "_maybe_await",
+    "_normalize_channel_name",
+    "_optional_bool_env",
+    "_optional_int_env",
+    "_optional_str",
+    "_optional_string_env",
+    "_safe_int",
+    "extract_message_attachments",
+    "extract_user_links_from_message",
+)

--- a/tests/engineering/test_channel_router_persistence.py
+++ b/tests/engineering/test_channel_router_persistence.py
@@ -168,7 +168,7 @@ class PersistResearchArtifactsTests(unittest.TestCase):
 
         with patch(
             "yule_orchestrator.discord.engineering_channel_router."
-            "persist_research_artifacts"
+            "_legacy.persist_research_artifacts"
         ) as persist_spy:
             persist_spy.side_effect = lambda session, *_a, **_kw: session
             result = self._route(
@@ -202,7 +202,7 @@ class PersistResearchArtifactsTests(unittest.TestCase):
 
         with patch(
             "yule_orchestrator.discord.engineering_channel_router."
-            "persist_research_artifacts"
+            "_legacy.persist_research_artifacts"
         ) as persist_spy:
             persist_spy.side_effect = lambda session, *_a, **_kw: session
             result = self._route(
@@ -236,7 +236,7 @@ class PersistResearchArtifactsTests(unittest.TestCase):
 
         with patch(
             "yule_orchestrator.discord.engineering_channel_router."
-            "persist_research_artifacts"
+            "_legacy.persist_research_artifacts"
         ) as persist_spy:
             self._route(
                 message=message,

--- a/tests/engineering/test_channel_router_routing.py
+++ b/tests/engineering/test_channel_router_routing.py
@@ -591,7 +591,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -639,7 +639,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -681,7 +681,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -734,7 +734,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
         kickoff_fn = AsyncMock(side_effect=AssertionError("kickoff should not run"))
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
             return_value=EngineeringRoutingDecision(
                 action="join_existing_work",
                 matched_session_id="open-1",
@@ -781,7 +781,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
         loop_fn = AsyncMock(side_effect=AssertionError("loop should not run"))
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
             return_value=EngineeringRoutingDecision(
                 action="ask_for_clarification",
                 reason="후보 두 건이 비슷합니다",


### PR DESCRIPTION
## 어떤 변경인가요?

3316줄 monolith ``engineering_channel_router.py`` 를 11 책임 모듈로 분해하는 **phase 1** (audit + 5 leaf/mid module 추출). 외부 import 사이트 (bot.py / commands.py / supervisor.py / 테스트 fixture 다수) 무회귀, 4672 PASS 유지.

P0-L 와 동일 패턴: audit doc → ``git mv`` 패키지 facade → step-wise extraction → ``_legacy.py`` 점진 축소. 본 PR 이후 `_legacy.py` 는 3316 → 2535 줄, 새 모듈 5 개 (총 ~1500 줄) 가 책임 단위로 분리됨.

## 작업 상세 내용

### Phase 1 — leaf + mid module 추출 (6 commit)

- [x] **step 1**: audit doc (`docs/p0p-engineering-channel-router-decomposition.md`) — 11 module split + Mermaid 의존 그래프 + 추출 순서 + P0-K/M/N 가드 일관성 노트
- [x] **step 2**: `git mv` → `engineering_channel_router/_legacy.py` + ``__init__.py`` facade. ``from ..agents.*`` → ``from ...agents.*`` 23 곳 + sibling import 8 곳 보정. test mock 경로 ``_legacy.<name>`` 으로 갱신 6 곳.
- [x] **step 3**: ``models.py`` — 6 frozen dataclass + 7 Callable alias (leaf)
- [x] **step 4**: ``utils.py`` — env reader + 값 coercion + message parsing + ``_maybe_await`` + ``_attach_recall_coverage`` (leaf)
- [x] **step 5**: ``intent_detection.py`` — ``is_engineering_channel`` + ``detect_confirmation_signal`` + continue/new-thread predicate + ``_CONFIRMATION_KEYWORDS``
- [x] **step 6**: ``session_persistence.py`` — 14 helper (``_persist_*`` 7 + ``_load_session_by_id`` / ``_most_recent_session`` + ``_work_report_to_dict`` + proposal serialization + ``_record_persistence_failure`` + ``_is_terminal``)

### Phase 2 (다음 PR — 6 commit 예정)

- [ ] step 7-8: ``coding_gate.py`` / ``obsidian_gate.py`` (수정 권한 + 저장 승인 흐름)
- [ ] step 9: ``research_loop.py`` (P0-K command-only 가드 + research_loop hook + forum status persistence)
- [ ] step 10: ``reporting.py`` (``_emit_work_report_preview`` + ``_format_clarification_message`` + outcome coercion)
- [ ] step 11: ``runtime_preflight.py`` (``_run_runtime_preflight`` + ``_handle_join_or_append``)
- [ ] step 12: ``main.py`` 에 ``route_engineering_message`` + clarification CREATE driver 만 남기고 ``_legacy.py`` 제거

## 참고할만한 자료

- audit doc: `docs/p0p-engineering-channel-router-decomposition.md`
- parent: #138 (engineering_conversation monolith — closed by PR #153), P0-L 패턴 재사용
- 후속 라이브 버그 수정 (#149 등) 의 변경 표면 축소가 목적

## 회귀

- baseline: 4672 PASS + 1 skipped (P0-L 직후)
- final: **4672 PASS + 1 skipped** — 매 step 후 ``pytest tests -q`` drift 없음
- P0-K / P0-M / P0-N1~5 가드 모두 동등 보존 (특히 ``_research_loop_blocked_by_command_only`` 3 call site + ``is_non_actionable_prompt`` firewall 4 site).

## 다음 단계

- 본 PR 머지 후 즉시 phase 2 (step 7-12) 새 브랜치에서 시작.