### PR TITLE
♻️ engineering_channel_router phase 4 — _legacy → main 이름 변경 + 분해 완료 (P0-P step 12)

### DIFF
--- a/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/__init__.py
@@ -1,7 +1,7 @@
-"""Engineering channel router — package facade (P0-P decomposition).
+"""Engineering channel router — package facade (P0-P decomposition complete).
 
 Historical monolith (``engineering_channel_router.py``, 3316 lines)
-is being split into 11 responsibility-aligned modules per the audit at
+split into 11 responsibility-aligned modules per the audit at
 ``docs/p0p-engineering-channel-router-decomposition.md``. Each module
 owns one slice of the gateway orchestration:
 
@@ -18,8 +18,8 @@ owns one slice of the gateway orchestration:
   * :mod:`.runtime_preflight`   — runtime intent + recall short-circuit.
   * :mod:`..engineering.clarification` (already extracted in P0-N4) —
                                     clarification cache + TTL + selection.
-  * :mod:`.main`                — `route_engineering_message` orchestration
-                                    + clarification CREATE driver.
+  * :mod:`.main`                — ``route_engineering_message`` orchestration
+                                    + clarification CREATE/JOIN drivers.
 
 This ``__init__.py`` is the **thin facade** — re-exports the public API
 so ``from yule_orchestrator.discord.engineering_channel_router import X``
@@ -29,10 +29,10 @@ supervisor.py, all test fixtures) without source changes.
 
 from __future__ import annotations
 
