### PR TITLE
🐛 approved coding session 이 coding_execute 로 dispatch 안 되는 버그 수정 + status 진단 surface

### DIFF
--- a/src/yule_orchestrator/agents/coding/authorization.py
+++ b/src/yule_orchestrator/agents/coding/authorization.py
@@ -693,12 +693,54 @@ def _format_research_only_message(proposal: CodingAuthorizationProposal) -> str:
     return "\n".join(lines)
 
 
+def proposal_from_dict(payload: Mapping[str, object]) -> CodingAuthorizationProposal:
+    """Re-hydrate a :class:`CodingAuthorizationProposal` from session.extra.
+
+    The Discord coding gate persists proposals via ``to_dict`` (mirror in
+    ``discord/engineering_channel_router/session_persistence.py``). Both
+    the Discord chat approval path AND the ``/engineer_approve`` slash
+    command need to rebuild the proposal to derive the executor coding_job,
+    so the factory lives in the agents layer rather than duplicated per
+    caller.
+
+    Defaults are deliberate:
+    - ``executor_role`` falls back to ``tech-lead`` for implementation
+      mode (matches the recommender's default reviewer-as-executor stub)
+      and to empty string for research-only (no executor by contract).
+    - ``approval_required`` defaults True because dropping an unset value
+      to False would unsafely loosen the user-approval gate.
+    """
+
+    lifecycle_mode = str(payload.get("lifecycle_mode") or LIFECYCLE_MODE_IMPLEMENTATION)
+    raw_executor = payload.get("executor_role")
+    if lifecycle_mode == LIFECYCLE_MODE_RESEARCH_ONLY:
+        executor_role = str(raw_executor or "")
+    else:
+        executor_role = str(raw_executor or "tech-lead")
+    return CodingAuthorizationProposal(
+        session_id=payload.get("session_id"),
+        user_request=str(payload.get("user_request") or ""),
+        executor_role=executor_role,
+        review_roles=tuple(payload.get("review_roles") or ()),
+        participant_roles=tuple(payload.get("participant_roles") or ()),
+        write_scope=tuple(payload.get("write_scope") or ()),
+        forbidden_scope=tuple(payload.get("forbidden_scope") or ()),
+        reason=str(payload.get("reason") or ""),
+        safety_rules=tuple(payload.get("safety_rules") or ()),
+        approval_required=bool(payload.get("approval_required", True)),
+        metadata=dict(payload.get("metadata") or {}),
+        lifecycle_mode=lifecycle_mode,
+        research_leads=tuple(payload.get("research_leads") or ()),
+    )
+
+
 __all__ = (
     "CodingAuthorizationProposal",
     "LIFECYCLE_MODE_IMPLEMENTATION",
     "LIFECYCLE_MODE_RESEARCH_ONLY",
     "format_authorization_message",
     "load_role_profile",
+    "proposal_from_dict",
     "recommend_authorization",
     "reset_role_profile_cache",
 )

--- a/src/yule_orchestrator/agents/workflow.py
+++ b/src/yule_orchestrator/agents/workflow.py
@@ -11,11 +11,14 @@ only path that flips a write-requested session into ``approved``.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping, Optional, Sequence
 
+from .coding.authorization import proposal_from_dict
+from .coding.job import STATUS_READY, build_coding_job_from_proposal
 from .messaging.dispatcher import Dispatcher, DispatchPlan, DispatchRequest, TaskType
 from .review_loop import (
     ReviewFeedback,
@@ -34,6 +37,9 @@ from .workflow_state import (
     save_session,
     update_session,
 )
+
+
+_logger = logging.getLogger(__name__)
 
 
 _URL_PATTERN = re.compile(r"https?://[\w\-./?=&%#:+,@!~*'();$]+", re.IGNORECASE)
@@ -152,6 +158,7 @@ class WorkflowOrchestrator:
             state=WorkflowState.APPROVED,
             write_blocked_reason=None,
         )
+        approved = _promote_coding_proposal_to_ready_job(approved, now=self.now_fn())
         return update_session(approved, now=self.now_fn())
 
     def reject(self, session_id: str, *, reason: str) -> WorkflowSession:
@@ -475,3 +482,66 @@ def _format_used_reference(item: Mapping[str, Any]) -> str:
     if rationale:
         head += f"\n  ↪ {rationale}"
     return head
