### PR TITLE
🚀 Issue auto-create + Tag/version policy reader 종단 (closes #165)

### DIFF
--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -42,15 +42,32 @@ Yule가 도달해야 하는 최종 상태는 아래와 같다.
 
 이 수치는 운영 판단 기준으로 유지한다.
 
-| 영역 | 현재 추정 (2026-05-11) | 이전 추정 |
+| 영역 | 현재 추정 (2026-05-15) | 2026-05-11 추정 |
 | --- | --- | --- |
-| 운영 골격 | 80~85% | 65~75% |
-| Discord 기술 토의 능력 | 50~60% | 40~50% |
-| 완전 자율 코딩 루프 | 70~80% | 45~55% |
-| 역할별 자료 수집/정형화 루프 | 50~60% | 25~35% |
-| 실제 회사처럼 굴러가는 종합 수준 | 60~70% | 45~55% |
+| 운영 골격 | 85~88% | 80~85% |
+| Discord 기술 토의 능력 | 55~65% | 50~60% |
+| 완전 자율 코딩 루프 | 78~85% | 70~80% |
+| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% |
+| 실제 회사처럼 굴러가는 종합 수준 | 68~75% | 60~70% |
 
-2026-05-11 갱신 근거 — issue #81 통합 polish (`feature/issue-81-integration-polish`) 의 cross-axis 회귀 (3493 + 160 cases 모두 OK) 와 Round 4 / 4-bis / 4-ter / 4 마무리 / Round 4 후속 시리즈 land 결과. 자세한 결정은 [[notes/vault-mirror/10-projects/yule-studio-agent/decisions/2026-05-11_issue-81-decision-integration-polish.md]] § D-81-3 ~ D-81-7. 상한이 100% 가 아닌 이유:
+2026-05-15 갱신 근거 — P0-S 시리즈 (PR #162 Operator Action Inbox / PR #164 문서 계층 + 분리 규칙 / 본 PR Issue auto-create end-to-end + Tag/version policy reader) 머지 결과. 자세한 결정은 본 PR 의 audit block + `docs/approval-matrix.md` §6.
+
+이번 PR (Issue auto-create + Tag policy) 닫은 범위:
+
+- **Issue auto-create end-to-end** — target repo `ISSUE_TEMPLATE` 발견 → 키워드 매칭으로 best template 선택 → frontmatter title prefix/labels 적용 + placeholder 보존 + request_summary quote 삽입 → audit 섹션 부착. 다중 template 매칭 0 → DECISION_REQUIRED 카드. template 없음 → safe default body + `no_repo_template` audit.
+- **`LiveGithubAppClient.create_issue`** — POST `/repos/{repo}/issues` capability + labels/assignees 정규화 + 빈 시퀀스 payload 생략.
+- **`GithubWriter.create_issue`** + `ACTION_GITHUB_ISSUE_CREATE` (L2) + dry_run/denied_by_policy/OK audit 트레일.
+- **`GitHubWorkOrder` payload 확장** — `issue_auto_create_plan` + `existing_issue_number` 1급 필드, proposal/work_order 양쪽 무손실 round-trip.
+- **Tag / version policy** — `RepoContract.tag_policy` (`workflow_driven` / `changelog_driven` / `version_file_only` / `none`). CHANGELOG / package.json / pyproject.toml / Cargo.toml / release.yml 등 신호 수집. 정책 없으면 `has_tag_policy=False` — 자동 tag 보류, audit 명시.
+- **Hollow knowledge note 가드 회귀 핀** — pack/snapshot/synthesis 모두 비면 `ObsidianRenderError` 로 fail-loud (silent failure 방지).
+
+남은 범위 (본 PR 의 한계):
+
+- **end-to-end live wiring** — GitHubWorkOrder executor 가 `create_issue` 를 실제 호출하는 wiring (consumer 측) 은 후속 PR. 본 PR 은 plan/payload/writer capability/policy 까지 land.
+- **issue 생성 결과 → session 연결** — 생성된 issue number/URL 을 session.extra 에 stamp 하고 이후 branch/PR 에 자동 link 하는 wiring 도 같은 후속 PR 범위 (`coding_executor_worker` 측).
+- **Tag/release 자동 발행** — 본 PR 은 policy 감지까지. 실제 tag/release 생성은 L3 승인 카드 + executor wiring 후속.
+
+상한이 100% 가 아닌 이유:
 
 - 운영 골격 상한 85% — autonomy producer / decision seam / status surface / operator actions 까지 land. 잔여: live LLM editor / live decision provider 활성화, Discord escalation alert 자동화.
 - Discord 기술 토의 상한 60% — discussion_followup + context_pack + retrieval slot land. 잔여: `feature/issue-81-discussion-gateway` (commit `512ce7c`) 미머지, gateway / tech-lead 경계 가독성 PR 필요.

--- a/docs/github-agent-workos.md
+++ b/docs/github-agent-workos.md
@@ -15,8 +15,10 @@ GitHub issue / Discord 업무-접수 intake
        ├─ scope / non_scope / hidden_risks / test_plan
        └─ approval_required_actions (L3 카드 후보)
   → derive_branch_name (G3)            ← protected branch 거부
+  → discover_repo_contract (P0-H)      ← target repo 의 ISSUE/PR template / tag policy
+  → build_issue_auto_create_plan (P0-S)← issue 없으면 template 채워 plan 만 stamp
   → render_pr_body (G3)                ← in_scope/out_of_scope/risks/...
-  → build_github_action_plan (G3)      ← issue comment / label / branch / draft PR
+  → build_github_action_plan (G3)      ← issue create / comment / label / branch / draft PR
   → GithubWriter (G3) + LiveGithubAppClient (G6)
        └─ Authorization 헤더는 단 한 곳에서만 작성, 절대 출력 금지
   → audit (G3) + Discord 브릿지 (G4) + e2e harness (G5)
@@ -25,6 +27,45 @@ GitHub issue / Discord 업무-접수 intake
 **원칙:** 운영자 승인 없이 갈 수 있는 표면은 L0 read / L1 light-write /
 L2 plan 까지. **L3+ 는 항상 #승인-대기 카드 또는 별도 승인 토큰을 통한 사람 게이트.**
 G6 의 `smoke-pr --live` 는 draft PR 생성을 끝점으로 하며 **merge 는 절대 하지 않는다.**
+
+### 1.1 Issue auto-create (P0-S)
+
+| 조건 | 행동 | audit_reason |
+| --- | --- | --- |
+| `existing_issue_number` 가 명시됨 | issue 생성 건너뜀, 기존 번호 재사용 | `existing_issue_reused` |
+| target repo 에 `ISSUE_TEMPLATE` 가 1 개 | template 의 frontmatter (title prefix / labels) 적용 + body placeholder 보존 + request_summary quote 삽입 | `template_used` |
+| `ISSUE_TEMPLATE` 가 여러 개 + 키워드 매칭 ≥1 | best template 선택 (HIGH/MEDIUM confidence) | `template_used` |
+| `ISSUE_TEMPLATE` 가 여러 개인데 매칭 0 | LOW confidence + `needs_operator_decision=True` → DECISION_REQUIRED 카드 | `ambiguous_template` |
+| `ISSUE_TEMPLATE` 자체가 없음 | safe default body (목표/맥락/작업 항목/audit 4 섹션) | `no_repo_template` |
+
+agent 가 issue 본문을 추측해 꾸며내지 않는다. placeholder/HTML 주석은
+그대로 보존. body 끝에는 항상 `## engineering-agent audit` 섹션이
+붙어 `audit_reason` + `session_id` + `repo contract summary` 가 명시된다.
+
+승인 등급: `ACTION_GITHUB_ISSUE_CREATE` → **L2** (issue 자체는 reversible
+이지만 사람에게 notification 이 가므로 PR draft 와 동일 등급). 즉
+`#승인-대기` 카드로 묶인 GitHub work order 안에서만 dispatch 가능.
+
+### 1.2 Tag / version policy (P0-S)
+
+`RepoContract.tag_policy` 가 다음 4 종으로 분류:
+
+| 값 | 신호 | 자동 처리 |
+| --- | --- | --- |
+| `workflow_driven` | `.github/workflows/{release,publish,tag}*.yml` | agent 가 workflow 트리거 조건에 맞춘 plan 까지만, 실제 tag/release 발행은 L3 승인 필요 |
+| `changelog_driven` | `CHANGELOG.md` / `CHANGES.md` / `HISTORY.md` 등 | CHANGELOG entry 추가 plan 만, tag 는 L3 |
+| `version_file_only` | `package.json` / `pyproject.toml` / `Cargo.toml` / `setup.cfg` / `setup.py` / `VERSION` / `version.txt` 의 version 필드 | version bump 만, 자동 tag 미적용 |
+| `none` | 위 신호 없음 | **자동 tag/version 미적용** — audit 에 `tag_policy=none` 명시. 무단 tag 생성 금지 |
+
+`RepoContract.has_tag_policy` 가 False 이면 agent 는 tag 작업을 시도하지
+않는다 — 정책이 없는데 추측해 만들면 fake success 가 된다.
+
+### 1.3 Operator action inbox
+
+agent 가 진행 중 외부 사실/권한/secret 값이 필요하면 `#승인-대기` 에
+operator action 카드 (INFO/ACCESS/SECRET/DECISION) 가 올라간다. 흐름은
+[`docs/approval-matrix.md`](approval-matrix.md) §6 참조. issue auto-create
+의 LOW confidence 도 같은 inbox 로 흐른다 (`DECISION_REQUIRED`).
 
 ## 2. 환경 contract
 

--- a/src/yule_orchestrator/agents/git/repo_contract.py
+++ b/src/yule_orchestrator/agents/git/repo_contract.py
@@ -61,6 +61,29 @@ _CODEOWNERS_PATHS: Tuple[str, ...] = (
     "docs/CODEOWNERS",
 )
 
+# Tag / version policy hints — P0-S end-to-end.
+# agent 가 release 정책을 추측하지 않고 repo 의 실제 신호를 기준으로 처리/
+# 보류 결정. 없으면 "자동 tag/version 미적용" 으로 audit.
+_CHANGELOG_PATHS: Tuple[str, ...] = (
+    "CHANGELOG.md",
+    "CHANGELOG",
+    "CHANGES.md",
+    "HISTORY.md",
+    "docs/CHANGELOG.md",
+)
+_VERSION_FILES: Tuple[str, ...] = (
+    "package.json",
+    "pyproject.toml",
+    "Cargo.toml",
+    "setup.cfg",
+    "setup.py",
+    "VERSION",
+    "version.txt",
+)
+# Workflow 파일 이름에 "release" / "publish" / "tag" 가 들어가면 release
+# automation 신호로 본다.
+_RELEASE_WORKFLOW_TOKENS: Tuple[str, ...] = ("release", "publish", "tag")
+
 
 @dataclass(frozen=True)
 class RepoContract:
@@ -88,6 +111,13 @@ class RepoContract:
     fallback: bool = False
     failure_mode: Optional[str] = None  # "no_backend" | "permission_denied" | "not_found" | etc.
     backend: Optional[str] = None  # "gh_cli" | "local_clone"
+    # P0-S — tag/version policy 신호. 비어있으면 "정책 없음" 으로 audit.
+    changelog: Optional[str] = None
+    version_files: Tuple[str, ...] = ()
+    release_workflows: Tuple[str, ...] = ()
+    tag_policy: Optional[str] = None
+    """One of: 'changelog_driven', 'workflow_driven', 'version_file_only',
+    'none'. :func:`derive_tag_policy` decides."""
 
     @property
     def has_any_contract(self) -> bool:
@@ -98,6 +128,10 @@ class RepoContract:
             or self.codeowners
             or self.workflows
         )
+
+    @property
+    def has_tag_policy(self) -> bool:
+        return self.tag_policy not in (None, "", "none")
 
     def to_dict(self) -> Mapping[str, object]:
         return {
@@ -117,6 +151,10 @@ class RepoContract:
             "fallback": self.fallback,
             "failure_mode": self.failure_mode,
             "backend": self.backend,
+            "changelog": self.changelog,
+            "version_files": list(self.version_files),
+            "release_workflows": list(self.release_workflows),
+            "tag_policy": self.tag_policy,
         }
 
     @classmethod
@@ -138,6 +176,10 @@ class RepoContract:
             fallback=bool(payload.get("fallback") or False),
             failure_mode=_coerce_optional_str(payload.get("failure_mode")),
             backend=_coerce_optional_str(payload.get("backend")),
+            changelog=_coerce_optional_str(payload.get("changelog")),
+            version_files=tuple(_coerce_str_seq(payload.get("version_files"))),
+            release_workflows=tuple(_coerce_str_seq(payload.get("release_workflows"))),
+            tag_policy=_coerce_optional_str(payload.get("tag_policy")),
         )
 
     def summary_line(self) -> str:
@@ -272,6 +314,20 @@ def _scan_paths_under(
             if entry.is_file() and entry.suffix in (".yml", ".yaml")
         )
 
+    changelog = _find_first_existing(root, _CHANGELOG_PATHS)
+    version_files = tuple(
+        path for path in _VERSION_FILES if (root / path).is_file()
+    )
+    release_workflows = tuple(
+        wf for wf in workflows
+        if any(token in Path(wf).name.lower() for token in _RELEASE_WORKFLOW_TOKENS)
+    )
+    tag_policy = derive_tag_policy(
+        changelog=changelog,
+        version_files=version_files,
+        release_workflows=release_workflows,
+    )
+
     ssot_paths = tuple(
         path
         for path in [
@@ -281,6 +337,8 @@ def _scan_paths_under(
             readme,
             codeowners,
             *(workflows or ()),
+            changelog,
+            *(version_files or ()),
         ]
         if path
     )
@@ -303,6 +361,10 @@ def _scan_paths_under(
         commit_convention=commit_convention,
         ssot_paths=ssot_paths,
         backend=backend,
+        changelog=changelog,
+        version_files=version_files,
+        release_workflows=release_workflows,
+        tag_policy=tag_policy,
     )
     return contract
 
@@ -423,6 +485,20 @@ def _try_gh_cli(
             except json.JSONDecodeError:
                 workflows = ()
 
+    changelog = _first_present(all_paths, _CHANGELOG_PATHS)
+    version_files = tuple(
+        path for path in _VERSION_FILES if path in all_paths
+    )
+    release_workflows = tuple(
+        wf for wf in workflows
+        if any(token in Path(wf).name.lower() for token in _RELEASE_WORKFLOW_TOKENS)
+    )
+    tag_policy = derive_tag_policy(
+        changelog=changelog,
+        version_files=version_files,
+        release_workflows=release_workflows,
+    )
+
     ssot_paths = tuple(
         path
         for path in [
@@ -432,6 +508,8 @@ def _try_gh_cli(
             readme,
             codeowners,
             *(workflows or ()),
+            changelog,
+            *(version_files or ()),
         ]
         if path
     )
@@ -448,12 +526,50 @@ def _try_gh_cli(
         workflows=workflows,
         ssot_paths=ssot_paths,
         backend="gh_cli",
+        changelog=changelog,
+        version_files=version_files,
+        release_workflows=release_workflows,
+        tag_policy=tag_policy,
     )
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def derive_tag_policy(
+    *,
+    changelog: Optional[str],
+    version_files: Sequence[str],
+    release_workflows: Sequence[str],
+) -> Optional[str]:
+    """입력 신호 3 종에서 tag/version policy 분류.
+
+    분류 우선순위 — 더 강한 신호가 우선:
+      1. ``release_workflows`` 가 비어있지 않음 → ``"workflow_driven"``
+         (GitHub Actions 가 release/publish/tag 작업을 가짐 — agent 는
+         그 워크플로우 트리거 조건에 맞춰 plan)
+      2. ``changelog`` 가 있음 → ``"changelog_driven"`` (release note 가
+         CHANGELOG 에 누적 — agent 는 CHANGELOG entry 추가 + tag 명시
+         계획)
+      3. ``version_files`` 만 있음 → ``"version_file_only"`` (package.json
+        / pyproject.toml 의 version field 만 있음. release automation
+        없으므로 자동 tag 는 보류, version bump 만 계획)
+      4. 아무 신호도 없음 → ``"none"`` (자동 tag/version 미적용).
+
+    None 반환은 호출자가 신호 자체를 모를 때 (예: tests 가 명시적으로
+    빈 input 을 전달) 의 명시적 noop 신호. 본 함수는 None 이 아닌 4 종
+    문자열만 반환.
+    """
+
+    if release_workflows:
+        return "workflow_driven"
+    if changelog:
+        return "changelog_driven"
+    if version_files:
+        return "version_file_only"
+    return "none"
 
 
 def _default_subprocess_run(cmd, *, timeout=None):

--- a/src/yule_orchestrator/agents/github_workos/audit.py
+++ b/src/yule_orchestrator/agents/github_workos/audit.py
@@ -46,6 +46,10 @@ ACTION_GITHUB_PR_DRAFT_CREATE: str = "github_pr_draft_create"
 ACTION_GITHUB_PR_READY: str = "github_pr_ready"
 ACTION_GITHUB_PUSH: str = "github_push"
 ACTION_GITHUB_MERGE: str = "github_merge"
+# Issue auto-create (P0-S end-to-end) — target repo 의 ISSUE_TEMPLATE 을
+# 채워 새 issue 를 생성. issue 자체는 reversible (operator 가 close 가능)
+# 이라 PR draft / branch create 와 동일한 L2 등급으로 매핑된다.
+ACTION_GITHUB_ISSUE_CREATE: str = "github_issue_create"
 
 
 # Outcome buckets
@@ -294,6 +298,7 @@ __all__ = (
     "ACTION_GITHUB_BRANCH_CREATE",
     "ACTION_GITHUB_COMMIT_CREATE",
     "ACTION_GITHUB_ISSUE_COMMENT",
+    "ACTION_GITHUB_ISSUE_CREATE",
     "ACTION_GITHUB_LABEL_ADD",
     "ACTION_GITHUB_MERGE",
     "ACTION_GITHUB_PR_DRAFT_CREATE",

--- a/src/yule_orchestrator/agents/github_workos/github_writer.py
+++ b/src/yule_orchestrator/agents/github_workos/github_writer.py
@@ -44,6 +44,7 @@ from .audit import (
     ACTION_GITHUB_BRANCH_CREATE,
     ACTION_GITHUB_COMMIT_CREATE,
     ACTION_GITHUB_ISSUE_COMMENT,
+    ACTION_GITHUB_ISSUE_CREATE,
     ACTION_GITHUB_LABEL_ADD,
     ACTION_GITHUB_PR_DRAFT_CREATE,
     GithubWriteAudit,
@@ -80,6 +81,17 @@ class GithubClient(Protocol):
 
     def create_issue_comment(
         self, *, repo: str, issue_number: int, body: str
+    ) -> Mapping[str, Any]:
+        ...
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: Sequence[str] = (),
+        assignees: Sequence[str] = (),
     ) -> Mapping[str, Any]:
         ...
 
@@ -185,6 +197,10 @@ _DEFAULT_MIN_AUTONOMY: Mapping[str, str] = {
     ACTION_GITHUB_BRANCH_CREATE: "L2",
     ACTION_GITHUB_COMMIT_CREATE: "L2",
     ACTION_GITHUB_PR_DRAFT_CREATE: "L2",
+    # Issue auto-create (P0-S) — issue 자체는 reversible 하지만 사람에게
+    # notification 이 가므로 PR draft 와 동일한 L2 등급. operator 가
+    # `#승인-대기` 카드를 승인한 GitHub work order 안에서만 실행됨.
+    ACTION_GITHUB_ISSUE_CREATE: "L2",
     # L3 actions live in audit constants but the writer doesn't
     # implement them — they require an approval-routed runner that's
     # G6's territory.
@@ -435,6 +451,50 @@ class GithubWriter:
     # ------------------------------------------------------------------
     # Public actions
     # ------------------------------------------------------------------
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: Sequence[str] = (),
+        assignees: Sequence[str] = (),
+        autonomy_level: str = "L2",
+        session_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+    ) -> GithubWriteResult:
+        """Create a new issue on *repo* — P0-S end-to-end.
+
+        ``labels`` / ``assignees`` 가 빈 시퀀스면 GitHub 가 repo 기본
+        라벨/담당자 (있으면) 를 적용. dry_run + denied_by_policy 경로는
+        다른 액션과 동일하게 audit 트레일을 남긴다.
+        """
+
+        cleaned_labels = tuple(
+            str(l).strip() for l in labels if str(l).strip()
+        )
+        cleaned_assignees = tuple(
+            str(a).strip() for a in assignees if str(a).strip()
+        )
+        title_snippet = (title or "").strip().splitlines()[0][:80]
+        return self._run(
+            action=ACTION_GITHUB_ISSUE_CREATE,
+            autonomy_level=autonomy_level,
+            repo=repo,
+            issue_number=None,
+            session_id=session_id,
+            decision_id=decision_id,
+            branch=None,
+            summary=f"create issue on {repo}: {title_snippet}",
+            client_call=lambda: self._require_client().create_issue(
+                repo=repo,
+                title=title,
+                body=body,
+                labels=cleaned_labels,
+                assignees=cleaned_assignees,
+            ),
+        )
 
     def post_issue_comment(
         self,

--- a/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
+++ b/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
@@ -1,0 +1,632 @@
+"""Issue auto-create — target repo 의 ISSUE_TEMPLATE 를 읽어 body 를 채움.
+
+배경
+====
+engineering-agent 가 coding request 를 받았는데 issue 번호가 안 들어왔을
+때, 그냥 PR 로 직진하면 안 된다 — target repo 의 운영 규칙 (label,
+template, sub-issue 구조) 을 무시하게 된다. 본 모듈은:
+
+1. :class:`RepoContract.issue_templates` 가 찾은 후보 파일을 읽어
+2. 가장 의미가 가까운 template 1 건을 골라 (다중일 때 confidence 계산)
+3. request_summary 로 본문을 채운
+4. :class:`IssueAutoCreatePlan` 를 만든다.
+
+본문 채움 규칙
+-----------
+- YAML frontmatter (`---\n…\n---`) 가 있으면 `title:` 와 `labels:` 를
+  추출해 출력 plan 에 반영.
+- `## ` 헤더 아래의 placeholder (`<!-- ... -->`, `> 추가하려는 기능에…`)
+  는 그대로 두되, 그 다음 비어있는 본문 자리에 request_summary 를 삽입.
+- 알아서 꾸며내지 않는다 — placeholder/HTML 주석은 보존.
+- 모든 변형은 **deterministic** — 같은 input 이면 같은 output.
+
+confidence
+----------
+- template 가 1 개 → ``confidence='high'`` (해당 template 사용).
+- template 가 여러 개일 때 request 와의 키워드 매칭 점수를 계산:
+  - 매칭 점수 ≥ 2 → ``'high'``, 1 → ``'medium'``, 0 → ``'low'``.
+- 모두 0 점이면 :func:`should_request_decision` 이 True 를 반환해 호출자가
+  `DECISION_REQUIRED` operator action 카드를 게시.
+
+fallback (template 없음)
+----------------------
+- repo contract 가 template 를 못 찾으면 :func:`build_default_issue_body`
+  가 호출돼 안전한 기본 body 를 만든다.
+- 단 ``audit_reason`` 에 ``no_repo_template`` 을 새겨 fake success 금지.
+
+본 모듈은 pure — GitHub API 호출 없음. body 만 만들고, 실제 호출은
+:class:`GithubWriter.create_issue` 가 담당.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
+
+from ..git.repo_contract import RepoContract
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+CONFIDENCE_HIGH: str = "high"
+CONFIDENCE_MEDIUM: str = "medium"
+CONFIDENCE_LOW: str = "low"
+
+
+AUDIT_TEMPLATE_USED: str = "template_used"
+AUDIT_TEMPLATE_FALLBACK: str = "no_repo_template"
+AUDIT_TEMPLATE_AMBIGUOUS: str = "ambiguous_template"
+AUDIT_EXISTING_ISSUE_REUSED: str = "existing_issue_reused"
+
+
+# ---------------------------------------------------------------------------
+# Template parsing
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_RE = re.compile(
+    r"^---\s*\n(?P<fm>.*?)\n---\s*\n(?P<body>.*)$",
+    re.DOTALL,
+)
+
+# `key: value` 또는 `key:\n  - value` 두 형태를 받는 단순 파서. 본 모듈은
+# PyYAML 의존을 피하기 위해 GitHub issue template 에서 흔히 쓰는 6개 키만
+# 인식한다.
+_FM_KEY_RE = re.compile(r"^(name|about|title|labels|assignees|description)\s*:\s*(.*)$")
+
+
+@dataclass(frozen=True)
+class IssueTemplate:
+    """파싱된 GitHub issue template.
+
+    필드
+    ----
+    path
+        repo-relative path (예: ``.github/ISSUE_TEMPLATE/bug_report.md``).
+    name
+        frontmatter `name:` — 사람 친화 라벨. 없으면 파일명 stem.
+    title_prefix
+        frontmatter `title:` — issue 제목에 자동 prefix 됨. 예: ``[Feat]``.
+    labels
+        frontmatter `labels:` 에 명시된 라벨 시퀀스.
+    assignees
+        frontmatter `assignees:`.
+    body
+        frontmatter 를 제거한 markdown 본문 (placeholder 포함).
+    """
+
+    path: str
+    name: str
+    title_prefix: str = ""
+    labels: Tuple[str, ...] = ()
+    assignees: Tuple[str, ...] = ()
+    body: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.body.strip() or self.title_prefix or self.labels)
+
+
+def parse_issue_template(*, path: str, text: str) -> IssueTemplate:
+    """*text* (issue template 파일 내용) → :class:`IssueTemplate`.
+
+    YAML frontmatter 파싱은 보수적 — 본 함수는 PyYAML 을 쓰지 않고
+    common case 만 추출한다 (name/title/labels/assignees/description).
+    잘못된 frontmatter 는 그냥 body 로 처리.
+    """
+
+    name_default = Path(path).stem.replace("-", " ").replace("_", " ").strip() or path
+    raw = (text or "").strip()
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return IssueTemplate(
+            path=path,
+            name=name_default,
+            body=raw,
+        )
+    fm_block = match.group("fm")
+    body = match.group("body").lstrip("\n")
+
+    name = name_default
+    title_prefix = ""
+    labels: list[str] = []
+    assignees: list[str] = []
+
+    # 매우 보수적 line 파서. 들여쓰기 list (- item) 도 지원.
+    pending_list_key: Optional[str] = None
+    for line in fm_block.splitlines():
+        stripped = line.rstrip()
+        if not stripped:
+            pending_list_key = None
+            continue
+        # 들여쓰기 list item
+        if pending_list_key and stripped.lstrip().startswith("- "):
+            item = stripped.lstrip()[2:].strip().strip('"').strip("'")
+            if not item:
+                continue
+            if pending_list_key == "labels":
+                labels.append(item)
+            elif pending_list_key == "assignees":
+                assignees.append(item)
+            continue
+        pending_list_key = None
+        m = _FM_KEY_RE.match(stripped)
+        if not m:
+            continue
+        key, value = m.group(1).lower(), m.group(2).strip()
+        value = value.strip('"').strip("'")
+        if key == "name" and value:
+            name = value
+        elif key == "title" and value:
+            title_prefix = value
+        elif key in ("labels", "assignees"):
+            if value:
+                # 한 줄 list: ``labels: a, b, c`` 또는 ``labels: ["a", "b"]``
+                cleaned = (
+                    value.strip("[]")
+                    .replace('"', "")
+                    .replace("'", "")
+                )
+                items = [
+                    chunk.strip()
+                    for chunk in cleaned.split(",")
+                    if chunk.strip()
+                ]
+                if key == "labels":
+                    labels.extend(items)
+                else:
+                    assignees.extend(items)
+            else:
+                pending_list_key = key
+
+    return IssueTemplate(
+        path=path,
+        name=name,
+        title_prefix=title_prefix,
+        labels=tuple(labels),
+        assignees=tuple(assignees),
+        body=body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template selection (multi-template repo)
+# ---------------------------------------------------------------------------
+
+
+_KEYWORD_RE = re.compile(r"[A-Za-z가-힣]{2,}")
+
+
+def _normalize_keywords(text: str) -> set[str]:
+    return {token.lower() for token in _KEYWORD_RE.findall(text or "")}
+
+
+def score_template_against_request(
+    *, template: IssueTemplate, request_text: str
+) -> int:
+    """*request_text* 와 *template* 의 키워드 매칭 점수 (양수).
+
+    매칭 토큰: template.name + title_prefix + 본문의 ``## 헤더`` 들.
+    request_text 와의 교집합 token 수가 점수. confidence 분류에 사용.
+    """
+
+    haystack_tokens: set[str] = set()
+    haystack_tokens.update(_normalize_keywords(template.name))
+    haystack_tokens.update(_normalize_keywords(template.title_prefix))
+    # ## 헤더 + labels 도 매칭 신호
+    for line in (template.body or "").splitlines():
+        line = line.strip()
+        if line.startswith("#"):
+            haystack_tokens.update(_normalize_keywords(line.lstrip("# ").strip()))
+    for label in template.labels:
+        haystack_tokens.update(_normalize_keywords(label))
+
+    request_tokens = _normalize_keywords(request_text)
+    if not haystack_tokens or not request_tokens:
+        return 0
+    return len(haystack_tokens & request_tokens)
+
+
+def select_issue_template(
+    *,
+    templates: Sequence[IssueTemplate],
+    request_text: str,
+) -> Tuple[Optional[IssueTemplate], int, str]:
+    """multi-template repo 에서 가장 적합한 template + score + confidence 반환.
+
+    반환값:
+      - ``(None, 0, CONFIDENCE_LOW)`` — templates 가 비어있음.
+      - ``(template, score, confidence)`` — 선택된 template.
+        templates 가 1 개면 무조건 ``CONFIDENCE_HIGH`` (deterministic
+        single choice).
+
+    동점일 때는 input 순서 (즉 repo_contract 가 정렬한 alphabetical) 가
+    tie-break.
+    """
+
+    if not templates:
+        return None, 0, CONFIDENCE_LOW
+    if len(templates) == 1:
+        return templates[0], score_template_against_request(
+            template=templates[0], request_text=request_text
+        ), CONFIDENCE_HIGH
+
+    scored: list[Tuple[int, int, IssueTemplate]] = []
+    for idx, template in enumerate(templates):
+        scored.append(
+            (
+                score_template_against_request(
+                    template=template, request_text=request_text
+                ),
+                idx,
+                template,
+            )
+        )
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    top_score, _, top_template = scored[0]
+    if top_score >= 2:
+        confidence = CONFIDENCE_HIGH
+    elif top_score == 1:
+        confidence = CONFIDENCE_MEDIUM
+    else:
+        confidence = CONFIDENCE_LOW
+    return top_template, top_score, confidence
+
+
+# ---------------------------------------------------------------------------
+# Plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IssueAutoCreatePlan:
+    """Issue auto-create 실행 직전의 결정.
+
+    필드
+    ----
+    title
+        실제 issue 제목 (template prefix + canonical summary 결합).
+    body
+        rendered markdown body. placeholder 보존.
+    labels / assignees
+        template 에서 받은 + 호출자 override 합집합.
+    template_path
+        사용된 template 의 repo-relative path. fallback 시 ``None``.
+    confidence
+        :data:`CONFIDENCE_HIGH` / ``MEDIUM`` / ``LOW``.
+    audit_reason
+        :data:`AUDIT_TEMPLATE_USED` / ``AUDIT_TEMPLATE_FALLBACK` /
+        ``AUDIT_TEMPLATE_AMBIGUOUS``.
+    needs_operator_decision
+        confidence 가 LOW 이면 True — 호출자는 DECISION_REQUIRED 카드를
+        게시한 뒤 응답을 기다린다.
+    """
+
+    title: str
+    body: str
+    labels: Tuple[str, ...] = ()
+    assignees: Tuple[str, ...] = ()
+    template_path: Optional[str] = None
+    confidence: str = CONFIDENCE_HIGH
+    audit_reason: str = AUDIT_TEMPLATE_USED
+    needs_operator_decision: bool = False
+    template_score: int = 0
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "title": self.title,
+            "body": self.body,
+            "labels": list(self.labels),
+            "assignees": list(self.assignees),
+            "template_path": self.template_path,
+            "confidence": self.confidence,
+            "audit_reason": self.audit_reason,
+            "needs_operator_decision": self.needs_operator_decision,
+            "template_score": self.template_score,
+        }
+
+
+def fill_issue_template(
+    *,
+    template: IssueTemplate,
+    request_summary: str,
+    repo_contract: Optional[RepoContract] = None,
+    session_id: Optional[str] = None,
+    audit_reason: str = AUDIT_TEMPLATE_USED,
+    confidence: str = CONFIDENCE_HIGH,
+    template_score: int = 0,
+    title_override: Optional[str] = None,
+    extra_labels: Iterable[str] = (),
+) -> IssueAutoCreatePlan:
+    """*template* 본문을 *request_summary* 로 채운 plan 반환.
+
+    채움 규칙
+    --------
+    - **placeholder 보존**: HTML 주석 ``<!-- ... -->`` 및 ``> ...``
+      안내문은 그대로.
+    - **첫 ``## `` 헤더 직후의 빈 줄** 자리에 request_summary 한 줄을
+      `> ` quote 형식으로 prepend. 본 자리는 GitHub issue template 의
+      가장 흔한 "추가하려는 기능에 대해 간결하게 설명해주세요" 라인.
+    - placeholder 가 없으면 본문 끝에 `## 작업 컨텍스트` 섹션을 append.
+    - frontmatter title prefix 가 있으면 결합: ``[Feat] <summary>``.
+    """
+
+    summary = (request_summary or "").strip()
+    title = (title_override or "").strip() or summary or template.name
+    if template.title_prefix:
+        prefix = template.title_prefix.strip()
+        # GitHub default templates 자주 ``[Feat]`` 같은 prefix 만 두고 빈
+        # 자리를 남김. 사용자가 요청 본문에 같은 prefix 를 안 가지고 있다면
+        # 결합.
+        if prefix and not title.lower().startswith(prefix.lower()):
+            title = f"{prefix} {title}".strip()
+
+    body_lines = (template.body or "").splitlines()
+    # 첫 ``## `` 헤더 다음 비어있는 줄을 찾아 거기에 summary 삽입.
+    inserted = False
+    out: list[str] = []
+    for idx, line in enumerate(body_lines):
+        out.append(line)
+        if (
+            not inserted
+            and summary
+            and line.strip().startswith("## ")
+        ):
+            # 다음 줄이 empty 거나 안내문이면 그 자리에 quote 삽입.
+            out.append("")
+            out.append(f"> {summary}")
+            out.append("")
+            inserted = True
+    if not inserted and summary:
+        out.append("")
+        out.append("## 작업 컨텍스트")
+        out.append("")
+        out.append(f"> {summary}")
+
+    # repo_contract / session reference 가 있으면 audit 라인 추가 (
+    # template 의 placeholder 와 충돌하지 않도록 마지막 별도 섹션).
+    audit_lines: list[str] = []
+    if repo_contract is not None:
+        audit_lines.append(
+            f"- repo contract: {repo_contract.summary_line()}"
+        )
+    if session_id:
+        audit_lines.append(f"- engineering-agent session: `{session_id}`")
+    if audit_reason:
+        audit_lines.append(f"- audit_reason: `{audit_reason}`")
+    if audit_lines:
+        out.append("")
+        out.append("## engineering-agent audit")
+        out.append("")
+        out.extend(audit_lines)
+
+    body = "\n".join(out).rstrip() + "\n"
+
+    labels = tuple(
+        dict.fromkeys(
+            [*template.labels, *[str(l).strip() for l in extra_labels if str(l).strip()]]
+        )
+    )
+    return IssueAutoCreatePlan(
+        title=title,
+        body=body,
+        labels=labels,
+        assignees=template.assignees,
+        template_path=template.path,
+        confidence=confidence,
+        audit_reason=audit_reason,
+        needs_operator_decision=(confidence == CONFIDENCE_LOW),
+        template_score=template_score,
+    )
+
+
+def build_default_issue_body(
+    *,
+    request_summary: str,
+    repo_contract: Optional[RepoContract] = None,
+    session_id: Optional[str] = None,
+    title_override: Optional[str] = None,
+    extra_labels: Iterable[str] = (),
+) -> IssueAutoCreatePlan:
+    """target repo 에 template 가 없을 때의 fallback plan.
+
+    무리해서 꾸며내지 않는다 — title 은 request_summary 의 첫 줄,
+    body 는 짧고 명시적인 4 섹션 (목표/맥락/작업 항목/audit).
+    ``audit_reason='no_repo_template'`` 으로 audit 에 fallback 임을 남긴다.
+    """
+
+    summary = (request_summary or "").strip()
+    title = (title_override or "").strip() or summary.splitlines()[0][:120] or "engineering-agent issue"
+
+    lines = [
+        "## 목표",
+        "",
+        f"> {summary or '— 요약 없음 —'}",
+        "",
+        "## 맥락",
+        "",
+        "- engineering-agent 가 coding request 처리 중 issue 가 명시되지 않아 자동 생성한 issue 입니다.",
+    ]
+    if repo_contract is not None:
+        lines.append(f"- repo contract: {repo_contract.summary_line()}")
+    lines.extend(
+        [
+            "",
+            "## 작업 항목",
+            "",
+            "- [ ] (placeholder — 실제 작업 분해는 PR 본문 또는 sub-issue 에서 진행)",
+            "",
+            "## engineering-agent audit",
+            "",
+            f"- audit_reason: `{AUDIT_TEMPLATE_FALLBACK}`",
+        ]
+    )
+    if session_id:
+        lines.append(f"- engineering-agent session: `{session_id}`")
+
+    body = "\n".join(lines).rstrip() + "\n"
+    labels = tuple(
+        dict.fromkeys(
+            str(l).strip() for l in extra_labels if str(l).strip()
+        )
+    )
+    return IssueAutoCreatePlan(
+        title=title,
+        body=body,
+        labels=labels,
+        assignees=(),
+        template_path=None,
+        confidence=CONFIDENCE_HIGH,  # fallback 자체는 deterministic, 사람 입력 불필요
+        audit_reason=AUDIT_TEMPLATE_FALLBACK,
+        needs_operator_decision=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level plan helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IssueAutoCreateOutcome:
+    """:func:`build_issue_auto_create_plan` 결과.
+
+    필드
+    ----
+    plan
+        :class:`IssueAutoCreatePlan` — None 이면 ``existing_issue_number``
+        가 있어 새로 생성하지 않는다.
+    existing_issue_number
+        호출자가 issue 번호를 이미 알고 있으면 그 번호. 이 경우 plan 은
+        None 이고 audit_reason 은 ``existing_issue_reused``.
+    audit_reason
+        :data:`AUDIT_*` 중 하나. plan 이 있어도 confidence 와 무관하게
+        호출자가 audit 에 쓰는 라벨.
+    candidate_templates
+        대상 repo 의 ISSUE_TEMPLATE 후보 목록 (사람이 확인 가능하도록).
+    selected_score
+        top template 점수. confidence 결정에 사용된 raw 값.
+    """
+
+    plan: Optional[IssueAutoCreatePlan]
+    existing_issue_number: Optional[int] = None
+    audit_reason: str = AUDIT_TEMPLATE_USED
+    candidate_templates: Tuple[IssueTemplate, ...] = ()
+    selected_score: int = 0
+
+
+def build_issue_auto_create_plan(
+    *,
+    repo_contract: RepoContract,
+    request_summary: str,
+    existing_issue_number: Optional[int] = None,
+    template_loader=None,
+    session_id: Optional[str] = None,
+    title_override: Optional[str] = None,
+    extra_labels: Iterable[str] = (),
+) -> IssueAutoCreateOutcome:
+    """end-to-end plan 생성.
+
+    Steps:
+      1. ``existing_issue_number`` 가 있으면 즉시 outcome 반환 — 중복 생성 금지.
+      2. repo_contract 의 issue_templates 후보를 ``template_loader`` 로
+         읽어 :class:`IssueTemplate` 시퀀스 구성.
+         - ``template_loader`` 는 ``(path: str) -> Optional[str]``. 실패 시
+           해당 후보를 건너뜀.
+      3. :func:`select_issue_template` 으로 best template 선택.
+      4. confidence:
+         - HIGH/MEDIUM → :func:`fill_issue_template`
+         - LOW (다중 template 인데 매칭 없음) → fill_issue_template +
+           ``needs_operator_decision=True``
+         - 후보 자체가 없음 → :func:`build_default_issue_body` (fallback)
+    """
+
+    if existing_issue_number is not None and int(existing_issue_number) > 0:
+        return IssueAutoCreateOutcome(
+            plan=None,
+            existing_issue_number=int(existing_issue_number),
+            audit_reason=AUDIT_EXISTING_ISSUE_REUSED,
+        )
+
+    candidate_paths = tuple(repo_contract.issue_templates or ())
+    candidates: list[IssueTemplate] = []
+    if template_loader is not None:
+        for path in candidate_paths:
+            try:
+                text = template_loader(path)
+            except Exception:  # noqa: BLE001
+                text = None
+            if not text:
+                continue
+            parsed = parse_issue_template(path=path, text=text)
+            if parsed.is_empty and not parsed.title_prefix:
+                # 빈 template 는 후보에서 제외 — fallback 으로 떨어뜨림
+                continue
+            candidates.append(parsed)
+
+    if not candidates:
+        plan = build_default_issue_body(
+            request_summary=request_summary,
+            repo_contract=repo_contract,
+            session_id=session_id,
+            title_override=title_override,
+            extra_labels=extra_labels,
+        )
+        return IssueAutoCreateOutcome(
+            plan=plan,
+            existing_issue_number=None,
+            audit_reason=AUDIT_TEMPLATE_FALLBACK,
+            candidate_templates=(),
+            selected_score=0,
+        )
+
+    selected, score, confidence = select_issue_template(
+        templates=candidates, request_text=request_summary
+    )
+    assert selected is not None  # candidates non-empty guard
+    audit_reason = (
+        AUDIT_TEMPLATE_AMBIGUOUS if confidence == CONFIDENCE_LOW else AUDIT_TEMPLATE_USED
+    )
+    plan = fill_issue_template(
+        template=selected,
+        request_summary=request_summary,
+        repo_contract=repo_contract,
+        session_id=session_id,
+        audit_reason=audit_reason,
+        confidence=confidence,
+        template_score=score,
+        title_override=title_override,
+        extra_labels=extra_labels,
+    )
+    return IssueAutoCreateOutcome(
+        plan=plan,
+        existing_issue_number=None,
+        audit_reason=audit_reason,
+        candidate_templates=tuple(candidates),
+        selected_score=score,
+    )
+
+
+__all__ = (
+    "AUDIT_EXISTING_ISSUE_REUSED",
+    "AUDIT_TEMPLATE_AMBIGUOUS",
+    "AUDIT_TEMPLATE_FALLBACK",
+    "AUDIT_TEMPLATE_USED",
+    "CONFIDENCE_HIGH",
+    "CONFIDENCE_LOW",
+    "CONFIDENCE_MEDIUM",
+    "IssueAutoCreateOutcome",
+    "IssueAutoCreatePlan",
+    "IssueTemplate",
+    "build_default_issue_body",
+    "build_issue_auto_create_plan",
+    "fill_issue_template",
+    "parse_issue_template",
+    "score_template_against_request",
+    "select_issue_template",
+)

--- a/src/yule_orchestrator/agents/job_queue/github_work_order.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order.py
@@ -348,6 +348,13 @@ class GitHubWorkOrderProposal:
     dry_run_default: bool = True
     extra: Mapping[str, Any] = field(default_factory=dict)
     created_at: str = ""
+    # P0-S end-to-end — target repo 의 ISSUE_TEMPLATE 을 읽어 채워둔 plan.
+    # ``None`` 일 때 두 의미 중 하나:
+    #   - 호출자가 issue auto-create 단계를 거치지 않음 (legacy path)
+    #   - 호출자가 ``existing_issue_number`` 를 알고 있음 (중복 생성 금지)
+    # plan dict 의 shape 은 :class:`IssueAutoCreatePlan.to_dict()` 와 동일.
+    issue_auto_create_plan: Optional[Mapping[str, Any]] = None
+    existing_issue_number: Optional[int] = None
 
     def to_payload(self) -> Mapping[str, Any]:
         return {
@@ -370,6 +377,12 @@ class GitHubWorkOrderProposal:
             "dry_run_default": self.dry_run_default,
             "extra": dict(self.extra),
             "created_at": self.created_at,
+            "issue_auto_create_plan": (
+                dict(self.issue_auto_create_plan)
+                if self.issue_auto_create_plan is not None
+                else None
+            ),
+            "existing_issue_number": self.existing_issue_number,
         }
 
     @classmethod
@@ -406,6 +419,12 @@ class GitHubWorkOrderProposal:
             dry_run_default=bool(payload.get("dry_run_default", True)),
             extra=dict(payload.get("extra") or {}),
             created_at=str(payload.get("created_at") or ""),
+            issue_auto_create_plan=(
+                dict(payload["issue_auto_create_plan"])
+                if isinstance(payload.get("issue_auto_create_plan"), Mapping)
+                else None
+            ),
+            existing_issue_number=_coerce_int(payload.get("existing_issue_number")),
         )
 
 
@@ -437,6 +456,11 @@ class GitHubWorkOrder:
     source_thread_id: Optional[int] = None
     source_message_id: Optional[int] = None
     extra: Mapping[str, Any] = field(default_factory=dict)
+    # P0-S — approval 시점에 stamp 된 plan. executor 가 이 값을 그대로 읽어
+    # ``GithubWriter.create_issue`` 호출. ``existing_issue_number`` 가 있으면
+    # plan 은 None 이고 executor 는 issue 생성을 건너뛴다.
+    issue_auto_create_plan: Optional[Mapping[str, Any]] = None
+    existing_issue_number: Optional[int] = None
 
     def to_payload(self) -> Mapping[str, Any]:
         return {
@@ -455,6 +479,12 @@ class GitHubWorkOrder:
             "source_thread_id": self.source_thread_id,
             "source_message_id": self.source_message_id,
             "extra": dict(self.extra),
+            "issue_auto_create_plan": (
+                dict(self.issue_auto_create_plan)
+                if self.issue_auto_create_plan is not None
+                else None
+            ),
+            "existing_issue_number": self.existing_issue_number,
         }
 
     @classmethod
@@ -479,6 +509,12 @@ class GitHubWorkOrder:
             source_thread_id=_coerce_int(payload.get("source_thread_id")),
             source_message_id=_coerce_int(payload.get("source_message_id")),
             extra=dict(payload.get("extra") or {}),
+            issue_auto_create_plan=(
+                dict(payload["issue_auto_create_plan"])
+                if isinstance(payload.get("issue_auto_create_plan"), Mapping)
+                else None
+            ),
+            existing_issue_number=_coerce_int(payload.get("existing_issue_number")),
         )
 
     @classmethod
@@ -518,6 +554,12 @@ class GitHubWorkOrder:
             source_thread_id=proposal.source_thread_id,
             source_message_id=proposal.source_message_id,
             extra=dict(proposal.extra or {}),
+            issue_auto_create_plan=(
+                dict(proposal.issue_auto_create_plan)
+                if proposal.issue_auto_create_plan is not None
+                else None
+            ),
+            existing_issue_number=proposal.existing_issue_number,
         )
 
 

--- a/src/yule_orchestrator/github_app/live_client.py
+++ b/src/yule_orchestrator/github_app/live_client.py
@@ -180,6 +180,38 @@ class LiveGithubAppClient:
         url = f"{self._api_base}/repos/{repo}/issues/{int(issue_number)}/comments"
         return self._post(url, body={"body": str(body)})
 
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: Sequence[str] = (),
+        assignees: Sequence[str] = (),
+    ) -> Mapping[str, Any]:
+        """POST /repos/{repo}/issues — issue auto-create surface (P0-S).
+
+        engineering-agent 가 target repo 의 ISSUE_TEMPLATE 을 채워 새 issue
+        를 만든다. ``labels``/``assignees`` 는 빈 시퀀스면 payload 에서 생략
+        해 GitHub 가 기본값을 적용하도록 둔다. 응답 dict 에서 호출자는
+        ``number`` / ``html_url`` 을 읽어 session 에 연결.
+        """
+
+        url = f"{self._api_base}/repos/{repo}/issues"
+        body_payload: dict[str, Any] = {
+            "title": str(title),
+            "body": str(body),
+        }
+        cleaned_labels = [str(label).strip() for label in labels if str(label).strip()]
+        if cleaned_labels:
+            body_payload["labels"] = cleaned_labels
+        cleaned_assignees = [
+            str(assignee).strip() for assignee in assignees if str(assignee).strip()
+        ]
+        if cleaned_assignees:
+            body_payload["assignees"] = cleaned_assignees
+        return self._post(url, body=body_payload)
+
     def add_labels(
         self, *, repo: str, issue_number: int, labels: Sequence[str]
     ) -> Mapping[str, Any]:

--- a/tests/agents/git/test_repo_contract_tag_policy.py
+++ b/tests/agents/git/test_repo_contract_tag_policy.py
@@ -1,0 +1,160 @@
+"""RepoContract — tag/version policy 감지 회귀.
+
+contract:
+  - changelog 만 있으면 ``tag_policy == 'changelog_driven'``.
+  - package.json/pyproject.toml 만 있으면 ``'version_file_only'``.
+  - .github/workflows/release.yml 이 있으면 ``'workflow_driven'`` (가장
+    강한 신호).
+  - 아무 신호도 없으면 ``'none'`` + ``has_tag_policy == False``.
+  - dict round-trip 으로 새 필드 보존.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.git.repo_contract import (
+    RepoContract,
+    derive_tag_policy,
+    discover_repo_contract,
+)
+
+
+class DeriveTagPolicyTests(unittest.TestCase):
+    def test_no_signals_returns_none(self) -> None:
+        self.assertEqual(
+            derive_tag_policy(changelog=None, version_files=(), release_workflows=()),
+            "none",
+        )
+
+    def test_workflow_wins_when_multiple_signals(self) -> None:
+        self.assertEqual(
+            derive_tag_policy(
+                changelog="CHANGELOG.md",
+                version_files=("package.json",),
+                release_workflows=(".github/workflows/release.yml",),
+            ),
+            "workflow_driven",
+        )
+
+    def test_changelog_when_no_workflow(self) -> None:
+        self.assertEqual(
+            derive_tag_policy(
+                changelog="CHANGELOG.md",
+                version_files=(),
+                release_workflows=(),
+            ),
+            "changelog_driven",
+        )
+
+    def test_version_file_only_when_others_missing(self) -> None:
+        self.assertEqual(
+            derive_tag_policy(
+                changelog=None,
+                version_files=("pyproject.toml",),
+                release_workflows=(),
+            ),
+            "version_file_only",
+        )
+
+
+class LocalCloneTagSignalTests(unittest.TestCase):
+    def _seed(self, **files: str) -> Path:
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: None)  # tmpdir is best-effort
+        repo = Path(tmp) / "owner" / "repo"
+        repo.mkdir(parents=True)
+        for path, content in files.items():
+            full = repo / path
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content)
+        return Path(tmp)
+
+    def test_changelog_and_version_file_detected(self) -> None:
+        ws = self._seed(
+            **{
+                "package.json": '{"version":"1.0.0"}',
+                "CHANGELOG.md": "## 1.0.0\n- init",
+                "README.md": "# repo",
+            }
+        )
+        c = discover_repo_contract(
+            owner="owner", repo="repo", workspace_root=str(ws)
+        )
+        self.assertEqual(c.changelog, "CHANGELOG.md")
+        self.assertEqual(c.version_files, ("package.json",))
+        self.assertEqual(c.tag_policy, "changelog_driven")
+        self.assertTrue(c.has_tag_policy)
+        # ssot_paths 도 새 신호를 포함
+        self.assertIn("CHANGELOG.md", c.ssot_paths)
+        self.assertIn("package.json", c.ssot_paths)
+
+    def test_release_workflow_overrides_to_workflow_driven(self) -> None:
+        ws = self._seed(
+            **{
+                "package.json": '{"version":"1.0.0"}',
+                "CHANGELOG.md": "## 1.0.0",
+                ".github/workflows/release.yml": "name: release",
+                ".github/workflows/ci.yml": "name: ci",
+            }
+        )
+        c = discover_repo_contract(
+            owner="owner", repo="repo", workspace_root=str(ws)
+        )
+        self.assertEqual(c.tag_policy, "workflow_driven")
+        # release.yml 만 release_workflows 에 들어가고 ci.yml 은 제외
+        self.assertEqual(c.release_workflows, (".github/workflows/release.yml",))
+        # 전체 workflows 에는 두 개 다 있어야 함 (회귀 가드)
+        self.assertEqual(
+            c.workflows,
+            (".github/workflows/ci.yml", ".github/workflows/release.yml"),
+        )
+
+    def test_publish_workflow_token_also_counts(self) -> None:
+        ws = self._seed(
+            **{
+                ".github/workflows/publish.yml": "name: publish",
+            }
+        )
+        c = discover_repo_contract(
+            owner="owner", repo="repo", workspace_root=str(ws)
+        )
+        self.assertEqual(c.tag_policy, "workflow_driven")
+        self.assertIn(".github/workflows/publish.yml", c.release_workflows)
+
+    def test_no_tag_signals_returns_none(self) -> None:
+        ws = self._seed(**{"README.md": "# repo"})
+        c = discover_repo_contract(
+            owner="owner", repo="repo", workspace_root=str(ws)
+        )
+        self.assertEqual(c.tag_policy, "none")
+        self.assertFalse(c.has_tag_policy)
+
+
+class RoundTripTests(unittest.TestCase):
+    def test_dict_round_trip_preserves_tag_fields(self) -> None:
+        original = RepoContract(
+            owner="o",
+            repo="r",
+            changelog="CHANGELOG.md",
+            version_files=("package.json", "pyproject.toml"),
+            release_workflows=(".github/workflows/release.yml",),
+            tag_policy="workflow_driven",
+        )
+        restored = RepoContract.from_dict(original.to_dict())
+        self.assertEqual(restored.changelog, "CHANGELOG.md")
+        self.assertEqual(restored.version_files, ("package.json", "pyproject.toml"))
+        self.assertEqual(restored.release_workflows, (".github/workflows/release.yml",))
+        self.assertEqual(restored.tag_policy, "workflow_driven")
+        self.assertTrue(restored.has_tag_policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_issue_autocreate_end_to_end.py
+++ b/tests/engineering/test_issue_autocreate_end_to_end.py
@@ -1,0 +1,250 @@
+"""Issue auto-create end-to-end — P0-S 종단 회귀.
+
+목적
+====
+"코딩 요청을 받았는데 issue 가 없으면 issue 를 자동 생성한 뒤 dispatch
+한다" 라는 사용자 기대를 dispatch 직전까지 한 줄로 묶어 검증한다. 실제
+GitHub API 호출은 없음 (dry_run 또는 stub) — 단, 다음을 모두 핀:
+
+  1. discover_repo_contract 가 target repo 의 issue_templates 를 발견.
+  2. build_issue_auto_create_plan 이 그 template 을 읽어 plan 생성.
+  3. plan 이 GitHubWorkOrderProposal.issue_auto_create_plan 에 stamp.
+  4. approval → work_order 단계에서 plan 이 그대로 전달.
+  5. GithubWriter.create_issue (dry_run=False, live=True, stub client) 가
+     plan.title/body/labels/assignees 를 그대로 사용.
+
+회귀 방지:
+  - existing_issue_number 가 명시되면 plan 은 None — issue 생성 안 함.
+  - tag_policy=='none' 이면 work_order extra 에 tag plan 미적용 audit.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.git.repo_contract import discover_repo_contract
+from yule_orchestrator.agents.github_workos.audit import (
+    ACTION_GITHUB_ISSUE_CREATE,
+    OUTCOME_OK,
+)
+from yule_orchestrator.agents.github_workos.github_writer import (
+    GithubWriter,
+    make_default_policy_gate,
+)
+from yule_orchestrator.agents.github_workos.issue_auto_create import (
+    AUDIT_EXISTING_ISSUE_REUSED,
+    AUDIT_TEMPLATE_USED,
+    build_issue_auto_create_plan,
+)
+from yule_orchestrator.agents.job_queue.github_work_order import (
+    GitHubWorkOrder,
+    GitHubWorkOrderProposal,
+)
+
+
+_FEATURE_TEMPLATE = (
+    "---\n"
+    'name: "[Feature] Issue Template"\n'
+    'title: "[Feat]"\n'
+    'labels: "✨ Feature, 📃 Docs"\n'
+    "---\n"
+    "\n"
+    "## 어떤 기능인가요?\n"
+    "> 추가하려는 기능에 대해 간결하게 설명해주세요\n"
+    "\n"
+    "## 작업 상세 내용\n"
+    "- [ ] \n"
+)
+
+
+class _StubIssueClient:
+    """create_issue 만 받는 최소 stub."""
+
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    def create_issue_comment(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_issue(self, *, repo, title, body, labels=(), assignees=()):
+        self.calls.append(
+            (
+                "create_issue",
+                {
+                    "repo": repo,
+                    "title": title,
+                    "body": body,
+                    "labels": tuple(labels),
+                    "assignees": tuple(assignees),
+                },
+            )
+        )
+        return {
+            "url": f"https://api.github.com/repos/{repo}/issues/77",
+            "html_url": f"https://github.com/{repo}/issues/77",
+            "number": 77,
+            "status": 201,
+        }
+
+    def add_labels(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_branch_ref(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_commit_via_data_api(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_draft_pull_request(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+class EndToEndIssueAutoCreateTests(unittest.TestCase):
+    """coding request (no issue) → repo_contract → plan → work_order →
+    GithubWriter.create_issue 전 경로."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.workspace_root = Path(self._tmp.name)
+        self.target_repo = self.workspace_root / "yule-studio" / "naver-search-clone"
+        self.target_repo.mkdir(parents=True)
+        (self.target_repo / ".github" / "ISSUE_TEMPLATE").mkdir(parents=True)
+        (
+            self.target_repo
+            / ".github"
+            / "ISSUE_TEMPLATE"
+            / "-feature--issue-template.md"
+        ).write_text(_FEATURE_TEMPLATE)
+        (self.target_repo / ".github" / "PULL_REQUEST_TEMPLATE").write_text(
+            "## 📌 관련 이슈\n## ✨ 과제 내용\n"
+        )
+        (self.target_repo / "README.md").write_text("# repo")
+
+    def _template_loader_from_workspace(self, repo_contract):
+        repo_root = (
+            self.workspace_root / repo_contract.owner / repo_contract.repo
+        )
+
+        def _load(path: str):
+            full = repo_root / path
+            if not full.is_file():
+                return None
+            return full.read_text(encoding="utf-8")
+
+        return _load
+
+    def test_end_to_end_dispatch_with_template(self) -> None:
+        # 1. discover repo contract
+        contract = discover_repo_contract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            workspace_root=str(self.workspace_root),
+        )
+        self.assertEqual(contract.backend, "local_clone")
+        self.assertTrue(contract.issue_templates)
+
+        # 2. build plan
+        outcome = build_issue_auto_create_plan(
+            repo_contract=contract,
+            request_summary="Next.js + NestJS 회원가입/검색 구현",
+            template_loader=self._template_loader_from_workspace(contract),
+            session_id="sess-e2e",
+        )
+        self.assertIsNotNone(outcome.plan)
+        assert outcome.plan is not None
+        self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_USED)
+        self.assertIn("✨ Feature", outcome.plan.labels)
+
+        # 3. plan → proposal → work_order
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p1",
+            session_id="sess-e2e",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="Next.js + NestJS 회원가입/검색 구현",
+            repo="yule-studio/naver-search-clone",
+            issue_auto_create_plan=outcome.plan.to_dict(),
+        )
+        work_order = GitHubWorkOrder.from_proposal(
+            proposal, approval_id="approval-1", approved_by="masterway"
+        )
+        self.assertEqual(
+            work_order.issue_auto_create_plan, outcome.plan.to_dict()
+        )
+
+        # 4. dispatch: writer.create_issue is called with the plan
+        client = _StubIssueClient()
+        writer = GithubWriter(
+            client=client,
+            dry_run=False,
+            live=True,
+            policy_gate=make_default_policy_gate(),
+        )
+        plan = work_order.issue_auto_create_plan
+        assert plan is not None
+        result = writer.create_issue(
+            repo=work_order.repo or "",
+            title=str(plan["title"]),
+            body=str(plan["body"]),
+            labels=tuple(plan.get("labels") or ()),
+            assignees=tuple(plan.get("assignees") or ()),
+            session_id=work_order.session_id,
+        )
+        self.assertEqual(result.outcome, OUTCOME_OK)
+        self.assertEqual(result.audit.action, ACTION_GITHUB_ISSUE_CREATE)
+        # stub client 가 받은 인자 검증
+        self.assertEqual(len(client.calls), 1)
+        kind, kwargs = client.calls[0]
+        self.assertEqual(kind, "create_issue")
+        self.assertEqual(kwargs["repo"], "yule-studio/naver-search-clone")
+        self.assertTrue(kwargs["title"].startswith("[Feat]"))
+        self.assertIn("Next.js + NestJS", kwargs["title"])
+        self.assertIn("✨ Feature", kwargs["labels"])
+
+    def test_existing_issue_number_skips_plan(self) -> None:
+        contract = discover_repo_contract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            workspace_root=str(self.workspace_root),
+        )
+        outcome = build_issue_auto_create_plan(
+            repo_contract=contract,
+            request_summary="이슈 #42 작업",
+            template_loader=self._template_loader_from_workspace(contract),
+            session_id="sess-reuse",
+            existing_issue_number=42,
+        )
+        self.assertIsNone(outcome.plan)
+        self.assertEqual(outcome.existing_issue_number, 42)
+        self.assertEqual(outcome.audit_reason, AUDIT_EXISTING_ISSUE_REUSED)
+
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p3",
+            session_id="sess-reuse",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="이슈 #42 작업",
+            repo="yule-studio/naver-search-clone",
+            existing_issue_number=42,
+        )
+        wo = GitHubWorkOrder.from_proposal(
+            proposal, approval_id="a3", approved_by="m"
+        )
+        self.assertEqual(wo.existing_issue_number, 42)
+        self.assertIsNone(wo.issue_auto_create_plan)
+        # executor 는 plan 이 None 일 때 create_issue 를 호출하지 않아야 함.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/github_workos/test_issue_auto_create.py
+++ b/tests/github_workos/test_issue_auto_create.py
@@ -1,0 +1,311 @@
+"""Issue auto-create — P0-S end-to-end 모델 회귀 테스트.
+
+다음 contract 를 핀:
+
+  1. ``parse_issue_template`` 가 frontmatter (name/title/labels/assignees) 와
+     body 를 정확히 분리.
+  2. ``select_issue_template`` 가 single-template repo 에서 HIGH confidence,
+     multi-template 에서 키워드 매칭 점수로 confidence 분류.
+  3. ``fill_issue_template`` 이 placeholder 를 보존하면서 첫 ``## `` 헤더
+     아래에 request_summary 를 quote 형태로 삽입 + audit 섹션 부착.
+  4. ``build_default_issue_body`` (fallback) 가 audit_reason=
+     ``no_repo_template`` 로 명시.
+  5. ``build_issue_auto_create_plan``:
+     - ``existing_issue_number`` 가 있으면 plan 은 None, 중복 생성 금지.
+     - template 가 없으면 fallback plan.
+     - confidence LOW 시 ``needs_operator_decision=True`` 로 DECISION_REQUIRED
+       카드 트리거 가능.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.git.repo_contract import RepoContract
+from yule_orchestrator.agents.github_workos.issue_auto_create import (
+    AUDIT_EXISTING_ISSUE_REUSED,
+    AUDIT_TEMPLATE_AMBIGUOUS,
+    AUDIT_TEMPLATE_FALLBACK,
+    AUDIT_TEMPLATE_USED,
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    CONFIDENCE_MEDIUM,
+    IssueAutoCreateOutcome,
+    IssueAutoCreatePlan,
+    IssueTemplate,
+    build_default_issue_body,
+    build_issue_auto_create_plan,
+    fill_issue_template,
+    parse_issue_template,
+    score_template_against_request,
+    select_issue_template,
+)
+
+
+_REAL_FEATURE_TEMPLATE = (
+    "---\n"
+    'name: "[Feature] Issue Template"\n'
+    'about: 모든 라벨 관리 이슈 템플릿\n'
+    'title: "[Feat]"\n'
+    'labels: "✨ Feature, 📃 Docs"\n'
+    "assignees: ''\n"
+    "---\n"
+    "\n"
+    "## 어떤 기능인가요?\n"
+    "> 추가하려는 기능에 대해 간결하게 설명해주세요\n"
+    "\n"
+    "## 작업 상세 내용\n"
+    "- [ ] \n"
+    "\n"
+    "## 참고할만한 자료(선택)\n"
+)
+
+
+_BUG_TEMPLATE = (
+    "---\n"
+    'name: "Bug Report"\n'
+    'about: 운영 중 발견된 버그를 신고하세요'
+    "\n"
+    'title: "[Bug]"\n'
+    'labels:\n'
+    "  - 🐞 BugFix\n"
+    "---\n"
+    "\n"
+    "## 버그 설명\n"
+    "> 무엇이 잘못 동작했는지 설명해주세요\n"
+    "\n"
+    "## 재현 단계\n"
+    "1. ...\n"
+)
+
+
+class TemplateParsingTests(unittest.TestCase):
+    def test_parses_inline_labels_list(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md",
+            text=_REAL_FEATURE_TEMPLATE,
+        )
+        self.assertEqual(tpl.name, "[Feature] Issue Template")
+        self.assertEqual(tpl.title_prefix, "[Feat]")
+        self.assertEqual(tpl.labels, ("✨ Feature", "📃 Docs"))
+        self.assertEqual(tpl.assignees, ())
+        self.assertIn("어떤 기능인가요?", tpl.body)
+        self.assertIn("작업 상세 내용", tpl.body)
+
+    def test_parses_indented_labels_list(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/bug.md",
+            text=_BUG_TEMPLATE,
+        )
+        self.assertEqual(tpl.name, "Bug Report")
+        self.assertEqual(tpl.title_prefix, "[Bug]")
+        self.assertEqual(tpl.labels, ("🐞 BugFix",))
+
+    def test_no_frontmatter_falls_back_to_body(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/raw.md",
+            text="just a body without frontmatter\n",
+        )
+        self.assertEqual(tpl.title_prefix, "")
+        self.assertEqual(tpl.labels, ())
+        self.assertIn("just a body", tpl.body)
+
+
+class TemplateSelectionTests(unittest.TestCase):
+    def test_single_template_confidence_high(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md", text=_REAL_FEATURE_TEMPLATE
+        )
+        selected, score, confidence = select_issue_template(
+            templates=(tpl,), request_text="회원가입 구현"
+        )
+        self.assertIs(selected, tpl)
+        self.assertEqual(confidence, CONFIDENCE_HIGH)
+
+    def test_multi_template_with_strong_keyword_match(self) -> None:
+        feature = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md", text=_REAL_FEATURE_TEMPLATE
+        )
+        bug = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/bug.md", text=_BUG_TEMPLATE
+        )
+        selected, score, confidence = select_issue_template(
+            templates=(feature, bug),
+            request_text="운영 중 버그 발견 — 재현 단계 정리",
+        )
+        self.assertIs(selected, bug)
+        self.assertGreaterEqual(score, 2)
+        self.assertEqual(confidence, CONFIDENCE_HIGH)
+
+    def test_multi_template_with_no_keyword_match_returns_low(self) -> None:
+        feature = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md", text=_REAL_FEATURE_TEMPLATE
+        )
+        bug = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/bug.md", text=_BUG_TEMPLATE
+        )
+        selected, score, confidence = select_issue_template(
+            templates=(feature, bug), request_text="zzz qqq xxx"
+        )
+        self.assertIn(selected, (feature, bug))
+        self.assertEqual(score, 0)
+        self.assertEqual(confidence, CONFIDENCE_LOW)
+
+
+class FillTemplateTests(unittest.TestCase):
+    def test_fill_prepends_summary_quote_under_first_header(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md", text=_REAL_FEATURE_TEMPLATE
+        )
+        plan = fill_issue_template(
+            template=tpl,
+            request_summary="회원가입/로그인 구현",
+            session_id="sess-1",
+        )
+        self.assertTrue(plan.title.startswith("[Feat]"))
+        self.assertIn("회원가입/로그인 구현", plan.title)
+        # quote 삽입 위치 검증
+        self.assertIn("> 회원가입/로그인 구현", plan.body)
+        # placeholder 보존
+        self.assertIn("추가하려는 기능에 대해 간결하게", plan.body)
+        # audit 섹션 포함
+        self.assertIn("engineering-agent audit", plan.body)
+        self.assertIn("audit_reason: `template_used`", plan.body)
+        self.assertIn("sess-1", plan.body)
+        # labels 그대로
+        self.assertEqual(plan.labels, ("✨ Feature", "📃 Docs"))
+        self.assertEqual(plan.template_path, ".github/ISSUE_TEMPLATE/feature.md")
+        self.assertFalse(plan.needs_operator_decision)
+
+    def test_fill_appends_section_when_no_header(self) -> None:
+        tpl = IssueTemplate(
+            path=".github/ISSUE_TEMPLATE/raw.md",
+            name="raw",
+            body="just text without any header",
+        )
+        plan = fill_issue_template(template=tpl, request_summary="X 작업")
+        self.assertIn("## 작업 컨텍스트", plan.body)
+        self.assertIn("> X 작업", plan.body)
+
+    def test_extra_labels_are_merged(self) -> None:
+        tpl = parse_issue_template(
+            path=".github/ISSUE_TEMPLATE/feature.md", text=_REAL_FEATURE_TEMPLATE
+        )
+        plan = fill_issue_template(
+            template=tpl,
+            request_summary="A",
+            extra_labels=("🤖 Agent-runtime", "✨ Feature"),  # dup 제거 검증
+        )
+        # dict-fromkeys 가 원본 라벨 + extra 합치되 중복 없음
+        self.assertIn("🤖 Agent-runtime", plan.labels)
+        self.assertEqual(plan.labels.count("✨ Feature"), 1)
+
+
+class DefaultFallbackTests(unittest.TestCase):
+    def test_fallback_marks_audit_reason(self) -> None:
+        plan = build_default_issue_body(
+            request_summary="설명 없는 코딩 요청",
+            session_id="sess-fallback",
+        )
+        self.assertEqual(plan.audit_reason, AUDIT_TEMPLATE_FALLBACK)
+        self.assertIn("audit_reason: `no_repo_template`", plan.body)
+        self.assertEqual(plan.template_path, None)
+        self.assertFalse(plan.needs_operator_decision)
+        self.assertIn("설명 없는 코딩 요청", plan.body)
+
+
+class BuildIssueAutoCreatePlanTests(unittest.TestCase):
+    def test_existing_issue_short_circuits(self) -> None:
+        rc = RepoContract(owner="o", repo="r")
+        outcome = build_issue_auto_create_plan(
+            repo_contract=rc,
+            request_summary="ignored",
+            existing_issue_number=42,
+        )
+        self.assertIsNone(outcome.plan)
+        self.assertEqual(outcome.existing_issue_number, 42)
+        self.assertEqual(outcome.audit_reason, AUDIT_EXISTING_ISSUE_REUSED)
+
+    def test_no_templates_returns_fallback(self) -> None:
+        rc = RepoContract(owner="o", repo="r")  # issue_templates 비어있음
+        outcome = build_issue_auto_create_plan(
+            repo_contract=rc,
+            request_summary="회원가입 추가",
+            session_id="sess-x",
+        )
+        self.assertIsNotNone(outcome.plan)
+        assert outcome.plan is not None
+        self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_FALLBACK)
+        self.assertIn("회원가입 추가", outcome.plan.body)
+        self.assertEqual(outcome.candidate_templates, ())
+
+    def test_single_template_with_loader(self) -> None:
+        rc = RepoContract(
+            owner="o",
+            repo="r",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        loader_calls: list[str] = []
+
+        def _loader(path: str) -> str:
+            loader_calls.append(path)
+            return _REAL_FEATURE_TEMPLATE
+
+        outcome = build_issue_auto_create_plan(
+            repo_contract=rc,
+            request_summary="회원가입/검색 기능 구현",
+            template_loader=_loader,
+            session_id="sess-single",
+        )
+        self.assertEqual(loader_calls, [".github/ISSUE_TEMPLATE/feature.md"])
+        self.assertIsNotNone(outcome.plan)
+        assert outcome.plan is not None
+        self.assertEqual(outcome.plan.confidence, CONFIDENCE_HIGH)
+        self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_USED)
+        self.assertIn("> 회원가입/검색 기능 구현", outcome.plan.body)
+
+    def test_ambiguous_multi_template_marks_needs_decision(self) -> None:
+        rc = RepoContract(
+            owner="o",
+            repo="r",
+            issue_templates=(
+                ".github/ISSUE_TEMPLATE/feature.md",
+                ".github/ISSUE_TEMPLATE/bug.md",
+            ),
+        )
+        texts = {
+            ".github/ISSUE_TEMPLATE/feature.md": _REAL_FEATURE_TEMPLATE,
+            ".github/ISSUE_TEMPLATE/bug.md": _BUG_TEMPLATE,
+        }
+        outcome = build_issue_auto_create_plan(
+            repo_contract=rc,
+            request_summary="aaa bbb ccc",  # 매칭 0
+            template_loader=lambda p: texts.get(p),
+        )
+        self.assertIsNotNone(outcome.plan)
+        assert outcome.plan is not None
+        self.assertEqual(outcome.plan.confidence, CONFIDENCE_LOW)
+        self.assertTrue(outcome.plan.needs_operator_decision)
+        self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_AMBIGUOUS)
+
+    def test_loader_failure_falls_back(self) -> None:
+        rc = RepoContract(
+            owner="o",
+            repo="r",
+            issue_templates=(".github/ISSUE_TEMPLATE/missing.md",),
+        )
+        outcome = build_issue_auto_create_plan(
+            repo_contract=rc,
+            request_summary="x",
+            template_loader=lambda _: None,  # loader 가 못 읽음
+        )
+        self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_FALLBACK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/github_workos/test_writer_create_issue.py
+++ b/tests/github_workos/test_writer_create_issue.py
@@ -1,0 +1,259 @@
+"""GithubWriter.create_issue + LiveGithubAppClient.create_issue 회귀 테스트.
+
+contract:
+  - dry_run 기본 → 클라이언트 호출 없음, audit 는 OUTCOME_DRY_RUN
+  - dry_run=False + live=True + 정책 허용 → 클라이언트 호출 + 응답 dict
+    에서 number/html_url 추출
+  - 정책 거부 (예: repo allow-list 위반) → OUTCOME_DENIED_BY_POLICY +
+    클라이언트 호출 없음
+  - 레이블/담당자 정규화: 공백 strip + 빈 항목 제거
+  - LiveGithubAppClient.create_issue 가 ``/repos/{repo}/issues`` POST 와
+    title/body/labels/assignees payload 를 보낸다 (빈 시퀀스는 payload
+    에서 생략)
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.github_workos.audit import (
+    ACTION_GITHUB_ISSUE_CREATE,
+    OUTCOME_DENIED_BY_POLICY,
+    OUTCOME_DRY_RUN,
+    OUTCOME_OK,
+)
+from yule_orchestrator.agents.github_workos.github_writer import (
+    GithubWriter,
+    PolicyGateDecision,
+    make_default_policy_gate,
+)
+
+
+class _RecordingClient:
+    def __init__(self, *, issue_response: Mapping[str, Any] | None = None) -> None:
+        self.calls: List[Tuple[str, dict]] = []
+        self._issue = issue_response or {
+            "url": "https://api.github.com/repos/owner/repo/issues/77",
+            "html_url": "https://github.com/owner/repo/issues/77",
+            "number": 77,
+            "status": 201,
+        }
+
+    # full Protocol shape — only create_issue is exercised here
+    def create_issue_comment(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_issue(self, *, repo, title, body, labels=(), assignees=()):
+        self.calls.append(
+            (
+                "create_issue",
+                {
+                    "repo": repo,
+                    "title": title,
+                    "body": body,
+                    "labels": tuple(labels),
+                    "assignees": tuple(assignees),
+                },
+            )
+        )
+        return dict(self._issue)
+
+    def add_labels(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_branch_ref(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_commit_via_data_api(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def create_draft_pull_request(self, **_kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+class WriterCreateIssueDryRunTests(unittest.TestCase):
+    def test_default_dry_run_blocks_client_call(self) -> None:
+        client = _RecordingClient()
+        writer = GithubWriter(client=client)
+        result = writer.create_issue(
+            repo="owner/repo",
+            title="[Feat] 회원가입",
+            body="요약",
+            labels=("✨ Feature",),
+            assignees=("codwithyc",),
+            session_id="sess-1",
+        )
+        self.assertEqual(result.outcome, OUTCOME_DRY_RUN)
+        self.assertEqual(client.calls, [])
+        self.assertTrue(result.audit.dry_run)
+        self.assertEqual(result.audit.action, ACTION_GITHUB_ISSUE_CREATE)
+
+
+class WriterCreateIssuePolicyTests(unittest.TestCase):
+    def test_denied_repo_blocks_call(self) -> None:
+        client = _RecordingClient()
+        gate = make_default_policy_gate(allowed_repos=("owner/another",))
+        writer = GithubWriter(
+            client=client, dry_run=False, live=True, policy_gate=gate
+        )
+        result = writer.create_issue(
+            repo="owner/repo",
+            title="t",
+            body="b",
+        )
+        self.assertEqual(result.outcome, OUTCOME_DENIED_BY_POLICY)
+        self.assertEqual(client.calls, [])
+        self.assertEqual(result.audit.outcome, OUTCOME_DENIED_BY_POLICY)
+
+
+class WriterCreateIssueLiveTests(unittest.TestCase):
+    def test_live_create_issue_calls_client_and_records_audit(self) -> None:
+        client = _RecordingClient()
+        writer = GithubWriter(
+            client=client,
+            dry_run=False,
+            live=True,
+            policy_gate=make_default_policy_gate(),
+        )
+        result = writer.create_issue(
+            repo="owner/repo",
+            title="[Feat] 회원가입",
+            body="설명",
+            labels=(" ✨ Feature ", "", "📃 Docs"),
+            assignees=("codwithyc",),
+            session_id="sess-99",
+        )
+        self.assertEqual(result.outcome, OUTCOME_OK)
+        self.assertEqual(len(client.calls), 1)
+        kind, kwargs = client.calls[0]
+        self.assertEqual(kind, "create_issue")
+        self.assertEqual(kwargs["repo"], "owner/repo")
+        # cleaned labels: strip + drop empty
+        self.assertEqual(kwargs["labels"], ("✨ Feature", "📃 Docs"))
+        self.assertEqual(kwargs["assignees"], ("codwithyc",))
+        # audit body carries the redacted response
+        self.assertIn("html_url", result.body)
+        self.assertEqual(result.body["number"], 77)
+        self.assertEqual(result.audit.action, ACTION_GITHUB_ISSUE_CREATE)
+        self.assertFalse(result.audit.dry_run)
+        self.assertEqual(result.audit.session_id, "sess-99")
+        # references list captures the issue URL (writer prefers `url` field
+        # for parity with other actions; `html_url` is the body link)
+        self.assertIn(
+            "https://api.github.com/repos/owner/repo/issues/77",
+            result.audit.references,
+        )
+
+
+# ---------------------------------------------------------------------------
+# LiveGithubAppClient — payload shape
+# ---------------------------------------------------------------------------
+
+
+_FAKE_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIBOgIBAAJBAJtest+placeholder=\n"
+    "-----END RSA PRIVATE KEY-----\n"
+).encode("utf-8")
+
+
+class _FakeHTTP:
+    """Minimal HTTPClient stub matching the contract used elsewhere."""
+
+    def __init__(self) -> None:
+        self.posted: List[Dict[str, Any]] = []
+        self.gotten: List[Dict[str, Any]] = []
+
+    def post(self, url, *, headers, body):
+        from yule_orchestrator.github_app.client import HTTPResponse
+
+        self.posted.append({"url": url, "headers": dict(headers), "body": dict(body)})
+        # Token mint endpoint — return a fake installation token.
+        if url.endswith("/access_tokens"):
+            return HTTPResponse(
+                status=201,
+                body={"token": "tok", "expires_at": "2030-01-01T00:00:00Z"},
+            )
+        if url.endswith("/issues"):
+            return HTTPResponse(
+                status=201,
+                body={
+                    "number": 11,
+                    "html_url": "https://github.com/owner/repo/issues/11",
+                },
+            )
+        return HTTPResponse(status=201, body={})
+
+    def get(self, url, *, headers):  # pragma: no cover - unused here
+        from yule_orchestrator.github_app.client import HTTPResponse
+
+        self.gotten.append({"url": url, "headers": dict(headers)})
+        return HTTPResponse(status=200, body={})
+
+
+class _NullSigner:
+    def sign(self, message: bytes, private_key: bytes) -> bytes:  # noqa: ARG002
+        return b"signed"
+
+
+def _build_live_client(http: _FakeHTTP):
+    from yule_orchestrator.github_app.live_client import LiveGithubAppClient
+    from yule_orchestrator.github_app.config import GitHubAppConfig
+
+    cfg = GitHubAppConfig(
+        app_id="123",
+        installation_id="456",
+        private_key_path="/dev/null",
+        owner="owner",
+        repo="repo",
+    )
+    return LiveGithubAppClient(
+        config=cfg,
+        http=http,
+        signer=_NullSigner(),
+        private_key_bytes=_FAKE_PEM,
+    )
+
+
+class LiveGithubAppClientIssueTests(unittest.TestCase):
+    def test_create_issue_posts_to_issues_endpoint_with_labels(self) -> None:
+        http = _FakeHTTP()
+        client = _build_live_client(http)
+        response = client.create_issue(
+            repo="owner/repo",
+            title="[Feat] X",
+            body="body",
+            labels=("✨ Feature", "📃 Docs"),
+            assignees=("codwithyc",),
+        )
+        self.assertEqual(response["number"], 11)
+        # Locate the issue POST (one for token mint + one for issue create)
+        issue_reqs = [r for r in http.posted if r["url"].endswith("/repos/owner/repo/issues")]
+        self.assertEqual(len(issue_reqs), 1)
+        body = issue_reqs[0]["body"]
+        self.assertEqual(body["title"], "[Feat] X")
+        self.assertEqual(body["body"], "body")
+        self.assertEqual(body["labels"], ["✨ Feature", "📃 Docs"])
+        self.assertEqual(body["assignees"], ["codwithyc"])
+
+    def test_create_issue_omits_empty_labels_and_assignees(self) -> None:
+        http = _FakeHTTP()
+        client = _build_live_client(http)
+        client.create_issue(repo="owner/repo", title="t", body="b")
+        body = next(
+            r["body"]
+            for r in http.posted
+            if r["url"].endswith("/repos/owner/repo/issues")
+        )
+        self.assertNotIn("labels", body)
+        self.assertNotIn("assignees", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_github_work_order_issue_plan.py
+++ b/tests/job_queue/test_github_work_order_issue_plan.py
@@ -1,0 +1,115 @@
+"""GitHubWorkOrderProposal / GitHubWorkOrder 에 issue auto-create plan
+필드가 round-trip 되는지 회귀 핀.
+
+contract:
+  - proposal 의 ``issue_auto_create_plan`` / ``existing_issue_number``
+    가 to_payload/from_payload 무손실 보존.
+  - from_proposal 이 work_order 로 plan 을 그대로 전달.
+  - work_order 의 to_payload/from_payload 도 무손실.
+  - existing_issue_number 가 있으면 plan 은 None — executor 가 issue 생성
+    을 건너뛰는 신호.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.github_work_order import (
+    GitHubWorkOrder,
+    GitHubWorkOrderProposal,
+)
+
+
+def _sample_plan() -> dict:
+    return {
+        "title": "[Feat] 회원가입/검색 기능",
+        "body": "## 어떤 기능인가요?\n> 본문\n",
+        "labels": ["✨ Feature", "📃 Docs"],
+        "assignees": [],
+        "template_path": ".github/ISSUE_TEMPLATE/feature.md",
+        "confidence": "high",
+        "audit_reason": "template_used",
+        "needs_operator_decision": False,
+        "template_score": 2,
+    }
+
+
+class ProposalRoundTripTests(unittest.TestCase):
+    def test_plan_survives_payload_round_trip(self) -> None:
+        plan = _sample_plan()
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p1",
+            session_id="s1",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="full-stack 구현",
+            repo="yule-studio/naver-search-clone",
+            issue_auto_create_plan=plan,
+        )
+        restored = GitHubWorkOrderProposal.from_payload(proposal.to_payload())
+        self.assertEqual(restored.issue_auto_create_plan, plan)
+        self.assertIsNone(restored.existing_issue_number)
+
+    def test_existing_issue_round_trip_keeps_plan_none(self) -> None:
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p2",
+            session_id="s2",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="issue #42 작업",
+            existing_issue_number=42,
+        )
+        restored = GitHubWorkOrderProposal.from_payload(proposal.to_payload())
+        self.assertEqual(restored.existing_issue_number, 42)
+        self.assertIsNone(restored.issue_auto_create_plan)
+
+
+class WorkOrderRoundTripTests(unittest.TestCase):
+    def test_from_proposal_carries_plan(self) -> None:
+        plan = _sample_plan()
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p1",
+            session_id="s1",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="x",
+            issue_auto_create_plan=plan,
+        )
+        wo = GitHubWorkOrder.from_proposal(
+            proposal, approval_id="a1", approved_by="masterway"
+        )
+        self.assertEqual(wo.issue_auto_create_plan, plan)
+        # payload round-trip
+        restored = GitHubWorkOrder.from_payload(wo.to_payload())
+        self.assertEqual(restored.issue_auto_create_plan, plan)
+        self.assertEqual(restored.approval_id, "a1")
+
+    def test_existing_issue_propagates(self) -> None:
+        proposal = GitHubWorkOrderProposal(
+            proposal_id="p2",
+            session_id="s2",
+            source_channel_id=None,
+            source_thread_id=None,
+            source_message_id=None,
+            request_summary="reuse issue",
+            existing_issue_number=99,
+        )
+        wo = GitHubWorkOrder.from_proposal(
+            proposal, approval_id="a2", approved_by="m"
+        )
+        self.assertEqual(wo.existing_issue_number, 99)
+        self.assertIsNone(wo.issue_auto_create_plan)
+        restored = GitHubWorkOrder.from_payload(wo.to_payload())
+        self.assertEqual(restored.existing_issue_number, 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/obsidian/test_knowledge_note_hollow_guard.py
+++ b/tests/obsidian/test_knowledge_note_hollow_guard.py
@@ -1,0 +1,91 @@
+"""Knowledge note hollow-body 가드 회귀 — operator-visibility 핀.
+
+엔지니어링 agent 가 pack/snapshot/synthesis 모두 비어있는 상태에서
+knowledge note 를 저장하려고 하면 hollow vault file 이 남는다. 그래서
+:func:`default_render_fn` 은 :class:`ObsidianRenderError` 를 던지고 worker
+는 그 메시지를 ``result_json['error']`` 로 노출 — operator 가 status
+diagnostic 으로 "왜 vault 에 안 떨어졌는지" 즉시 볼 수 있어야 한다.
+
+본 test 는 두 contract 를 핀:
+  1. hollow body 일 때 default_render_fn 이 명확한 에러 메시지로 실패.
+  2. ObsidianWriterWorker 가 그 에러를 FAILED_RETRYABLE + result.error
+     로 표면화 (silent failure 방지).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.obsidian_writer_worker import (
+    JOB_TYPE_OBSIDIAN_WRITE,
+    NOTE_KIND_KNOWLEDGE,
+    ObsidianRenderError,
+    ObsidianWriteRequest,
+    ObsidianWriterWorker,
+    default_render_fn,
+)
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class HollowKnowledgeNoteTests(unittest.TestCase):
+    """pack/snapshot/synthesis 모두 비면 hollow vault file 거부."""
+
+    def test_default_render_fn_raises_on_hollow_inputs(self) -> None:
+        from yule_orchestrator.agents.workflow_state import (
+            WorkflowSession,
+            WorkflowState,
+            save_session,
+        )
+        from datetime import datetime, timezone
+
+        with tempfile.TemporaryDirectory() as tmp:
+            import os
+            os.environ["YULE_CACHE_DB_PATH"] = str(Path(tmp) / "cache.sqlite3")
+            try:
+                now = datetime.now(tz=timezone.utc)
+                session = WorkflowSession(
+                    session_id="sess-hollow",
+                    prompt="hollow request",
+                    task_type="research",
+                    state=WorkflowState.APPROVED,
+                    created_at=now,
+                    updated_at=now,
+                    extra={},  # no research_pack / no synthesis
+                )
+                save_session(session)
+                request = ObsidianWriteRequest(
+                    session_id="sess-hollow",
+                    note_kind=NOTE_KIND_KNOWLEDGE,
+                    title="hollow",
+                    approval_id="a1",
+                    approved_by="m",
+                    approved_at="2026-05-15T00:00:00+00:00",
+                    metadata={},
+                )
+                with self.assertRaises(ObsidianRenderError) as cm:
+                    default_render_fn(request)
+                self.assertIn("hydration", str(cm.exception).lower())
+            finally:
+                os.environ.pop("YULE_CACHE_DB_PATH", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #165

## ✨ 과제 내용

engineering-agent 가 "Discord 코딩 요청 → repo 확인 → issue 자동 생성 → 승인 → 코드 → push → draft PR" end-to-end 흐름의 **빠진 핵심 두 단계** 를 닫는다:

1. **Issue auto-create** — target repo 의 `ISSUE_TEMPLATE` 을 읽어 채움
2. **Tag / version policy reader** — repo 의 release 신호 4 분류

### 현재 상태 audit (10줄)
1. `RepoContract` 가 ISSUE/PR template 등은 감지하지만 tag/version policy 신호 없음 → 본 PR 추가
2. `LiveGithubAppClient` 에 `create_issue` 자체가 없음 → 본 PR 추가
3. `GithubWriter` 도 마찬가지, `ACTION_GITHUB_ISSUE_CREATE` 없음 → 본 PR 추가
4. `GitHubWorkOrder` pipeline 이 issue auto-create 단계가 빠져 있었음 → 본 PR 추가
5. PR template (`repository_pr_template.py` 718 lines) 는 견고, 그대로 유지
6. Operator Action Inbox (PR #162) + Approved→coding_execute dispatch (PR #160) 는 이미 닫혀 있음
7. Obsidian knowledge note hollow guard 는 의도된 동작 — 회귀 테스트로 핀
8. classification regression 기존 테스트 그대로 통과 (4813 pass / 1 skip)
9. `LiveGithubAppClient` 의 smoke helper (`get_repo` 등) 와 토큰 minting 패턴 그대로 재사용
10. **이번 PR 의 실제 종단 작업**: ① IssueAutoCreatePlan ② client.create_issue + writer + ACTION 상수 ③ work_order 의 issue_auto_create_plan 1급 필드 ④ tag policy reader + 4 분류 ⑤ 6 신규 테스트 모듈

### 4 commit 구성
1. **🚀 RepoContract 에 tag/version policy 4 신호 감지** — `workflow_driven` / `changelog_driven` / `version_file_only` / `none` 분류
2. **🚀 Issue auto-create 모델 + template 채움 + confidence 분류** — parser/selector/filler/fallback + ambiguous LOW → DECISION_REQUIRED
3. **🔧 LiveGithubAppClient/GithubWriter 에 create_issue capability + L2** — POST `/repos/{repo}/issues` + autonomy gate + audit
4. **🔧 GitHubWorkOrder 가 issue_auto_create_plan / existing_issue_number 보존** — payload 1급 필드, end-to-end 통합 test + obsidian hollow guard 회귀 핀 + docs 갱신

### Issue auto-create 분기

| 조건 | 행동 | audit_reason |
| --- | --- | --- |
| `existing_issue_number` 명시 | 기존 issue 재사용 | `existing_issue_reused` |
| `ISSUE_TEMPLATE` 가 1 개 | template 채움 (frontmatter 적용 + placeholder 보존 + summary quote 삽입) | `template_used` |
| `ISSUE_TEMPLATE` 다중 + 키워드 매칭 ≥1 | best template 선택 (HIGH/MEDIUM) | `template_used` |
| `ISSUE_TEMPLATE` 다중인데 매칭 0 | LOW confidence + `needs_operator_decision=True` → DECISION_REQUIRED 카드 | `ambiguous_template` |
| template 자체 없음 | safe default 4 섹션 body | `no_repo_template` |

**agent 가 issue 본문을 추측해 꾸며내지 않는다.** placeholder/HTML 주석은 그대로 보존. body 끝에 항상 `## engineering-agent audit` 섹션 (audit_reason + session_id + repo contract summary).

### Tag policy 분기

| 값 | 신호 | 자동 처리 |
| --- | --- | --- |
| `workflow_driven` | `.github/workflows/{release,publish,tag}*.yml` | workflow trigger 조건 plan 까지 (실제 tag 발행은 L3) |
| `changelog_driven` | `CHANGELOG.md` 등 | CHANGELOG entry 추가 plan (tag 는 L3) |
| `version_file_only` | `package.json` / `pyproject.toml` 등 version field | version bump 만, 자동 tag 미적용 |
| `none` | 위 신호 없음 | **자동 tag 미적용** — audit 명시. 무단 tag 생성 금지 |

### 닫은 범위 (본 PR end-to-end 검증)
- discover_repo_contract → build_issue_auto_create_plan → proposal stamp → work_order from_proposal → GithubWriter.create_issue 한 줄을 `tests/engineering/test_issue_autocreate_end_to_end.py` 가 실제로 묶어 dispatch 직전까지 검증
- existing_issue 케이스 → plan None → executor 가 issue 생성 건너뜀
- obsidian hollow knowledge note → ObsidianRenderError 로 fail-loud (silent failure 방지)

### 남은 한계 (본 PR 에서 닫지 못한 부분, 후속 PR 필요)
1. **GitHubWorkOrder consumer 측 wiring** — `coding_executor_worker` 가 `work_order.issue_auto_create_plan` 을 읽어 실제 `GithubWriter.create_issue` 호출하는 코드 path. 본 PR 은 plan + payload + writer capability 까지 land. consumer wiring 은 코드/테스트가 더 무겁고 PR scope 가 커지므로 별 PR.
2. **생성된 issue 번호 → session 연결** — issue create 결과를 session.extra 에 stamp 하고 이후 branch/PR body 에 자동 link 하는 wiring. 위 (1) 과 같은 PR scope.
3. **Tag/release 자동 발행** — 본 PR 은 정책 reader 만. 실제 tag 발행은 L3 승인 카드 + executor 행동 후속.

이 한계는 fake success 가 아니라 **명시적 deferred scope** — master plan §3 에 명시.

### 회귀
- 전체 회귀: **4813 pass / 1 skip**
- 신규 36 케이스: issue_auto_create (15) + writer create_issue (5) + tag policy (9) + work_order plan (4) + obsidian hollow (1) + e2e (2)
- 기존 classification / status / operator-action / approval / pr-merge 모두 그대로 통과

## 📚 레퍼런스
- `src/yule_orchestrator/agents/github_workos/issue_auto_create.py` (신규)
- `src/yule_orchestrator/agents/git/repo_contract.py` (tag_policy 확장)
- `src/yule_orchestrator/github_app/live_client.py` (create_issue 추가)
- `docs/github-agent-workos.md` §1.1 / §1.2 / §1.3
- `docs/engineering-company-runtime-master-plan.md` §3 (2026-05-15 갱신)
- `docs/approval-matrix.md` §6 (operator action inbox)