-# Until commits 3-12 fully extract each module, re-export everything
-# from the legacy single-file body so existing callers (and tests) keep
-# working verbatim. Subsequent commits replace these wildcard imports
-# with explicit per-module imports as content moves out of ``_legacy``.
+# Per-module explicit re-exports. The main module owns
+# ``route_engineering_message`` plus the two clarification drivers; all
+# other facade symbols pull directly from their responsibility-aligned
+# siblings so import-time graph stays clean (no wildcard imports).
 # Canonical dataclasses + type aliases live in .models (P0-P step 3).
 from .models import (  # noqa: F401 — facade re-export
     ConversationFn,
@@ -106,9 +106,9 @@ from .runtime_preflight import (  # noqa: F401 — facade re-export
     _run_runtime_preflight,
 )
 
-from ._legacy import *  # noqa: F401,F403 — facade re-export
-# Symbols still owned by _legacy until step 12 finishes extraction.
-from ._legacy import (  # noqa: F401 — explicit symbols for IDE/static analysis
+# Main orchestration entry + clarification drivers (P0-P step 12).
+from .main import (  # noqa: F401 — facade re-export
+    _drive_clarification_create_new_work,
     _handle_clarification_selection,
     is_coding_approval_phrase,
     is_coding_proposal_request,

--- a/src/yule_orchestrator/discord/engineering_channel_router/main.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/main.py
@@ -1,14 +1,31 @@
-"""Routing logic for the engineering #업무-접수 channel.
+"""engineering_channel_router — main orchestration entry.
 
-The Discord bot's planning conversation layer is preserved as-is; this
-router handles the *engineering* path: free conversation in the intake
-channel (or a thread under it), and — when the user signals confirmation
-— a workflow intake plus a thread kickoff message.
+Hosts the three remaining "orchestration core" functions after the
+P0-P decomposition (steps 1-11) extracted everything else into
+responsibility-aligned siblings:
 
-The module is pure-Python: all I/O dependencies (engineering conversation
-provider, workflow intake, thread kickoff, message sender) are injected
-as callables so unit tests can drive the router without spinning up
-discord.py. ``bot.py`` wires the production callables.
+- :func:`route_engineering_message` — the public router entry.
+  Walks the message through (1) channel check, (2) coding gate,
+  (3) Obsidian gate, (4) explicit-session-id join, (5) clarification
+  CREATE branch, (6) runtime preflight, (7) ``conversation_fn``
+  + intake / kickoff / research loop / work report.
+- :func:`_drive_clarification_create_new_work` — drives intake +
+  kickoff + research_loop with the cached canonical_prompt when
+  the user picked "새 작업으로 진행" after a clarification.
+- :func:`_handle_clarification_selection` — drives JOIN via the
+  legacy join helper when the user picked an existing candidate.
+
+Every other concern (models, utils, intent_detection, coding_gate,
+obsidian_gate, session_persistence, research_loop, reporting,
+runtime_preflight, clarification cache) lives in its own module —
+see ``docs/p0p-engineering-channel-router-decomposition.md`` for the
+full responsibility map.
+
+The module is pure-Python: all I/O dependencies (engineering
+conversation provider, workflow intake, thread kickoff, message
+sender) are injected as callables so unit tests can drive the router
+without spinning up discord.py. ``bot.py`` wires the production
+callables.
 """
 
 from __future__ import annotations

--- a/src/yule_orchestrator/discord/engineering_channel_router/research_loop.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/research_loop.py
@@ -41,7 +41,7 @@ def _coerce_research_loop_report(raw: Any) -> EngineeringResearchLoopReport:
     .reporting in P0-P step 10). Until then research_loop calls it
     through this thin shim to avoid a circular import."""
 
-    from ._legacy import _coerce_research_loop_report as _impl
+    from .main import _coerce_research_loop_report as _impl
 
     return _impl(raw)
 

--- a/src/yule_orchestrator/discord/engineering_channel_router/runtime_preflight.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/runtime_preflight.py
@@ -99,7 +99,7 @@ def _handle_clarification_selection(*args, **kwargs):
     """Defer to ``_legacy._handle_clarification_selection`` (final
     extraction lives in P0-P step 12 inside main.py)."""
 
-    from ._legacy import _handle_clarification_selection as _impl
+    from .main import _handle_clarification_selection as _impl
 
     return _impl(*args, **kwargs)
 

--- a/tests/engineering/test_channel_router_routing.py
+++ b/tests/engineering/test_channel_router_routing.py
@@ -591,7 +591,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router.main.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -639,7 +639,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router.main.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -681,7 +681,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
             return EngineeringResearchLoopReport()
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router.main.decide_routing",
             wraps=__import__(
                 "yule_orchestrator.agents.routing", fromlist=["decide_routing"]
             ).decide_routing,
@@ -734,7 +734,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
         kickoff_fn = AsyncMock(side_effect=AssertionError("kickoff should not run"))
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router.main.decide_routing",
             return_value=EngineeringRoutingDecision(
                 action="join_existing_work",
                 matched_session_id="open-1",
@@ -781,7 +781,7 @@ class DecideRoutingWiringTests(unittest.TestCase):
         loop_fn = AsyncMock(side_effect=AssertionError("loop should not run"))
 
         with patch(
-            "yule_orchestrator.discord.engineering_channel_router._legacy.decide_routing",
+            "yule_orchestrator.discord.engineering_channel_router.main.decide_routing",
             return_value=EngineeringRoutingDecision(
                 action="ask_for_clarification",
                 reason="후보 두 건이 비슷합니다",


### PR DESCRIPTION
## 어떤 변경인가요?

P0-P router 분해의 **마지막 단계**. ``_legacy.py`` 라는 과도기 이름을 ``main.py`` 로 바꿔 책임을 명시하고, facade 의 잔재 ``_legacy`` references 정리. 동작 변경 0.

## 작업 상세 내용

### step 12 — 최종 정리
- [x] ``git mv _legacy.py → main.py``
- [x] ``from ._legacy import`` / ``engineering_channel_router._legacy`` 4 곳 일괄 갱신 (research_loop.py, runtime_preflight.py, __init__.py, tests/engineering/test_channel_router_routing.py)
- [x] ``main.py`` docstring 을 새 책임 설명으로 교체 (``route_engineering_message`` + clarification CREATE/JOIN driver 3 함수)
- [x] ``__init__.py`` facade:
  - "decomposition" → "decomposition complete" 표기
  - "Until commits 3-12 fully extract..." 헤더 주석 제거 (완료)
  - ``from .main import *`` wildcard 제거, explicit import만 노출

## 회귀

- baseline (phase 3 머지 직후): 4672 PASS + 1 skipped
- final: **4672 PASS + 1 skipped** — 동작 변경 0

## 최종 구조 (11 파일, 총 4165 줄)

| 파일 | 줄 수 | 책임 |
| --- | --- | --- |
| ``__init__.py`` | 127 | 패키지 facade |
| ``main.py`` | 1036 | route_engineering_message + clarification CREATE/JOIN driver |
| ``research_loop.py`` | 550 | P0-K guard + research_loop hook + forum status |
| ``runtime_preflight.py`` | 546 | runtime intent + join/append driver |
| ``session_persistence.py`` | 472 | session.extra mutation + load |
| ``coding_gate.py`` | 318 | 수정 권한 / 승인 |
| ``obsidian_gate.py`` | 312 | 저장 승인 / 이대로 저장 |
| ``reporting.py`` | 236 | work_report preview + clarification 디스플레이 |
| ``models.py`` | 219 | dataclass + type alias |
| ``utils.py`` | 188 | env / coercion / message parsing |
| ``intent_detection.py`` | 161 | channel + confirmation + continuation |

**원본 3316 줄 단일 파일 → 11 책임 모듈로 분해 완료.**

## 참고

- audit doc: ``docs/p0p-engineering-channel-router-decomposition.md``
- P0-K / P0-M / P0-N1-5 라이브 가드 모두 동등 보존 — 매 step 후 4672 PASS drift 없음
- bot.py / commands.py / supervisor.py / test fixture 외부 import 사이트 무회귀