### PR TITLE
🐛 /engineer_intake 가 planning-bot 에 등록되는 ownership 버그 수정

### DIFF
--- a/src/yule_orchestrator/discord/bot/_legacy.py
+++ b/src/yule_orchestrator/discord/bot/_legacy.py
@@ -34,7 +34,7 @@ from ..runtime.checkpoint_state import (
     filter_unresponded_checkpoints,
     save_checkpoint_pending_response,
 )
-from ..commands import register_discord_commands
+from ..commands import register_discord_commands, resolve_bot_role_set_from_env
 from ..conversation import build_conversation_response_envelope
 from ..config import DiscordBotConfig
 from ..engineering_channel_router import (
@@ -158,10 +158,17 @@ def run_discord_bot(repo_root: Path) -> None:
                     f"configured={config.application_id}, actual={actual_application_id}. "
                     "The token-linked application will be used."
                 )
+            # Role-scoped registration: planning-bot subprocess registers
+            # only planning commands, engineering gateway only ``/engineer_*``.
+            # The follow-up ``tree.sync`` PUTs the resulting set on Discord
+            # so any stale commands from a previous boot (e.g. ``/engineer_*``
+            # left over on planning-bot) get cleared.
+            bot_role_set = resolve_bot_role_set_from_env()
             register_discord_commands(
                 self,
                 guild_id=config.guild_id,
                 notify_user_id=config.notify_user_id,
+                role_set=bot_role_set,
             )
             guild = discord.Object(id=config.guild_id)
             await self.tree.sync(guild=guild)

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -4,8 +4,9 @@ import asyncio
 import os
 import uuid
 from datetime import date, datetime
