### PR TITLE
🚀 #승인-대기 를 operator action inbox 로 확장 (P0-S, closes #161)

### DIFF
--- a/docs/approval-matrix.md
+++ b/docs/approval-matrix.md
@@ -136,3 +136,93 @@ operator 의 실제 vault repo (`yule-agent-vault`) 가 현재 workspace 에 클
 `session.extra['agent_ops_audit']` 에 `AgentOpsEntry` 로 append.
 A-M10b 에서 vault `40-agent-ops/<date>.md` 자동 export.
 A-M10c 에서 `#봇-상태` daily summary 게시.
+
+## 6. Operator Action Inbox — 기술 자율 vs 외부 사실 (P0-S)
+
+`#승인-대기` 채널은 더 이상 *approval-only* 가 아니라 **operator action
+inbox** 로 동작한다. agent 가 진행 중에 사람의 응답을 필요로 하는 모든
+순간이 같은 채널 카드로 표면화돼야 한다 — "조용히 멈추는" 회귀를
+영구히 막는 것이 §6 의 본질이다.
+
+### 6.1 5 가지 request_type
+
+| request_type | 의미 | 세션 sub-state | approval_kind |
+| --- | --- | --- | --- |
+| `APPROVAL_REQUIRED` | write/push/PR/merge/deploy 같은 **승인** | `waiting_approval` | 기존 vocabulary (`engineering_write` / `pr_merge` / …) |
+| `INFO_REQUIRED` | 서버 IP, 도메인, 운영 사실, 배포 대상 식별자 등 | `waiting_user_input` | `info_request` |
+| `ACCESS_REQUIRED` | SSH/서버 접근/권한 부여/repo access/cloud access | `waiting_access` | `access_request` |
+| `SECRET_REQUIRED` | 실제 secret 값/저장 위치/secret 등록 승인 | `waiting_secret` | `secret_request` |
+| `DECISION_REQUIRED` | 드물게 사람 정책/제품 판단 (단순 기술 선택은 금지) | `waiting_user_input` | `decision_request` |
+
+세션 macro state (`WorkflowState`) 와 직교하며,
+`session.extra["operator_state"]` 에 저장된다. 응답이 도착해 미해결이
+모두 해소되면 `running` 으로 복귀.
+
+### 6.2 기술 자율 vs 외부 사실 경계
+
+| 영역 | agent 자율 | 사람에게 요청 |
+| --- | --- | --- |
+| 인증 방식 | JWT vs session 선택 | — |
+| 데이터 모델 | 기본 DB 이름 규칙 | 기존 운영 DB endpoint |
+| 인프라 구조 | Docker Compose 구조, 디렉터리 구조 | 클라우드 프로젝트 / 계정 식별자 |
+| 프레임워크 | Next/Nest 연결 방식, auth/API 구조 | — |
+| 일반 기술 선택 | 라이브러리 선택, 테스트 도구 | — |
+| 서버 / 운영 | — | 실제 서버 IP / hostname, 실제 도메인 |
+| 접근 권한 | — | SSH user / key, 환경 수정 인가 |
+| Secret | secret 키 이름 정의, `.env.example` / compose / CI wiring 작성, GitHub Actions secret 이름 제안, 어떤 값이 필요한지 설명 | 실제 secret 값, secret 저장 위치, secret 등록 승인 |
+
+위 경계는 코드에서도 명시:
+`src/yule_orchestrator/agents/coding/authorization.py` →
+`TECH_DECISION_AUTONOMOUS` / `EXTERNAL_FACT_HUMAN_REQUIRED` /
+`classify_user_request_facts(...)`.
+
+### 6.3 Secret hard rails
+
+agent 가 자동으로 해도 되는 것
+- secret key **이름** 정의 (예: `JWT_SECRET`, `STRIPE_API_KEY`)
+- `.env.example` / `docker-compose.yml` / GitHub Actions workflow 의
+  **wiring** 작성 (값은 `${{ secrets.JWT_SECRET }}` 같은 placeholder)
+- "이 시크릿이 왜 필요한지" 사용자에게 설명
+
+agent 가 절대 자동으로 하면 안 되는 것
+- 실제 secret 값을 임의 생성해 운영 환경에 저장
+- GitHub secret / cloud secret manager 를 사용자 동의 없이 수정
+- prod `.env` 파일 직접 변경
+- 기존 secret 값을 다른 위치로 복사 / mirror
+
+위 두 목록은 `src/yule_orchestrator/agents/operator_action.py` 의
+`SECRET_AUTO_ALLOWED` / `SECRET_AUTO_FORBIDDEN` 와 동기화 유지.
+
+`SECRET_REQUIRED` 카드의 thread reply 는 반드시 **저장 위치만** 받는다 —
+`secret_value=...` / `raw_value=...` / `value=...` 형태로 raw 값이 채널
+에 붙으면 reply parser 가 거부하고 `RESPONSE_OPERATOR_SECRET_VALUE_REJECTED`
+응답을 게시한다.
+
+### 6.4 Operator action 카드 — 필수 필드
+
+각 카드는 최소 다음을 포함해야 한다 (
+`render_operator_action_card`):
+
+- `request_type` 라벨 + 이모지
+- `session_id` + `requested_by`
+- 현재 `stage` (어디서 멈췄는지)
+- `why_blocked` (왜 사람이 필요한지)
+- `expected_answer` (지금 필요한 답변 1개 또는 짧은 목록)
+- `answer_examples` (`host=10.0.0.5` 같은 thread reply 예시)
+- "이 카드의 thread 에서 답하라" 안내
+- `next_action` (응답 후 어떤 작업이 이어지는지)
+- `timeout_hint` (가능하면 timeout / fallback 메모)
+
+### 6.5 Hard rules
+
+- 사람 응답이 필요한데 카드 없이 멈추면 **금지** — 멈출 때는 반드시
+  `#승인-대기` 카드 게시.
+- 외부 사실을 추측해서 진행 **금지**.
+- secret 값을 agent 가 임의로 만들고 운영에 주입 **금지**.
+- 단순 기술 판단을 불필요하게 사람에게 떠넘기지 말 것 — `DECISION_REQUIRED`
+  남용 금지.
+- 승인/정보/접근/secret 요청은 모두 auditable 해야 함
+  (`session.extra["operator_pending_requests"]` /
+  `session.extra["operator_answered_requests"]`).
+- 본문 채널 / 업무-접수 / 운영-리서치에서 흩어진 응답을 기대하지 말 것 —
+  반드시 카드 thread.

--- a/src/yule_orchestrator/agents/coding/authorization.py
+++ b/src/yule_orchestrator/agents/coding/authorization.py
@@ -151,10 +151,15 @@ class CodingAuthorizationProposal:
 _DEFAULT_SAFETY_RULES: Tuple[str, ...] = (
     "사용자 승인 phrase가 도착하기 전 어떤 production write도 시작하지 않는다",
     "수정 전 요약된 계획을 먼저 사용자에게 보여 준다",
-    "secret / .env / 운영 자격 증명에 접근하지 않는다",
+    # P0-S — secret 작업의 자율/승인 경계는 docs/approval-matrix.md §6 참조
+    "agent 자율 가능: secret 키 이름 정의, .env.example/compose/CI wiring, "
+    "GitHub Actions secret 이름 제안. 실제 secret 값/저장 위치는 SECRET_REQUIRED 카드로 사람에게 받는다",
     "git reset --hard / git push --force / 자동 deploy 같은 destructive 명령을 실행하지 않는다",
     "write_scope 밖의 파일을 수정하지 않는다",
     "변경 전후 관련 단위/통합 테스트를 실행하고 결과를 보고한다",
+    # P0-S — 외부 사실 / 권한 / secret 값 추측 금지
+    "서버 IP / SSH 자격 / 실제 도메인 / 운영 DB endpoint / 클라우드 계정 식별자는 추측하지 않고 INFO_REQUIRED · ACCESS_REQUIRED 카드로 사람에게 받는다",
+    "사람 응답이 필요한데 #승인-대기 카드 없이 세션이 멈추는 것을 금지한다 — 멈출 때는 반드시 operator action 카드를 게시한다",
 )
 
 
@@ -734,10 +739,70 @@ def proposal_from_dict(payload: Mapping[str, object]) -> CodingAuthorizationProp
     )
 
 
