### PR TITLE
📃 md 문서 계층/우선순위 + 파일 분리(700/1000줄) 규칙 명문화 (closes #163)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,95 @@
-# Yule Studio Agent
+# Yule Studio Agent — 문서 내비게이션
 
-This file provides Codex context for this repository.  
-(이 파일은 Codex가 이 레포지토리의 작업 맥락을 이해하기 위한 컨텍스트 파일이다)
+이 파일은 Codex/Claude/Gemini 같은 외부 에이전트와 사용자가 **이 레포에서
+어떤 문서를 언제 읽어야 하는지** 한 화면에 정리한 진입점이다. 상세 규칙
+자체는 본문 markdown 들이 책임지고, 본 파일은 "어디를 봐야 하는지" 만
+알려준다.
 
-Shared project rules are defined in `CLAUDE.md`.  
-(공통 프로젝트 규칙은 `CLAUDE.md`에 정의되어 있다)
+> 핵심 원칙
+> - **Codex/Claude 는 매번 모든 md 를 읽는다고 가정하지 않는다.**
+> - **자주 강제해야 하는 규칙은 상위 문서 (root `CLAUDE.md`) 에 둔다.**
+> - **세부적인 도메인 규칙은 작업 맥락에서만 읽히는 하위 문서에 둔다.**
+>
+> 이 가정 아래 본 진입점은 항상 짧게 유지한다.
 
-## Codex Role
-- Treat Codex as an advisor, reviewer, and patch proposer by default unless a task explicitly assigns it as an executor.  
-  (작업에서 명시적으로 executor 역할을 부여하지 않는 한, Codex는 기본적으로 advisor, reviewer, patch proposer로 동작한다)
+## 1. 문서 계층 (high → low specificity)
 
-- Prefer code review, implementation risk analysis, test-focused feedback, and patch suggestions.  
-  (코드 리뷰, 구현 위험 분석, 테스트 중심 피드백, 패치 제안을 우선한다)
+```
+AGENTS.md ─── 진입점 / 어떤 문서를 언제 볼지 안내 (지금 이 파일)
+    │
+    ├── CLAUDE.md ─────────── 전역 공통 규칙 (모든 에이전트/모든 작업)
+    │
+    └── agents/<agent>/
+            ├── CLAUDE.md ──── 에이전트 전용 규칙 + 작업 맥락별 세부 문서 안내
+            ├── CODE_LAYOUT.md ── 모듈 책임 / ownership / 파일 분리 기준
+            └── (도메인 정책)
 
-- Do not modify files, run destructive commands, or access secrets unless explicitly approved by the user.  
-  (사용자의 명시적 승인 없이 파일 수정, 파괴적 명령 실행, secret 접근을 하지 않는다)
+policies/
+    ├── reference/   ── BRANCH / COMMIT / NAMING 같은 참조 규칙
+    └── runtime/     ── 에이전트별 운영 정책 (governance / mvp-scope / …)
 
-- When working on the Engineering Agent, follow `agents/engineering-agent/agent.json` and the relevant policy files if they exist.  
-  (Engineering Agent 작업 시 `agents/engineering-agent/agent.json`과 관련 정책 파일이 존재하면 이를 따른다)
+docs/
+    ├── operations.md / approval-matrix.md / autonomy-policy.md  ── 운영/승인
+    ├── architecture.md / engineering.md / planning.md           ── 아키텍처
+    └── 그 외 토픽별 가이드 (ci-* / discord / memory / testing …)
+```
 
-- Do not treat `.codex/` as shareable project policy. It is local runtime configuration and should stay ignored by Git.  
-  (`.codex/`를 공유 프로젝트 정책으로 다루지 않는다. 이는 로컬 실행 설정이며 Git에서 무시되어야 한다)
+## 2. 읽기 우선순위 — "어떤 작업이면 어떤 문서를 보는가"
+
+| 거의 항상 읽는다 | 1. `AGENTS.md` (이 파일) |
+|---|---|
+|   | 2. root `CLAUDE.md` — 전역 안전 / 코딩 컨벤션 / 파일 크기 규칙 |
+
+작업 맥락이 정해진 다음 추가로 읽는 문서:
+
+| 작업 맥락 | 우선 읽을 문서 |
+| --- | --- |
+| engineering-agent 전반 | `agents/engineering-agent/CLAUDE.md` |
+| 코드 구조 / 리팩터링 / 모듈 분할 | `agents/engineering-agent/CODE_LAYOUT.md` |
+| 브랜치 / 커밋 / PR / 네이밍 | `policies/reference/{BRANCH_STRATEGY,COMMIT_CONVENTION,NAMING_CONVENTION}.md` |
+| 승인 / 자율 / hard rail | `docs/approval-matrix.md`, `docs/autonomy-policy.md` |
+| 운영 / 배포 / 상태 / 업타임 | `docs/operations.md`, `docs/configuration.md` |
+| Discord / forum / member-bot | `docs/discord.md`, `docs/runtime-member-bot-dispatch-parity.md` |
+| 거버넌스 / Obsidian write ownership | `docs/engineering-agent-governance.md` (+ `policies/runtime/agents/engineering-agent/*`) |
+| 테스트 작성 / 회귀 가이드 | `docs/testing.md` |
+
+규칙:
+- 위 표에 없는 토픽이면 그 작업과 가장 가까운 디렉터리의 `CLAUDE.md`,
+  그 다음 `docs/<topic>.md` 순으로 찾는다.
+- 같은 의미의 규칙이 두 문서에 있으면 **상위 문서가 우선**한다 (`CLAUDE.md`
+  ≻ agent-specific `CLAUDE.md` ≻ `CODE_LAYOUT.md` ≻ `policies/reference`).
+- 새 규칙을 추가할 때는 "자주 강제해야 하면 상위, 도메인 한정이면 하위" 를
+  지켜 같은 규칙이 여러 문서에 흩어지지 않게 한다.
+
+## 3. 외부 에이전트별 역할 안내
+
+### Codex (이 파일이 진입점)
+- 기본은 **advisor / reviewer / patch proposer**. executor 역할은 작업이
+  명시할 때만.
+- 코드 리뷰, 구현 위험 분석, 테스트 중심 피드백, 패치 제안을 우선한다.
+- 사용자의 명시적 승인 없이 파일 수정, 파괴적 명령 실행, secret 접근을
+  하지 않는다.
+- engineering-agent 작업 시 `agents/engineering-agent/agent.json` 과
+  관련 정책 파일이 존재하면 이를 따른다.
+- `.codex/` 는 로컬 실행 설정이며 공유 정책으로 다루지 않는다.
+
+### Claude (Claude Code / API)
+- root `CLAUDE.md` + 작업 맥락의 agent `CLAUDE.md` 가 일차 컨텍스트.
+- 작업이 코드 구조 변경을 동반하면 `agents/engineering-agent/CODE_LAYOUT.md`
+  를 함께 읽는다.
+
+### Gemini CLI
+- 기본은 **advisor**. 분석 / 요구사항 검토 / 긴 맥락 검토 / 계획 보조 우선.
+- 자세한 역할 컨텍스트는 [`GEMINI.md`](GEMINI.md) 참고.
+
+## 4. 변경 시 반드시 동기화할 것
+
+새 md 를 추가하거나 핵심 규칙을 옮기면 다음을 같이 갱신한다:
+
+- 이 파일의 §2 표 (작업 맥락 → 문서 매핑)
+- root `CLAUDE.md` 의 "읽기 우선순위 / 코딩 컨벤션" 섹션
+- 영향받는 agent 의 `CLAUDE.md`
+- 영향받는 모듈의 `CODE_LAYOUT.md`
+
+> 같은 규칙이 여러 문서에 중복되면 일부만 갱신돼 silently 어긋난다.
+> 한 곳에만 두고 나머지는 cross-link 한다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,98 @@
-# Yule Studio Agent
+# Yule Studio Agent — 전역 규칙
+
+> 진입점은 [`AGENTS.md`](AGENTS.md). 본 파일은 **모든 에이전트 / 모든 작업
+> 에 적용되는 전역 공통 규칙** 만 둔다. 도메인 한정 규칙은
+> `agents/<agent>/CLAUDE.md` 또는 `docs/<topic>.md` 에 둔다.
 
 ## Purpose
-This repository is a personal agent platform for managing the user's GitHub projects, issues, documents, and workflows across multiple repositories.  
-(이 레포지토리는 여러 GitHub 프로젝트의 이슈, 문서, 작업 흐름을 관리하기 위한 개인 에이전트 플랫폼이다)
-
-Current priority:
-- Build the `engineering-agent` MVP.  
-  (현재는 `engineering-agent` MVP 개발에만 집중한다)
+이 레포지토리는 여러 GitHub 프로젝트의 이슈, 문서, 작업 흐름을 관리하는
+**개인 에이전트 플랫폼**이다. 현재 우선순위는 `engineering-agent` MVP.
 
 ## Platform Direction
-- This repository will host multiple specialized agents.  
-  (이 레포는 여러 개의 역할별 전문 에이전트를 포함하는 플랫폼으로 구성한다)
-
-- Each agent must have a clear and focused responsibility.  
-  (각 에이전트는 명확하고 좁은 책임 범위를 가져야 한다)
-
-- Do not mix responsibilities across agents unless explicitly required.  
-  (명시적인 필요가 없으면 에이전트 간 책임을 섞지 않는다)
-
-- Shared principles are defined in this root `CLAUDE.md`.  
-  (공통 원칙은 루트 `CLAUDE.md`에서 정의한다)
-
-- Agent-specific rules must be defined in each agent directory's `CLAUDE.md`.  
-  (에이전트별 세부 규칙은 각 에이전트 디렉터리의 `CLAUDE.md`에서 정의한다)
+- 이 레포는 여러 역할별 전문 에이전트를 포함하는 플랫폼이다.
+- 각 에이전트는 **명확하고 좁은 책임 범위** 를 가진다.
+- 명시적 필요가 없으면 에이전트 간 책임을 섞지 않는다.
+- 공통 원칙은 본 파일 (root `CLAUDE.md`).
+- 에이전트별 세부 규칙은 각 에이전트 디렉터리의 `CLAUDE.md`.
+- 모듈 책임 / 파일 분리 기준은 각 에이전트 디렉터리의 `CODE_LAYOUT.md`.
 
 ## Core Safety Rules
-- Never commit secrets, credentials, private keys, or local runtime state.  
-  (비밀 정보, 인증 정보, 개인 키, 로컬 실행 상태는 절대 커밋하지 않는다)
+- **secret / 자격 정보 / 개인 키 / 로컬 runtime state 절대 커밋 금지.**
+- **파괴적 명령 / 프로덕션 배포 / 민감 자격 접근 전 사람 승인 필수.**
+- 자동 결정의 자율 등급 / 승인 매트릭스는 [`docs/autonomy-policy.md`](docs/autonomy-policy.md),
+  [`docs/approval-matrix.md`](docs/approval-matrix.md) 가 SSoT.
 
-- Human approval is required before destructive commands, production deployments, or secret access.  
-  (파괴적 명령, 프로덕션 배포, 민감한 인증 정보 접근 전에는 반드시 사람의 승인이 필요하다)
+## Operator Action Inbox
+사람 응답이 필요한 모든 순간은 `#승인-대기` 카드로 표면화한다 — 조용히
+멈추는 것 금지. 5 가지 request_type (APPROVAL/INFO/ACCESS/SECRET/DECISION)
+는 [`docs/approval-matrix.md`](docs/approval-matrix.md) §6 참조.
+
+## 읽기 우선순위 (요약)
+| 항상 | `AGENTS.md` → 본 파일 |
+| --- | --- |
+| 코드 구조 작업 | + `agents/<agent>/CLAUDE.md` + `agents/<agent>/CODE_LAYOUT.md` |
+| 브랜치/커밋/PR | + `policies/reference/*` |
+| 승인/운영 | + `docs/autonomy-policy.md` / `docs/approval-matrix.md` / `docs/operations.md` |
+
+전체 매핑은 `AGENTS.md` §2.
+
+## 전역 코딩 컨벤션 (요약)
+
+> 본 섹션은 **자주 강제해야 하는** 항목만 둔다. 도메인 한정 규칙은
+> 각 `CODE_LAYOUT.md` / `policies/reference/*` 에 위임한다.
+
+### 파일 크기 / 책임 분리
+- **700 줄 초과** → 책임 분리 검토 warning. PR 본문에 "왜 한 파일에
+  남겨야 하는지" 적지 않으면 검토자가 분리를 요청해도 됨.
+- **1000 줄 초과** → 기본적으로 분리 대상.
+- **1000 줄 초과 + 책임 2개 이상** → 분리 필수 (별도 PR 또는 동일 PR
+  의 첫 commit 으로).
+- 예외 (아래 중 하나면 분리 미루기 가능):
+  - generated file (`*.pb.py` / `_pb2.py` 같은 코드 생성물)
+  - fixture / snapshot / test data
+  - 큰 registry / mapping 성격 파일 (선언만 있고 분기 로직 없음)
+  - in-flight refactor 중인 `_legacy.py` 등 명시적 임시 파일
+- 예외를 적용할 때는 해당 파일 상단 docstring 또는 모듈 옆
+  `CODE_LAYOUT.md` 에 **이유** 를 남긴다.
+
+### 책임 분리 신호
+다음이 한 파일에서 동시에 보이면 분리 후보다 — 길이보다 우선한다.
+
+- intake / intent classification / routing / state persistence /
+  formatting / external integration 중 **3 가지 이상** 이 한 파일에 섞임
+- 같은 phrase / regex 가 여러 함수에서 반복 patch 됨
+- 한 함수가 다른 도메인의 dataclass 를 직접 mutate
+- "임시" / "TODO" / "FIXME" 가 같은 파일에 5개 이상 누적
+
+### 모듈 형태
+- `router` 는 **얇은 orchestration** 으로 유지 — 토큰 점수 / 캐시 read-write /
+  collector 는 다른 모듈에 위임.
+- `conversation` 은 **intent / response shaping** 중심.
+- 도메인 로직 (deliberation / report 작성 / vault write) 은 자체 모듈.
+- 같은 도메인의 helper 가 늘면 패키지 (`<name>/__init__.py`) 로 승격.
+
+### Commit / PR / 브랜치
+- 한국어 commit 메시지 + gitmoji 1개 + `변경 이유 / 주요 변경 사항 / 비고`
+  3 섹션. 자세한 형식은 [`policies/reference/COMMIT_CONVENTION.md`](policies/reference/COMMIT_CONVENTION.md).
+- PR 1 개당 **최소 3 commit** 으로 논리 분할. squash 는 docs-only 1-commit
+  chore 에만.
+- 브랜치 / 라벨 / assignee 규칙은 [`policies/reference/BRANCH_STRATEGY.md`](policies/reference/BRANCH_STRATEGY.md) +
+  [`docs/engineering-agent-governance.md`](docs/engineering-agent-governance.md).
+
+### 테스트
+- 새 기능 추가 시 **새 테스트** 우선 작성. 기존 테스트가 다 통과하는데
+  새 회귀 라인이 비어있으면 PR 검토 거부.
+- 회귀 라인이 어느 디렉터리에 떨어져야 하는지는 각 `CODE_LAYOUT.md` 의
+  "tests/ 매핑" 표 참조.
+- 자세한 테스트 가이드는 [`docs/testing.md`](docs/testing.md).
+
+## 동기화 규칙
+새 규칙을 추가하거나 옮기면 다음 중 영향받는 곳만 갱신한다 (중복 회피).
+
+- `AGENTS.md` §2 표 — 작업 맥락 → 문서 매핑이 바뀌면
+- 본 파일의 "읽기 우선순위" / "코딩 컨벤션" 요약 — 전역 규칙이 추가되면
+- `agents/<agent>/CLAUDE.md` — 도메인 한정 규칙이면
+- `agents/<agent>/CODE_LAYOUT.md` — 모듈 책임 / 파일 분리 기준이 바뀌면
+
+> 같은 규칙을 두 곳에 복제하면 한쪽만 갱신돼 silently 어긋난다. 한 곳에만
+> 두고 나머지는 cross-link.

--- a/agents/engineering-agent/CLAUDE.md
+++ b/agents/engineering-agent/CLAUDE.md
@@ -1,5 +1,9 @@
 # Engineering Agent (Engineering Department)
 
+> 진입점은 [`/AGENTS.md`](../../AGENTS.md), 전역 규칙은 [`/CLAUDE.md`](../../CLAUDE.md).
+> 본 파일은 **engineering-agent 작업 시에만** 추가로 읽는 도메인 규칙을 둔다.
+> 작업 맥락별 세부 문서 안내는 §"작업 맥락별 읽기 가이드" 참고.
+
 ## Position In Organization
 Engineering Agent는 향후 도입될 **CTO 조직**의 기술 실행 부서다. 현재는 CTO 에이전트가 아직 만들어지지 않았으므로, 외부 인터페이스인 `planning-agent`와 사용자 그리고 추후 `orchestrator-agent`로부터 직접 작업 요청을 받는다.
 
@@ -72,3 +76,54 @@ Engineering Agent는 **엔지니어링 부서의 게이트웨이**다. 외부에
 - 멤버 5명의 역할/책임/입출력 계약 문서 ✅ (현재 단계)
 - 부서 게이트웨이 정의 ✅ (현재 단계)
 - LLM 러너 추상화, 디스패처, 멀티봇 Discord 통합 → 다음 마일스톤
+
+## 작업 맥락별 읽기 가이드
+
+> 매번 모든 문서를 읽지 않는다. 작업 맥락이 정해지면 본 표에서 해당 행만
+> 추가로 읽는다. 같은 규칙이 두 문서에 있으면 더 상위 문서가 우선
+> ( `/CLAUDE.md` ≻ 본 파일 ≻ `CODE_LAYOUT.md` ≻ `policies/reference/*` ).
+
+| 작업 맥락 | 추가로 읽을 문서 | 비고 |
+| --- | --- | --- |
+| 모듈 책임 / 파일 분리 / 리팩터링 | [`CODE_LAYOUT.md`](CODE_LAYOUT.md) | lifecycle stage → 책임 모듈 매핑 + 700/1000줄 분리 규칙 |
+| Discord routing (engineering_channel_router) | [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"Discord 라우팅 모듈 책임 정리" | router 가 가져도 되는 책임 / 가지면 안 되는 책임 |
+| Engineering conversation (intent / response) | [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"Discord 라우팅 모듈 책임 정리" | router vs conversation 분리 신호 |
+| Runtime / always-on / job_queue | [`/docs/operations.md`](../../docs/operations.md), [`/docs/runtime-recall-first.md`](../../docs/runtime-recall-first.md), [`/docs/runtime-member-bot-dispatch-parity.md`](../../docs/runtime-member-bot-dispatch-parity.md) | runtime / supervisor / heartbeat |
+| 승인 / 자율 / 카드 | [`/docs/approval-matrix.md`](../../docs/approval-matrix.md), [`/docs/autonomy-policy.md`](../../docs/autonomy-policy.md), [`/docs/pr-approval-merge.md`](../../docs/pr-approval-merge.md) | request_type 5종 / autonomy ladder L0-L4 |
+| Obsidian / vault / write ownership | [`/docs/engineering-agent-governance.md`](../../docs/engineering-agent-governance.md), [`policies/runtime/agents/engineering-agent/obsidian-governance.md`](../../policies/runtime/agents/engineering-agent/obsidian-governance.md) | 3-mode 결정 트리 / 7 role × surface |
+| Issue / PR / branch / commit | [`/docs/engineering-agent-governance.md`](../../docs/engineering-agent-governance.md), [`policies/runtime/agents/engineering-agent/github-workflow.md`](../../policies/runtime/agents/engineering-agent/github-workflow.md), [`policies/reference/COMMIT_CONVENTION.md`](../../policies/reference/COMMIT_CONVENTION.md), [`policies/reference/BRANCH_STRATEGY.md`](../../policies/reference/BRANCH_STRATEGY.md), [`policies/reference/NAMING_CONVENTION.md`](../../policies/reference/NAMING_CONVENTION.md) | 라벨 / assignee / commit 분리 / kickoff |
+| Research / collector / role-take | [`/docs/research-budget.md`](../../docs/research-budget.md), [`/docs/role-knowledge-feeds.md`](../../docs/role-knowledge-feeds.md) | 활성 role 기반 research budget |
+| Lifecycle (intake → work_report) | [`LIFECYCLE.md`](LIFECYCLE.md) | 12 stage 정의 |
+| 테스트 작성 | [`/docs/testing.md`](../../docs/testing.md), [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"tests/ 매핑" | 어느 디렉터리에 어떤 테스트가 떨어져야 하는지 |
+| Discord member-bot / dispatcher | [`/docs/discord.md`](../../docs/discord.md), [`/docs/runtime-member-bot-dispatch-parity.md`](../../docs/runtime-member-bot-dispatch-parity.md) | bot.py / member_bot 진입부 |
+| Configuration / env / CI 알림 | [`/docs/configuration.md`](../../docs/configuration.md), [`/docs/ci-discord-notifications.md`](../../docs/ci-discord-notifications.md) | env 변수 / CI 알림 채널 |
+
+## 코딩 작업 시 강제 규칙 (engineering-agent 특화)
+
+전역 규칙은 [`/CLAUDE.md`](../../CLAUDE.md). 본 섹션은 engineering 코드 작업 시
+**추가로** 강제할 항목.
+
+- **router 는 얇게.** `discord/engineering_channel_router/` 의 어떤 모듈도
+  토큰 점수 / 캐시 / collector 호출을 직접 수행하지 않는다 — 위임 대상은
+  [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"Discord 라우팅 모듈 책임 정리" 참조.
+- **lifecycle stage 마다 ownership 모듈이 있다.** 새 책임을 추가할 때는
+  먼저 [`CODE_LAYOUT.md`](CODE_LAYOUT.md) 표를 보고 어디에 들어갈지 결정한다.
+  적합한 모듈이 없으면 신규 모듈 신설 (한 파일에 우겨넣지 않음).
+- **engineering_team_runtime / engineering_conversation / research/collector 같은
+  대형 패키지** 는 의미 그룹별 sub-module 로 분해한다. 700줄 warning /
+  1000줄 split 규칙 ( `/CLAUDE.md` ) 이 그대로 적용.
+- **회귀 테스트 우선.** 코드 변경마다 `tests/engineering/` 또는
+  `tests/discord/` 의 해당 lifecycle 테스트 추가/갱신. 자세한 매핑은
+  [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"tests/ 매핑".
+
+## 멤버별 세부 규칙
+
+각 역할 멤버의 책임 / 입출력 계약은 자기 폴더의 `CLAUDE.md`:
+
+- [`tech-lead/CLAUDE.md`](tech-lead/CLAUDE.md)
+- [`backend-engineer/CLAUDE.md`](backend-engineer/CLAUDE.md)
+- [`frontend-engineer/CLAUDE.md`](frontend-engineer/CLAUDE.md)
+- [`product-designer/CLAUDE.md`](product-designer/CLAUDE.md)
+- [`qa-engineer/CLAUDE.md`](qa-engineer/CLAUDE.md)
+- [`devops-engineer/CLAUDE.md`](devops-engineer/CLAUDE.md)
+- [`ai-engineer/CLAUDE.md`](ai-engineer/CLAUDE.md)

--- a/agents/engineering-agent/CODE_LAYOUT.md
+++ b/agents/engineering-agent/CODE_LAYOUT.md
@@ -2,6 +2,10 @@
 
 이 문서는 engineering-agent lifecycle 의 각 단계가 어느 모듈에서 책임지는지 빠르게 찾기 위한 지도입니다. 코드 변경 전에 "이 책임이 어디에 있어야 하지?" 를 먼저 확인하는 용도이고, 큰 rename / 분할은 별도 브랜치로 진행합니다.
 
+> 본 문서는 **engineering-agent 모듈 ownership + 파일 분리 기준** 의 SSoT.
+> 전역 코딩 컨벤션 요약은 [`/CLAUDE.md`](../../CLAUDE.md), 작업 맥락별 읽기
+> 가이드는 [`CLAUDE.md`](CLAUDE.md) §"작업 맥락별 읽기 가이드" 참조.
+
 ## Lifecycle stages → 책임 모듈
 
 | stage | module(s) | 핵심 함수 / 클래스 |
@@ -60,6 +64,85 @@
 - `engineering_channel_router.py` 가 4k LOC 를 넘는다 → forum publishing / status helpers 추출 검토
 - `agents/research_collector.py` 가 다중 provider 어댑터를 다 품게 됨 → `agents/research/` 패키지로 분할 검토
 - session.extra dict 의 키가 30 개를 넘는다 → 명명규약 + nested namespace 도입 검토 (`session.extra['research'] = {...}`)
+
+## 파일 크기 / 책임 분리 규칙
+
+> 길이보다 더 중요한 것은 **책임 수** 다. 단, 1000 줄은 강한 분리 신호다.
+> 본 규칙은 [`/CLAUDE.md`](../../CLAUDE.md) §"전역 코딩 컨벤션" 의 engineering-agent
+> 측 적용 가이드.
+
+### 등급별 액션
+
+| LOC | 액션 | 비고 |
+| --- | --- | --- |
+| ~700 | 안전 | — |
+| 700 ~ 1000 | **warning** — 분리 검토 | PR 본문에 "왜 한 파일에 남기나" 한 줄 적기. 검토자가 분리 요청 가능 |
+| 1000 초과 | **default split** | 별도 브랜치 또는 같은 PR 의 첫 commit 으로 분리 |
+| 1000 초과 + 책임 2개 이상 | **분리 필수** | 분리 없이 머지하지 않음 |
+
+### 책임 분리 신호
+
+다음이 한 파일에서 동시에 보이면 길이와 무관하게 분리 후보:
+
+- intake / intent classification / routing / state persistence / formatting /
+  external integration 중 **3 가지 이상** 이 한 파일에 섞임
+- 같은 phrase / regex 패턴이 여러 함수에서 반복 patch 됨 ("phrase patch
+  반복 파일")
+- 한 함수가 다른 도메인의 dataclass 를 직접 mutate
+- "임시" / "TODO" / "FIXME" 가 같은 파일에 5 개 이상 누적
+- 한 파일의 import top-level 이 30 줄을 초과
+
+### 분리 방식
+
+| 상황 | 권장 분리 방식 |
+| --- | --- |
+| 모듈이 한 도메인 + 여러 helper 로 커짐 | 같은 패키지 안의 sub-module 로 추출 (`foo/__init__.py` + `foo/<sub>.py`) |
+| 여러 도메인이 섞임 | 도메인별 모듈로 분할 후 패키지화 |
+| 모놀리스 → 점진 분해 중 | 임시 `_legacy.py` 사용 (파일 상단에 분해 플랜 docstring 필수) |
+| 큰 registry / data table | 분리 대신 데이터/로직 분리 (`_data.py` + `_logic.py`) |
+
+### 예외 정책
+
+다음은 분리 미루기 가능. 단, **이유 docstring 필수**:
+
+- generated file (`*.pb.py`, `*_pb2.py` 등 코드 생성물)
+- fixture / snapshot / test data
+- 큰 registry / mapping 성격 파일 (선언만, 분기 로직 없음)
+- in-flight refactor 중인 `_legacy.py` (해체 진행 중인 모놀리스)
+
+예외를 적용한 파일은 본 문서의 "현재 예외" 표에 추가:
+
+#### 현재 예외 (in-flight refactor 등)
+
+| 파일 | LOC | 이유 |
+| --- | --- | --- |
+| `src/yule_orchestrator/discord/bot/_legacy.py` | ~2700 | P0-Q discord/ 분해 진행 중 — 의미 그룹 추출 후 점진 제거 |
+| `src/yule_orchestrator/discord/engineering_team_runtime/_legacy.py` | ~2150 | P0-Q discord/ 분해 진행 중 — 같은 사이클 |
+| `src/yule_orchestrator/runtime/status.py` | ~2000 | 라이브 상태 표면화 — 도메인 단일, 단계별 helper 추출 후속 작업 |
+| `src/yule_orchestrator/agents/research/collector.py` | ~2400 | 다중 provider adapter — `agents/research/<provider>` 패키지화 후속 |
+| `src/yule_orchestrator/agents/deliberation.py` | ~1750 | TechLead 합의 단일 도메인 — open_research/synthesis 분리 검토 |
+
+새 파일이 1000 줄을 넘었는데 위에 없으면 분리 PR 을 먼저 띄우거나,
+이 표에 이유와 함께 추가해야 한다. silently 자라는 것을 막기 위함.
+
+### Router / conversation / runtime 의 별도 가드
+
+| 영역 | 한도 신호 |
+| --- | --- |
+| `discord/engineering_channel_router/main.py` | 1000 줄 근처가 되면 forum publishing / status helper / preflight 추출 |
+| `discord/engineering_conversation/research_bootstrap.py` | 1000 줄 근처가 되면 intent / formatter / bootstrap 분리 |
+| `agents/research/collector.py` | provider 어댑터별 sub-module 로 패키지화 |
+| `agents/deliberation.py` | open_research / synthesis 별 sub-module |
+
+### 자동 점검 훅과의 관계
+
+- 정책 / 프롬프트 / 템플릿 크기는 [`tests/governance/test_prompt_size_ceiling.py`](../../tests/governance/test_prompt_size_ceiling.py)
+  가 단일 파일 / 전체 preamble / `.tmpl` ceiling 을 강제.
+- 본 문서의 1000 줄 규칙은 governance smoke test
+  [`tests/engineering/test_engineering_agent_governance_doc.py`](../../tests/engineering/test_engineering_agent_governance_doc.py)
+  의 docstring 검증 라인이 핵심 섹션 존재를 지킨다.
+- 위 두 자동 가드와 본 규칙은 **상호 보완** — ceiling 은 토큰/회귀
+  보호, 본 규칙은 책임 분리 보호.
 
 ## Phase 1-5 변경 요약 (이 문서가 만들어진 배경)
 

--- a/tests/governance/test_docs_hierarchy.py
+++ b/tests/governance/test_docs_hierarchy.py
@@ -1,0 +1,234 @@
+"""Lint-style smoke test — 문서 계층 / 읽기 우선순위 / 파일 분리 규칙.
+
+본 test 는 다음 정책의 *contract* 자체를 강제한다. 통과 = 문서 계층이
+살아있다는 뜻.
+
+검사 대상:
+  * `AGENTS.md`              — 진입점 / 작업 맥락 → 문서 매핑 표
+  * `CLAUDE.md`              — 전역 규칙 / 코딩 컨벤션 / 1000줄 분리 규칙
+  * `agents/engineering-agent/CLAUDE.md`     — 작업 맥락별 읽기 가이드
+  * `agents/engineering-agent/CODE_LAYOUT.md` — 700/1000줄 분리 + 책임 신호
+
+핵심 회귀 라인이 silently 사라지면 fail. 같은 규칙이 여러 문서에
+중복돼 한쪽만 갱신되는 사고를 가장 먼저 잡아낸다.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    path = _REPO_ROOT / rel
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path.read_text(encoding="utf-8")
+
+
+class AgentsEntryPointTests(unittest.TestCase):
+    """`AGENTS.md` 가 진입점 + 문서 매핑 표 + 외부 에이전트 안내를 가짐."""
+
+    def setUp(self) -> None:
+        self.text = _read("AGENTS.md")
+
+    def test_navigation_section_present(self) -> None:
+        for needle in (
+            "문서 내비게이션",
+            "문서 계층",
+            "읽기 우선순위",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_does_not_assume_all_docs_read(self) -> None:
+        # 핵심 가정 — 매번 모든 md 를 읽는다고 가정하지 않는다.
+        self.assertIn("매번 모든 md 를 읽는다고 가정하지 않는다", self.text)
+
+    def test_priority_table_links_root_claude_md(self) -> None:
+        # 항상 읽는 두 문서 명시
+        self.assertIn("`AGENTS.md`", self.text)
+        self.assertIn("CLAUDE.md", self.text)
+
+    def test_codex_role_section_present(self) -> None:
+        # 기존 Codex 역할 안내가 합쳐졌는지 확인 (안전 가드)
+        for needle in (
+            "advisor",
+            "patch proposer",
+            ".codex/",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_cross_links_to_engineering_agent(self) -> None:
+        # engineering-agent 도메인 진입 경로
+        self.assertIn("agents/engineering-agent/CLAUDE.md", self.text)
+        self.assertIn("agents/engineering-agent/CODE_LAYOUT.md", self.text)
+
+    def test_synchronization_note_present(self) -> None:
+        # 새 규칙 추가 시 동기화 안내
+        self.assertIn("동기화", self.text)
+
+
+class RootClaudeMdTests(unittest.TestCase):
+    """root `CLAUDE.md` 가 전역 규칙 + 코딩 컨벤션 + 1000 줄 규칙을 가짐."""
+
+    def setUp(self) -> None:
+        self.text = _read("CLAUDE.md")
+
+    def test_purpose_and_platform_direction_kept(self) -> None:
+        # 기존 안전 룰이 회귀 없이 살아있는지
+        self.assertIn("Purpose", self.text)
+        self.assertIn("Platform Direction", self.text)
+        self.assertIn("Core Safety Rules", self.text)
+        self.assertIn("secret", self.text)
+        self.assertIn("파괴적 명령", self.text)
+
+    def test_reading_priority_summary_present(self) -> None:
+        self.assertIn("읽기 우선순위", self.text)
+
+    def test_coding_convention_summary_present(self) -> None:
+        self.assertIn("전역 코딩 컨벤션", self.text)
+        self.assertIn("파일 크기", self.text)
+
+    def test_file_size_thresholds_present(self) -> None:
+        # 700 줄 warning + 1000 줄 split 두 임계값 모두 명시
+        self.assertIn("700", self.text)
+        self.assertIn("1000", self.text)
+
+    def test_responsibility_split_signal_present(self) -> None:
+        self.assertIn("책임 분리 신호", self.text)
+
+    def test_router_thin_principle_present(self) -> None:
+        self.assertIn("router", self.text)
+        self.assertIn("얇은 orchestration", self.text)
+
+    def test_commit_pr_branch_links(self) -> None:
+        # 도메인 한정 규칙은 cross-link
+        self.assertIn("policies/reference/COMMIT_CONVENTION.md", self.text)
+        self.assertIn("policies/reference/BRANCH_STRATEGY.md", self.text)
+
+    def test_operator_action_inbox_present(self) -> None:
+        self.assertIn("Operator Action Inbox", self.text)
+        self.assertIn("approval-matrix", self.text)
+
+
+class EngineeringAgentClaudeMdTests(unittest.TestCase):
+    """`agents/engineering-agent/CLAUDE.md` 가 작업 맥락별 읽기 가이드를 가짐."""
+
+    def setUp(self) -> None:
+        self.text = _read("agents/engineering-agent/CLAUDE.md")
+
+    def test_entry_point_reference_present(self) -> None:
+        # AGENTS.md / root CLAUDE.md 로 올라가는 cross-link
+        self.assertIn("AGENTS.md", self.text)
+        self.assertIn("/CLAUDE.md", self.text)
+
+    def test_context_reading_guide_section_present(self) -> None:
+        self.assertIn("작업 맥락별 읽기 가이드", self.text)
+
+    def test_code_layout_link_present(self) -> None:
+        self.assertIn("CODE_LAYOUT.md", self.text)
+
+    def test_priority_chain_documented(self) -> None:
+        # 같은 규칙 충돌 시 우선순위가 명시돼있어야 silent regression 방지
+        self.assertIn("`/CLAUDE.md` ≻ 본 파일 ≻ `CODE_LAYOUT.md`", self.text)
+
+    def test_engineering_specific_rules_present(self) -> None:
+        # router 얇게 / lifecycle ownership / 700-1000 신호
+        for needle in (
+            "router 는 얇게",
+            "lifecycle stage 마다 ownership",
+            "회귀 테스트 우선",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+
+class CodeLayoutMdTests(unittest.TestCase):
+    """`agents/engineering-agent/CODE_LAYOUT.md` 가 분리 규칙 + 예외 정책 보유."""
+
+    def setUp(self) -> None:
+        self.text = _read("agents/engineering-agent/CODE_LAYOUT.md")
+
+    def test_legacy_lifecycle_table_kept(self) -> None:
+        # 기존 lifecycle stage 표가 회귀 없이 살아있는지
+        self.assertIn("Lifecycle stages → 책임 모듈", self.text)
+        self.assertIn("intake / triage", self.text)
+
+    def test_size_section_present(self) -> None:
+        self.assertIn("파일 크기 / 책임 분리 규칙", self.text)
+
+    def test_threshold_table_present(self) -> None:
+        # 700 / 1000 두 등급 + default split 명시
+        self.assertIn("700", self.text)
+        self.assertIn("1000", self.text)
+        self.assertIn("default split", self.text)
+        self.assertIn("분리 필수", self.text)
+
+    def test_responsibility_signals_present(self) -> None:
+        for needle in (
+            "intake",
+            "intent classification",
+            "routing",
+            "state persistence",
+            "phrase patch",
+        ):
+            self.assertIn(needle, self.text, needle)
+
+    def test_exception_policy_present(self) -> None:
+        self.assertIn("예외 정책", self.text)
+        self.assertIn("generated file", self.text)
+        self.assertIn("_legacy.py", self.text)
+
+    def test_current_exception_table_present(self) -> None:
+        # in-flight 모놀리스 명시 — 분리 진행 중인 파일이 silently 더 자라
+        # 면 표를 갱신해야 한다는 신호
+        self.assertIn("현재 예외", self.text)
+        self.assertIn("_legacy.py", self.text)
+
+    def test_governance_smoke_test_link_present(self) -> None:
+        self.assertIn("test_prompt_size_ceiling.py", self.text)
+        self.assertIn("test_engineering_agent_governance_doc.py", self.text)
+
+
+class CrossDocumentConsistencyTests(unittest.TestCase):
+    """문서 간 핵심 라인이 어긋나지 않는지 lint-style 검사."""
+
+    def test_root_and_engineering_agent_agree_on_size_threshold(self) -> None:
+        root = _read("CLAUDE.md")
+        layout = _read("agents/engineering-agent/CODE_LAYOUT.md")
+        # 두 문서 모두 700 / 1000 두 임계값을 가짐 (한 쪽만 바뀌면 어긋남)
+        for needle in ("700", "1000"):
+            self.assertIn(needle, root, f"root CLAUDE missing {needle}")
+            self.assertIn(needle, layout, f"CODE_LAYOUT missing {needle}")
+
+    def test_agents_md_lists_engineering_agent_claude(self) -> None:
+        agents = _read("AGENTS.md")
+        self.assertIn("agents/engineering-agent/CLAUDE.md", agents)
+
+    def test_agents_md_lists_engineering_agent_code_layout(self) -> None:
+        agents = _read("AGENTS.md")
+        self.assertIn("agents/engineering-agent/CODE_LAYOUT.md", agents)
+
+    def test_engineering_claude_lists_external_doc_set(self) -> None:
+        ec = _read("agents/engineering-agent/CLAUDE.md")
+        # 외부 cross-link 핵심 5종이 작업 맥락 매핑에 모두 등장
+        for needle in (
+            "approval-matrix.md",
+            "autonomy-policy.md",
+            "operations.md",
+            "engineering-agent-governance.md",
+            "testing.md",
+        ):
+            self.assertIn(needle, ec, f"engineering CLAUDE missing {needle}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #163

## ✨ 과제 내용

### 배경
현재 문서가 여러 층 (AGENTS.md / root CLAUDE.md / agent CLAUDE.md / CODE_LAYOUT.md / policies/reference / runtime/docs) 에 흩어져 있어 외부 에이전트(Codex/Claude/Gemini) 와 사용자가 **"어떤 작업일 때 어떤 문서를 우선 읽어야 하는지"** 가 명시적으로 정리되어 있지 않다. 또한 최근 engineering_conversation / engineering_channel_router 같은 대형 파일 이슈가 있었기 때문에 **파일 길이 / 책임 분리** 기준을 코딩 컨벤션으로 명확히 둘 필요가 있다.

### 핵심 원칙 (코드/문서로 박힘)
- **Codex/Claude 는 매번 모든 md 를 읽는다고 가정하지 않는다**
- **자주 강제하는 규칙은 상위 문서 (root `CLAUDE.md`) 에**
- **세부 도메인 규칙은 작업 맥락에서만 읽히는 하위 문서에**
- 같은 규칙은 한 곳에만 두고 나머지는 cross-link (silent 어긋남 방지)
- **파일 길이보다 책임 수가 더 중요하지만, 1000 줄은 강한 분리 신호**

### 4 commit 구성
1. **📃 AGENTS.md 를 문서 진입점화** — 문서 계층 트리 + 작업 맥락 → 문서 매핑 표 (12 행) + 외부 에이전트 안내 + 동기화 규칙
2. **📃 root CLAUDE.md 에 전역 코딩 컨벤션 + 1000줄 분리 규칙 명문화** — 읽기 우선순위 요약 + 700/1000 임계값 + 책임 분리 신호 + router 얇게 + commit/PR/branch cross-link + Operator Action Inbox 라인
3. **📃 engineering-agent CLAUDE/CODE_LAYOUT 에 작업 맥락 가이드 + 분리 규칙** — engineering CLAUDE 에 12 행 매핑 표 + 우선순위 chain + 강제 규칙. CODE_LAYOUT 에 등급별 액션 표 + 책임 분리 신호 + 분리 방식 + 예외 정책 + "현재 예외" in-flight 표 + 자동 점검 훅 cross-link
4. **✅ 문서 계층/우선순위/분리 규칙 silent regression 방지 smoke test** — `tests/governance/test_docs_hierarchy.py` 30 케이스

### 파일 분리 규칙 요약 (CODE_LAYOUT.md §파일 크기)

| LOC | 액션 |
| --- | --- |
| ~700 | 안전 |
| 700 ~ 1000 | warning — PR 본문에 "왜 한 파일에 남기나" 한 줄 적기 |
| 1000 초과 | default split (별도 브랜치 또는 같은 PR 첫 commit) |
| 1000 초과 + 책임 2개 이상 | 분리 필수 (분리 없이 머지하지 않음) |

예외 (이유 docstring 필수): generated file / fixture·snapshot·test data / 큰 registry-mapping (선언만) / in-flight refactor `_legacy.py`. 현재 예외 5건은 CODE_LAYOUT.md 표에 LOC + 이유 명시.

### 책임 분리 신호 (길이와 무관하게 후보)
- intake / intent / routing / state persistence / formatting / external integration 중 **3 가지 이상** 한 파일에 혼재
- 같은 phrase / regex 가 여러 함수에서 반복 patch (= "phrase patch 반복 파일")
- 한 함수가 다른 도메인 dataclass 를 직접 mutate
- TODO/FIXME 가 같은 파일에 5+ 누적
- import top-level 30+ 줄

### 회귀 / 한계
- 본 PR 은 **policy/structure 정리** 이며 코드 동작은 변경 없음
- 신규 lint test 30 케이스 + 기존 governance smoke 30 케이스 모두 통과
- 전체 회귀 **4777 pass / 1 skip**
- 모든 md 내부 링크 검증 통과
- in-flight 모놀리스 (`_legacy.py` 5건 등) 의 실제 분해는 본 PR 범위 외 — CODE_LAYOUT.md "현재 예외" 표가 후속 PR 의 진척 가시화 surface

## 📚 레퍼런스
- 진입점: `AGENTS.md`
- 전역 규칙: `CLAUDE.md`
- engineering 도메인: `agents/engineering-agent/CLAUDE.md` + `agents/engineering-agent/CODE_LAYOUT.md`
- 자동 가드: `tests/governance/test_docs_hierarchy.py`, `tests/governance/test_prompt_size_ceiling.py`, `tests/engineering/test_engineering_agent_governance_doc.py`