+
+
+def _promote_coding_proposal_to_ready_job(
+    session: WorkflowSession,
+    *,
+    now: datetime,
+) -> WorkflowSession:
+    """If the approve()-time session carries a pending coding_proposal,
+    synthesise a ``coding_job`` with ``status="ready"`` into ``session.extra``.
+
+    Why: the engineering-agent has TWO approval paths — the Discord chat
+    phrase gate (which already writes ``coding_job=ready`` via
+    ``_persist_coding_job``) and the ``/engineer_approve`` slash command
+    (which only flipped the workflow state). Without this promotion the
+    slash command leaves ``coding_job`` either missing or still
+    ``pending-approval``, so the autonomy producer's dispatcher
+    (``iter_ready_coding_jobs``) never sees the session and no
+    ``coding_execute`` row ever lands on the queue. Result: ``ALIVE``
+    executor + ``approved`` session + zero progress notes — exactly the
+    bug surfaced by session ``3163b5cf6c9b``.
+
+    Idempotent: when ``coding_job`` is already present with
+    ``status == "ready"`` we leave it untouched so the Discord chat
+    approval path (which may run first) keeps its own audit fields like
+    ``approved_at`` rather than being overwritten.
+    """
+
+    extra = dict(getattr(session, "extra", {}) or {})
+    proposal_payload = extra.get("coding_proposal")
+    if not isinstance(proposal_payload, Mapping) or not proposal_payload:
+        return session
+
+    existing_job = extra.get("coding_job")
+    if isinstance(existing_job, Mapping):
+        existing_status = str(existing_job.get("status") or "").strip().lower()
+        if existing_status == STATUS_READY:
+            return session
+
+    try:
+        proposal = proposal_from_dict(proposal_payload)
+        job = build_coding_job_from_proposal(
+            proposal,
+            status=STATUS_READY,
+            approved_at=_coerce_utc(now),
+        )
+    except Exception:  # noqa: BLE001 - never block approve() on coding_job synth
+        _logger.warning(
+            "approve(): failed to synthesise coding_job from coding_proposal "
+            "(session=%s); state still flips to approved but dispatcher will "
+            "skip this session until coding_job is repaired",
+            getattr(session, "session_id", "?"),
+            exc_info=True,
+        )
+        return session
+
+    extra["coding_job"] = job.to_dict()
+    return replace(session, extra=extra)
+
+
+def _coerce_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/src/yule_orchestrator/discord/engineering_channel_router/session_persistence.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/session_persistence.py
@@ -395,28 +395,7 @@ def _proposal_to_dict(proposal: CodingAuthorizationProposal) -> Mapping[str, obj
         "research_leads": list(proposal.research_leads),
     }
 