+# ---------------------------------------------------------------------------
+# 기술 자율 vs 외부 사실 — operator action 가드 (P0-S)
+# ---------------------------------------------------------------------------
+
+
+# 단순 기술 선택은 agent 가 자율로 정하고 사람에게 묻지 않는다. 이 목록은
+# 명시 가드 — 새 항목을 추가하면 docs/approval-matrix.md §6 도 같이 갱신.
+TECH_DECISION_AUTONOMOUS: Tuple[str, ...] = (
+    "JWT vs session 선택",
+    "기본 DB 이름 규칙",
+    "Docker Compose 구조",
+    "Next/Nest 연결 방식",
+    "auth/API 구조",
+    "디렉터리 구조",
+    "구현에 필요한 일반적인 라이브러리/프레임워크 선택",
+)
+
+
+# 외부 사실 / 권한 / secret 값은 추측 금지 — 반드시 사람에게 카드로 요청.
+EXTERNAL_FACT_HUMAN_REQUIRED: Tuple[str, ...] = (
+    "실제 서버 IP / hostname",
+    "SSH user / key / 접근 방식",
+    "실제 운영 도메인",
+    "실제 secret 값",
+    "기존 운영 DB / Redis / API endpoint",
+    "클라우드 프로젝트 / 계정 식별자",
+    "이 서버/환경을 수정해도 되는가 같은 접근 권한 사실",
+)
+
+
+def classify_user_request_facts(text: str) -> Mapping[str, Tuple[str, ...]]:
+    """*text* 가 외부 사실 키워드를 포함하면 어떤 카드 타입이 필요한지 반환.
+
+    값은 ``{"INFO_REQUIRED": ("서버 ip",), "SECRET_REQUIRED": ()}`` 같은
+    형태. 빈 시퀀스는 해당 타입의 카드는 필요없음을 의미.
+
+    coding executor / planner 가 dispatch 직전에 이 헬퍼를 돌려 "지금 외부
+    사실이 필요한가" 를 검사한다. 본 함수는 보수적이라 false negative 가
+    있을 수 있음 — 호출자는 추가 컨텍스트로 보강 가능.
+    """
+
+    from ..operator_action import EXTERNAL_FACT_KEYWORDS, OperatorActionType
+
+    bucket: dict[str, list[str]] = {
+        OperatorActionType.INFO_REQUIRED.value: [],
+        OperatorActionType.ACCESS_REQUIRED.value: [],
+        OperatorActionType.SECRET_REQUIRED.value: [],
+    }
+    haystack = " ".join((text or "").lower().split())
+    if not haystack:
+        return {key: () for key in bucket}
+    for keyword, request_type in EXTERNAL_FACT_KEYWORDS:
+        if keyword in haystack and keyword not in bucket[request_type.value]:
+            bucket[request_type.value].append(keyword)
+    return {key: tuple(values) for key, values in bucket.items()}
+
+
 __all__ = (
     "CodingAuthorizationProposal",
+    "EXTERNAL_FACT_HUMAN_REQUIRED",
     "LIFECYCLE_MODE_IMPLEMENTATION",
     "LIFECYCLE_MODE_RESEARCH_ONLY",
+    "TECH_DECISION_AUTONOMOUS",
+    "classify_user_request_facts",
     "format_authorization_message",
     "load_role_profile",
     "proposal_from_dict",

--- a/src/yule_orchestrator/agents/job_queue/approval_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/approval_worker.py
@@ -55,6 +55,23 @@ APPROVAL_KIND_RESEARCH_PROMOTION: str = "research_promotion"
 APPROVAL_KIND_OBSIDIAN_WRITE: str = "obsidian_write"
 APPROVAL_KIND_ENGINEERING_WRITE: str = "engineering_write"
 
+# Operator action inbox (P0-S) — `#승인-대기` 가 approval-only 가 아니라
+# 정보/접근/secret/판단 요청까지 같은 채널에서 처리하기 위한 새 kind 들.
+# render 분기는 ``ApprovalRequest.extra['operator_action']`` 페이로드를
+# :func:`yule_orchestrator.agents.operator_action.render_operator_action_card`
+# 로 위임한다 — 같은 worker, 같은 dedup, 같은 reply router.
+APPROVAL_KIND_INFO_REQUEST: str = "info_request"
+APPROVAL_KIND_ACCESS_REQUEST: str = "access_request"
+APPROVAL_KIND_SECRET_REQUEST: str = "secret_request"
+APPROVAL_KIND_DECISION_REQUEST: str = "decision_request"
+
+OPERATOR_ACTION_KINDS: Tuple[str, ...] = (
+    APPROVAL_KIND_INFO_REQUEST,
+    APPROVAL_KIND_ACCESS_REQUEST,
+    APPROVAL_KIND_SECRET_REQUEST,
+    APPROVAL_KIND_DECISION_REQUEST,
+)
+
 
 # Skipped reasons surfaced via :class:`ApprovalJobOutcome`. Made into
 # constants so the gateway / status diagnostic can match exact values
@@ -171,7 +188,28 @@ def render_approval_request(request: ApprovalRequest) -> str:
     action + source thread pointer + approval phrase hint. The
     rendered text is **stable across worker restarts** (no
     timestamps embedded) so dedup hits are visible by content too.
+
+    P0-S — operator action 카드 (INFO/ACCESS/SECRET/DECISION) 는 별도
+    렌더러를 가진다. ``request.extra['operator_action']`` 페이로드가
+    있으면 그쪽으로 위임한다.
     """
+
+    operator_payload = (request.extra or {}).get("operator_action")
+    if isinstance(operator_payload, Mapping):
+        # 지연 import — operator_action 은 agents/ 패키지 위에 있고
+        # job_queue/ 는 그 자식이므로 상위 import 가 가능하다. circular
+        # 방지로 함수 호출 시점에만 가져온다.
+        from ..operator_action import (
+            OperatorActionRequest,
+            render_operator_action_card,
+        )
+
+        try:
+            op_request = OperatorActionRequest.from_extra_payload(operator_payload)
+        except Exception:  # noqa: BLE001 — payload 손상 시 기본 렌더로 fallback
+            op_request = None
+        if op_request is not None:
+            return render_operator_action_card(op_request)
 
     kind_label = _APPROVAL_KIND_LABELS.get(
         request.approval_kind, request.approval_kind
@@ -210,6 +248,10 @@ _APPROVAL_KIND_LABELS: Mapping[str, str] = {
     APPROVAL_KIND_RESEARCH_PROMOTION: "리서치 결과 승격",
     APPROVAL_KIND_OBSIDIAN_WRITE: "Obsidian 저장",
     APPROVAL_KIND_ENGINEERING_WRITE: "코드 변경",
+    APPROVAL_KIND_INFO_REQUEST: "정보 필요",
+    APPROVAL_KIND_ACCESS_REQUEST: "접근 / 권한 필요",
+    APPROVAL_KIND_SECRET_REQUEST: "Secret 필요",
+    APPROVAL_KIND_DECISION_REQUEST: "정책 / 제품 판단 필요",
 }
 
 
@@ -525,9 +567,14 @@ def _short_error(exc: BaseException) -> str:
 
 
 __all__ = (
+    "APPROVAL_KIND_ACCESS_REQUEST",
+    "APPROVAL_KIND_DECISION_REQUEST",
     "APPROVAL_KIND_ENGINEERING_WRITE",
+    "APPROVAL_KIND_INFO_REQUEST",
     "APPROVAL_KIND_OBSIDIAN_WRITE",
     "APPROVAL_KIND_RESEARCH_PROMOTION",
+    "APPROVAL_KIND_SECRET_REQUEST",
+    "OPERATOR_ACTION_KINDS",
     "ApprovalChannelResolver",
     "ApprovalJobOutcome",
     "ApprovalPostFn",

--- a/src/yule_orchestrator/agents/job_queue/operator_action_reply.py
+++ b/src/yule_orchestrator/agents/job_queue/operator_action_reply.py
@@ -1,0 +1,280 @@
+"""Operator action thread reply handler — P0-S.
+
+`#승인-대기` 채널의 operator action 카드 (INFO/ACCESS/SECRET/DECISION)
+에 대한 thread reply 를 처리한다. 기존 :mod:`approval_reply` 가
+APPROVE/REJECT/HOLD/UNCLEAR 어휘만 다루는 것과 분리해 둔다 — 새
+유형은 ``key=value`` 라인 기반이라 어휘 파서를 공유할 수 없다.
+
+흐름
+====
+1. ``route_approval_channel_message`` 가 reply 메시지를 본다.
+2. 이 모듈의 :func:`find_pending_operator_action_for_reply` 가 thread
+   reply 위치를 보고 SAVED operator action 카드 1 건을 찾는다.
+3. :func:`handle_operator_action_reply` 가 텍스트를 파싱하고 session
+   extra 를 갱신한 결과를 :class:`OperatorActionReplyOutcome` 으로 반환.
+4. 위 outcome 은 router 가 친절한 ack 메시지를 게시할 때 사용한다.
+
+세션 갱신은 ``WorkflowSession.extra`` 의:
+
+- ``operator_state`` (:class:`OperatorSessionState`)
+- ``operator_pending_requests``
+- ``operator_answered_requests``
+
+세 키만 건드린다. WorkflowState (intake/approved/in_progress/...) 는
+손대지 않는다 — sub-state 라서 macro state 와 직교한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence
+
+from ..operator_action import (
+    OperatorActionReply,
+    OperatorActionRequest,
+    OperatorActionType,
+    OperatorSessionState,
+    operator_action_request_from_approval_payload,
+    parse_operator_action_reply,
+    stamp_answered_request,
+)
+from .approval_worker import (
+    JOB_TYPE_APPROVAL_POST,
+    OPERATOR_ACTION_KINDS,
+)
+from .state_machine import JobState
+from .store import Job, JobQueue
+
+
+_REPLYABLE_STATES: tuple[JobState, ...] = (JobState.SAVED,)
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def find_pending_operator_action_for_reply(
+    *,
+    queue: JobQueue,
+    session_id: str,
+    source_message_id: Optional[int] = None,
+    source_thread_id: Optional[int] = None,
+) -> Optional[Job]:
+    """SAVED 상태의 operator-action ``approval_post`` job 중 reply 가 가장
+    가능성 높은 1 건을 반환.
+
+    우선순위:
+      1. ``source_message_id`` 정확 매칭
+      2. ``source_thread_id`` 매칭 (가장 최근)
+      3. 세션의 가장 최근 operator-action SAVED 카드
+
+    어떤 카드도 없으면 ``None`` — caller 는 일반 approval 핸들러로
+    fallback 한다.
+    """
+
+    if not session_id:
+        return None
+    candidates: list[Job] = []
+    for job in queue.list_for_session(session_id, states=_REPLYABLE_STATES):
+        if job.job_type != JOB_TYPE_APPROVAL_POST:
+            continue
+        kind = (job.payload or {}).get("approval_kind")
+        if kind not in OPERATOR_ACTION_KINDS:
+            continue
+        candidates.append(job)
+    if not candidates:
+        return None
+
+    if source_message_id is not None:
+        for job in candidates:
+            existing = (job.payload or {}).get("source_message_id")
+            if existing is not None and int(existing) == int(source_message_id):
+                return job
+
+    if source_thread_id is not None:
+        thread_matches = [
+            job
+            for job in candidates
+            if (job.payload or {}).get("source_thread_id") is not None
+            and int((job.payload or {}).get("source_thread_id"))
+            == int(source_thread_id)
+        ]
+        if thread_matches:
+            return max(thread_matches, key=lambda j: j.created_at)
+
+    return max(candidates, key=lambda j: j.created_at)
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OperatorActionReplyOutcome:
+    """:func:`handle_operator_action_reply` 결과.
+
+    - ``handled`` False: 매칭 카드 없음 — caller 가 fallback.
+    - ``handled`` True 인데 ``reply.is_complete`` False: 응답 부족 / 거부.
+    - ``handled`` True 이고 ``reply.is_complete`` True: 세션 상태 복귀.
+    """
+
+    handled: bool
+    request_type: Optional[OperatorActionType] = None
+    approval_job_id: Optional[str] = None
+    request: Optional[OperatorActionRequest] = None
+    reply: Optional[OperatorActionReply] = None
+    new_state: Optional[OperatorSessionState] = None
+    audit: Mapping[str, Any] = field(default_factory=dict)
+    skipped_reason: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Session adapter — caller injects load/update so 모듈은 storage agnostic
+# ---------------------------------------------------------------------------
+
+
+from typing import Callable
+
+LoadSessionFn = Callable[[str], Optional[Any]]
+UpdateSessionFn = Callable[[Any, Mapping[str, Any]], Any]
+
+
+def _default_load_session(session_id: str) -> Optional[Any]:
+    try:
+        from ..workflow_state import load_session as _load
+    except Exception:  # noqa: BLE001 - partial install
+        return None
+    try:
+        return _load(session_id)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _default_update_session(session: Any, extra: Mapping[str, Any]) -> Any:
+    try:
+        from dataclasses import replace as _replace
+        from ..workflow_state import update_session as _update
+    except Exception:  # noqa: BLE001
+        return session
+    try:
+        updated = _replace(session, extra=dict(extra))
+        return _update(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        return session
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+
+def handle_operator_action_reply(
+    *,
+    queue: JobQueue,
+    text: str,
+    session_id: str,
+    answered_by: str,
+    answered_at: Optional[str] = None,
+    source_message_id: Optional[int] = None,
+    source_thread_id: Optional[int] = None,
+    load_session_fn: Optional[LoadSessionFn] = None,
+    update_session_fn: Optional[UpdateSessionFn] = None,
+) -> OperatorActionReplyOutcome:
+    """thread reply *text* 를 operator-action 카드에 매핑해 처리.
+
+    side-effect 는 두 가지뿐:
+      - SAVED operator-action job 1 건을 찾아 그 request 를 복원.
+      - 매칭되면 :func:`stamp_answered_request` 결과를 세션 extra 로 저장.
+
+    queue 의 ``approval_post`` row 자체는 SAVED 그대로 유지한다 — 같은
+    카드에 2 차 응답이 들어올 수 있고, gateway 가 재요청 카드를 다시
+    enqueue 할 수도 있다. dedup 은 enqueue 측의 ``find_active`` 가 이미
+    담당.
+    """
+
+    job = find_pending_operator_action_for_reply(
+        queue=queue,
+        session_id=session_id,
+        source_message_id=source_message_id,
+        source_thread_id=source_thread_id,
+    )
+    if job is None:
+        return OperatorActionReplyOutcome(
+            handled=False, skipped_reason="no_matching_operator_action"
+        )
+
+    request = operator_action_request_from_approval_payload(job.payload or {})
+    if request is None:
+        return OperatorActionReplyOutcome(
+            handled=False,
+            approval_job_id=job.job_id,
+            skipped_reason="missing_operator_action_payload",
+        )
+
+    reply = parse_operator_action_reply(
+        request_type=request.request_type, text=text
+    )
+
+    answered_at_iso = (answered_at or "").strip() or _utc_now_iso()
+    load_fn = load_session_fn or _default_load_session
+    update_fn = update_session_fn or _default_update_session
+
+    session = load_fn(session_id)
+    new_extra: Mapping[str, Any] = {}
+    new_state: Optional[OperatorSessionState] = None
+    if session is not None:
+        existing_extra = getattr(session, "extra", None) or {}
+        new_extra = stamp_answered_request(
+            session_extra=existing_extra,
+            reply=reply,
+            answered_by=answered_by,
+            answered_at=answered_at_iso,
+        )
+        try:
+            update_fn(session, new_extra)
+        except Exception:  # noqa: BLE001 — audit is best-effort
+            pass
+        raw_state = (
+            new_extra.get("operator_state")
+            if isinstance(new_extra, Mapping)
+            else None
+        )
+        if isinstance(raw_state, str):
+            try:
+                new_state = OperatorSessionState(raw_state)
+            except ValueError:
+                new_state = None
+
+    return OperatorActionReplyOutcome(
+        handled=True,
+        request_type=request.request_type,
+        approval_job_id=job.job_id,
+        request=request,
+        reply=reply,
+        new_state=new_state,
+        audit={
+            "answered_by": answered_by,
+            "answered_at": answered_at_iso,
+            "source_message_id": source_message_id,
+            "source_thread_id": source_thread_id,
+            "request_type": request.request_type.value,
+            "is_complete": reply.is_complete,
+            "rejected_reason": reply.rejected_reason,
+        },
+    )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+__all__ = (
+    "LoadSessionFn",
+    "OperatorActionReplyOutcome",
+    "UpdateSessionFn",
+    "find_pending_operator_action_for_reply",
+    "handle_operator_action_reply",
+)

--- a/src/yule_orchestrator/agents/operator_action.py
+++ b/src/yule_orchestrator/agents/operator_action.py
@@ -1,0 +1,729 @@
+"""Operator action inbox — `#승인-대기` 가 approval-only 가 아닌
+operator-facing inbox 로 동작하기 위한 모델/렌더러/리플라이 파서.
+
+배경
+====
+현재 `#승인-대기` 는 ``ApprovalRequest`` (write/PR/merge/deploy 같은
+승인 액션) 카드만 게시한다. 그러나 engineering-agent 가 진행 중에
+필요한 외부 정보 (서버 IP, SSH 자격, 실제 secret 값) 까지 같은
+채널에서 받아내야 "조용히 멈추는" 회귀를 막을 수 있다.
+
+기술 자율 vs 외부 사실 경계 (`docs/approval-matrix.md` §6 참조):
+
+- **agent 가 스스로 판단**: JWT vs session, DB 이름, Docker compose
+  구조, Next/Nest 연결 방식, auth/API 구조, 디렉터리 구조, 일반
+  기술 선택.
+- **반드시 사람에게 받음**: 실제 서버 IP / hostname, SSH user/key,
+  실제 도메인, 실제 secret 값, 운영 DB/Redis/API endpoint, 클라우드
+  계정 식별자, "이 환경 수정해도 되는가" 같은 권한 사실.
+
+본 모듈은 두 번째 항목을 위한 **operator action request** 를 정의한다.
+queue / Discord / session 어느 한 쪽에도 의존하지 않는 pure 모델로
+유지해 어디서든 import 가능하게 한다.
+
+핵심 surface
+============
+- :class:`OperatorActionType` — 5 가지 요청 유형.
+- :class:`OperatorSessionState` — 세션 대기 상태.
+- :class:`OperatorActionRequest` — 카드/세션 양쪽이 공유하는 dataclass.
+- :func:`render_operator_action_card` — markdown 카드 본문.
+- :func:`parse_operator_action_reply` — `key=value` 응답 파서.
+- :func:`session_state_for_request_type` — request_type → 대기 상태 매핑.
+- :func:`is_external_fact_required` — 사람에게 물어야 하는 키워드 감지.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class OperatorActionType(str, Enum):
+    """5 가지 operator-facing 요청 유형.
+
+    문자열 값은 ``ApprovalRequest.extra['operator_action']['request_type']``
+    에 저장돼 SQLite TEXT 컬럼을 그대로 round-trip 한다. 새 유형을 추가할
+    때는 :data:`_REQUEST_TYPE_LABELS` / :data:`_REQUEST_TYPE_HINTS` 도
+    같이 갱신해야 한다.
+    """
+
+    APPROVAL_REQUIRED = "approval_required"
+    INFO_REQUIRED = "info_required"
+    ACCESS_REQUIRED = "access_required"
+    SECRET_REQUIRED = "secret_required"
+    DECISION_REQUIRED = "decision_required"
+
+
+class OperatorSessionState(str, Enum):
+    """세션이 어떤 종류의 사람 응답을 기다리는지.
+
+    ``WorkflowState`` (세션 macro 라이프사이클) 옆에 붙는 sub-state.
+    `session.extra['operator_state']` 에 저장된다. ``running`` 은 모든
+    필요한 응답이 채워진 뒤 복귀하는 기본값이다.
+    """
+
+    RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
+    WAITING_USER_INPUT = "waiting_user_input"
+    WAITING_ACCESS = "waiting_access"
+    WAITING_SECRET = "waiting_secret"
+    BLOCKED_EXTERNAL = "blocked_external"
+
+
+# 기술 선택 vs 외부 사실 경계의 좌측 (agent 자율) — 본 모듈은 우측에
+# 해당하는 외부 사실 키워드만 감지한다. 좌측 키워드는 코드/문서 레퍼런스
+# 용도로만 남기고 dispatcher 가 알아서 판단한다.
+EXTERNAL_FACT_KEYWORDS: Tuple[Tuple[str, OperatorActionType], ...] = (
+    # INFO — 운영 사실 / 식별자
+    ("서버 ip", OperatorActionType.INFO_REQUIRED),
+    ("server ip", OperatorActionType.INFO_REQUIRED),
+    ("hostname", OperatorActionType.INFO_REQUIRED),
+    ("실제 도메인", OperatorActionType.INFO_REQUIRED),
+    ("운영 도메인", OperatorActionType.INFO_REQUIRED),
+    ("배포 대상 서버", OperatorActionType.INFO_REQUIRED),
+    ("운영 db", OperatorActionType.INFO_REQUIRED),
+    ("운영 redis", OperatorActionType.INFO_REQUIRED),
+    ("운영 api endpoint", OperatorActionType.INFO_REQUIRED),
+    ("클라우드 프로젝트", OperatorActionType.INFO_REQUIRED),
+    ("cloud project", OperatorActionType.INFO_REQUIRED),
+    ("계정 식별자", OperatorActionType.INFO_REQUIRED),
+    # ACCESS — 권한 / 접근
+    ("ssh 접근", OperatorActionType.ACCESS_REQUIRED),
+    ("ssh user", OperatorActionType.ACCESS_REQUIRED),
+    ("ssh key", OperatorActionType.ACCESS_REQUIRED),
+    ("ssh-key", OperatorActionType.ACCESS_REQUIRED),
+    ("repo access", OperatorActionType.ACCESS_REQUIRED),
+    ("권한 부여", OperatorActionType.ACCESS_REQUIRED),
+    ("환경 수정해도", OperatorActionType.ACCESS_REQUIRED),
+    ("이 서버 수정해도", OperatorActionType.ACCESS_REQUIRED),
+    ("cloud access", OperatorActionType.ACCESS_REQUIRED),
+    # SECRET — 실제 값 / 저장 위치
+    ("실제 secret 값", OperatorActionType.SECRET_REQUIRED),
+    ("실제 secret value", OperatorActionType.SECRET_REQUIRED),
+    ("secret 등록", OperatorActionType.SECRET_REQUIRED),
+    ("secret 저장 위치", OperatorActionType.SECRET_REQUIRED),
+    ("jwt_secret 값", OperatorActionType.SECRET_REQUIRED),
+    ("api 키 값", OperatorActionType.SECRET_REQUIRED),
+    ("api key 값", OperatorActionType.SECRET_REQUIRED),
+    ("실제 토큰", OperatorActionType.SECRET_REQUIRED),
+)
+
+
+def session_state_for_request_type(
+    request_type: OperatorActionType,
+) -> OperatorSessionState:
+    """request_type 에 대응하는 ``waiting_*`` 상태."""
+
+    return _REQUEST_TYPE_TO_STATE.get(
+        request_type, OperatorSessionState.BLOCKED_EXTERNAL
+    )
+
+
+_REQUEST_TYPE_TO_STATE: Mapping[OperatorActionType, OperatorSessionState] = {
+    OperatorActionType.APPROVAL_REQUIRED: OperatorSessionState.WAITING_APPROVAL,
+    OperatorActionType.INFO_REQUIRED: OperatorSessionState.WAITING_USER_INPUT,
+    OperatorActionType.ACCESS_REQUIRED: OperatorSessionState.WAITING_ACCESS,
+    OperatorActionType.SECRET_REQUIRED: OperatorSessionState.WAITING_SECRET,
+    OperatorActionType.DECISION_REQUIRED: OperatorSessionState.WAITING_USER_INPUT,
+}
+
+
+# ---------------------------------------------------------------------------
+# Hard rails — agent 가 절대 자동으로 하면 안 되는 secret 작업
+# ---------------------------------------------------------------------------
+
+
+SECRET_AUTO_ALLOWED: Tuple[str, ...] = (
+    "secret key 이름 정의",
+    ".env.example / compose / CI wiring 작성",
+    "GitHub Actions secret 이름 제안",
+    "어떤 값이 필요한지 설명",
+)
+"""agent 가 사람 승인 없이 진행해도 되는 secret 관련 작업 목록.
+
+본 리스트 밖의 secret 작업 (실제 값 생성, secret store/cloud secret
+manager 무단 수정, prod `.env` 직접 변경) 은 SECRET_REQUIRED 로
+사람에게 명시 요청해야 한다.
+"""
+
+
+SECRET_AUTO_FORBIDDEN: Tuple[str, ...] = (
+    "실제 secret 값을 임의로 생성해 운영 환경에 저장",
+    "GitHub secret / cloud secret manager 를 사용자 동의 없이 수정",
+    "prod .env 파일을 직접 변경",
+    "기존 secret 값을 다른 위치로 복사 / mirror",
+)
+
+
+# ---------------------------------------------------------------------------
+# Request dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OperatorActionRequest:
+    """Operator-facing action 요청.
+
+    `#승인-대기` 카드 한 장이 가져야 할 모든 정보를 보유한다. queue 의
+    ``ApprovalRequest`` 와 1:1 으로 매핑돼 ``approval_post`` job 의
+    payload 로 round-trip 된다 — 변환 헬퍼는
+    :func:`to_approval_request_payload` / :func:`from_approval_request_extra`.
+
+    필드
+    ----
+    request_type
+        :class:`OperatorActionType` — 5 유형 중 하나.
+    session_id
+        세션 식별자. 응답 router 가 어느 세션의 ``operator_state`` 를
+        업데이트할지 결정하는 근거.
+    stage
+        지금 멈춘 단계 ("backend-engineer 가 deploy 직전").
+    why_blocked
+        한국어로 "왜 사람이 필요한지" — 예: "deploy target 서버 IP 를
+        agent 가 추측할 수 없습니다".
+    expected_answer
+        지금 필요한 답변 1줄. 짧을수록 좋다.
+    answer_examples
+        ``("host=10.0.0.5",)`` 처럼 thread reply 예시 시퀀스.
+    next_action
+        응답 후 어떤 작업이 이어지는지. operator 가 "내가 답하면 어디로
+        가는지" 즉시 알 수 있어야 함.
+    timeout_hint
+        timeout / fallback 메모. 비어있을 수 있음.
+    """
+
+    request_type: OperatorActionType
+    session_id: str
+    title: str
+    stage: str
+    why_blocked: str
+    expected_answer: str
+    answer_examples: Tuple[str, ...] = ()
+    next_action: str = ""
+    timeout_hint: str = ""
+    requested_by: str = "engineering-agent"
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Round-trip helpers — ApprovalRequest.extra ↔ OperatorActionRequest
+    # ------------------------------------------------------------------
+
+    def to_extra_payload(self) -> Mapping[str, Any]:
+        """``ApprovalRequest.extra['operator_action']`` 에 들어갈 dict."""
+
+        return {
+            "request_type": self.request_type.value,
+            "session_id": self.session_id,
+            "title": self.title,
+            "stage": self.stage,
+            "why_blocked": self.why_blocked,
+            "expected_answer": self.expected_answer,
+            "answer_examples": list(self.answer_examples),
+            "next_action": self.next_action,
+            "timeout_hint": self.timeout_hint,
+            "requested_by": self.requested_by,
+            "extra": dict(self.extra),
+        }
+
+    @classmethod
+    def from_extra_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> "OperatorActionRequest":
+        """:meth:`to_extra_payload` 의 역변환. queue row 에서 복원할 때 사용."""
+
+        raw_type = str(payload.get("request_type") or "").strip()
+        try:
+            request_type = OperatorActionType(raw_type)
+        except ValueError:
+            request_type = OperatorActionType.APPROVAL_REQUIRED
+        return cls(
+            request_type=request_type,
+            session_id=str(payload.get("session_id") or ""),
+            title=str(payload.get("title") or ""),
+            stage=str(payload.get("stage") or ""),
+            why_blocked=str(payload.get("why_blocked") or ""),
+            expected_answer=str(payload.get("expected_answer") or ""),
+            answer_examples=tuple(
+                str(item) for item in (payload.get("answer_examples") or ())
+            ),
+            next_action=str(payload.get("next_action") or ""),
+            timeout_hint=str(payload.get("timeout_hint") or ""),
+            requested_by=str(
+                payload.get("requested_by") or "engineering-agent"
+            ),
+            extra=dict(payload.get("extra") or {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Card rendering
+# ---------------------------------------------------------------------------
+
+
+_REQUEST_TYPE_LABELS: Mapping[OperatorActionType, str] = {
+    OperatorActionType.APPROVAL_REQUIRED: "승인 필요",
+    OperatorActionType.INFO_REQUIRED: "정보 필요",
+    OperatorActionType.ACCESS_REQUIRED: "접근 / 권한 필요",
+    OperatorActionType.SECRET_REQUIRED: "Secret 필요",
+    OperatorActionType.DECISION_REQUIRED: "정책 / 제품 판단 필요",
+}
+
+
+_REQUEST_TYPE_EMOJIS: Mapping[OperatorActionType, str] = {
+    OperatorActionType.APPROVAL_REQUIRED: "✅",
+    OperatorActionType.INFO_REQUIRED: "❓",
+    OperatorActionType.ACCESS_REQUIRED: "🔐",
+    OperatorActionType.SECRET_REQUIRED: "🗝️",
+    OperatorActionType.DECISION_REQUIRED: "🧭",
+}
+
+
+_REQUEST_TYPE_REPLY_HINT: Mapping[OperatorActionType, str] = {
+    OperatorActionType.APPROVAL_REQUIRED: (
+        "이 카드 thread 에서 `승인` / `이대로 진행` 또는 `반려` / `보류` 로 답해 주세요."
+    ),
+    OperatorActionType.INFO_REQUIRED: (
+        "이 카드 thread 에서 `key=value` 형태 (예: `host=10.0.0.5`) 로 답해 주세요."
+    ),
+    OperatorActionType.ACCESS_REQUIRED: (
+        "이 카드 thread 에서 `user=...`, `auth=ssh-key` 같이 답해 주세요. 실제 키 값은 직접 붙이지 말고 저장 위치를 지정합니다."
+    ),
+    OperatorActionType.SECRET_REQUIRED: (
+        "이 카드 thread 에서 `github_secret=NAME` 또는 `env_file=.env.prod` 로 저장 위치/주입 방법을 지정해 주세요. 값 자체는 채널에 붙이지 마세요."
+    ),
+    OperatorActionType.DECISION_REQUIRED: (
+        "이 카드 thread 에서 한 줄로 결정 (예: `decision=옵션A`) 을 적어 주세요."
+    ),
+}
+
+
+def render_operator_action_card(request: OperatorActionRequest) -> str:
+    """*request* 를 ``#승인-대기`` 채널에 게시할 markdown 본문으로 렌더링.
+
+    카드는 6 블록으로 구성: 헤더 / 세션·단계 / 이유 / 필요한 답변 +
+    예시 / 응답 후 동작 / thread reply 안내. 결정성 (입력이 같으면 출력
+    같음) 을 유지해 ``ApprovalWorker`` 의 dedup 키가 동일 카드를 재게시
+    하지 않게 한다.
+    """
+
+    label = _REQUEST_TYPE_LABELS.get(
+        request.request_type, request.request_type.value
+    )
+    emoji = _REQUEST_TYPE_EMOJIS.get(request.request_type, "📨")
+    lines: list[str] = []
+    lines.append(
+        f"{emoji} **[{label}] {request.title or request.request_type.value}**"
+    )
+    lines.append("")
+    lines.append(
+        f"세션: `{request.session_id or 'unknown'}` · 요청자: `{request.requested_by}`"
+    )
+    if request.stage:
+        lines.append(f"단계: {request.stage}")
+    lines.append("")
+
+    if request.why_blocked:
+        lines.append("🔎 왜 사람이 필요한가")
+        lines.append(request.why_blocked)
+        lines.append("")
+
+    if request.expected_answer:
+        lines.append("📥 지금 필요한 답변")
+        lines.append(f"- {request.expected_answer}")
+    if request.answer_examples:
+        lines.append("")
+        lines.append("📌 답변 예시")
+        for example in request.answer_examples:
+            if example:
+                lines.append(f"- `{example}`")
+    lines.append("")
+
+    if request.next_action:
+        lines.append("➡️ 응답 후 진행")
+        lines.append(request.next_action)
+        lines.append("")
+
+    if request.timeout_hint:
+        lines.append(f"⏱ 타임아웃 / fallback: {request.timeout_hint}")
+        lines.append("")
+
+    hint = _REQUEST_TYPE_REPLY_HINT.get(
+        request.request_type, _REQUEST_TYPE_REPLY_HINT[OperatorActionType.APPROVAL_REQUIRED]
+    )
+    lines.append(hint)
+
+    if request.request_type == OperatorActionType.SECRET_REQUIRED:
+        lines.append("")
+        lines.append(
+            "🛡 hard rail: agent 는 실제 secret 값을 생성/저장/수정하지 "
+            "않습니다. 저장 위치만 지정해 주세요."
+        )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Reply parsing
+# ---------------------------------------------------------------------------
+
+
+_KV_LINE_RE = re.compile(
+    r"(?P<key>[A-Za-z_][A-Za-z0-9_.-]*)\s*=\s*(?P<value>.+?)\s*$"
+)
+
+
+# request_type 별로 "응답이 충분한가" 를 판단할 때 보는 필수 키 집합.
+# 한 카드가 두 종류 키를 동시에 받을 수 있도록 둘 중 하나만 매칭돼도 OK.
+_REQUIRED_KEYS_BY_TYPE: Mapping[OperatorActionType, Tuple[Tuple[str, ...], ...]] = {
+    OperatorActionType.INFO_REQUIRED: (
+        ("host",),
+        ("hostname",),
+        ("ip",),
+        ("domain",),
+        ("endpoint",),
+        ("project",),
+        ("account",),
+    ),
+    OperatorActionType.ACCESS_REQUIRED: (
+        ("user", "auth"),
+        ("ssh_user",),
+        ("ssh_key",),
+        ("access_method",),
+    ),
+    OperatorActionType.SECRET_REQUIRED: (
+        ("github_secret",),
+        ("env_file",),
+        ("vault_path",),
+        ("secret_store",),
+        ("cloud_secret",),
+    ),
+    OperatorActionType.DECISION_REQUIRED: (("decision",), ("choice",)),
+    OperatorActionType.APPROVAL_REQUIRED: (("intent",),),
+}
+
+
+# secret 카드에 대해 "raw 값" 을 그대로 채널에 붙인 응답을 거부할 때
+# 사용. 값 자체가 공유되면 audit 누수가 생긴다 — 저장 위치만 받는다.
+_SECRET_VALUE_KEY_HINT_RE = re.compile(
+    r"(?:^|\W)(secret_value|raw_value|value)\s*=", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class OperatorActionReply:
+    """파싱된 thread reply 결과.
+
+    ``answers`` 는 정규화된 key=value mapping. ``is_complete`` 는 해당
+    request_type 의 필수 키 집합 중 하나가 충족됐는지 여부 — True 일 때
+    상위 router 는 세션 상태를 ``running`` 으로 복귀시킨다.
+    ``rejected_reason`` 은 secret 카드에 raw 값이 붙은 경우 등 거부 사유.
+    """
+
+    request_type: OperatorActionType
+    answers: Mapping[str, str]
+    is_complete: bool
+    rejected_reason: Optional[str] = None
+    raw_text: str = ""
+
+
+def parse_operator_action_reply(
+    *,
+    request_type: OperatorActionType,
+    text: str,
+) -> OperatorActionReply:
+    """thread reply *text* 를 ``key=value`` 라인들로 분해해 결과 반환.
+
+    파싱 규칙
+    --------
+    - 한 줄에 하나씩 ``key=value`` 형태. 키는 알파벳/숫자/`.-_`.
+    - 줄 머리에 `- ` / `* ` 가 붙어도 허용.
+    - 동일 키가 여러 번 나오면 마지막 값을 채택 (덮어쓰기 의도).
+    - SECRET_REQUIRED 카드에 ``secret_value=...`` / ``raw_value=...``
+      / ``value=...`` 로 raw 값을 붙이면 ``rejected_reason="secret_value_inline"``
+      을 채워 응답 자체를 거부한다 (저장 위치만 받는다).
+    """
+
+    raw = (text or "").strip()
+    answers: dict[str, str] = {}
+
+    if request_type == OperatorActionType.SECRET_REQUIRED and _SECRET_VALUE_KEY_HINT_RE.search(raw):
+        return OperatorActionReply(
+            request_type=request_type,
+            answers={},
+            is_complete=False,
+            rejected_reason="secret_value_inline",
+            raw_text=raw,
+        )
+
+    for line in raw.splitlines():
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        # bullet prefix 제거
+        if cleaned.startswith(("- ", "* ", "• ")):
+            cleaned = cleaned[2:].strip()
+        match = _KV_LINE_RE.match(cleaned)
+        if not match:
+            continue
+        key = match.group("key").strip().lower()
+        value = match.group("value").strip().strip("`").strip()
+        if not value:
+            continue
+        answers[key] = value
+
+    if not answers:
+        # APPROVAL_REQUIRED 는 텍스트 자체가 의도라 별도 처리. 다른 타입은
+        # 키 형태가 안 맞으면 미완으로 본다.
+        return OperatorActionReply(
+            request_type=request_type,
+            answers={},
+            is_complete=False,
+            rejected_reason="no_key_value_pairs" if request_type != OperatorActionType.APPROVAL_REQUIRED else None,
+            raw_text=raw,
+        )
+
+    requirement_groups = _REQUIRED_KEYS_BY_TYPE.get(request_type, ())
+    is_complete = False
+    for group in requirement_groups:
+        if all(key in answers for key in group):
+            is_complete = True
+            break
+
+    return OperatorActionReply(
+        request_type=request_type,
+        answers=answers,
+        is_complete=is_complete,
+        rejected_reason=None if is_complete else "missing_required_keys",
+        raw_text=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# External-fact detector — agent 자율 판단 vs 사람 요청 가드
+# ---------------------------------------------------------------------------
+
+
+def is_external_fact_required(text: str) -> Optional[OperatorActionType]:
+    """*text* 가 외부 사실/권한/secret 키워드를 포함하면 해당 타입 반환.
+
+    None 일 때는 agent 가 자율 판단해도 된다는 뜻. 이 헬퍼는 보수적이라
+    상위 호출자가 추가 정보를 가지고 있다면 override 할 수 있다.
+    """
+
+    if not text:
+        return None
+    haystack = " ".join(text.lower().split())
+    for keyword, request_type in EXTERNAL_FACT_KEYWORDS:
+        if keyword in haystack:
+            return request_type
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Session-state stamping helpers (pure — caller persists)
+# ---------------------------------------------------------------------------
+
+
+SESSION_EXTRA_OPERATOR_STATE_KEY: str = "operator_state"
+"""``WorkflowSession.extra`` 에 :class:`OperatorSessionState` 가 저장되는 키."""
+
+SESSION_EXTRA_PENDING_REQUESTS_KEY: str = "operator_pending_requests"
+"""``WorkflowSession.extra`` 에 미해결 ``OperatorActionRequest`` 가 쌓이는 list."""
+
+SESSION_EXTRA_ANSWERED_KEY: str = "operator_answered_requests"
+"""사람이 답을 채운 ``OperatorActionReply`` 가 쌓이는 audit list."""
+
+
+def stamp_pending_request(
+    *,
+    session_extra: Mapping[str, Any],
+    request: OperatorActionRequest,
+) -> Mapping[str, Any]:
+    """*session_extra* 에 미해결 요청과 ``waiting_*`` 상태를 새겨 반환.
+
+    pure: 입력 dict 를 mutate 하지 않고 새 dict 를 만든다. caller 가
+    이 결과로 ``WorkflowSession.extra`` 를 갱신한 뒤 ``update_session``
+    으로 persistence.
+    """
+
+    extra: dict[str, Any] = dict(session_extra or {})
+    pending: list[Any] = list(extra.get(SESSION_EXTRA_PENDING_REQUESTS_KEY) or [])
+    pending.append({
+        "request_type": request.request_type.value,
+        "title": request.title,
+        "stage": request.stage,
+        "why_blocked": request.why_blocked,
+        "expected_answer": request.expected_answer,
+    })
+    # cap 32 — 한 세션에 그 이상 미해결이면 어차피 운영 사고
+    if len(pending) > 32:
+        pending = pending[-32:]
+    extra[SESSION_EXTRA_PENDING_REQUESTS_KEY] = pending
+    extra[SESSION_EXTRA_OPERATOR_STATE_KEY] = session_state_for_request_type(
+        request.request_type
+    ).value
+    return extra
+
+
+def stamp_answered_request(
+    *,
+    session_extra: Mapping[str, Any],
+    reply: OperatorActionReply,
+    answered_by: str,
+    answered_at: str,
+) -> Mapping[str, Any]:
+    """*session_extra* 에 응답 audit 을 새기고, 미해결이 모두 해소되면
+    ``operator_state`` 를 ``running`` 으로 복귀시킨다."""
+
+    extra: dict[str, Any] = dict(session_extra or {})
+    answered: list[Any] = list(extra.get(SESSION_EXTRA_ANSWERED_KEY) or [])
+    answered.append({
+        "request_type": reply.request_type.value,
+        "answers": dict(reply.answers),
+        "answered_by": answered_by,
+        "answered_at": answered_at,
+        "rejected_reason": reply.rejected_reason,
+        "is_complete": reply.is_complete,
+    })
+    if len(answered) > 64:
+        answered = answered[-64:]
+    extra[SESSION_EXTRA_ANSWERED_KEY] = answered
+
+    if not reply.is_complete:
+        # 응답이 불완전하면 상태는 그대로 (사람이 다시 답할 때까지 대기)
+        return extra
+
+    # 같은 타입의 미해결 1 건을 제거 — pending 은 가장 오래된 것부터 제거.
+    pending: list[Any] = list(extra.get(SESSION_EXTRA_PENDING_REQUESTS_KEY) or [])
+    target_value = reply.request_type.value
+    for index, entry in enumerate(pending):
+        if isinstance(entry, dict) and entry.get("request_type") == target_value:
+            del pending[index]
+            break
+    extra[SESSION_EXTRA_PENDING_REQUESTS_KEY] = pending
+
+    if not pending:
+        extra[SESSION_EXTRA_OPERATOR_STATE_KEY] = OperatorSessionState.RUNNING.value
+    else:
+        # 다음 미해결의 타입을 다시 반영
+        next_entry = pending[0]
+        try:
+            next_type = OperatorActionType(str(next_entry.get("request_type")))
+        except (ValueError, AttributeError):
+            next_type = OperatorActionType.APPROVAL_REQUIRED
+        extra[SESSION_EXTRA_OPERATOR_STATE_KEY] = session_state_for_request_type(
+            next_type
+        ).value
+
+    return extra
+
+
+# ---------------------------------------------------------------------------
+# ApprovalRequest 변환 — queue 측 페이로드와 1:1 매핑
+# ---------------------------------------------------------------------------
+
+
+# request_type → ``ApprovalRequest.approval_kind`` 매핑. APPROVAL_REQUIRED
+# 만 호출자가 자체 kind 를 지정하도록 None 반환 (engineering_write /
+# pr_merge / obsidian_write 등 기존 vocabulary 가 그대로 쓰임).
+_REQUEST_TYPE_TO_APPROVAL_KIND: Mapping[OperatorActionType, Optional[str]] = {
+    OperatorActionType.APPROVAL_REQUIRED: None,
+    OperatorActionType.INFO_REQUIRED: "info_request",
+    OperatorActionType.ACCESS_REQUIRED: "access_request",
+    OperatorActionType.SECRET_REQUIRED: "secret_request",
+    OperatorActionType.DECISION_REQUIRED: "decision_request",
+}
+
+
+def operator_action_to_approval_payload(
+    request: OperatorActionRequest,
+    *,
+    approval_kind_override: Optional[str] = None,
+    summary: str = "",
+    requested_action: str = "",
+    created_by: str = "",
+    source_channel_id: Optional[int] = None,
+    source_thread_id: Optional[int] = None,
+    source_message_id: Optional[int] = None,
+) -> Mapping[str, Any]:
+    """*request* 를 ``ApprovalRequest.to_payload()`` 가 기대하는 dict 으로 변환.
+
+    queue 의 ``ApprovalWorker.enqueue`` 에 그대로 넘길 수 있는 모양이다.
+    ``ApprovalRequest`` 자체를 import 하지 않고 dict shape 만 만든다 —
+    operator_action 모듈은 job_queue 의존을 갖지 않는다.
+    """
+
+    kind = approval_kind_override or _REQUEST_TYPE_TO_APPROVAL_KIND.get(
+        request.request_type
+    )
+    if not kind:
+        kind = "operator_action"
+
+    summary_value = summary or request.why_blocked
+    requested = requested_action or request.expected_answer
+    created = created_by or request.requested_by
+
+    extra: dict[str, Any] = dict(request.extra or {})
+    extra["operator_action"] = request.to_extra_payload()
+
+    return {
+        "session_id": request.session_id,
+        "approval_kind": kind,
+        "title": request.title or kind,
+        "summary": summary_value,
+        "requested_action": requested,
+        "created_by": created,
+        "source_channel_id": source_channel_id,
+        "source_thread_id": source_thread_id,
+        "source_message_id": source_message_id,
+        "extra": extra,
+    }
+
+
+def operator_action_request_from_approval_payload(
+    payload: Mapping[str, Any],
+) -> Optional[OperatorActionRequest]:
+    """``approval_post`` queue row 의 payload 에서
+    :class:`OperatorActionRequest` 를 복원. 없으면 ``None``.
+
+    reply router 가 어느 카드인지 식별한 뒤 해당 request 를 다시
+    빌드해 reply 처리에 사용한다.
+    """
+
+    extra = (payload or {}).get("extra") or {}
+    op_payload = extra.get("operator_action") if isinstance(extra, Mapping) else None
+    if not isinstance(op_payload, Mapping):
+        return None
+    try:
+        return OperatorActionRequest.from_extra_payload(op_payload)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = (
+    "EXTERNAL_FACT_KEYWORDS",
+    "OperatorActionReply",
+    "OperatorActionRequest",
+    "OperatorActionType",
+    "OperatorSessionState",
+    "SECRET_AUTO_ALLOWED",
+    "SECRET_AUTO_FORBIDDEN",
+    "SESSION_EXTRA_ANSWERED_KEY",
+    "SESSION_EXTRA_OPERATOR_STATE_KEY",
+    "SESSION_EXTRA_PENDING_REQUESTS_KEY",
+    "is_external_fact_required",
+    "operator_action_request_from_approval_payload",
+    "operator_action_to_approval_payload",
+    "parse_operator_action_reply",
+    "render_operator_action_card",
+    "session_state_for_request_type",
+    "stamp_answered_request",
+    "stamp_pending_request",
+)

--- a/src/yule_orchestrator/discord/approval/reply_router.py
+++ b/src/yule_orchestrator/discord/approval/reply_router.py
@@ -38,7 +38,13 @@ from ...agents.job_queue.approval_reply import (
     parse_approval_intent,
 )
 from ...agents.job_queue.obsidian_writer_worker import ObsidianWriterWorker
+from ...agents.job_queue.operator_action_reply import (
+    OperatorActionReplyOutcome,
+    find_pending_operator_action_for_reply,
+    handle_operator_action_reply,
+)
 from ...agents.job_queue.store import JobQueue
+from ...agents.operator_action import OperatorActionType, OperatorSessionState
 
 
 logger = logging.getLogger(__name__)
@@ -71,6 +77,35 @@ RESPONSE_REJECTION_AUDIT_FAILED: str = (
 )
 
 
+# Operator action reply (P0-S) — INFO/ACCESS/SECRET/DECISION 카드 ack.
+RESPONSE_OPERATOR_INFO_OK: str = (
+    "📥 정보 받았어요. 세션을 다시 진행 (`running`) 으로 돌려놓을게요."
+)
+RESPONSE_OPERATOR_ACCESS_OK: str = (
+    "🔐 접근 정보 받았어요. 세션을 다시 진행 (`running`) 으로 돌려놓을게요."
+)
+RESPONSE_OPERATOR_SECRET_OK: str = (
+    "🗝 secret 저장 위치 받았어요. 실제 값은 지정한 위치에서 주입됩니다 — agent 가 값을 직접 만들지 않습니다."
+)
+RESPONSE_OPERATOR_DECISION_OK: str = (
+    "🧭 결정 받았어요. 세션을 다시 진행 (`running`) 으로 돌려놓을게요."
+)
+RESPONSE_OPERATOR_MISSING_KEYS: str = (
+    "❓ 응답에서 필요한 `key=value` 를 찾지 못했어요. 카드의 답변 예시를 참고해 다시 답해 주세요."
+)
+RESPONSE_OPERATOR_SECRET_VALUE_REJECTED: str = (
+    "🚫 secret 값을 채널에 직접 붙이지 마세요. 저장 위치만 지정해 주세요 — 예: `github_secret=JWT_SECRET` 또는 `env_file=.env.prod`."
+)
+
+
+_OPERATOR_OK_RESPONSES: dict[OperatorActionType, str] = {
+    OperatorActionType.INFO_REQUIRED: RESPONSE_OPERATOR_INFO_OK,
+    OperatorActionType.ACCESS_REQUIRED: RESPONSE_OPERATOR_ACCESS_OK,
+    OperatorActionType.SECRET_REQUIRED: RESPONSE_OPERATOR_SECRET_OK,
+    OperatorActionType.DECISION_REQUIRED: RESPONSE_OPERATOR_DECISION_OK,
+}
+
+
 # Inputs the adapter doesn't own — injected so tests can drive the
 # behaviour without a real Discord client / live SQLite session.
 SessionListerFn = Callable[[], Iterable[Any]]
@@ -86,12 +121,17 @@ class ApprovalReplyRouteResult:
     a deliberate no-op. The caller must NOT fall through to the
     engineering route in that case — replies in the approval
     channel are not engineering intake.
+
+    P0-S — operator-action 카드 (INFO/ACCESS/SECRET/DECISION) 응답이
+    매칭되면 ``operator_outcome`` 이 채워진다. ``outcome`` (기존
+    APPROVE/REJECT 처리 결과) 과 둘 중 하나만 set 된다.
     """
 
     handled: bool
     outcome: Optional[ApprovalReplyOutcome] = None
     response_sent: Optional[str] = None
     skipped_reason: Optional[str] = None
+    operator_outcome: Optional[OperatorActionReplyOutcome] = None
 
 
 def is_approval_channel_message(
@@ -168,6 +208,48 @@ async def route_approval_channel_message(
             handled=True, skipped_reason="empty_message"
         )
 
+    source_message_id = _safe_int(getattr(message, "id", None))
+    source_thread_id = _safe_int(
+        getattr(getattr(message, "channel", None), "id", None)
+    )
+    approved_by = _author_handle(message)
+
+    # P0-S — operator-action 카드 매칭이 우선. INFO/ACCESS/SECRET/DECISION
+    # 카드는 ``key=value`` 어휘라서 일반 approval intent 파서에 걸리면
+    # UNCLEAR 로 떨어져 사람 응답이 잠깐 사라진다. 채널의 SAVED
+    # operator-action 카드를 먼저 본다.
+    operator_session_id = _resolve_session_for_reply(
+        message=message, session_lister=session_lister
+    )
+    if operator_session_id and (
+        find_pending_operator_action_for_reply(
+            queue=queue,
+            session_id=operator_session_id,
+            source_message_id=source_message_id,
+            source_thread_id=source_thread_id,
+        )
+        is not None
+    ):
+        op_outcome = handle_operator_action_reply(
+            queue=queue,
+            text=text,
+            session_id=operator_session_id,
+            answered_by=approved_by,
+            answered_at=now_iso,
+            source_message_id=source_message_id,
+            source_thread_id=source_thread_id,
+        )
+        op_response = _render_operator_outcome_message(op_outcome)
+        if op_response is not None:
+            await send_chunks(message.channel, op_response)
+        return ApprovalReplyRouteResult(
+            handled=True,
+            outcome=None,
+            response_sent=op_response,
+            skipped_reason=op_outcome.skipped_reason,
+            operator_outcome=op_outcome,
+        )
+
     intent = parse_approval_intent(text)
     if intent in (ApprovalIntent.HOLD, ApprovalIntent.UNCLEAR):
         # The helper still calls handle_approval_reply for
@@ -181,10 +263,7 @@ async def route_approval_channel_message(
             skipped_reason="intent_not_actionable",
         )
 
-    session_id = _resolve_session_for_reply(
-        message=message,
-        session_lister=session_lister,
-    )
+    session_id = operator_session_id
     if not session_id:
         await send_chunks(message.channel, RESPONSE_NO_MATCH)
         return ApprovalReplyRouteResult(
@@ -193,12 +272,6 @@ async def route_approval_channel_message(
             response_sent=RESPONSE_NO_MATCH,
             skipped_reason="no_session_for_reply",
         )
-
-    approved_by = _author_handle(message)
-    source_message_id = _safe_int(getattr(message, "id", None))
-    source_thread_id = _safe_int(
-        getattr(getattr(message, "channel", None), "id", None)
-    )
 
     outcome = handle_approval_reply(
         queue=queue,
@@ -222,6 +295,33 @@ async def route_approval_channel_message(
         response_sent=response,
         skipped_reason=outcome.skipped_reason,
     )
+
+
+def _render_operator_outcome_message(
+    outcome: OperatorActionReplyOutcome,
+) -> Optional[str]:
+    """operator-action reply outcome → 짧은 ack 메시지.
+
+    - ``rejected_reason == "secret_value_inline"``: 보안 가드. 채널에
+      raw secret 을 붙인 응답을 명시적으로 거부한다.
+    - ``rejected_reason == "missing_required_keys"`` 등 미완: 다시 답해
+      달라고 안내.
+    - 완료: request_type 별 친절한 ack.
+    """
+
+    if not outcome.handled:
+        return None
+    reply = outcome.reply
+    if reply is None:
+        return RESPONSE_OPERATOR_MISSING_KEYS
+
+    if reply.rejected_reason == "secret_value_inline":
+        return RESPONSE_OPERATOR_SECRET_VALUE_REJECTED
+    if not reply.is_complete:
+        return RESPONSE_OPERATOR_MISSING_KEYS
+
+    request_type = outcome.request_type or reply.request_type
+    return _OPERATOR_OK_RESPONSES.get(request_type, RESPONSE_OPERATOR_INFO_OK)
 
 
 def _render_outcome_message(outcome: ApprovalReplyOutcome) -> Optional[str]:
@@ -356,6 +456,12 @@ __all__ = (
     "RESPONSE_DUPLICATE",
     "RESPONSE_HOLD_OR_UNCLEAR",
     "RESPONSE_NO_MATCH",
+    "RESPONSE_OPERATOR_ACCESS_OK",
+    "RESPONSE_OPERATOR_DECISION_OK",
+    "RESPONSE_OPERATOR_INFO_OK",
+    "RESPONSE_OPERATOR_MISSING_KEYS",
+    "RESPONSE_OPERATOR_SECRET_OK",
+    "RESPONSE_OPERATOR_SECRET_VALUE_REJECTED",
     "RESPONSE_REJECTED",
     "RESPONSE_REJECTION_AUDIT_FAILED",
     "RESPONSE_UNSUPPORTED_KIND",

--- a/tests/agents/coding/test_authorization_external_facts.py
+++ b/tests/agents/coding/test_authorization_external_facts.py
@@ -1,0 +1,140 @@
+"""기술 자율 vs 외부 사실 — authorization 가드 테스트 (P0-S).
+
+엔지니어링 에이전트가 단순 기술 선택 (JWT/DB/Docker 구조) 은 자율로
+정하고, 서버 IP / SSH / secret 값 같은 외부 사실은 반드시 사람에게
+요청해야 한다는 경계를 코드 레벨로 고정.
+
+  1. JWT vs session 같은 기술 선택은 ``classify_user_request_facts``
+     가 어떤 외부 사실 카드도 요구하지 않는다.
+  2. 서버 IP / SSH / secret 키워드가 나오면 INFO/ACCESS/SECRET 버킷에
+     키워드가 잡힌다.
+  3. ``_DEFAULT_SAFETY_RULES`` 에 secret 자율/사람 경계와 "카드 없이
+     멈추는 것 금지" 룰이 들어있다.
+  4. ``recommend_authorization`` 의 기존 흐름은 회귀 없이 그대로 동작
+     (JWT 같은 단순 기술 요청도 executor 만 정하고 사람에게 카드를
+     떠넘기지 않는다).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.authorization import (
+    EXTERNAL_FACT_HUMAN_REQUIRED,
+    TECH_DECISION_AUTONOMOUS,
+    _DEFAULT_SAFETY_RULES,
+    classify_user_request_facts,
+    recommend_authorization,
+    reset_role_profile_cache,
+)
+from yule_orchestrator.agents.operator_action import OperatorActionType
+
+
+class TechAutonomousVsExternalFactBoundaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_role_profile_cache()
+
+    def test_jwt_vs_session_is_pure_tech_choice(self) -> None:
+        result = classify_user_request_facts(
+            "JWT 로 갈지 session 으로 갈지 결정해서 인증 흐름 만들어줘"
+        )
+        # 어떤 외부 사실 버킷도 채워지면 안 됨 — 단순 기술 선택은 자율
+        self.assertEqual(result[OperatorActionType.INFO_REQUIRED.value], ())
+        self.assertEqual(result[OperatorActionType.ACCESS_REQUIRED.value], ())
+        self.assertEqual(result[OperatorActionType.SECRET_REQUIRED.value], ())
+
+    def test_db_name_choice_is_pure_tech_choice(self) -> None:
+        result = classify_user_request_facts(
+            "이 서비스 DB 이름 어떻게 잡으면 좋을까?"
+        )
+        self.assertEqual(result[OperatorActionType.INFO_REQUIRED.value], ())
+        self.assertEqual(result[OperatorActionType.ACCESS_REQUIRED.value], ())
+        self.assertEqual(result[OperatorActionType.SECRET_REQUIRED.value], ())
+
+    def test_server_ip_request_triggers_info_bucket(self) -> None:
+        result = classify_user_request_facts(
+            "배포 대상 서버 IP 가 필요한 deploy 스크립트 작성해줘"
+        )
+        self.assertIn("서버 ip", result[OperatorActionType.INFO_REQUIRED.value])
+
+    def test_ssh_request_triggers_access_bucket(self) -> None:
+        result = classify_user_request_facts(
+            "prod 서버에 ssh 접근 가능한 deploy 자동화 만들어줘"
+        )
+        self.assertTrue(
+            len(result[OperatorActionType.ACCESS_REQUIRED.value]) >= 1,
+            f"expected ACCESS bucket non-empty, got {result}",
+        )
+
+    def test_secret_value_request_triggers_secret_bucket(self) -> None:
+        result = classify_user_request_facts(
+            "JWT_SECRET 값을 등록해서 wiring 마무리해줘"
+        )
+        self.assertTrue(
+            len(result[OperatorActionType.SECRET_REQUIRED.value]) >= 1,
+            f"expected SECRET bucket non-empty, got {result}",
+        )
+
+    def test_empty_request_returns_empty_buckets(self) -> None:
+        result = classify_user_request_facts("")
+        for bucket in result.values():
+            self.assertEqual(bucket, ())
+
+
+class SafetyRulesContentTests(unittest.TestCase):
+    def test_secret_boundary_rule_present(self) -> None:
+        joined = "\n".join(_DEFAULT_SAFETY_RULES)
+        # secret 자율 가능 / 사람 요청 경계 명시
+        self.assertIn("agent 자율 가능", joined)
+        self.assertIn(".env.example", joined)
+        self.assertIn("SECRET_REQUIRED 카드", joined)
+
+    def test_silent_stop_forbidden_rule_present(self) -> None:
+        joined = "\n".join(_DEFAULT_SAFETY_RULES)
+        self.assertIn("카드 없이 세션이 멈추는", joined)
+
+    def test_external_fact_rule_present(self) -> None:
+        joined = "\n".join(_DEFAULT_SAFETY_RULES)
+        self.assertIn("INFO_REQUIRED", joined)
+        self.assertIn("ACCESS_REQUIRED", joined)
+
+
+class StaticBoundaryDocumentationTests(unittest.TestCase):
+    """경계 목록이 코드에 박혀있어 docs 와 동기화 검증 가능한지 확인."""
+
+    def test_tech_autonomous_includes_jwt_session(self) -> None:
+        joined = " | ".join(TECH_DECISION_AUTONOMOUS)
+        self.assertIn("JWT vs session", joined)
+        self.assertIn("DB 이름", joined)
+        self.assertIn("Docker Compose", joined)
+
+    def test_external_fact_includes_server_ip_and_secret(self) -> None:
+        joined = " | ".join(EXTERNAL_FACT_HUMAN_REQUIRED)
+        self.assertIn("실제 서버 IP", joined)
+        self.assertIn("SSH user", joined)
+        self.assertIn("실제 secret 값", joined)
+
+
+class AuthorizationRecommenderRegressionTests(unittest.TestCase):
+    """기존 recommender 흐름이 회귀 없이 동작."""
+
+    def setUp(self) -> None:
+        reset_role_profile_cache()
+
+    def test_jwt_request_still_picks_backend_engineer(self) -> None:
+        # JWT 같은 단순 기술 선택은 사람 입력 없이 backend-engineer 가
+        # executor 로 자동 선정. operator action 카드를 강제하지 않는다.
+        proposal = recommend_authorization(
+            user_request="JWT 기반 API 인증 흐름 추가해줘",
+        )
+        self.assertEqual(proposal.executor_role, "backend-engineer")
+        self.assertTrue(proposal.approval_required)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_operator_action.py
+++ b/tests/agents/test_operator_action.py
@@ -1,0 +1,467 @@
+"""Operator action inbox 모델 / 렌더러 / 파서 테스트 — P0-S.
+
+`#승인-대기` 가 approval-only 가 아니라 **operator action inbox** 로
+동작하기 위한 핵심 회귀 라인. 다음 라인을 모두 핀:
+
+  1. 5 가지 ``OperatorActionType`` 값.
+  2. ``render_operator_action_card`` 가 request_type 별로 헤더/이모지/
+     thread reply 안내를 정확히 분기.
+  3. ``parse_operator_action_reply`` 가 ``key=value`` 라인을 정확히
+     파싱하고, 필수 키 그룹이 충족되면 ``is_complete=True`` 반환.
+  4. SECRET 카드에 raw 값 (``secret_value=`` / ``raw_value=`` / ``value=``)
+     이 들어오면 거부 (``rejected_reason="secret_value_inline"``).
+  5. ``stamp_pending_request`` / ``stamp_answered_request`` 가
+     session.extra 의 ``operator_state`` / pending list / answered list
+     를 정확히 변경.
+  6. ``is_external_fact_required`` 가 키워드별로 올바른 타입 반환.
+  7. ``operator_action_to_approval_payload`` round-trip 으로
+     ``ApprovalRequest.from_payload`` 가 그대로 다시 카드를 렌더 가능.
+  8. ``render_approval_request`` 가 operator_action payload 를 감지하면
+     :func:`render_operator_action_card` 로 위임 — 즉 같은 worker 가
+     기존 카드와 새 카드를 모두 출력.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    ApprovalRequest,
+    OPERATOR_ACTION_KINDS,
+    APPROVAL_KIND_INFO_REQUEST,
+    APPROVAL_KIND_ACCESS_REQUEST,
+    APPROVAL_KIND_SECRET_REQUEST,
+    APPROVAL_KIND_DECISION_REQUEST,
+    render_approval_request,
+)
+from yule_orchestrator.agents.operator_action import (
+    OperatorActionRequest,
+    OperatorActionType,
+    OperatorSessionState,
+    SECRET_AUTO_ALLOWED,
+    SECRET_AUTO_FORBIDDEN,
+    SESSION_EXTRA_ANSWERED_KEY,
+    SESSION_EXTRA_OPERATOR_STATE_KEY,
+    SESSION_EXTRA_PENDING_REQUESTS_KEY,
+    is_external_fact_required,
+    operator_action_request_from_approval_payload,
+    operator_action_to_approval_payload,
+    parse_operator_action_reply,
+    render_operator_action_card,
+    session_state_for_request_type,
+    stamp_answered_request,
+    stamp_pending_request,
+)
+
+
+def _info_request() -> OperatorActionRequest:
+    return OperatorActionRequest(
+        request_type=OperatorActionType.INFO_REQUIRED,
+        session_id="sess-1",
+        title="deploy 대상 서버 IP 필요",
+        stage="backend-engineer 가 deploy 직전",
+        why_blocked="deploy target 서버 IP 를 추측할 수 없습니다",
+        expected_answer="운영 서버 IP 또는 hostname",
+        answer_examples=("host=10.0.0.5", "hostname=api.prod.example.com"),
+        next_action="backend-engineer 가 deploy 스크립트의 host 값을 채워 진행",
+        timeout_hint="30 분 무응답 시 deploy 보류",
+    )
+
+
+def _access_request() -> OperatorActionRequest:
+    return OperatorActionRequest(
+        request_type=OperatorActionType.ACCESS_REQUIRED,
+        session_id="sess-2",
+        title="prod 서버 SSH 접근 정보 필요",
+        stage="devops-engineer 가 systemd 설정 변경 직전",
+        why_blocked="prod 서버 SSH user/key 를 모릅니다",
+        expected_answer="user / auth 방식",
+        answer_examples=("user=deploy", "auth=ssh-key"),
+        next_action="devops-engineer 가 SSH 접속해 systemd 재시작",
+    )
+
+
+def _secret_request() -> OperatorActionRequest:
+    return OperatorActionRequest(
+        request_type=OperatorActionType.SECRET_REQUIRED,
+        session_id="sess-3",
+        title="JWT_SECRET 저장 위치 필요",
+        stage="backend-engineer 가 auth 모듈 wiring 직전",
+        why_blocked="실제 JWT_SECRET 값을 추측해 만들 수 없습니다",
+        expected_answer="github_secret 이름 또는 env_file 경로",
+        answer_examples=("github_secret=JWT_SECRET", "env_file=.env.prod"),
+        next_action="auth 모듈이 지정 위치에서 secret 을 읽도록 wiring",
+    )
+
+
+def _decision_request() -> OperatorActionRequest:
+    return OperatorActionRequest(
+        request_type=OperatorActionType.DECISION_REQUIRED,
+        session_id="sess-4",
+        title="유료 플랜 환불 정책 확인 필요",
+        stage="backend-engineer 가 환불 핸들러 구현 직전",
+        why_blocked="환불 가능 기간 정책이 제품 결정 사항입니다",
+        expected_answer="환불 가능 일수 또는 정책 옵션",
+        answer_examples=("decision=14일 이내 전액 환불",),
+        next_action="결정대로 환불 핸들러 작성",
+    )
+
+
+class OperatorActionTypeEnumTests(unittest.TestCase):
+    def test_five_types_present(self) -> None:
+        self.assertEqual(
+            {t.value for t in OperatorActionType},
+            {
+                "approval_required",
+                "info_required",
+                "access_required",
+                "secret_required",
+                "decision_required",
+            },
+        )
+
+    def test_session_state_for_each_type(self) -> None:
+        self.assertEqual(
+            session_state_for_request_type(OperatorActionType.APPROVAL_REQUIRED),
+            OperatorSessionState.WAITING_APPROVAL,
+        )
+        self.assertEqual(
+            session_state_for_request_type(OperatorActionType.INFO_REQUIRED),
+            OperatorSessionState.WAITING_USER_INPUT,
+        )
+        self.assertEqual(
+            session_state_for_request_type(OperatorActionType.ACCESS_REQUIRED),
+            OperatorSessionState.WAITING_ACCESS,
+        )
+        self.assertEqual(
+            session_state_for_request_type(OperatorActionType.SECRET_REQUIRED),
+            OperatorSessionState.WAITING_SECRET,
+        )
+        self.assertEqual(
+            session_state_for_request_type(OperatorActionType.DECISION_REQUIRED),
+            OperatorSessionState.WAITING_USER_INPUT,
+        )
+
+
+class OperatorCardRenderingTests(unittest.TestCase):
+    def test_info_card_includes_required_fields(self) -> None:
+        text = render_operator_action_card(_info_request())
+        self.assertIn("[정보 필요]", text)
+        self.assertIn("deploy 대상 서버 IP 필요", text)
+        self.assertIn("세션: `sess-1`", text)
+        self.assertIn("왜 사람이 필요한가", text)
+        self.assertIn("운영 서버 IP", text)
+        self.assertIn("`host=10.0.0.5`", text)
+        self.assertIn("응답 후 진행", text)
+        self.assertIn("타임아웃", text)
+        self.assertIn("이 카드 thread 에서", text)
+
+    def test_secret_card_carries_hard_rail(self) -> None:
+        text = render_operator_action_card(_secret_request())
+        self.assertIn("[Secret 필요]", text)
+        self.assertIn("github_secret=JWT_SECRET", text)
+        self.assertIn("env_file=.env.prod", text)
+        # Hard rail line — agent 는 실제 값을 만들지 않음.
+        self.assertIn("실제 secret 값을 생성/저장/수정하지", text)
+
+    def test_access_card_uses_access_label(self) -> None:
+        text = render_operator_action_card(_access_request())
+        self.assertIn("[접근 / 권한 필요]", text)
+        self.assertIn("user=deploy", text)
+        self.assertIn("auth=ssh-key", text)
+
+    def test_decision_card_uses_decision_label(self) -> None:
+        text = render_operator_action_card(_decision_request())
+        self.assertIn("[정책 / 제품 판단 필요]", text)
+        self.assertIn("decision=14일 이내 전액 환불", text)
+
+    def test_render_is_deterministic(self) -> None:
+        a = render_operator_action_card(_info_request())
+        b = render_operator_action_card(_info_request())
+        self.assertEqual(a, b)
+
+
+class OperatorReplyParserTests(unittest.TestCase):
+    def test_info_reply_with_host_is_complete(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.INFO_REQUIRED,
+            text="host=10.0.0.5",
+        )
+        self.assertEqual(reply.answers, {"host": "10.0.0.5"})
+        self.assertTrue(reply.is_complete)
+        self.assertIsNone(reply.rejected_reason)
+
+    def test_access_reply_requires_user_and_auth(self) -> None:
+        # user 만 있으면 미완 (그룹 ("user","auth") 충족 안 됨, ssh_user 도 없음)
+        partial = parse_operator_action_reply(
+            request_type=OperatorActionType.ACCESS_REQUIRED,
+            text="user=deploy",
+        )
+        self.assertFalse(partial.is_complete)
+        self.assertEqual(partial.rejected_reason, "missing_required_keys")
+
+        full = parse_operator_action_reply(
+            request_type=OperatorActionType.ACCESS_REQUIRED,
+            text="user=deploy\nauth=ssh-key",
+        )
+        self.assertEqual(full.answers, {"user": "deploy", "auth": "ssh-key"})
+        self.assertTrue(full.is_complete)
+
+    def test_secret_reply_with_github_secret_is_complete(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.SECRET_REQUIRED,
+            text="github_secret=JWT_SECRET",
+        )
+        self.assertTrue(reply.is_complete)
+        self.assertEqual(reply.answers, {"github_secret": "JWT_SECRET"})
+
+    def test_secret_reply_with_raw_value_rejected(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.SECRET_REQUIRED,
+            text="value=super-secret-string",
+        )
+        self.assertFalse(reply.is_complete)
+        self.assertEqual(reply.rejected_reason, "secret_value_inline")
+        self.assertEqual(reply.answers, {})
+
+    def test_secret_reply_with_secret_value_alias_rejected(self) -> None:
+        for alias in ("secret_value", "raw_value"):
+            reply = parse_operator_action_reply(
+                request_type=OperatorActionType.SECRET_REQUIRED,
+                text=f"{alias}=top-secret",
+            )
+            self.assertEqual(reply.rejected_reason, "secret_value_inline")
+
+    def test_decision_reply(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.DECISION_REQUIRED,
+            text="decision=14일 이내 전액 환불",
+        )
+        self.assertTrue(reply.is_complete)
+
+    def test_bullet_prefix_is_stripped(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.INFO_REQUIRED,
+            text="- host=10.0.0.5",
+        )
+        self.assertTrue(reply.is_complete)
+        self.assertEqual(reply.answers, {"host": "10.0.0.5"})
+
+    def test_unrecognised_keys_stay_unparsed(self) -> None:
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.INFO_REQUIRED,
+            text="just a free form sentence about something",
+        )
+        self.assertFalse(reply.is_complete)
+        self.assertEqual(reply.rejected_reason, "no_key_value_pairs")
+
+
+class SessionStampingTests(unittest.TestCase):
+    def test_stamp_pending_sets_waiting_state_and_appends(self) -> None:
+        extra = stamp_pending_request(
+            session_extra={}, request=_info_request()
+        )
+        self.assertEqual(
+            extra[SESSION_EXTRA_OPERATOR_STATE_KEY],
+            OperatorSessionState.WAITING_USER_INPUT.value,
+        )
+        pending = extra[SESSION_EXTRA_PENDING_REQUESTS_KEY]
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0]["request_type"], "info_required")
+        self.assertEqual(pending[0]["title"], "deploy 대상 서버 IP 필요")
+
+    def test_stamp_pending_does_not_mutate_input(self) -> None:
+        original = {"unrelated": True}
+        stamp_pending_request(session_extra=original, request=_secret_request())
+        self.assertEqual(original, {"unrelated": True})
+
+    def test_stamp_answered_running_returns_when_only_pending_resolved(self) -> None:
+        after_pending = stamp_pending_request(
+            session_extra={}, request=_info_request()
+        )
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.INFO_REQUIRED, text="host=10.0.0.5"
+        )
+        after_answered = stamp_answered_request(
+            session_extra=after_pending,
+            reply=reply,
+            answered_by="masterway",
+            answered_at="2026-05-15T10:00:00+00:00",
+        )
+        self.assertEqual(
+            after_answered[SESSION_EXTRA_OPERATOR_STATE_KEY],
+            OperatorSessionState.RUNNING.value,
+        )
+        self.assertEqual(after_answered[SESSION_EXTRA_PENDING_REQUESTS_KEY], [])
+        answered = after_answered[SESSION_EXTRA_ANSWERED_KEY]
+        self.assertEqual(len(answered), 1)
+        self.assertTrue(answered[0]["is_complete"])
+        self.assertEqual(answered[0]["answered_by"], "masterway")
+
+    def test_stamp_answered_keeps_waiting_when_more_pending(self) -> None:
+        # 2 카드 pending, 첫 번째만 응답 — state 는 두 번째의 type 으로
+        extra = stamp_pending_request(session_extra={}, request=_info_request())
+        extra = stamp_pending_request(session_extra=extra, request=_secret_request())
+        reply = parse_operator_action_reply(
+            request_type=OperatorActionType.INFO_REQUIRED, text="host=10.0.0.5"
+        )
+        after = stamp_answered_request(
+            session_extra=extra,
+            reply=reply,
+            answered_by="m",
+            answered_at="2026-05-15T10:00:00+00:00",
+        )
+        self.assertEqual(
+            after[SESSION_EXTRA_OPERATOR_STATE_KEY],
+            OperatorSessionState.WAITING_SECRET.value,
+        )
+        self.assertEqual(len(after[SESSION_EXTRA_PENDING_REQUESTS_KEY]), 1)
+        self.assertEqual(
+            after[SESSION_EXTRA_PENDING_REQUESTS_KEY][0]["request_type"],
+            "secret_required",
+        )
+
+    def test_stamp_answered_incomplete_keeps_pending_and_state(self) -> None:
+        extra = stamp_pending_request(session_extra={}, request=_secret_request())
+        bad = parse_operator_action_reply(
+            request_type=OperatorActionType.SECRET_REQUIRED,
+            text="value=raw-string",
+        )
+        after = stamp_answered_request(
+            session_extra=extra,
+            reply=bad,
+            answered_by="m",
+            answered_at="2026-05-15T10:00:00+00:00",
+        )
+        # state 그대로 waiting_secret, pending 그대로
+        self.assertEqual(
+            after[SESSION_EXTRA_OPERATOR_STATE_KEY],
+            OperatorSessionState.WAITING_SECRET.value,
+        )
+        self.assertEqual(len(after[SESSION_EXTRA_PENDING_REQUESTS_KEY]), 1)
+        # audit 에는 거부 사유까지 기록
+        last = after[SESSION_EXTRA_ANSWERED_KEY][-1]
+        self.assertFalse(last["is_complete"])
+        self.assertEqual(last["rejected_reason"], "secret_value_inline")
+
+
+class ExternalFactDetectorTests(unittest.TestCase):
+    def test_server_ip_keyword_returns_info(self) -> None:
+        self.assertEqual(
+            is_external_fact_required("배포 대상 서버 IP 가 필요해요"),
+            OperatorActionType.INFO_REQUIRED,
+        )
+
+    def test_ssh_keyword_returns_access(self) -> None:
+        self.assertEqual(
+            is_external_fact_required("prod 서버 SSH 접근 가능?"),
+            OperatorActionType.ACCESS_REQUIRED,
+        )
+
+    def test_secret_value_keyword_returns_secret(self) -> None:
+        self.assertEqual(
+            is_external_fact_required("실제 secret 값 알려줘"),
+            OperatorActionType.SECRET_REQUIRED,
+        )
+
+    def test_pure_tech_choice_does_not_trigger(self) -> None:
+        # JWT vs session 같은 단순 기술 선택은 자율 판단
+        self.assertIsNone(
+            is_external_fact_required("JWT 로 갈지 session 으로 갈지 결정해줘")
+        )
+        self.assertIsNone(
+            is_external_fact_required("DB 이름 어떻게 잡지")
+        )
+        self.assertIsNone(
+            is_external_fact_required("Docker Compose 구조 잡아줘")
+        )
+
+
+class ApprovalPayloadRoundTripTests(unittest.TestCase):
+    def test_payload_roundtrip_renders_same_card(self) -> None:
+        op = _info_request()
+        payload = operator_action_to_approval_payload(
+            op,
+            created_by="backend-engineer",
+            source_thread_id=42,
+            source_message_id=99,
+        )
+        # 새 kind 가 OPERATOR_ACTION_KINDS 안에 있어야 reply router 가 찾는다
+        self.assertIn(payload["approval_kind"], OPERATOR_ACTION_KINDS)
+        self.assertEqual(payload["approval_kind"], APPROVAL_KIND_INFO_REQUEST)
+
+        request = ApprovalRequest.from_payload(payload)
+        rendered_via_worker = render_approval_request(request)
+        rendered_direct = render_operator_action_card(op)
+        # render_approval_request 가 operator_action payload 를 감지해서 동일하게 렌더링
+        self.assertEqual(rendered_via_worker, rendered_direct)
+
+    def test_payload_roundtrip_recovers_request(self) -> None:
+        op = _secret_request()
+        payload = operator_action_to_approval_payload(op)
+        recovered = operator_action_request_from_approval_payload(payload)
+        self.assertIsNotNone(recovered)
+        assert recovered is not None  # for type checker
+        self.assertEqual(recovered.request_type, OperatorActionType.SECRET_REQUIRED)
+        self.assertEqual(recovered.title, "JWT_SECRET 저장 위치 필요")
+        self.assertEqual(
+            recovered.answer_examples,
+            ("github_secret=JWT_SECRET", "env_file=.env.prod"),
+        )
+
+    def test_existing_approval_payload_without_operator_action_renders_default(self) -> None:
+        # 회귀 보장: 기존 ApprovalRequest (operator_action 없음) 는 기본 렌더로 fallback
+        request = ApprovalRequest(
+            session_id="legacy-1",
+            approval_kind="obsidian_write",
+            title="legacy 카드",
+            summary="기존 흐름",
+            requested_action="저장 승인",
+            created_by="research_worker",
+        )
+        text = render_approval_request(request)
+        self.assertIn("[승인 요청 — Obsidian 저장]", text)
+        self.assertIn("legacy 카드", text)
+        # 새 카드 마커는 절대 안 나와야 함
+        self.assertNotIn("정보 필요", text)
+        self.assertNotIn("Secret 필요", text)
+
+    def test_each_request_type_uses_correct_kind(self) -> None:
+        cases = (
+            (_info_request(), APPROVAL_KIND_INFO_REQUEST),
+            (_access_request(), APPROVAL_KIND_ACCESS_REQUEST),
+            (_secret_request(), APPROVAL_KIND_SECRET_REQUEST),
+            (_decision_request(), APPROVAL_KIND_DECISION_REQUEST),
+        )
+        for op, expected_kind in cases:
+            with self.subTest(request_type=op.request_type):
+                payload = operator_action_to_approval_payload(op)
+                self.assertEqual(payload["approval_kind"], expected_kind)
+
+
+class SecretHardRailDocumentedTests(unittest.TestCase):
+    """Hard rail 목록이 모듈에 코드 형태로 박혀있는지 확인.
+
+    추후 누군가가 SECRET_AUTO_FORBIDDEN 항목을 임의로 지우면 이 테스트가
+    fail 해서 docs/approval-matrix.md §6.3 가 검증 없이 무너지는 것을
+    막는다.
+    """
+
+    def test_allowed_list_includes_env_example_wiring(self) -> None:
+        joined = " | ".join(SECRET_AUTO_ALLOWED)
+        self.assertIn(".env.example", joined)
+        self.assertIn("GitHub Actions secret 이름", joined)
+
+    def test_forbidden_list_includes_prod_env_change(self) -> None:
+        joined = " | ".join(SECRET_AUTO_FORBIDDEN)
+        self.assertIn("prod .env 파일을 직접 변경", joined)
+        self.assertIn("실제 secret 값", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_approval_reply_router_operator_action.py
+++ b/tests/discord/test_approval_reply_router_operator_action.py
@@ -1,0 +1,507 @@
+"""Operator-action reply 라우팅 회귀 테스트 — P0-S.
+
+`#승인-대기` 채널에 operator-action (INFO/ACCESS/SECRET/DECISION) 카드가
+SAVED 로 들어가 있을 때, 사용자가 thread 에서 ``key=value`` 응답을
+보내면:
+
+  1. router 가 operator-action 카드를 우선 매칭한다 (기존 approval
+     vocabulary 보다 먼저).
+  2. 응답이 완전하면 친절한 ack (`RESPONSE_OPERATOR_INFO_OK` 등) 게시.
+  3. SECRET 카드에 raw 값을 붙이면 거부 응답.
+  4. 응답이 부족하면 미완 응답.
+  5. operator-action 카드가 없을 때는 기존 approval 흐름이 그대로
+     동작 (회귀 방지).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    APPROVAL_KIND_OBSIDIAN_WRITE,
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.obsidian_writer_worker import (
+    ObsidianWriterWorker,
+)
+from yule_orchestrator.agents.job_queue.operator_action_reply import (
+    handle_operator_action_reply,
+)
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.agents.operator_action import (
+    OperatorActionRequest,
+    OperatorActionType,
+    OperatorSessionState,
+    operator_action_to_approval_payload,
+    stamp_pending_request,
+)
+from yule_orchestrator.discord.approval.reply_router import (
+    RESPONSE_APPROVED,
+    RESPONSE_OPERATOR_ACCESS_OK,
+    RESPONSE_OPERATOR_DECISION_OK,
+    RESPONSE_OPERATOR_INFO_OK,
+    RESPONSE_OPERATOR_MISSING_KEYS,
+    RESPONSE_OPERATOR_SECRET_OK,
+    RESPONSE_OPERATOR_SECRET_VALUE_REJECTED,
+    route_approval_channel_message,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _msg(*, channel_id: int, content: str, message_id: int = 999, author_bot: bool = False):
+    channel = SimpleNamespace(id=channel_id, name="승인-대기")
+    author = SimpleNamespace(
+        id=42,
+        bot=author_bot,
+        name="masterway",
+        global_name="masterway",
+    )
+    return SimpleNamespace(
+        channel=channel, author=author, content=content, id=message_id
+    )
+
+
+class _OperatorActionFixture(unittest.TestCase):
+    SESSION_ID = "sess-op-1"
+    APPROVAL_CHANNEL_ID = 70000
+
+    def setUp(self) -> None:  # noqa: D401
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._db = Path(self._tmp.name) / "queue.sqlite3"
+        self.queue = JobQueue(db_path=self._db)
+        self.heartbeats = HeartbeatStore(db_path=self._db)
+
+        async def _post_fn(_request, _rendered):
+            return {"posted_message_id": 1}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post_fn,
+            channel_resolver=lambda: 8888,
+        )
+
+        # ObsidianWriterWorker stub — needed because route_* signature
+        # demands one even when the operator-action branch fires.
+        def _render_fn(_request):
+            return {"rendered": True}
+
+        def _write_fn(_note, _vault, _request):
+            return None
+
+        self.obsidian_worker = ObsidianWriterWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            render_fn=_render_fn,
+            write_fn=_write_fn,
+            vault_root_resolver=lambda _r: Path(self._tmp.name) / "vault",
+        )
+
+        self.sent: List[str] = []
+
+        async def _send_chunks(_channel, text: str, *args, **kwargs):
+            self.sent.append(text)
+
+        self.send_chunks = _send_chunks
+
+        # 카드의 source_thread_id 가 reply 가 들어온 채널 (= APPROVAL_CHANNEL_ID)
+        # 이라고 가정 — discord 에서 thread reply 가 channel.id 로 들어오는
+        # 케이스를 모사. session lister 도 같은 thread 로 매칭 가능하게 둔다.
+        self.fake_session = SimpleNamespace(
+            session_id=self.SESSION_ID,
+            thread_id=self.APPROVAL_CHANNEL_ID,
+            updated_at="2026-05-15T10:00",
+            extra={},
+        )
+        self.session_lister = lambda: [self.fake_session]
+
+    def _seed_operator_action_card(
+        self, request: OperatorActionRequest
+    ) -> str:
+        payload = operator_action_to_approval_payload(
+            request,
+            created_by="backend-engineer",
+            source_thread_id=self.APPROVAL_CHANNEL_ID,
+            source_message_id=12345,
+        )
+        approval_request = ApprovalRequest.from_payload(payload)
+        outcome = _run(self.approval_worker.run_one(approval_request))
+        assert outcome.job is not None
+        return outcome.job.job_id
+
+    def _seed_obsidian_card(self) -> str:
+        request = ApprovalRequest(
+            session_id=self.SESSION_ID,
+            approval_kind=APPROVAL_KIND_OBSIDIAN_WRITE,
+            title="결정 노트",
+            summary="x",
+            requested_action="vault 저장",
+            created_by="tech-lead",
+            source_thread_id=self.APPROVAL_CHANNEL_ID,
+            source_message_id=42,
+            extra={"decision_id": "dec-1"},
+        )
+        outcome = _run(self.approval_worker.run_one(request))
+        assert outcome.job is not None
+        return outcome.job.job_id
+
+
+class OperatorActionDispatchTests(_OperatorActionFixture):
+    def test_info_card_reply_routes_to_operator_handler(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.INFO_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="deploy 대상 서버 IP 필요",
+                stage="backend-engineer 가 deploy 직전",
+                why_blocked="서버 IP 추측 불가",
+                expected_answer="host 또는 hostname",
+                answer_examples=("host=10.0.0.5",),
+                next_action="deploy 진행",
+            )
+        )
+
+        msg = _msg(channel_id=self.APPROVAL_CHANNEL_ID, content="host=10.0.0.5")
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+
+        self.assertTrue(result.handled)
+        self.assertIsNotNone(result.operator_outcome)
+        op = result.operator_outcome
+        assert op is not None
+        self.assertTrue(op.handled)
+        self.assertEqual(op.request_type, OperatorActionType.INFO_REQUIRED)
+        assert op.reply is not None
+        self.assertTrue(op.reply.is_complete)
+        self.assertEqual(op.reply.answers, {"host": "10.0.0.5"})
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_INFO_OK])
+
+    def test_secret_card_with_raw_value_is_rejected(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.SECRET_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="JWT_SECRET 저장 위치 필요",
+                stage="auth wiring",
+                why_blocked="실제 JWT_SECRET 값을 만들 수 없습니다",
+                expected_answer="github_secret 이름 또는 env_file 경로",
+                answer_examples=("github_secret=JWT_SECRET",),
+                next_action="auth 모듈 wiring",
+            )
+        )
+
+        msg = _msg(
+            channel_id=self.APPROVAL_CHANNEL_ID,
+            content="value=super-secret-string",
+        )
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_SECRET_VALUE_REJECTED])
+        op = result.operator_outcome
+        assert op is not None and op.reply is not None
+        self.assertEqual(op.reply.rejected_reason, "secret_value_inline")
+        self.assertFalse(op.reply.is_complete)
+
+    def test_secret_card_with_github_secret_is_accepted(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.SECRET_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="JWT_SECRET 저장 위치 필요",
+                stage="auth wiring",
+                why_blocked="실제 JWT_SECRET 값을 만들 수 없습니다",
+                expected_answer="github_secret 이름 또는 env_file 경로",
+                answer_examples=("github_secret=JWT_SECRET",),
+                next_action="auth 모듈 wiring",
+            )
+        )
+
+        msg = _msg(
+            channel_id=self.APPROVAL_CHANNEL_ID,
+            content="github_secret=JWT_SECRET",
+        )
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertTrue(result.handled)
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_SECRET_OK])
+
+    def test_access_card_reply(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.ACCESS_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="prod SSH 접근 필요",
+                stage="systemd 재시작 직전",
+                why_blocked="prod SSH user / key 모릅니다",
+                expected_answer="user / auth 방식",
+                answer_examples=("user=deploy", "auth=ssh-key"),
+                next_action="systemd 재시작",
+            )
+        )
+        msg = _msg(
+            channel_id=self.APPROVAL_CHANNEL_ID,
+            content="user=deploy\nauth=ssh-key",
+        )
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_ACCESS_OK])
+
+    def test_decision_card_reply(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.DECISION_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="환불 정책 확인 필요",
+                stage="환불 핸들러 직전",
+                why_blocked="제품 결정 사항입니다",
+                expected_answer="환불 정책",
+                answer_examples=("decision=14일 이내 전액 환불",),
+                next_action="환불 핸들러 작성",
+            )
+        )
+        msg = _msg(
+            channel_id=self.APPROVAL_CHANNEL_ID,
+            content="decision=14일 이내 전액 환불",
+        )
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_DECISION_OK])
+
+    def test_missing_keys_returns_friendly_hint(self) -> None:
+        self._seed_operator_action_card(
+            OperatorActionRequest(
+                request_type=OperatorActionType.INFO_REQUIRED,
+                session_id=self.SESSION_ID,
+                title="deploy 대상 서버 IP 필요",
+                stage="backend-engineer 가 deploy 직전",
+                why_blocked="서버 IP 추측 불가",
+                expected_answer="host 또는 hostname",
+                answer_examples=("host=10.0.0.5",),
+                next_action="deploy 진행",
+            )
+        )
+
+        msg = _msg(
+            channel_id=self.APPROVAL_CHANNEL_ID,
+            content="음 잘 모르겠어",
+        )
+        _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertEqual(self.sent, [RESPONSE_OPERATOR_MISSING_KEYS])
+
+    def test_existing_obsidian_approval_flow_unchanged(self) -> None:
+        # 회귀 보장 — operator-action 카드가 없으면 기존 obsidian write
+        # 흐름이 그대로 동작.
+        self._seed_obsidian_card()
+        msg = _msg(channel_id=self.APPROVAL_CHANNEL_ID, content="승인")
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        # operator-action 카드가 없었으므로 outcome 은 기존 path
+        self.assertIsNone(result.operator_outcome)
+        self.assertEqual(len(self.sent), 1)
+        # 새 path 응답이 절대 안 나와야 함
+        self.assertNotIn(RESPONSE_OPERATOR_SECRET_OK, self.sent)
+        self.assertNotIn(RESPONSE_OPERATOR_INFO_OK, self.sent)
+
+    def test_silent_stop_regression_card_required(self) -> None:
+        """카드가 SAVED 가 아니면 (= 게시 자체를 안 했으면) operator-action
+        분기가 발동하지 않아야 한다 — 즉 "카드 없이 멈추면 안 된다" 의
+        역방향 회귀: 카드가 없으면 라우터도 조용히 처리하지 않고 일반
+        approval path 로 빠지는지.
+        """
+
+        # operator-action 카드를 enqueue 하지 않고 reply 만 들어옴.
+        msg = _msg(channel_id=self.APPROVAL_CHANNEL_ID, content="host=10.0.0.5")
+        result = _run(
+            route_approval_channel_message(
+                message=msg,
+                bot_user=SimpleNamespace(id=0),
+                queue=self.queue,
+                obsidian_worker=self.obsidian_worker,
+                approval_channel_id=self.APPROVAL_CHANNEL_ID,
+                session_lister=self.session_lister,
+                send_chunks=self.send_chunks,
+            )
+        )
+        self.assertTrue(result.handled)
+        # operator-action 분기는 절대 발동하지 않음
+        self.assertIsNone(result.operator_outcome)
+
+
+class HandleOperatorActionReplyDirectTests(unittest.TestCase):
+    """``handle_operator_action_reply`` 직접 호출 — session.extra 갱신 라인 고정."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.queue = JobQueue(db_path=Path(self._tmp.name) / "q.sqlite3")
+        self.heartbeats = HeartbeatStore(
+            db_path=Path(self._tmp.name) / "q.sqlite3"
+        )
+
+        async def _post_fn(_request, _rendered):
+            return {"posted_message_id": 1}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post_fn,
+            channel_resolver=lambda: 8888,
+        )
+
+    def _seed(self, request: OperatorActionRequest) -> str:
+        payload = operator_action_to_approval_payload(
+            request, source_thread_id=11, source_message_id=22
+        )
+        ar = ApprovalRequest.from_payload(payload)
+        outcome = _run(self.approval_worker.run_one(ar))
+        assert outcome.job is not None
+        return outcome.job.job_id
+
+    def test_session_state_returns_to_running_after_complete_reply(self) -> None:
+        request = OperatorActionRequest(
+            request_type=OperatorActionType.INFO_REQUIRED,
+            session_id="sess-x",
+            title="server ip 필요",
+            stage="deploy 직전",
+            why_blocked="추측 금지",
+            expected_answer="host",
+            answer_examples=("host=1.1.1.1",),
+            next_action="deploy",
+        )
+        self._seed(request)
+
+        # 가짜 session: 이미 waiting_user_input 상태로 들어가 있다고 가정
+        existing_extra = stamp_pending_request(session_extra={}, request=request)
+        captured: dict[str, Any] = {}
+
+        def _load(_session_id):
+            return SimpleNamespace(extra=existing_extra)
+
+        def _update(session, new_extra):
+            captured["extra"] = dict(new_extra)
+            return session
+
+        outcome = handle_operator_action_reply(
+            queue=self.queue,
+            text="host=1.1.1.1",
+            session_id="sess-x",
+            answered_by="masterway",
+            answered_at="2026-05-15T10:00:00+00:00",
+            source_message_id=22,
+            source_thread_id=11,
+            load_session_fn=_load,
+            update_session_fn=_update,
+        )
+
+        self.assertTrue(outcome.handled)
+        self.assertEqual(outcome.new_state, OperatorSessionState.RUNNING)
+        # session 갱신 페이로드도 같은 결정 반영
+        self.assertEqual(
+            captured["extra"]["operator_state"],
+            OperatorSessionState.RUNNING.value,
+        )
+        # pending list 비었음
+        self.assertEqual(captured["extra"]["operator_pending_requests"], [])
+
+    def test_no_matching_card_returns_handled_false(self) -> None:
+        outcome = handle_operator_action_reply(
+            queue=self.queue,
+            text="host=1.1.1.1",
+            session_id="no-such-session",
+            answered_by="m",
+            source_message_id=22,
+            source_thread_id=11,
+            load_session_fn=lambda _: None,
+            update_session_fn=lambda s, e: s,
+        )
+        self.assertFalse(outcome.handled)
+        self.assertEqual(outcome.skipped_reason, "no_matching_operator_action")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #161

## ✨ 과제 내용

### 배경
지금까지 `#승인-대기` 채널은 **approval-only** 였다. 그래서:
- 승인 필요한 작업인데 카드/요청이 안 올라오고 조용히 멈출 수 있었다
- 비승인 작업이라도 **서버 IP / SSH 자격 / 실제 secret 값** 같은 외부 정보가 필요할 때 사용자 응답 surface 가 부족했다

본 PR 은 `#승인-대기` 를 **operator action inbox** 로 확장한다. 5 가지 request_type 을 지원:

| request_type | 의미 | 세션 sub-state | approval_kind |
| --- | --- | --- | --- |
| `APPROVAL_REQUIRED` | write/push/PR/merge/deploy 같은 **승인** | `waiting_approval` | 기존 vocabulary |
| `INFO_REQUIRED` | 서버 IP, 도메인, 운영 사실 | `waiting_user_input` | `info_request` |
| `ACCESS_REQUIRED` | SSH/서버 접근/repo access | `waiting_access` | `access_request` |
| `SECRET_REQUIRED` | 실제 secret 값/저장 위치 | `waiting_secret` | `secret_request` |
| `DECISION_REQUIRED` | 정책/제품 판단 (단순 기술 선택은 금지) | `waiting_user_input` | `decision_request` |

### 핵심 원칙
- **agent 자율 판단**: JWT vs session, 기본 DB 이름, Docker Compose 구조, Next/Nest 연결, auth/API 구조, 디렉터리 구조, 일반 기술 선택
- **사람 응답 필수**: 실제 서버 IP / hostname, SSH user/key, 실제 도메인, 실제 secret 값, 운영 DB/Redis/API endpoint, 클라우드 계정 식별자
- **사람 응답이 필요할 때 카드 없이 멈추는 것 금지** (`_DEFAULT_SAFETY_RULES` + docs §6.5)

### Secret hard rails
agent 자동 가능: secret 키 **이름** 정의, `.env.example` / compose / CI wiring, GitHub Actions secret 이름 제안

agent 절대 금지: 실제 secret 값 임의 생성/저장/수정, prod `.env` 직접 변경, 기존 secret 다른 위치 mirror

`SECRET_REQUIRED` 카드 thread 에 raw 값 (`secret_value=`, `value=`, `raw_value=`) 을 붙이면 reply parser 가 **명시적으로 거부** (`RESPONSE_OPERATOR_SECRET_VALUE_REJECTED`).

### 4 commit 구성
1. **🚀 OperatorActionRequest 모델 + 카드 렌더 도입** — pure 모델 (`agents/operator_action.py`)
2. **🔧 ApprovalWorker 가 operator action 카드 렌더/리플라이 처리** — kind 4종 추가, render 분기, `operator_action_reply.py`
3. **🔧 reply_router 가 operator action 카드를 우선 dispatch** — `key=value` 어휘를 일반 approval 파서 전에 처리
4. **🛡 기술 자율 vs 외부 사실 경계 가드 + docs §6 + 회귀 테스트** — `classify_user_request_facts`, docs §6 신설, 52 신규 테스트

### Operator action inbox 흐름

```
producer (코드)
   └─ OperatorActionRequest 빌드
   └─ operator_action_to_approval_payload(...)
   └─ ApprovalWorker.run_one(ApprovalRequest)
        └─ #승인-대기 채널에 카드 게시 (render_operator_action_card)
        └─ session.extra['operator_state'] = waiting_*

operator (채널)
   └─ 카드 thread 에서 `key=value` 응답
        └─ route_approval_channel_message
        └─ find_pending_operator_action_for_reply (operator-action 카드 우선)
        └─ handle_operator_action_reply
            └─ parse_operator_action_reply (필수 키 + secret 가드)
            └─ stamp_answered_request → operator_state = running
        └─ RESPONSE_OPERATOR_*_OK 게시
```

### 회귀 / 한계
- 기존 obsidian_write / pr_merge / engineering_write 흐름 100% 유지 (operator-action 카드가 없을 때만 fallback). 전체 회귀 3545 tests pass.
- 본 PR 은 **inbox 의 receiver 측** 만 land. 실제 producer (어떤 코드가 INFO/ACCESS/SECRET 카드를 enqueue 할지) wiring 은 후속 PR. 후속에서 `coding_execute_dispatcher` / `coding_executor_worker` 가 dispatch 직전 `classify_user_request_facts` 를 호출해 카드 자동 enqueue.
- Discord 카드의 thread/reply ↔ workflow_state.extra 영속화는 best-effort (load/update fn 주입 가능). 실 channel reply 가 들어오면 `_default_load_session` 으로 SQLite 캐시 업데이트.

## 📚 레퍼런스
- `docs/approval-matrix.md` §6 (신설) — 5 request_type / 자율 vs 외부 사실 경계 표 / SECRET hard rails / 카드 필수 필드
- `src/yule_orchestrator/agents/operator_action.py`
- `src/yule_orchestrator/agents/job_queue/operator_action_reply.py`
- `src/yule_orchestrator/agents/job_queue/approval_worker.py` (render 분기)
- `src/yule_orchestrator/discord/approval/reply_router.py`
- `src/yule_orchestrator/agents/coding/authorization.py` (자율/사람 경계 export)