+from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from ...agents import (
     Dispatcher,
@@ -29,17 +30,127 @@ from ..ui.formatter import (
 from ..runtime.planning import build_due_checkpoints, load_plan_today_snapshot
 
 
+class BotRoleSet(str, Enum):
+    """Which slash-command group a bot process should register.
+
+    Owning the right set per process prevents the wrong app from
+    receiving a command (e.g. planning-bot getting ``/engineer_intake``
+    and timing out because it has no orchestrator wiring).
+    """
+
+    ALL = "all"
+    PLANNING_ONLY = "planning-only"
+    ENGINEERING_ONLY = "engineering-only"
+
+
+DISCORD_BOT_ROLE_ENV = "DISCORD_BOT_ROLE"
+
+_ROLE_FROM_ENV: dict[str, BotRoleSet] = {
+    "planning": BotRoleSet.PLANNING_ONLY,
+    "planning-only": BotRoleSet.PLANNING_ONLY,
+    "planning-bot": BotRoleSet.PLANNING_ONLY,
+    "engineering-gateway": BotRoleSet.ENGINEERING_ONLY,
+    "engineering-only": BotRoleSet.ENGINEERING_ONLY,
+    "engineering": BotRoleSet.ENGINEERING_ONLY,
+    "all": BotRoleSet.ALL,
+    "": BotRoleSet.ALL,
+}
+
+
+def resolve_bot_role_set_from_env(env: Optional[Mapping[str, str]] = None) -> BotRoleSet:
+    """Map ``DISCORD_BOT_ROLE`` env value to a :class:`BotRoleSet`.
+
+    Unset / unknown values fall back to :attr:`BotRoleSet.ALL` so existing
+    single-process callers keep their previous behavior.
+    """
+
+    source = env if env is not None else os.environ
+    raw = (source.get(DISCORD_BOT_ROLE_ENV) or "").strip().lower()
+    return _ROLE_FROM_ENV.get(raw, BotRoleSet.ALL)
+
+
 def register_discord_commands(
     bot: "commands.Bot",
     guild_id: int,
     notify_user_id: int | None = None,
+    *,
+    role_set: BotRoleSet = BotRoleSet.ALL,
 ) -> None:
+    """Register slash commands on *bot*'s tree.
+
+    *role_set* controls which command groups are attached. The default
+    keeps the historic behavior (every command on every bot); production
+    callers now pass a narrower set so the wrong application can never
+    own a command. Planning-only / engineering-only convenience wrappers
+    (:func:`register_planning_commands`, :func:`register_engineering_commands`)
+    front this so call sites stay readable.
+    """
+
     import discord
     from discord import app_commands
 
     _bind_discord_runtime_globals(discord_module=discord, app_commands_module=app_commands)
     guild = discord.Object(id=guild_id)
     allowed_mentions = _build_allowed_mentions(discord)
+
+    if role_set in (BotRoleSet.ALL, BotRoleSet.PLANNING_ONLY):
+        _register_planning_commands_impl(
+            bot,
+            guild=guild,
+            allowed_mentions=allowed_mentions,
+            notify_user_id=notify_user_id,
+            discord=discord,
+            app_commands=app_commands,
+        )
+    if role_set in (BotRoleSet.ALL, BotRoleSet.ENGINEERING_ONLY):
+        _register_engineering_commands_impl(
+            bot,
+            guild=guild,
+            allowed_mentions=allowed_mentions,
+            discord=discord,
+            app_commands=app_commands,
+        )
+
+
+def register_planning_commands(
+    bot: "commands.Bot",
+    guild_id: int,
+    notify_user_id: int | None = None,
+) -> None:
+    """Register only the planning-bot owned commands (ping / plan_today / checkpoints_now)."""
+
+    register_discord_commands(
+        bot,
+        guild_id,
+        notify_user_id,
+        role_set=BotRoleSet.PLANNING_ONLY,
+    )
+
+
+def register_engineering_commands(
+    bot: "commands.Bot",
+    guild_id: int,
+    notify_user_id: int | None = None,
+) -> None:
+    """Register only the engineering-gateway owned ``/engineer_*`` commands."""
+
+    register_discord_commands(
+        bot,
+        guild_id,
+        notify_user_id,
+        role_set=BotRoleSet.ENGINEERING_ONLY,
+    )
+
+
+def _register_planning_commands_impl(
+    bot: "commands.Bot",
+    *,
+    guild: Any,
+    allowed_mentions: Any,
+    notify_user_id: int | None,
+    discord: Any,
+    app_commands: Any,
+) -> None:
 
     @bot.tree.command(name="ping", description="봇이 살아 있는지 확인합니다.", guild=guild)
     async def ping(interaction: discord.Interaction) -> None:
@@ -103,339 +214,6 @@ def register_discord_commands(
             discord_module=discord,
         )
 
-    @bot.tree.command(
-        name="engineer_intake",
-        description="engineering-agent에게 작업을 위임합니다 (접수 메시지를 채널에 게시).",
-        guild=guild,
-    )
-    @app_commands.describe(
-        prompt="자연어 작업 요청.",
-        task_type="명시 task type (생략 시 키워드 분류).",
-        write_requested="이 작업이 코드/문서 쓰기를 요구하는지 여부.",
-    )
-    async def engineer_intake(
-        interaction: "discord.Interaction",
-        prompt: str,
-        task_type: Optional[str] = None,
-        write_requested: bool = False,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            result = await asyncio.to_thread(
-                _run_engineer_intake,
-                prompt=prompt,
-                task_type=task_type,
-                write_requested=write_requested,
-                channel_id=interaction.channel_id,
-                user_id=interaction.user.id,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer intake 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            result.message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_show",
-        description="engineering-agent 워크플로 세션 상태를 조회합니다.",
-        guild=guild,
-    )
-    @app_commands.describe(session_id="조회할 워크플로 세션 id.")
-    async def engineer_show(
-        interaction: "discord.Interaction",
-        session_id: str,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            session = await asyncio.to_thread(_load_engineer_session, session_id=session_id)
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer show 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        if session is None:
-            await _send_message_chunks(
-                interaction,
-                f"session `{session_id}` 을 찾을 수 없습니다.",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        summary = (
-            f"**[engineering-agent] 세션 상태**\n"
-            f"세션 ID: `{session.session_id}`\n"
-            f"상태: {session.state.value}\n"
-            f"분류: {session.task_type}\n"
-            f"실행 후보: {session.executor_role} ({session.executor_runner or '?'})"
-        )
-        if session.write_blocked_reason:
-            summary += f"\n승인 대기: {session.write_blocked_reason}"
-        await _send_message_chunks(
-            interaction,
-            summary,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_review",
-        description="기존 세션에 PR 리뷰/Copilot/외부 피드백을 입력합니다.",
-        guild=guild,
-    )
-    @app_commands.describe(
-        session_id="피드백을 연결할 워크플로 세션 ID.",
-        summary="한 줄 요약 (라우팅에 사용).",
-        body="피드백 본문 (선택).",
-        severity="blocking / high / medium / low / nit (기본: medium).",
-        categories="쉼표로 구분한 카테고리 라벨 (예: ui, copy).",
-        source="github_pr_review / github_copilot / external_agent / user (기본: user).",
-        file_paths="쉼표로 구분한 영향 파일 경로 (선택).",
-    )
-    async def engineer_review(
-        interaction: "discord.Interaction",
-        session_id: str,
-        summary: str,
-        body: Optional[str] = None,
-        severity: Optional[str] = None,
-        categories: Optional[str] = None,
-        source: Optional[str] = None,
-        file_paths: Optional[str] = None,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            result = await asyncio.to_thread(
-                _run_engineer_review,
-                session_id=session_id,
-                summary=summary,
-                body=body,
-                severity=severity,
-                categories=categories,
-                source=source,
-                file_paths=file_paths,
-                channel_id=interaction.channel_id,
-                thread_id=getattr(interaction.channel, "id", None),
-                user_id=interaction.user.id,
-                author_name=str(interaction.user),
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer review 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            result.message + f"\n\n_피드백 ID_: `{result.feedback.feedback_id}`",
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_review_reply",
-        description="리뷰 피드백에 적용/제안/남은 이슈 회신을 게시합니다.",
-        guild=guild,
-    )
-    @app_commands.describe(
-        session_id="회신 대상 워크플로 세션 ID.",
-        feedback_id="회신 대상 feedback ID.",
-        applied="적용한 수정 (개행 또는 ; 으로 분리).",
-        proposed="추가 제안 (선택, 개행 또는 ; 분리).",
-        remaining="남은 이슈 (선택, 개행 또는 ; 분리).",
-    )
-    async def engineer_review_reply(
-        interaction: "discord.Interaction",
-        session_id: str,
-        feedback_id: str,
-        applied: str,
-        proposed: Optional[str] = None,
-        remaining: Optional[str] = None,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            result = await asyncio.to_thread(
-                _run_engineer_review_reply,
-                session_id=session_id,
-                feedback_id=feedback_id,
-                applied=applied,
-                proposed=proposed,
-                remaining=remaining,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer review reply 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            result.message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_approve",
-        description="engineering-agent 세션을 승인해 진행을 풀어줍니다.",
-        guild=guild,
-    )
-    @app_commands.describe(session_id="승인할 워크플로 세션 ID.")
-    async def engineer_approve(
-        interaction: "discord.Interaction",
-        session_id: str,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            message = await asyncio.to_thread(
-                _run_engineer_approve,
-                session_id=session_id,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer approve 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_reject",
-        description="engineering-agent 세션을 거절합니다 (사유 필수).",
-        guild=guild,
-    )
-    @app_commands.describe(
-        session_id="거절할 워크플로 세션 ID.",
-        reason="거절 사유 (운영 기록용, 한 줄).",
-    )
-    async def engineer_reject(
-        interaction: "discord.Interaction",
-        session_id: str,
-        reason: str,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            message = await asyncio.to_thread(
-                _run_engineer_reject,
-                session_id=session_id,
-                reason=reason,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer reject 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_progress",
-        description="진행 중인 engineering-agent 세션에 진행 메모를 남깁니다.",
-        guild=guild,
-    )
-    @app_commands.describe(
-        session_id="메모를 남길 워크플로 세션 ID.",
-        note="진행 메모 (한 줄, PR/Thread 링크는 본문에 그대로 붙여도 됩니다).",
-    )
-    async def engineer_progress(
-        interaction: "discord.Interaction",
-        session_id: str,
-        note: str,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            message = await asyncio.to_thread(
-                _run_engineer_progress,
-                session_id=session_id,
-                note=note,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer progress 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
-    @bot.tree.command(
-        name="engineer_complete",
-        description="engineering-agent 세션을 완료 상태로 닫고 요약을 게시합니다.",
-        guild=guild,
-    )
-    @app_commands.describe(
-        session_id="완료 처리할 워크플로 세션 ID.",
-        summary="완료 보고에 들어갈 요약 (한두 줄).",
-    )
-    async def engineer_complete(
-        interaction: "discord.Interaction",
-        session_id: str,
-        summary: str,
-    ) -> None:
-        if not await _safe_defer(interaction, discord_module=discord):
-            return
-        try:
-            message = await asyncio.to_thread(
-                _run_engineer_complete,
-                session_id=session_id,
-                summary=summary,
-            )
-        except (WorkflowError, ValueError) as exc:
-            await _send_message_chunks(
-                interaction,
-                f"engineer complete 실패: {exc}",
-                allowed_mentions=allowed_mentions,
-                discord_module=discord,
-            )
-            return
-        await _send_message_chunks(
-            interaction,
-            message,
-            allowed_mentions=allowed_mentions,
-            discord_module=discord,
-        )
-
     @bot.tree.command(name="checkpoints_now", description="지금 기준으로 다가오는 체크포인트를 보여줍니다.", guild=guild)
     @app_commands.describe(window_minutes="몇 분 앞까지 확인할지 설정합니다.")
     async def checkpoints_now(
@@ -461,6 +239,416 @@ def register_discord_commands(
             allowed_mentions=allowed_mentions,
             discord_module=discord,
         )
+
+    # engineer_* commands are registered by _register_engineering_commands_impl
+    # so the planning-bot application never owns them. See BotRoleSet docs.
+    return
+
+
+def _register_engineering_commands_impl(
+    bot: "commands.Bot",
+    *,
+    guild: Any,
+    allowed_mentions: Any,
+    discord: Any,
+    app_commands: Any,
+) -> None:
+    @bot.tree.command(
+        name="engineer_intake",
+        description="engineering-agent에게 작업을 위임합니다 (접수 메시지를 채널에 게시).",
+        guild=guild,
+    )
+    @app_commands.describe(
+        prompt="자연어 작업 요청.",
+        task_type="명시 task type (생략 시 키워드 분류).",
+        write_requested="이 작업이 코드/문서 쓰기를 요구하는지 여부.",
+    )
+    async def engineer_intake(
+        interaction: "discord.Interaction",
+        prompt: str,
+        task_type: Optional[str] = None,
+        write_requested: bool = False,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                result = await asyncio.to_thread(
+                    _run_engineer_intake,
+                    prompt=prompt,
+                    task_type=task_type,
+                    write_requested=write_requested,
+                    channel_id=interaction.channel_id,
+                    user_id=interaction.user.id,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer intake 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                result.message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_intake",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_show",
+        description="engineering-agent 워크플로 세션 상태를 조회합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(session_id="조회할 워크플로 세션 id.")
+    async def engineer_show(
+        interaction: "discord.Interaction",
+        session_id: str,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                session = await asyncio.to_thread(_load_engineer_session, session_id=session_id)
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer show 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            if session is None:
+                await _send_message_chunks(
+                    interaction,
+                    f"session `{session_id}` 을 찾을 수 없습니다.",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            summary = (
+                f"**[engineering-agent] 세션 상태**\n"
+                f"세션 ID: `{session.session_id}`\n"
+                f"상태: {session.state.value}\n"
+                f"분류: {session.task_type}\n"
+                f"실행 후보: {session.executor_role} ({session.executor_runner or '?'})"
+            )
+            if session.write_blocked_reason:
+                summary += f"\n승인 대기: {session.write_blocked_reason}"
+            await _send_message_chunks(
+                interaction,
+                summary,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_show",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_review",
+        description="기존 세션에 PR 리뷰/Copilot/외부 피드백을 입력합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="피드백을 연결할 워크플로 세션 ID.",
+        summary="한 줄 요약 (라우팅에 사용).",
+        body="피드백 본문 (선택).",
+        severity="blocking / high / medium / low / nit (기본: medium).",
+        categories="쉼표로 구분한 카테고리 라벨 (예: ui, copy).",
+        source="github_pr_review / github_copilot / external_agent / user (기본: user).",
+        file_paths="쉼표로 구분한 영향 파일 경로 (선택).",
+    )
+    async def engineer_review(
+        interaction: "discord.Interaction",
+        session_id: str,
+        summary: str,
+        body: Optional[str] = None,
+        severity: Optional[str] = None,
+        categories: Optional[str] = None,
+        source: Optional[str] = None,
+        file_paths: Optional[str] = None,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                result = await asyncio.to_thread(
+                    _run_engineer_review,
+                    session_id=session_id,
+                    summary=summary,
+                    body=body,
+                    severity=severity,
+                    categories=categories,
+                    source=source,
+                    file_paths=file_paths,
+                    channel_id=interaction.channel_id,
+                    thread_id=getattr(interaction.channel, "id", None),
+                    user_id=interaction.user.id,
+                    author_name=str(interaction.user),
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer review 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                result.message + f"\n\n_피드백 ID_: `{result.feedback.feedback_id}`",
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_review",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_review_reply",
+        description="리뷰 피드백에 적용/제안/남은 이슈 회신을 게시합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="회신 대상 워크플로 세션 ID.",
+        feedback_id="회신 대상 feedback ID.",
+        applied="적용한 수정 (개행 또는 ; 으로 분리).",
+        proposed="추가 제안 (선택, 개행 또는 ; 분리).",
+        remaining="남은 이슈 (선택, 개행 또는 ; 분리).",
+    )
+    async def engineer_review_reply(
+        interaction: "discord.Interaction",
+        session_id: str,
+        feedback_id: str,
+        applied: str,
+        proposed: Optional[str] = None,
+        remaining: Optional[str] = None,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                result = await asyncio.to_thread(
+                    _run_engineer_review_reply,
+                    session_id=session_id,
+                    feedback_id=feedback_id,
+                    applied=applied,
+                    proposed=proposed,
+                    remaining=remaining,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer review reply 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                result.message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_review_reply",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_approve",
+        description="engineering-agent 세션을 승인해 진행을 풀어줍니다.",
+        guild=guild,
+    )
+    @app_commands.describe(session_id="승인할 워크플로 세션 ID.")
+    async def engineer_approve(
+        interaction: "discord.Interaction",
+        session_id: str,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                message = await asyncio.to_thread(
+                    _run_engineer_approve,
+                    session_id=session_id,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer approve 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_approve",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_reject",
+        description="engineering-agent 세션을 거절합니다 (사유 필수).",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="거절할 워크플로 세션 ID.",
+        reason="거절 사유 (운영 기록용, 한 줄).",
+    )
+    async def engineer_reject(
+        interaction: "discord.Interaction",
+        session_id: str,
+        reason: str,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                message = await asyncio.to_thread(
+                    _run_engineer_reject,
+                    session_id=session_id,
+                    reason=reason,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer reject 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_reject",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_progress",
+        description="진행 중인 engineering-agent 세션에 진행 메모를 남깁니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="메모를 남길 워크플로 세션 ID.",
+        note="진행 메모 (한 줄, PR/Thread 링크는 본문에 그대로 붙여도 됩니다).",
+    )
+    async def engineer_progress(
+        interaction: "discord.Interaction",
+        session_id: str,
+        note: str,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                message = await asyncio.to_thread(
+                    _run_engineer_progress,
+                    session_id=session_id,
+                    note=note,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer progress 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_progress",
+                exc=exc,
+                discord_module=discord,
+            )
+
+    @bot.tree.command(
+        name="engineer_complete",
+        description="engineering-agent 세션을 완료 상태로 닫고 요약을 게시합니다.",
+        guild=guild,
+    )
+    @app_commands.describe(
+        session_id="완료 처리할 워크플로 세션 ID.",
+        summary="완료 보고에 들어갈 요약 (한두 줄).",
+    )
+    async def engineer_complete(
+        interaction: "discord.Interaction",
+        session_id: str,
+        summary: str,
+    ) -> None:
+        try:
+            if not await _safe_defer(interaction, discord_module=discord):
+                return
+            try:
+                message = await asyncio.to_thread(
+                    _run_engineer_complete,
+                    session_id=session_id,
+                    summary=summary,
+                )
+            except (WorkflowError, ValueError) as exc:
+                await _send_message_chunks(
+                    interaction,
+                    f"engineer complete 실패: {exc}",
+                    allowed_mentions=allowed_mentions,
+                    discord_module=discord,
+                )
+                return
+            await _send_message_chunks(
+                interaction,
+                message,
+                allowed_mentions=allowed_mentions,
+                discord_module=discord,
+            )
+        except Exception as exc:  # noqa: BLE001 - broad: must surface so Discord stops showing timeout
+            await _surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_complete",
+                exc=exc,
+                discord_module=discord,
+            )
 
 
 def _engineer_orchestrator() -> WorkflowOrchestrator:
@@ -714,4 +902,48 @@ async def _send_message_chunks(
             "warning: discord interaction webhook expired before followup could be delivered "
             f"(command={getattr(interaction.command, 'name', 'unknown')}, "
             f"user_id={getattr(interaction.user, 'id', 'unknown')})"
+        )
+
+
+async def _surface_unexpected_engineer_error(
+    interaction: "discord.Interaction",
+    *,
+    command_name: str,
+    exc: BaseException,
+    discord_module: Any,
+) -> None:
+    """Surface an unexpected exception via the Discord followup channel.
+
+    Without this, broad exceptions from ``/engineer_*`` handlers bubble
+    out before Discord receives any followup, which the Discord client
+    displays as a generic "애플리케이션이 응답하지 않았어요" timeout.
+    Operators then have no signal as to which command failed or why.
+
+    Best-effort: we try ``followup.send`` first (interaction was already
+    deferred in the happy path), fall back to ``response.send_message``
+    if it wasn't, and as a last resort log to stderr so the failure
+    isn't silent.
+    """
+
+    del discord_module  # API parity with other helpers; not needed here.
+    text = (
+        f"⚠️ `/{command_name}` 처리 중 예상치 못한 오류가 발생했어요.\n"
+        f"`{type(exc).__name__}`: {exc}"
+    )
+    delivered = False
+    try:
+        await interaction.followup.send(text)
+        delivered = True
+    except Exception:  # noqa: BLE001 - fall through to response.send_message
+        pass
+    if not delivered:
+        try:
+            await interaction.response.send_message(text)
+            delivered = True
+        except Exception:  # noqa: BLE001 - last-resort logging below
+            pass
+    if not delivered:
+        print(
+            "error: failed to surface unexpected /"
+            f"{command_name} error to Discord: {type(exc).__name__}: {exc}"
         )

--- a/src/yule_orchestrator/discord/runtime/supervisor.py
+++ b/src/yule_orchestrator/discord/runtime/supervisor.py
@@ -322,6 +322,13 @@ def _run_planning_in_subprocess(repo_root_str: str) -> None:  # pragma: no cover
             # yule-eng-gateway account.
             "DISCORD_ENGINEERING_INTAKE_CHANNEL_ID": "",
             "DISCORD_ENGINEERING_INTAKE_CHANNEL_NAME": "",
+            # Slash command ownership: planning-bot must NOT register
+            # /engineer_* commands. Without this discriminator the bot's
+            # setup_hook registers every command, planning-bot's app gets
+            # picked for /engineer_intake, and Discord shows
+            # "애플리케이션이 응답하지 않았어요" because no orchestrator
+            # is wired into this process.
+            "DISCORD_BOT_ROLE": "planning",
         }
     )
     run_discord_bot(repo_root=Path(repo_root_str))
@@ -341,6 +348,9 @@ def _run_engineering_gateway_in_subprocess(
     overrides = build_gateway_env_overrides(
         gateway_token=gateway_token, base_env={}
     )
+    # Engineering gateway owns ``/engineer_*`` and nothing else (planning
+    # commands like ``/plan_today`` stay on the planning-bot process).
+    overrides["DISCORD_BOT_ROLE"] = "engineering-gateway"
     _apply_env_overrides(overrides)
     run_discord_bot(repo_root=Path(repo_root_str))
 

--- a/tests/discord/test_command_role_split.py
+++ b/tests/discord/test_command_role_split.py
@@ -1,0 +1,398 @@
+"""Regression: slash-command ownership per bot role.
+
+Bug surfaced as ``/engineer_intake`` being picked up by planning-bot and
+showing ``애플리케이션이 응답하지 않았어요`` because planning-bot has no
+orchestrator wired. Fix: ``register_discord_commands`` accepts a
+:class:`BotRoleSet`, planning subprocess sets ``DISCORD_BOT_ROLE=planning``
+and only registers planning commands; engineering gateway analogously
+owns ``/engineer_*``.
+
+These tests stub ``discord`` / ``discord.app_commands`` so they can run
+without the real client installed, and verify the per-role command name
+set.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import MagicMock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+def _install_fake_discord_modules() -> tuple[Any, Any]:
+    """Install minimal fake ``discord`` + ``discord.app_commands`` modules.
+
+    Returns the (discord, app_commands) module objects so the caller can
+    uninstall them on teardown.
+    """
+
+    discord_mod = types.ModuleType("discord")
+
+    class _Object:
+        def __init__(self, *, id):
+            self.id = id
+
+    class _AllowedMentions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _NotFound(Exception):
+        pass
+
+    class _Interaction:  # for string-annotation lookups only
+        pass
+
+    discord_mod.Object = _Object
+    discord_mod.AllowedMentions = _AllowedMentions
+    discord_mod.NotFound = _NotFound
+    discord_mod.Interaction = _Interaction
+
+    ext_mod = types.ModuleType("discord.ext")
+    discord_mod.ext = ext_mod
+
+    app_commands_mod = types.ModuleType("discord.app_commands")
+
+    def _describe(**_kwargs):
+        def _wrap(fn):
+            return fn
+
+        return _wrap
+
+    class _Range:
+        def __class_getitem__(cls, _key):
+            return int
+
+    app_commands_mod.describe = _describe
+    app_commands_mod.Range = _Range
+    discord_mod.app_commands = app_commands_mod
+
+    sys.modules["discord"] = discord_mod
+    sys.modules["discord.ext"] = ext_mod
+    sys.modules["discord.app_commands"] = app_commands_mod
+    return discord_mod, app_commands_mod
+
+
+class _FakeTree:
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def command(self, *, name, description, guild=None):
+        del description, guild  # only the name matters for these tests
+
+        def _decorator(fn):
+            self.commands.append(name)
+            return fn
+
+        return _decorator
+
+
+class _FakeBot:
+    def __init__(self) -> None:
+        self.tree = _FakeTree()
+
+
+class CommandRoleSplitTests(unittest.TestCase):
+    """``register_discord_commands`` registers different command sets per role."""
+
+    def setUp(self) -> None:
+        self._previous_modules = {
+            name: sys.modules.get(name)
+            for name in ("discord", "discord.ext", "discord.app_commands")
+        }
+        _install_fake_discord_modules()
+        # Re-import the commands module against the freshly-stubbed discord
+        # so the ``import discord`` inside register_discord_commands resolves
+        # to our fake.
+        if "yule_orchestrator.discord.commands" in sys.modules:
+            del sys.modules["yule_orchestrator.discord.commands"]
+        from yule_orchestrator.discord import commands as commands_module
+
+        self.commands_module = commands_module
+
+    def tearDown(self) -> None:
+        for name, previous in self._previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        sys.modules.pop("yule_orchestrator.discord.commands", None)
+
+    def test_planning_role_excludes_engineer_intake(self) -> None:
+        bot = _FakeBot()
+
+        self.commands_module.register_discord_commands(
+            bot,
+            guild_id=123,
+            notify_user_id=None,
+            role_set=self.commands_module.BotRoleSet.PLANNING_ONLY,
+        )
+
+        self.assertIn("ping", bot.tree.commands)
+        self.assertIn("plan_today", bot.tree.commands)
+        self.assertIn("checkpoints_now", bot.tree.commands)
+        self.assertNotIn("engineer_intake", bot.tree.commands)
+        for name in bot.tree.commands:
+            self.assertFalse(
+                name.startswith("engineer_"),
+                msg=f"planning role should not own {name}",
+            )
+
+    def test_engineering_role_excludes_plan_today(self) -> None:
+        bot = _FakeBot()
+
+        self.commands_module.register_discord_commands(
+            bot,
+            guild_id=123,
+            notify_user_id=None,
+            role_set=self.commands_module.BotRoleSet.ENGINEERING_ONLY,
+        )
+
+        # Every engineer_* command must be registered…
+        expected_engineer_commands = {
+            "engineer_intake",
+            "engineer_show",
+            "engineer_review",
+            "engineer_review_reply",
+            "engineer_approve",
+            "engineer_reject",
+            "engineer_progress",
+            "engineer_complete",
+        }
+        self.assertTrue(
+            expected_engineer_commands.issubset(set(bot.tree.commands)),
+            msg=(
+                "engineering role missing commands: "
+                f"{expected_engineer_commands - set(bot.tree.commands)}"
+            ),
+        )
+        # …and no planning commands.
+        self.assertNotIn("ping", bot.tree.commands)
+        self.assertNotIn("plan_today", bot.tree.commands)
+        self.assertNotIn("checkpoints_now", bot.tree.commands)
+
+    def test_all_role_back_compat_registers_both_sets(self) -> None:
+        bot = _FakeBot()
+
+        self.commands_module.register_discord_commands(
+            bot,
+            guild_id=123,
+            notify_user_id=None,
+            role_set=self.commands_module.BotRoleSet.ALL,
+        )
+
+        self.assertIn("ping", bot.tree.commands)
+        self.assertIn("engineer_intake", bot.tree.commands)
+        self.assertIn("checkpoints_now", bot.tree.commands)
+
+    def test_default_role_set_is_all_for_back_compat(self) -> None:
+        bot = _FakeBot()
+
+        # Caller does not pass role_set — should behave like ALL.
+        self.commands_module.register_discord_commands(
+            bot,
+            guild_id=123,
+            notify_user_id=None,
+        )
+
+        self.assertIn("ping", bot.tree.commands)
+        self.assertIn("engineer_intake", bot.tree.commands)
+
+    def test_convenience_wrappers_match_role_sets(self) -> None:
+        planning_bot = _FakeBot()
+        engineering_bot = _FakeBot()
+
+        self.commands_module.register_planning_commands(planning_bot, guild_id=123)
+        self.commands_module.register_engineering_commands(engineering_bot, guild_id=123)
+
+        self.assertIn("ping", planning_bot.tree.commands)
+        self.assertNotIn("engineer_intake", planning_bot.tree.commands)
+
+        self.assertIn("engineer_intake", engineering_bot.tree.commands)
+        self.assertNotIn("ping", engineering_bot.tree.commands)
+
+
+class BotRoleSetEnvResolutionTests(unittest.TestCase):
+    """``resolve_bot_role_set_from_env`` interprets ``DISCORD_BOT_ROLE``."""
+
+    def setUp(self) -> None:
+        self._previous_modules = {
+            name: sys.modules.get(name)
+            for name in ("discord", "discord.ext", "discord.app_commands")
+        }
+        _install_fake_discord_modules()
+        if "yule_orchestrator.discord.commands" in sys.modules:
+            del sys.modules["yule_orchestrator.discord.commands"]
+        from yule_orchestrator.discord import commands as commands_module
+
+        self.commands_module = commands_module
+
+    def tearDown(self) -> None:
+        for name, previous in self._previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        sys.modules.pop("yule_orchestrator.discord.commands", None)
+
+    def test_planning_env_maps_to_planning_only(self) -> None:
+        result = self.commands_module.resolve_bot_role_set_from_env(
+            {"DISCORD_BOT_ROLE": "planning"}
+        )
+        self.assertEqual(result, self.commands_module.BotRoleSet.PLANNING_ONLY)
+
+    def test_engineering_gateway_env_maps_to_engineering_only(self) -> None:
+        result = self.commands_module.resolve_bot_role_set_from_env(
+            {"DISCORD_BOT_ROLE": "engineering-gateway"}
+        )
+        self.assertEqual(result, self.commands_module.BotRoleSet.ENGINEERING_ONLY)
+
+    def test_unset_env_falls_back_to_all(self) -> None:
+        result = self.commands_module.resolve_bot_role_set_from_env({})
+        self.assertEqual(result, self.commands_module.BotRoleSet.ALL)
+
+    def test_unknown_env_falls_back_to_all(self) -> None:
+        result = self.commands_module.resolve_bot_role_set_from_env(
+            {"DISCORD_BOT_ROLE": "something-else"}
+        )
+        self.assertEqual(result, self.commands_module.BotRoleSet.ALL)
+
+    def test_whitespace_and_case_are_normalized(self) -> None:
+        result = self.commands_module.resolve_bot_role_set_from_env(
+            {"DISCORD_BOT_ROLE": "  Engineering-Gateway  "}
+        )
+        self.assertEqual(result, self.commands_module.BotRoleSet.ENGINEERING_ONLY)
+
+
+class UnexpectedErrorFollowupTests(unittest.TestCase):
+    """Unexpected exceptions in /engineer_intake surface to Discord followup."""
+
+    def setUp(self) -> None:
+        self._previous_modules = {
+            name: sys.modules.get(name)
+            for name in ("discord", "discord.ext", "discord.app_commands")
+        }
+        _install_fake_discord_modules()
+        if "yule_orchestrator.discord.commands" in sys.modules:
+            del sys.modules["yule_orchestrator.discord.commands"]
+        from yule_orchestrator.discord import commands as commands_module
+
+        self.commands_module = commands_module
+
+    def tearDown(self) -> None:
+        for name, previous in self._previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        sys.modules.pop("yule_orchestrator.discord.commands", None)
+
+    def test_surface_unexpected_error_calls_followup_send(self) -> None:
+        followup = MagicMock()
+
+        async def _send(text):
+            followup.last_text = text
+
+        followup.send = _send
+
+        interaction = MagicMock()
+        interaction.followup = followup
+
+        async def run() -> None:
+            await self.commands_module._surface_unexpected_engineer_error(
+                interaction,
+                command_name="engineer_intake",
+                exc=RuntimeError("boom"),
+                discord_module=sys.modules["discord"],
+            )
+
+        asyncio.run(run())
+
+        self.assertIn("engineer_intake", followup.last_text)
+        self.assertIn("RuntimeError", followup.last_text)
+        self.assertIn("boom", followup.last_text)
+
+    def test_engineer_intake_handler_routes_unexpected_exception_to_followup(self) -> None:
+        # Capture the registered handler closure so we can call it directly
+        # with a fake interaction that triggers an unexpected exception.
+        captured_handlers: dict[str, Any] = {}
+
+        class CapturingTree:
+            def command(self, *, name, description, guild=None):
+                del description, guild
+
+                def _decorator(fn):
+                    captured_handlers[name] = fn
+                    return fn
+
+                return _decorator
+
+        class CapturingBot:
+            def __init__(self) -> None:
+                self.tree = CapturingTree()
+
+        bot = CapturingBot()
+        self.commands_module.register_discord_commands(
+            bot,
+            guild_id=123,
+            role_set=self.commands_module.BotRoleSet.ENGINEERING_ONLY,
+        )
+
+        self.assertIn("engineer_intake", captured_handlers)
+        handler = captured_handlers["engineer_intake"]
+
+        followup_messages: list[str] = []
+        response_messages: list[str] = []
+
+        class FakeResponse:
+            async def defer(self, *, thinking=True):
+                # Trigger an unexpected exception path: simulate a runtime
+                # error in defer itself (NOT a discord.NotFound). _safe_defer
+                # will re-raise -> outer broad except in the handler runs.
+                raise RuntimeError("unexpected defer crash")
+
+            async def send_message(self, text):
+                response_messages.append(text)
+
+        class FakeFollowup:
+            async def send(self, text, allowed_mentions=None):
+                del allowed_mentions
+                followup_messages.append(text)
+
+        class FakeUser:
+            id = 42
+
+        class FakeInteraction:
+            command = type("C", (), {"name": "engineer_intake"})()
+            user = FakeUser()
+            channel_id = 999
+            response = FakeResponse()
+            followup = FakeFollowup()
+
+        async def run() -> None:
+            await handler(
+                FakeInteraction(),
+                prompt="prompt",
+                task_type=None,
+                write_requested=False,
+            )
+
+        asyncio.run(run())
+
+        # We expect ONE followup message that names the command and the
+        # exception type — the planning-bot-style timeout no longer occurs.
+        self.assertEqual(len(followup_messages), 1)
+        body = followup_messages[0]
+        self.assertIn("engineer_intake", body)
+        self.assertIn("RuntimeError", body)
+        self.assertIn("unexpected defer crash", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
운영 버그: \`/engineer_intake\` 가 engineering gateway 전용이어야 하는데 planning-bot 에도 등록되어 잘못된 앱이 명령을 받고, 처리 실패 후 Discord 에 "애플리케이션이 응답하지 않았어요" timeout 이 뜸.

## ✨ 과제 내용

### 핵심 원인
1. \`register_discord_commands\` 가 ping/plan_today + \`engineer_*\` 까지 한 번에 등록
2. 이 함수가 모든 bot setup_hook 에서 공통 호출
3. planning-bot subprocess 는 intake 채널 env 만 비우고, slash command registration 은 제한 안 함
4. \`engineer_intake\` 핸들러는 \`WorkflowError\`/\`ValueError\` 만 catch — 그 외 예외는 followup 없이 새어나가 timeout 처럼 보임

### 해결
**command registration split**
- \`BotRoleSet\` enum (ALL / PLANNING_ONLY / ENGINEERING_ONLY) + \`role_set\` 파라미터
- \`_register_planning_commands_impl\`: ping / plan_today / checkpoints_now
- \`_register_engineering_commands_impl\`: engineer_intake / show / review / review_reply / approve / reject / progress / complete
- 편의 wrapper \`register_planning_commands\` / \`register_engineering_commands\`

**setup_hook + supervisor wiring**
- \`DISCORD_BOT_ROLE\` env 로 subprocess 종류 식별 (\`resolve_bot_role_set_from_env\`)
- supervisor: planning subprocess = \`planning\`, gateway subprocess = \`engineering-gateway\`
- bot/_legacy setup_hook: env 읽어서 \`role_set\` 으로 등록

**stale command cleanup**
- 후속 \`tree.sync(guild=guild)\` 가 새 command set 으로 PUT 수행 → planning-bot 에 남아 있던 stale \`engineer_*\` 자동 정리

**exception handling**
- 모든 \`engineer_*\` 핸들러 body 를 \`try / except Exception\` 으로 감쌈
- \`_surface_unexpected_engineer_error\`: \`followup.send\` → \`response.send_message\` → stderr 로 fallback, 명령명 + 예외 type/메시지 노출

## 🧪 테스트 (신규 12개 / 전체 4672 → 4684 pass)
- planning-bot command registry 에 \`engineer_intake\` 없음 ✓
- engineering gateway command registry 에 engineer_* 8개 모두 있음 ✓
- engineering gateway 에 plan_today / ping / checkpoints_now 없음 ✓
- \`engineer_intake\` unexpected exception → followup 으로 명령명 + 예외 surface ✓
- DISCORD_BOT_ROLE env 매핑 (planning / engineering-gateway / unknown / unset / 대소문자) ✓
- back-compat: role_set 미지정 → ALL 동일 동작 ✓

## 📚 레퍼런스
- 진단 출처: 운영 중 /engineer_intake 호출 시 timeout 표시 (planning-bot 가 ownership 가져감)

## ✅ Test plan
- [x] \`.venv/bin/python -m pytest tests -q\` → 4684 PASS / 1 skipped
- [ ] CI 그린 확인
- [ ] auto-merge