-def _proposal_from_dict(payload: Mapping[str, object]) -> CodingAuthorizationProposal:
-    lifecycle_mode = str(payload.get("lifecycle_mode") or "implementation")
-    raw_executor = payload.get("executor_role")
-    if lifecycle_mode == "research_only":
-        executor_role = str(raw_executor or "")
-    else:
-        executor_role = str(raw_executor or "tech-lead")
-    return CodingAuthorizationProposal(
-        session_id=payload.get("session_id"),
-        user_request=str(payload.get("user_request") or ""),
-        executor_role=executor_role,
-        review_roles=tuple(payload.get("review_roles") or ()),
-        participant_roles=tuple(payload.get("participant_roles") or ()),
-        write_scope=tuple(payload.get("write_scope") or ()),
-        forbidden_scope=tuple(payload.get("forbidden_scope") or ()),
-        reason=str(payload.get("reason") or ""),
-        safety_rules=tuple(payload.get("safety_rules") or ()),
-        approval_required=bool(payload.get("approval_required", True)),
-        metadata=dict(payload.get("metadata") or {}),
-        lifecycle_mode=lifecycle_mode,
-        research_leads=tuple(payload.get("research_leads") or ()),
-    )
+from ...agents.coding.authorization import proposal_from_dict as _proposal_from_dict  # noqa: E402,F401 — canonical factory now lives in agents layer
 
 def _load_session_by_id(
     list_sessions_fn: Callable[..., Sequence[Any]],

--- a/src/yule_orchestrator/runtime/status.py
+++ b/src/yule_orchestrator/runtime/status.py
@@ -68,10 +68,24 @@ _KIND_TO_JOB_TYPE: Mapping[ServiceKind, Optional[str]] = {
     ServiceKind.ROLE_WORKER: "role_take",
     ServiceKind.APPROVAL_WORKER: "approval_post",
     ServiceKind.OBSIDIAN_WRITER: "obsidian_write",
+    ServiceKind.CODING_EXECUTOR: "coding_execute",
     ServiceKind.SUPERVISOR: None,
     ServiceKind.DISCORD_GATEWAY: None,
     ServiceKind.RESERVED_DISCORD_GATEWAY: None,
 }
+
+
+# Job types we always surface in the queue summary, even when the row
+# count is zero, so operators can distinguish "executor up + nothing to
+# do" from "this job type isn't wired at all". Reflects the canonical
+# 4-worker set this runtime ships with.
+_ALWAYS_VISIBLE_JOB_TYPES: Tuple[str, ...] = (
+    "research_collect",
+    "role_take",
+    "approval_post",
+    "obsidian_write",
+    "coding_execute",
+)
 
 
 @dataclass(frozen=True)
@@ -226,6 +240,29 @@ class CompletionFunnelSummary:
 
 
 @dataclass(frozen=True)
+class CodingDispatchSummary:
+    """Approved-coding sessions waiting for the dispatcher.
+
+    ``ready_sessions`` counts sessions whose ``coding_proposal`` has
+    been promoted to ``coding_job=ready`` AND whose ``coding_execute``
+    dispatch hasn't fired yet. ``dispatched_sessions`` counts the ones
+    that already have a dispatch marker (so operators can confirm the
+    producer tick is actually running).
+
+    Used by operators to tell apart the two failure modes the user
+    hit on session ``3163b5cf6c9b``:
+
+    * executor ALIVE + 0 ready / 0 dispatched → no eligible work
+    * executor ALIVE + N>0 ready / 0 dispatched → producer tick missing
+    * executor ALIVE + 0 ready / N>0 dispatched → all caught up
+    """
+
+    ready_sessions: int = 0
+    dispatched_sessions: int = 0
+    sample_session_ids: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class RuntimeStatusReport:
     """Top-level snapshot returned by :func:`build_runtime_status`."""
 
@@ -239,6 +276,7 @@ class RuntimeStatusReport:
     autonomy_recent: Tuple[AutonomyTickSummary, ...] = ()
     completion_funnel_recent: Tuple[CompletionFunnelSummary, ...] = ()
     autonomy_locks_held: Tuple[str, ...] = ()
+    coding_dispatch: CodingDispatchSummary = CodingDispatchSummary()
 
 
 # ---------------------------------------------------------------------------
@@ -994,6 +1032,8 @@ def build_runtime_status(
         completion_funnel_recent=funnel_recent,
     )
 
+    coding_dispatch = _build_coding_dispatch_summary()
+
     return RuntimeStatusReport(
         profile=profile,
         generated_at=now_ts,
@@ -1005,6 +1045,44 @@ def build_runtime_status(
         autonomy_recent=autonomy_recent,
         completion_funnel_recent=funnel_recent,
         autonomy_locks_held=locks_held,
+        coding_dispatch=coding_dispatch,
+    )
+
+
+def _build_coding_dispatch_summary() -> CodingDispatchSummary:
+    """Count approved-coding sessions waiting for / already-dispatched to executor.
+
+    Best-effort: any exception from the workflow store falls back to a
+    zero summary so the rest of the status report still renders. The
+    operator surface treats "no data" as "no signal" rather than as
+    "executor up + no work" — see ``_build_warnings`` for the explicit
+    warning thresholds.
+    """
+
+    try:
+        from ..agents.job_queue.coding_execute_dispatcher import iter_ready_coding_jobs
+    except Exception:  # noqa: BLE001 - missing module shouldn't crash status
+        return CodingDispatchSummary()
+
+    ready_ids: list[str] = []
+    dispatched_ids: list[str] = []
+    try:
+        for ready in iter_ready_coding_jobs(include_dispatched=True):
+            session_id = str(ready.session_id or "")
+            if not session_id:
+                continue
+            if ready.has_been_dispatched():
+                dispatched_ids.append(session_id)
+            else:
+                ready_ids.append(session_id)
+    except Exception:  # noqa: BLE001 - cache hiccup shouldn't crash status
+        return CodingDispatchSummary()
+
+    sample = tuple(ready_ids[:5]) if ready_ids else tuple(dispatched_ids[:5])
+    return CodingDispatchSummary(
+        ready_sessions=len(ready_ids),
+        dispatched_sessions=len(dispatched_ids),
+        sample_session_ids=sample,
     )
 
 
@@ -1073,6 +1151,12 @@ def _build_job_type_summaries(
     oldest = queue.oldest_queued_at_per_type()
 
     job_types_seen: set[str] = {jt for (jt, _state) in counts.keys()}
+    # Always surface the canonical workers' job types so operators can
+    # tell "executor wired + idle" from "executor missing". Without this
+    # `runtime status` hides ``coding_execute`` (and the others) until
+    # the first row lands, making the absence indistinguishable from a
+    # mis-configured runtime.
+    job_types_seen.update(_ALWAYS_VISIBLE_JOB_TYPES)
     summaries: list[JobTypeSummary] = []
     for job_type in sorted(job_types_seen):
         queued = counts.get((job_type, JobState.QUEUED.value), 0)

--- a/tests/job_queue/test_approve_promotes_coding_job_to_ready.py
+++ b/tests/job_queue/test_approve_promotes_coding_job_to_ready.py
@@ -1,0 +1,219 @@
+"""Approved coding sessions actually reach the executor (session 3163b5cf6c9b).
+
+Reproduces the bug the operator filed: an ``/engineer_approve`` slash
+command flipped a write-requested session into ``approved`` but left
+``session.extra["coding_job"]`` either missing or stuck at
+``pending-approval``. The dispatcher's ready-scan
+(``iter_ready_coding_jobs``) therefore never saw the session and
+``coding_execute`` was never enqueued — exactly matching the user's
+``progress_notes=[] / summary=null / state=approved`` symptoms even
+though ``eng-coding-executor`` reported ``ALIVE``.
+
+These tests pin the fix: ``WorkflowOrchestrator.approve()`` promotes a
+pending ``coding_proposal`` into a ``coding_job`` with ``status="ready"``
+so the dispatcher hands the work to the executor on the next tick.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    WorkflowOrchestrator,
+    build_participants_pool,
+)
+from yule_orchestrator.agents.coding.authorization import (
+    CodingAuthorizationProposal,
+    LIFECYCLE_MODE_IMPLEMENTATION,
+)
+from yule_orchestrator.agents.coding.job import STATUS_READY
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+    iter_ready_coding_jobs,
+)
+from yule_orchestrator.agents.workflow_state import load_session, update_session
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_proposal_dict(session_id: str) -> dict:
+    proposal = CodingAuthorizationProposal(
+        session_id=session_id,
+        user_request="새 랜딩 hero 정리",
+        executor_role="backend-engineer",
+        review_roles=("tech-lead",),
+        participant_roles=("backend-engineer", "tech-lead"),
+        write_scope=("web/**",),
+        forbidden_scope=(".env",),
+        reason="Tech lead 추천",
+        safety_rules=("user 승인 phrase 도착 전 production write 금지",),
+        approval_required=True,
+        metadata={"repo_full_name": "yule-studio/test-repo"},
+        lifecycle_mode=LIFECYCLE_MODE_IMPLEMENTATION,
+        research_leads=(),
+    )
+    # Mirror Discord coding-gate's serialization format.
+    return {
+        "session_id": proposal.session_id,
+        "user_request": proposal.user_request,
+        "executor_role": proposal.executor_role,
+        "review_roles": list(proposal.review_roles),
+        "participant_roles": list(proposal.participant_roles),
+        "write_scope": list(proposal.write_scope),
+        "forbidden_scope": list(proposal.forbidden_scope),
+        "reason": proposal.reason,
+        "safety_rules": list(proposal.safety_rules),
+        "approval_required": proposal.approval_required,
+        "metadata": dict(proposal.metadata),
+        "lifecycle_mode": proposal.lifecycle_mode,
+        "research_leads": list(proposal.research_leads),
+    }
+
+
+class ApprovePromotesCodingJobTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_db = os.environ.get("YULE_CACHE_DB_PATH")
+        os.environ["YULE_CACHE_DB_PATH"] = os.path.join(self._tmp.name, "cache.sqlite3")
+        pool = build_participants_pool(Path("."), "engineering-agent")
+        self.orchestrator = WorkflowOrchestrator(Dispatcher(pool))
+
+    def tearDown(self) -> None:
+        if self._prev_db is None:
+            os.environ.pop("YULE_CACHE_DB_PATH", None)
+        else:
+            os.environ["YULE_CACHE_DB_PATH"] = self._prev_db
+
+    def _intake_with_pending_proposal(self) -> str:
+        intake = self.orchestrator.intake(
+            prompt="새 랜딩 hero 정리",
+            write_requested=True,
+        )
+        session_id = intake.session.session_id
+
+        # Mimic Discord coding-proposal persistence (``_persist_coding_proposal``):
+        # write ``extra["coding_proposal"]`` AND clear any prior coding_job.
+        session = load_session(session_id)
+        assert session is not None
+        new_extra = dict(session.extra or {})
+        new_extra["coding_proposal"] = _make_proposal_dict(session_id)
+        new_extra["coding_job"] = None
+        from dataclasses import replace as _replace
+
+        updated = _replace(session, extra=new_extra)
+        update_session(updated, now=_now())
+        return session_id
+
+    def test_approve_promotes_pending_proposal_to_ready_coding_job(self) -> None:
+        session_id = self._intake_with_pending_proposal()
+
+        approved = self.orchestrator.approve(session_id)
+
+        self.assertEqual(approved.state.value, "approved")
+        coding_job = (approved.extra or {}).get("coding_job")
+        self.assertIsInstance(coding_job, dict)
+        assert isinstance(coding_job, dict)
+        self.assertEqual(coding_job["status"], STATUS_READY)
+        self.assertEqual(coding_job["executor_role"], "backend-engineer")
+        # Approved timestamp gets stamped — guards against the
+        # build_coding_job_from_proposal contract drift.
+        self.assertTrue(coding_job.get("approved_at"))
+
+    def test_approve_is_idempotent_when_ready_coding_job_already_persisted(
+        self,
+    ) -> None:
+        # Pre-seed the session with a fully ready coding_job (e.g. the
+        # Discord chat-phrase approval path ran first). approve() must
+        # leave it untouched so the chat path's audit fields survive.
+        session_id = self._intake_with_pending_proposal()
+        from dataclasses import replace as _replace
+
+        session = load_session(session_id)
+        assert session is not None
+        pre_existing_job = {
+            "session_id": session_id,
+            "executor_role": "backend-engineer",
+            "status": STATUS_READY,
+            "approved_at": "2026-05-14T07:00:00+00:00",
+            "approved_via": "discord-chat-phrase",
+        }
+        extra = dict(session.extra or {})
+        extra["coding_job"] = pre_existing_job
+        update_session(_replace(session, extra=extra), now=_now())
+
+        approved = self.orchestrator.approve(session_id)
+        coding_job = (approved.extra or {}).get("coding_job")
+        self.assertIsInstance(coding_job, dict)
+        assert isinstance(coding_job, dict)
+        # approve() did not overwrite the chat-path audit fields.
+        self.assertEqual(coding_job.get("approved_via"), "discord-chat-phrase")
+        self.assertEqual(coding_job["status"], STATUS_READY)
+
+    def test_approve_without_pending_proposal_does_not_synth_coding_job(
+        self,
+    ) -> None:
+        # A research-only intake never had a coding_proposal. approve()
+        # must NOT invent one — that would let dispatcher pick the
+        # session and dispatch a bogus coding_execute.
+        intake = self.orchestrator.intake(prompt="문서만 조사", write_requested=False)
+        approved = self.orchestrator.approve(intake.session.session_id)
+        self.assertEqual(approved.state.value, "approved")
+        self.assertNotIn("coding_job", approved.extra or {})
+
+    def test_iter_ready_coding_jobs_picks_up_session_after_approve(self) -> None:
+        # End-to-end pin: approve() → iter_ready sees the session →
+        # dispatcher would enqueue coding_execute on the next tick.
+        session_id = self._intake_with_pending_proposal()
+        self.orchestrator.approve(session_id)
+
+        ready = list(iter_ready_coding_jobs())
+        ready_ids = {item.session_id for item in ready}
+        self.assertIn(session_id, ready_ids)
+
+    def test_iter_ready_coding_jobs_skips_session_after_dispatch_marker_lands(
+        self,
+    ) -> None:
+        # Once the dispatcher has stamped session.extra["coding_execute_dispatch"],
+        # the next iteration must not yield the session again
+        # (dispatch is idempotent; double-enqueue would burn executor cycles).
+        session_id = self._intake_with_pending_proposal()
+        self.orchestrator.approve(session_id)
+
+        from dataclasses import replace as _replace
+
+        session = load_session(session_id)
+        assert session is not None
+        extra = dict(session.extra or {})
+        extra[SESSION_EXTRA_DISPATCH_KEY] = {
+            "job_id": "job-abc123",
+            "dispatched_at": "2026-05-14T07:30:00+00:00",
+        }
+        update_session(_replace(session, extra=extra), now=_now())
+
+        ready = list(iter_ready_coding_jobs())
+        ready_ids = {item.session_id for item in ready}
+        self.assertNotIn(session_id, ready_ids)
+
+        # But include_dispatched=True still sees it — that's how the
+        # operator-surface counter distinguishes "ready waiting" from
+        # "ready + already dispatched".
+        all_ready = list(iter_ready_coding_jobs(include_dispatched=True))
+        all_ids = {item.session_id for item in all_ready}
+        self.assertIn(session_id, all_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_status.py
+++ b/tests/runtime/test_status.py
@@ -311,14 +311,34 @@ class QueueSummaryTests(_StatusFixture):
             report.warnings,
         )
 
-    def test_empty_queue_yields_no_job_types(self) -> None:
+    def test_empty_queue_yields_zero_row_canonical_job_types(self) -> None:
+        # Previously this asserted ``report.job_types == ()`` — meaning the
+        # operator surface hid every job type until it had work. That
+        # made "executor wired but idle" indistinguishable from "executor
+        # missing", which is the exact ambiguity the coding_execute
+        # operator-surface fix targets. Canonical job types are now always
+        # surfaced with zero rows.
         report = build_runtime_status(
             profile=self.PROFILE_NAME,
             queue=self.queue,
             heartbeats=self.heartbeats,
             now=_FIXED_NOW,
         )
-        self.assertEqual(report.job_types, ())
+        types_seen = {jt.job_type for jt in report.job_types}
+        self.assertTrue(
+            {
+                "research_collect",
+                "role_take",
+                "approval_post",
+                "obsidian_write",
+                "coding_execute",
+            }.issubset(types_seen),
+            msg=f"missing canonical job types: {types_seen}",
+        )
+        for jt in report.job_types:
+            self.assertEqual(jt.queued, 0)
+            self.assertEqual(jt.in_progress, 0)
+            self.assertEqual(jt.failed_terminal, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_status_coding_execute_surface.py
+++ b/tests/runtime/test_status_coding_execute_surface.py
@@ -1,0 +1,226 @@
+"""``runtime status`` exposes the coding-execute pipeline for operators.
+
+These tests pin the operator-surface portion of the
+``approved → coding_execute`` debugging session described by
+``3163b5cf6c9b``. Before the fix the executor service was reported but
+its expected job type was unknown, the queue summary hid
+``coding_execute`` while no work existed, and there was no way to tell
+"executor idle" from "executor missing".
+
+Coverage:
+
+* ``ServiceKind.CODING_EXECUTOR`` resolves to the ``coding_execute`` job
+  type on ``ServiceStatus.job_type``.
+* The queue summary always carries a ``coding_execute`` row, even on an
+  empty queue.
+* ``CodingDispatchSummary`` distinguishes "ready waiting" from
+  "ready + already dispatched" so operators can tell which side of the
+  producer tick they're on.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from dataclasses import replace as _replace
+from datetime import datetime, timezone
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    WorkflowOrchestrator,
+    build_participants_pool,
+)
+from yule_orchestrator.agents.coding.authorization import LIFECYCLE_MODE_IMPLEMENTATION
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatRecord, HeartbeatStore
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.agents.workflow_state import load_session, update_session
+from yule_orchestrator.runtime.services import ServiceKind
+from yule_orchestrator.runtime.status import (
+    _KIND_TO_JOB_TYPE,
+    CodingDispatchSummary,
+    build_runtime_status,
+)
+from pathlib import Path
+
+
+_FIXED_NOW = 1_700_000_000.0
+
+
+def _now_dt() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_proposal_dict(session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "user_request": "새 랜딩 hero 정리",
+        "executor_role": "backend-engineer",
+        "review_roles": ["tech-lead"],
+        "participant_roles": ["backend-engineer", "tech-lead"],
+        "write_scope": ["web/**"],
+        "forbidden_scope": [".env"],
+        "reason": "Tech lead 추천",
+        "safety_rules": ["user 승인 phrase 도착 전 write 금지"],
+        "approval_required": True,
+        "metadata": {"repo_full_name": "yule-studio/test-repo"},
+        "lifecycle_mode": LIFECYCLE_MODE_IMPLEMENTATION,
+        "research_leads": [],
+    }
+
+
+class CodingExecutorServiceKindTests(unittest.TestCase):
+    def test_coding_executor_service_kind_maps_to_coding_execute_job_type(self) -> None:
+        # The bug surface: `eng-coding-executor` showed ALIVE but its
+        # `job_type` field was empty, so operators couldn't pair the
+        # service health row with the queue/coding-dispatch rows.
+        self.assertEqual(_KIND_TO_JOB_TYPE[ServiceKind.CODING_EXECUTOR], "coding_execute")
+
+
+class _RuntimeStatusFixture(unittest.TestCase):
+    PROFILE_NAME = "engineering"
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev_db = os.environ.get("YULE_CACHE_DB_PATH")
+        os.environ["YULE_CACHE_DB_PATH"] = os.path.join(self._tmp.name, "cache.sqlite3")
+        self.queue = JobQueue(db_path=Path(self._tmp.name) / "queue.sqlite3")
+        self.heartbeats = HeartbeatStore(db_path=Path(self._tmp.name) / "hb.sqlite3")
+        pool = build_participants_pool(Path("."), "engineering-agent")
+        self.orchestrator = WorkflowOrchestrator(Dispatcher(pool))
+
+    def tearDown(self) -> None:
+        if self._prev_db is None:
+            os.environ.pop("YULE_CACHE_DB_PATH", None)
+        else:
+            os.environ["YULE_CACHE_DB_PATH"] = self._prev_db
+
+    def _approve_with_pending_proposal(self) -> str:
+        intake = self.orchestrator.intake(
+            prompt="새 랜딩 hero 정리",
+            write_requested=True,
+        )
+        session_id = intake.session.session_id
+        session = load_session(session_id)
+        assert session is not None
+        extra = dict(session.extra or {})
+        extra["coding_proposal"] = _make_proposal_dict(session_id)
+        extra["coding_job"] = None
+        update_session(_replace(session, extra=extra), now=_now_dt())
+        self.orchestrator.approve(session_id)
+        return session_id
+
+
+class QueueSummarySurfaceTests(_RuntimeStatusFixture):
+    def test_queue_summary_always_includes_coding_execute_even_on_empty_queue(
+        self,
+    ) -> None:
+        report = build_runtime_status(
+            profile=self.PROFILE_NAME,
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            now=_FIXED_NOW,
+        )
+        names = {jt.job_type for jt in report.job_types}
+        self.assertIn("coding_execute", names)
+        coding_row = next(jt for jt in report.job_types if jt.job_type == "coding_execute")
+        self.assertEqual(coding_row.queued, 0)
+        self.assertEqual(coding_row.in_progress, 0)
+
+
+class CodingDispatchSummaryTests(_RuntimeStatusFixture):
+    def test_empty_runtime_reports_zero_summary(self) -> None:
+        # No approved sessions, no dispatch markers → all zero, no sample.
+        report = build_runtime_status(
+            profile=self.PROFILE_NAME,
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            now=_FIXED_NOW,
+        )
+        self.assertEqual(report.coding_dispatch, CodingDispatchSummary())
+
+    def test_approved_session_without_dispatch_marker_counted_as_ready(self) -> None:
+        # This is the "executor alive but no dispatch" diagnostic case
+        # from the bug report. Operator should be able to see N>0 ready
+        # sessions and 0 dispatched, which means "approved coding flow
+        # reached the queue boundary but producer tick didn't fire".
+        session_id = self._approve_with_pending_proposal()
+
+        report = build_runtime_status(
+            profile=self.PROFILE_NAME,
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            now=_FIXED_NOW,
+        )
+        summary = report.coding_dispatch
+        self.assertEqual(summary.ready_sessions, 1)
+        self.assertEqual(summary.dispatched_sessions, 0)
+        self.assertIn(session_id, summary.sample_session_ids)
+
+    def test_dispatched_session_counted_under_dispatched_not_ready(self) -> None:
+        # Once the producer tick has run, the session keeps coding_job=
+        # ready BUT carries a dispatch marker. The summary moves it to
+        # ``dispatched_sessions`` so operators can see "all caught up".
+        session_id = self._approve_with_pending_proposal()
+        session = load_session(session_id)
+        assert session is not None
+        extra = dict(session.extra or {})
+        extra[SESSION_EXTRA_DISPATCH_KEY] = {
+            "job_id": "job-deadbeef",
+            "dispatched_at": "2026-05-14T08:00:00+00:00",
+        }
+        update_session(_replace(session, extra=extra), now=_now_dt())
+
+        report = build_runtime_status(
+            profile=self.PROFILE_NAME,
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            now=_FIXED_NOW,
+        )
+        summary = report.coding_dispatch
+        self.assertEqual(summary.ready_sessions, 0)
+        self.assertEqual(summary.dispatched_sessions, 1)
+
+
+class CodingExecutorServiceStatusJobTypeTests(_RuntimeStatusFixture):
+    def test_coding_executor_service_status_carries_coding_execute_job_type(
+        self,
+    ) -> None:
+        # Stamp a fresh heartbeat for the coding-executor service id so
+        # build_runtime_status sees it as ALIVE — same posture as the
+        # operator reported (executor up, dispatch missing).
+        from yule_orchestrator.runtime.services import list_services
+
+        services = list_services()
+        coding_specs = [s for s in services if s.kind == ServiceKind.CODING_EXECUTOR]
+        if not coding_specs:
+            self.skipTest("coding executor service not registered in this profile")
+        spec = coding_specs[0]
+        self.heartbeats.record(
+            spec.service_id,
+            pid=12345,
+            now=_FIXED_NOW - 1.0,
+        )
+
+        report = build_runtime_status(
+            profile=self.PROFILE_NAME,
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            now=_FIXED_NOW,
+        )
+        rows = [s for s in report.services if s.service_id == spec.service_id]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].job_type, "coding_execute")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
운영 사례: 세션 \`3163b5cf6c9b\` (full-stack-app, executor_role=backend-engineer, write_requested=true) 가 \`/engineer_approve\` 로 \`state=approved\` 까지 갔지만 \`progress_notes=[]\` / \`summary=null\` 로 영원히 멈춤. \`eng-coding-executor\` 는 \`ALIVE\` 인데 dispatch 가 안 일어남.

## ✨ 과제 내용

### 1. 원인 (왜 안 넘어갔는지)
- engineering-agent 의 승인 분기가 **2개** 존재:
  - **Discord 채팅 phrase** (\`_run_coding_authorization_gate\`) → \`_persist_coding_job\` 으로 \`session.extra["coding_job"]={..., status:"ready"}\` 를 직접 씀 ✓
  - **\`/engineer_approve\` 슬래시 명령** → \`WorkflowOrchestrator.approve()\` 가 \`WorkflowState.INTAKE → APPROVED\` 만 flip, \`session.extra["coding_job"]\` 은 안 건드림 ✗
- \`coding_execute_dispatcher.iter_ready_coding_jobs\` 는 \`coding_job.status == "ready"\` 만 yield → 슬래시 경로로 승인된 세션은 dispatcher 가 영원히 못 봄

### 2. 실제 수정
- **\`agents/workflow.py\`** \`approve()\` 에 \`_promote_coding_proposal_to_ready_job\` 후처리 호출
  - \`extra["coding_proposal"]\` 있고 \`coding_job\` 없거나 ready 아니면 \`build_coding_job_from_proposal(..., status=STATUS_READY, approved_at=now)\` 로 합성해 stamp
  - 이미 \`coding_job.status="ready"\` 면 무시 (Discord chat path 의 audit 필드 보존)
  - 합성 실패는 \`logger.warning\` 후 swallow — \`approve()\` 자체는 절대 실패 안 함
- **\`agents/coding/authorization.py\`** \`proposal_from_dict\` 추가 (canonical hydrator)
  - Discord 의 \`_proposal_from_dict\` 를 이쪽 re-export 로 통합 (한 곳 정의)

### 3. operator surface 보강 (\`runtime/status.py\`)
- \`_KIND_TO_JOB_TYPE\` 에 \`ServiceKind.CODING_EXECUTOR → "coding_execute"\` 매핑 추가 → \`eng-coding-executor\` 행이 어떤 큐를 소비하는지 표시됨
- \`_ALWAYS_VISIBLE_JOB_TYPES\` 도입 → \`research_collect / role_take / approval_post / obsidian_write / coding_execute\` 5종은 큐가 비어도 0-row 로 항상 표면화 (운영자가 "executor wired but idle" 과 "executor missing" 구분 가능)
- \`CodingDispatchSummary\` (ready_sessions / dispatched_sessions / sample_session_ids) 추가
  - \`ready=N + dispatched=0\` → producer tick 누락
  - \`ready=0 + dispatched=N\` → 정상 catch-up
  - \`ready=0 + dispatched=0\` → 작업 없음
  - \`iter_ready_coding_jobs(include_dispatched=True)\` 로 \`has_been_dispatched()\` 분기

### 4. 운영자가 봐야 하는 신호 (이 PR 머지 후)
1. \`runtime status\` 의 services 섹션에서 \`eng-coding-executor\` 행이 \`job_type=coding_execute\` 로 표시
2. queue 섹션에 \`coding_execute\` 행이 항상 보임 (0-row 라도)
3. \`coding_dispatch.ready_sessions > 0\` 이고 \`dispatched_sessions == 0\` 이면 → producer tick 안 도는 중 (\`UNKNOWN\` 인 \`eng-supervisor-watch\` / autonomy producer 점검)
4. \`coding_dispatch.dispatched_sessions > 0\` → 정상 진행, executor 가 받은 상태

## 🧪 테스트 (신규 11 testcase / 4684 → 4695 pass)
- pending coding_proposal 있는 INTAKE 세션을 approve() → coding_job.status="ready" ✓
- 이미 ready coding_job 있으면 approve() idempotent (audit 필드 보존) ✓
- coding_proposal 없는 research-only 세션은 coding_job 합성 안 함 ✓
- approve() 직후 iter_ready_coding_jobs() 가 해당 세션 yield ✓
- dispatch marker 찍히면 그 후 iter_ready 는 skip ✓
- ServiceKind.CODING_EXECUTOR → coding_execute job_type 매핑 ✓
- 빈 큐에서도 coding_execute row 노출 ✓
- CodingDispatchSummary ready/dispatched 분기 ✓

## 📚 레퍼런스
- 실제 진단: session \`3163b5cf6c9b\` (state=approved, progress_notes=[])
- 코드 ref: \`agents/job_queue/coding_execute_dispatcher.py\` (READY_STATUSES = frozenset({"ready"}))

## ✅ Test plan
- [x] \`.venv/bin/python -m pytest tests -q\` → 4695 PASS / 1 skipped
- [ ] CI green
- [ ] auto-merge