### PR TITLE
🚀 Issue-less bootstrap end-to-end — GitHubWorkOrderWorker + adapter plan stamp (closes #167)

### DIFF
--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -42,30 +42,36 @@ Yule가 도달해야 하는 최종 상태는 아래와 같다.
 
 이 수치는 운영 판단 기준으로 유지한다.
 
-| 영역 | 현재 추정 (2026-05-15) | 2026-05-11 추정 |
-| --- | --- | --- |
-| 운영 골격 | 85~88% | 80~85% |
-| Discord 기술 토의 능력 | 55~65% | 50~60% |
-| 완전 자율 코딩 루프 | 78~85% | 70~80% |
-| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% |
-| 실제 회사처럼 굴러가는 종합 수준 | 68~75% | 60~70% |
+| 영역 | 현재 추정 (2026-05-15, P0-S 종단) | 2026-05-15 (P0-S 1차) | 2026-05-11 추정 |
+| --- | --- | --- | --- |
+| 운영 골격 | 88~90% | 85~88% | 80~85% |
+| Discord 기술 토의 능력 | 55~65% | 55~65% | 50~60% |
+| 완전 자율 코딩 루프 | 82~88% | 78~85% | 70~80% |
+| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% | 50~60% |
+| 실제 회사처럼 굴러가는 종합 수준 | 72~80% | 68~75% | 60~70% |
 
-2026-05-15 갱신 근거 — P0-S 시리즈 (PR #162 Operator Action Inbox / PR #164 문서 계층 + 분리 규칙 / 본 PR Issue auto-create end-to-end + Tag/version policy reader) 머지 결과. 자세한 결정은 본 PR 의 audit block + `docs/approval-matrix.md` §6.
+2026-05-15 갱신 근거 — P0-S 시리즈 (PR #162 Operator Action Inbox / PR #164 문서 계층 / PR #166 Issue auto-create plan + Tag policy / 본 PR Issue-less bootstrap end-to-end consumer).
 
-이번 PR (Issue auto-create + Tag policy) 닫은 범위:
+이번 PR 닫은 범위 (issue-less bootstrap 종단):
 
-- **Issue auto-create end-to-end** — target repo `ISSUE_TEMPLATE` 발견 → 키워드 매칭으로 best template 선택 → frontmatter title prefix/labels 적용 + placeholder 보존 + request_summary quote 삽입 → audit 섹션 부착. 다중 template 매칭 0 → DECISION_REQUIRED 카드. template 없음 → safe default body + `no_repo_template` audit.
-- **`LiveGithubAppClient.create_issue`** — POST `/repos/{repo}/issues` capability + labels/assignees 정규화 + 빈 시퀀스 payload 생략.
-- **`GithubWriter.create_issue`** + `ACTION_GITHUB_ISSUE_CREATE` (L2) + dry_run/denied_by_policy/OK audit 트레일.
-- **`GitHubWorkOrder` payload 확장** — `issue_auto_create_plan` + `existing_issue_number` 1급 필드, proposal/work_order 양쪽 무손실 round-trip.
-- **Tag / version policy** — `RepoContract.tag_policy` (`workflow_driven` / `changelog_driven` / `version_file_only` / `none`). CHANGELOG / package.json / pyproject.toml / Cargo.toml / release.yml 등 신호 수집. 정책 없으면 `has_tag_policy=False` — 자동 tag 보류, audit 명시.
-- **Hollow knowledge note 가드 회귀 핀** — pack/snapshot/synthesis 모두 비면 `ObsidianRenderError` 로 fail-loud (silent failure 방지).
+- **`GitHubWorkOrderWorker` 신설** — `github_work_order` 큐 job 을 실제 drain 하는 consumer. `existing_issue_number` 있으면 issue 생성 skip + anchor stamp, `issue_auto_create_plan` 있으면 `GithubWriter.create_issue` 호출 + anchor stamp. dry_run / live / failed_retryable 모두 명시적 분기.
+- **`session.extra["github_work_order_issue"]`** anchor SSoT — downstream (branch / commit / PR / progress / Obsidian) 가 일관되게 읽을 단일 키. issue number / html_url / approval_id / created_via / audit_reason 보존.
+- **adapter wiring (`build_github_work_order_proposal`)** — `repo_contract` + `issue_template_loader` + `existing_issue_number` 파라미터로 plan 을 proposal 에 직접 stamp. 동일 session 이 이미 anchor 를 들고 있으면 자동으로 existing_anchor 로 전환 (중복 issue 생성 방지).
+- **end-to-end 회귀 테스트** — Discord intake → approval card → 승인 → work_order dispatch → worker drain → issue 생성 → anchor stamp → 재호출 시 anchor 재사용 한 줄 검증.
 
-남은 범위 (본 PR 의 한계):
+직전 PR (#166) 닫은 범위는 동일 그대로 유효:
 
-- **end-to-end live wiring** — GitHubWorkOrder executor 가 `create_issue` 를 실제 호출하는 wiring (consumer 측) 은 후속 PR. 본 PR 은 plan/payload/writer capability/policy 까지 land.
-- **issue 생성 결과 → session 연결** — 생성된 issue number/URL 을 session.extra 에 stamp 하고 이후 branch/PR 에 자동 link 하는 wiring 도 같은 후속 PR 범위 (`coding_executor_worker` 측).
-- **Tag/release 자동 발행** — 본 PR 은 policy 감지까지. 실제 tag/release 생성은 L3 승인 카드 + executor wiring 후속.
+- Issue auto-create model (parser/selector/filler/fallback + ambiguous → DECISION_REQUIRED)
+- `LiveGithubAppClient.create_issue` + `GithubWriter.create_issue` + `ACTION_GITHUB_ISSUE_CREATE` (L2)
+- `GitHubWorkOrder.issue_auto_create_plan` / `existing_issue_number` 1급 필드 round-trip
+- `RepoContract.tag_policy` 4 분류
+- Hollow knowledge note 가드 회귀 핀
+
+남은 범위 (이 PR 의 명시적 deferred):
+
+- **Branch / commit / push / draft PR wiring** — issue create 직후 같은 `GitHubWorkOrderWorker` (또는 별 worker) 가 branch 생성 → tree build → commit → ref move → draft PR 까지 잇는 wiring. issue anchor 키는 이미 SSoT 로 land 됐으므로 다음 PR 은 anchor 를 읽기만 한다.
+- **Tag/release 자동 발행** — 별도 worker + L3 카드.
+- **Discord 측 intake → adapter** wiring — 현재 adapter API 는 keyword arg 로 `repo_contract` / `issue_template_loader` 를 받음. engineering_channel_router 측에서 실제 호출 시점에 이 두 값을 주입하는 통합은 `repo_contract` 발견 위치가 router 측인지 background loop 측인지 추가 결정 후 별 PR.
 
 상한이 100% 가 아닌 이유:
 

--- a/docs/github-agent-workos.md
+++ b/docs/github-agent-workos.md
@@ -67,6 +67,35 @@ operator action 카드 (INFO/ACCESS/SECRET/DECISION) 가 올라간다. 흐름은
 [`docs/approval-matrix.md`](approval-matrix.md) §6 참조. issue auto-create
 의 LOW confidence 도 같은 inbox 로 흐른다 (`DECISION_REQUIRED`).
 
+### 1.4 Issue-less bootstrap end-to-end (P0-S)
+
+"issue 가 없는 repo 에 업무 요청만 들어와도 agent 가 스스로 issue 를
+만들고 그것을 anchor 로 끝까지 이어가는" 종단은 다음 모듈이 묶는다:
+
+```
+Discord intake
+  └─ build_github_work_order_proposal(repo_contract, issue_template_loader)
+       └─ build_issue_auto_create_plan       ← #166 PR
+       └─ session.extra.github_work_order_issue 이미 있으면 existing_anchor 로 전환
+  └─ ApprovalRequest 카드 (#승인-대기)
+  └─ 승인 → handle_github_work_approval_reply
+  └─ dispatch_github_work_order (queue)
+  └─ GitHubWorkOrderWorker.process_job        ← 이 PR 신설 consumer
+       └─ existing_issue_number 있으면 issue 생성 skip + anchor stamp
+       └─ plan 있으면 GithubWriter.create_issue 호출 + anchor stamp
+       └─ session.extra[`github_work_order_issue`] = {issue_number, html_url, ...}
+```
+
+`session.extra["github_work_order_issue"]` 가 **issue-anchored continuity**
+의 SSoT. downstream (branch / commit / draft PR / progress comment /
+Obsidian work-report) 는 이 키를 anchor 로 읽는다. 본 키는 오직
+`GitHubWorkOrderWorker` 만 쓴다 — 다른 path 가 stamp 하지 않음.
+
+dry_run / live 분기는 `work_order.dry_run` 을 따른다 (default True). True
+면 anchor 의 `created_via` 가 `dry_run_plan`, False 면 `auto_create` 또는
+`existing_anchor`. 잘못된 enqueue (repo 없음 / plan + existing 둘 다 없음)
+는 `failed_retryable` 로 떨어져 operator 가 status 에서 즉시 볼 수 있다.
+
 ## 2. 환경 contract
 
 | env key | 설명 | placeholder 거부 값 |

--- a/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
@@ -1,0 +1,568 @@
+"""GitHub work_order consumer — issue auto-create 종단 worker.
+
+배경
+====
+PR #166 이 `GitHubWorkOrder.issue_auto_create_plan` payload + GithubWriter
+`create_issue` capability 까지 land 했지만, **큐 job 을 실제 drain 하는
+consumer 가 없어** issue 가 GitHub 에 자동으로 생성되지 않았다. 본 모듈
+이 그 빠진 consumer 역할을 한다.
+
+흐름
+====
+queue 에 ``github_work_order`` job 이 들어오면:
+
+1. ``existing_issue_number`` 가 명시돼 있으면 — 이미 anchor 가 있는
+   기존 issue. 새 issue 를 만들지 않고 session.extra 에 그 번호만 stamp
+   한 뒤 SAVED 로 마침.
+2. ``issue_auto_create_plan`` 이 있으면 — :func:`GithubWriter.create_issue`
+   호출. dry_run 은 ``work_order.dry_run`` 을 따른다. 결과의 issue
+   number/url 을 session.extra 에 stamp.
+3. plan 도 existing 도 없으면 — 잘못된 enqueue. failed_retryable.
+
+session 갱신 키
+--------------
+``session.extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]`` 에 다음을 저장:
+
+```
+{
+  "issue_number": 77,                          # 생성/재사용된 번호
+  "html_url": "https://github.com/.../issues/77",
+  "title": "[Feat] 회원가입 ...",
+  "labels": ["✨ Feature", "📃 Docs"],
+  "approval_id": "approval-1",
+  "approved_by": "masterway",
+  "approved_at": "2026-05-15T...",
+  "dry_run": false,
+  "audit_reason": "template_used",            # 또는 existing_issue_reused / no_repo_template
+  "created_via": "auto_create" | "existing_anchor" | "dry_run_plan",
+  "outcome": "ok" | "denied_by_policy" | ...,
+  "work_order_job_id": "...",
+}
+```
+
+후속 단계 (branch / commit / PR) 는 이 key 를 anchor 로 읽어 모든 작업을
+같은 issue 에 묶는다. "issue-anchored continuity" 의 SSoT.
+
+dry_run
+-------
+``GithubWriter`` 의 ``dry_run`` 기본값과 동일하게 — work_order.dry_run
+이 True 면 client 호출 없이 audit 만 남기고, session.extra 의
+``created_via`` 는 ``"dry_run_plan"`` 으로 표기. operator 가 명시적으로
+``dry_run=False`` 를 work order 에 설정해야 실제 GitHub 호출이 발동.
+
+테스트 가능성
+-----------
+GithubWriter 는 caller 가 inject — production 은
+``LiveGithubAppClient`` + ``make_default_policy_gate`` 조합, 테스트는
+recording client + permissive policy gate 로 driven.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Optional, Tuple
+
+from .github_work_order import (
+    GitHubWorkOrder,
+    JOB_TYPE_GITHUB_WORK_ORDER,
+)
+from .heartbeat import HeartbeatStore
+from .state_machine import JobState
+from .store import Job, JobQueue
+
+
+logger = logging.getLogger(__name__)
+
+
+SERVICE_ID_GITHUB_WORK_ORDER_EXECUTOR: str = "eng-github-work-order-executor"
+
+
+# Skipped reason constants — surfaced via :class:`ExecutionOutcome` so the
+# supervisor diagnostic can match exact strings without substring guesses.
+SKIPPED_NO_REPO: str = "github_work_order_no_repo"
+SKIPPED_NO_WRITER: str = "github_work_order_no_writer"
+SKIPPED_MISSING_PLAN: str = "github_work_order_missing_plan_or_issue"
+SKIPPED_DRY_RUN_PLAN_ONLY: str = "github_work_order_dry_run_plan_only"
+SKIPPED_EXISTING_ANCHOR: str = "github_work_order_existing_anchor"
+
+
+CREATED_VIA_AUTO_CREATE: str = "auto_create"
+CREATED_VIA_EXISTING_ANCHOR: str = "existing_anchor"
+CREATED_VIA_DRY_RUN: str = "dry_run_plan"
+
+
+SESSION_EXTRA_GITHUB_ISSUE_KEY: str = "github_work_order_issue"
+"""``session.extra`` 에서 anchor issue 정보가 머무는 키. downstream
+(branch / PR / progress) 가 일관되게 이 키를 읽는다."""
+
+
+# ---------------------------------------------------------------------------
+# Writer Protocol — caller-injected
+# ---------------------------------------------------------------------------
+
+
+from typing import Protocol
+
+
+class _CreateIssueWriter(Protocol):
+    """Minimum :class:`GithubWriter` shape the executor needs."""
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels=(),
+        assignees=(),
+        autonomy_level: str = "L2",
+        session_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+    ):
+        ...
+
+
+# Production builder: turn a work order into a (writer, autonomy_level)
+# pair. The default builder reads env / config; tests inject a closure
+# returning a recording writer.
+WriterFactory = Callable[[GitHubWorkOrder], Tuple[Optional[_CreateIssueWriter], str]]
+
+
+# Session adapter — pure load/update injection for storage agnosticism.
+LoadSessionFn = Callable[[str], Optional[Any]]
+UpdateSessionFn = Callable[[Any, Mapping[str, Any]], Any]
+
+
+def _default_load_session(session_id: str) -> Optional[Any]:
+    try:
+        from ..workflow_state import load_session as _load
+    except Exception:  # noqa: BLE001 - partial install
+        return None
+    try:
+        return _load(session_id)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _default_update_session(session: Any, new_extra: Mapping[str, Any]) -> Any:
+    try:
+        from dataclasses import replace as _replace
+        from ..workflow_state import update_session as _update
+    except Exception:  # noqa: BLE001
+        return session
+    try:
+        updated = _replace(session, extra=dict(new_extra))
+        return _update(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        return session
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GitHubWorkOrderExecutionOutcome:
+    """Result of :meth:`GitHubWorkOrderWorker.process_job`."""
+
+    job: Optional[Job]
+    issue_number: Optional[int] = None
+    issue_url: Optional[str] = None
+    created_via: Optional[str] = None
+    skipped_reason: Optional[str] = None
+    audit_summary: Mapping[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+
+class GitHubWorkOrderWorker:
+    """Drain ``github_work_order`` queue jobs by creating / reusing issues.
+
+    The worker is the **single SSoT for issue-anchored continuity**:
+    after :meth:`process_job` returns OK, ``session.extra`` carries a
+    ``github_work_order_issue`` block that downstream (branch / PR /
+    progress comment) consults as the canonical anchor. No other code
+    path stamps that key.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: JobQueue,
+        writer_factory: WriterFactory,
+        heartbeats: Optional[HeartbeatStore] = None,
+        load_session_fn: Optional[LoadSessionFn] = None,
+        update_session_fn: Optional[UpdateSessionFn] = None,
+        worker_id: Optional[str] = None,
+    ) -> None:
+        self._queue = queue
+        self._writer_factory = writer_factory
+        self._heartbeats = heartbeats
+        self._load_session = load_session_fn or _default_load_session
+        self._update_session = update_session_fn or _default_update_session
+        self._worker_id = (
+            worker_id
+            or f"{SERVICE_ID_GITHUB_WORK_ORDER_EXECUTOR}:{os.getpid()}"
+        )
+
+    # ------------------------------------------------------------------
+    # Consumer side
+    # ------------------------------------------------------------------
+
+    def process_job(
+        self,
+        job: Job,
+        *,
+        now: Optional[float] = None,
+    ) -> GitHubWorkOrderExecutionOutcome:
+        """Drive *job* through assigned → in_progress → saved (or
+        failed_retryable). Returns a structured outcome the supervisor
+        can read without re-parsing the queue row."""
+
+        if self._heartbeats is not None:
+            try:
+                self._heartbeats.record(
+                    SERVICE_ID_GITHUB_WORK_ORDER_EXECUTOR,
+                    pid=os.getpid(),
+                    metadata={"job_id": job.job_id},
+                    now=now,
+                )
+            except Exception:  # noqa: BLE001 - observability only
+                pass
+
+        in_progress = self._queue.transition(
+            job.job_id, JobState.IN_PROGRESS, now=now
+        )
+        try:
+            work_order = GitHubWorkOrder.from_payload(in_progress.payload or {})
+        except Exception as exc:  # noqa: BLE001 - corrupt payload
+            self._queue.transition(
+                in_progress.job_id,
+                JobState.FAILED_RETRYABLE,
+                result={"error": f"payload_parse_error:{type(exc).__name__}"},
+                clear_lease=True,
+                now=now,
+            )
+            raise
+
+        # Reject early: no repo means we can't call GitHub. Mark
+        # failed_retryable so an operator who corrects the proposal can
+        # requeue without losing the row.
+        if not (work_order.repo or "").strip():
+            self._queue.transition(
+                in_progress.job_id,
+                JobState.FAILED_RETRYABLE,
+                result={"error": SKIPPED_NO_REPO},
+                clear_lease=True,
+                now=now,
+            )
+            return GitHubWorkOrderExecutionOutcome(
+                job=in_progress, skipped_reason=SKIPPED_NO_REPO
+            )
+
+        # Branch 1 — existing issue anchor. Just stamp session and exit.
+        if (
+            work_order.existing_issue_number is not None
+            and int(work_order.existing_issue_number) > 0
+        ):
+            outcome = self._stamp_existing_anchor(
+                job=in_progress, work_order=work_order, now=now
+            )
+            return outcome
+
+        # Branch 2 — auto-create plan. Need writer + plan.
+        plan = work_order.issue_auto_create_plan
+        if not isinstance(plan, Mapping) or not plan:
+            self._queue.transition(
+                in_progress.job_id,
+                JobState.FAILED_RETRYABLE,
+                result={"error": SKIPPED_MISSING_PLAN},
+                clear_lease=True,
+                now=now,
+            )
+            return GitHubWorkOrderExecutionOutcome(
+                job=in_progress, skipped_reason=SKIPPED_MISSING_PLAN
+            )
+
+        writer, autonomy_level = self._writer_factory(work_order)
+        if writer is None:
+            self._queue.transition(
+                in_progress.job_id,
+                JobState.FAILED_RETRYABLE,
+                result={"error": SKIPPED_NO_WRITER},
+                clear_lease=True,
+                now=now,
+            )
+            return GitHubWorkOrderExecutionOutcome(
+                job=in_progress, skipped_reason=SKIPPED_NO_WRITER
+            )
+
+        return self._execute_auto_create(
+            job=in_progress,
+            work_order=work_order,
+            plan=plan,
+            writer=writer,
+            autonomy_level=autonomy_level or "L2",
+            now=now,
+        )
+
+    # ------------------------------------------------------------------
+    # Branch helpers
+    # ------------------------------------------------------------------
+
+    def _stamp_existing_anchor(
+        self,
+        *,
+        job: Job,
+        work_order: GitHubWorkOrder,
+        now: Optional[float],
+    ) -> GitHubWorkOrderExecutionOutcome:
+        anchor = {
+            "issue_number": int(work_order.existing_issue_number or 0),
+            "html_url": None,
+            "title": None,
+            "labels": [],
+            "approval_id": work_order.approval_id,
+            "approved_by": work_order.approved_by,
+            "approved_at": work_order.approved_at,
+            "dry_run": work_order.dry_run,
+            "audit_reason": "existing_issue_reused",
+            "created_via": CREATED_VIA_EXISTING_ANCHOR,
+            "outcome": "ok",
+            "work_order_job_id": job.job_id,
+            "repo": work_order.repo,
+        }
+        self._write_session_anchor(work_order.session_id, anchor)
+        saved = self._queue.transition(
+            job.job_id,
+            JobState.SAVED,
+            result={
+                "created_via": CREATED_VIA_EXISTING_ANCHOR,
+                "issue_number": anchor["issue_number"],
+                "skipped_reason": SKIPPED_EXISTING_ANCHOR,
+            },
+            clear_lease=True,
+            now=now,
+        )
+        return GitHubWorkOrderExecutionOutcome(
+            job=saved,
+            issue_number=anchor["issue_number"],
+            issue_url=None,
+            created_via=CREATED_VIA_EXISTING_ANCHOR,
+            skipped_reason=SKIPPED_EXISTING_ANCHOR,
+            audit_summary={"anchor": anchor},
+        )
+
+    def _execute_auto_create(
+        self,
+        *,
+        job: Job,
+        work_order: GitHubWorkOrder,
+        plan: Mapping[str, Any],
+        writer: _CreateIssueWriter,
+        autonomy_level: str,
+        now: Optional[float],
+    ) -> GitHubWorkOrderExecutionOutcome:
+        title = str(plan.get("title") or "").strip()
+        body = str(plan.get("body") or "").strip()
+        labels = tuple(str(l) for l in (plan.get("labels") or ()))
+        assignees = tuple(str(a) for a in (plan.get("assignees") or ()))
+
+        result = writer.create_issue(
+            repo=str(work_order.repo or ""),
+            title=title,
+            body=body,
+            labels=labels,
+            assignees=assignees,
+            autonomy_level=autonomy_level,
+            session_id=work_order.session_id,
+            decision_id=work_order.proposal_id or None,
+        )
+
+        outcome_label = str(getattr(result, "outcome", "") or "")
+        succeeded = bool(getattr(result, "succeeded", False))
+        body_response = getattr(result, "body", {}) or {}
+        if not isinstance(body_response, Mapping):
+            body_response = {}
+        issue_number = _coerce_int(body_response.get("number"))
+        issue_url = (
+            body_response.get("html_url")
+            or body_response.get("url")
+            or None
+        )
+        if not succeeded and outcome_label != "ok":
+            # dry_run, denied_by_policy, failed — treat all non-ok as
+            # plan-only. We still stamp an anchor so operator can see
+            # the plan; only succeeded == True records a real issue.
+            issue_number = None
+            issue_url = None
+
+        created_via = (
+            CREATED_VIA_AUTO_CREATE
+            if succeeded
+            else CREATED_VIA_DRY_RUN
+        )
+        skipped_reason: Optional[str] = None
+        if not succeeded:
+            skipped_reason = SKIPPED_DRY_RUN_PLAN_ONLY
+
+        anchor = {
+            "issue_number": issue_number,
+            "html_url": issue_url,
+            "title": title,
+            "labels": list(labels),
+            "approval_id": work_order.approval_id,
+            "approved_by": work_order.approved_by,
+            "approved_at": work_order.approved_at,
+            "dry_run": work_order.dry_run,
+            "audit_reason": str(plan.get("audit_reason") or "template_used"),
+            "created_via": created_via,
+            "outcome": outcome_label or "unknown",
+            "work_order_job_id": job.job_id,
+            "repo": work_order.repo,
+            "template_path": plan.get("template_path"),
+        }
+        self._write_session_anchor(work_order.session_id, anchor)
+
+        # Always SAVED — even dry_run / denied is a deterministic
+        # outcome we want the operator to see in #봇-상태. failure means
+        # the writer raised an exception, which is converted below.
+        saved = self._queue.transition(
+            job.job_id,
+            JobState.SAVED,
+            result={
+                "created_via": created_via,
+                "issue_number": issue_number,
+                "issue_url": issue_url,
+                "outcome": outcome_label,
+                "skipped_reason": skipped_reason,
+            },
+            clear_lease=True,
+            now=now,
+        )
+        return GitHubWorkOrderExecutionOutcome(
+            job=saved,
+            issue_number=issue_number,
+            issue_url=str(issue_url) if issue_url else None,
+            created_via=created_via,
+            skipped_reason=skipped_reason,
+            audit_summary={"anchor": anchor},
+        )
+
+    # ------------------------------------------------------------------
+    # Session writer
+    # ------------------------------------------------------------------
+
+    def _write_session_anchor(
+        self, session_id: str, anchor: Mapping[str, Any]
+    ) -> None:
+        """Stamp the anchor on ``session.extra`` — best-effort.
+
+        The queue row is the authoritative record; session.extra is
+        the convenience surface so downstream (branch/PR/progress)
+        can read the issue number without scanning the queue.
+        """
+
+        if not session_id:
+            return
+        try:
+            session = self._load_session(session_id)
+        except Exception:  # noqa: BLE001
+            return
+        if session is None:
+            return
+        existing_extra = getattr(session, "extra", None) or {}
+        if not isinstance(existing_extra, Mapping):
+            existing_extra = {}
+        new_extra = dict(existing_extra)
+        new_extra[SESSION_EXTRA_GITHUB_ISSUE_KEY] = dict(anchor)
+        try:
+            self._update_session(session, new_extra)
+        except Exception:  # noqa: BLE001 - best effort
+            pass
+
+    # ------------------------------------------------------------------
+    # Producer-style helper for tests / single-shot dispatch
+    # ------------------------------------------------------------------
+
+    def run_one(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        proposal_id: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> Optional[GitHubWorkOrderExecutionOutcome]:
+        """Pick one queued github_work_order job and execute it.
+
+        Returns ``None`` when nothing is pickable. Useful from the
+        runtime supervisor's tick loop and from tests that want to
+        drive a single drain step.
+        """
+
+        picked = self._queue.pick(
+            worker_id=self._worker_id,
+            job_types=[JOB_TYPE_GITHUB_WORK_ORDER],
+            now=now,
+        )
+        if picked is None:
+            return None
+        if session_id and picked.session_id != session_id:
+            # Not our session — release the lease.
+            self._queue.transition(
+                picked.job_id,
+                JobState.QUEUED,
+                clear_lease=True,
+                now=now,
+            )
+            return None
+        if proposal_id:
+            payload = picked.payload or {}
+            if str(payload.get("proposal_id") or "") != proposal_id:
+                self._queue.transition(
+                    picked.job_id,
+                    JobState.QUEUED,
+                    clear_lease=True,
+                    now=now,
+                )
+                return None
+        return self.process_job(picked, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = (
+    "CREATED_VIA_AUTO_CREATE",
+    "CREATED_VIA_DRY_RUN",
+    "CREATED_VIA_EXISTING_ANCHOR",
+    "GitHubWorkOrderExecutionOutcome",
+    "GitHubWorkOrderWorker",
+    "LoadSessionFn",
+    "SERVICE_ID_GITHUB_WORK_ORDER_EXECUTOR",
+    "SESSION_EXTRA_GITHUB_ISSUE_KEY",
+    "SKIPPED_DRY_RUN_PLAN_ONLY",
+    "SKIPPED_EXISTING_ANCHOR",
+    "SKIPPED_MISSING_PLAN",
+    "SKIPPED_NO_REPO",
+    "SKIPPED_NO_WRITER",
+    "UpdateSessionFn",
+    "WriterFactory",
+)

--- a/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
+++ b/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
@@ -67,6 +67,12 @@ from ...agents.job_queue.approval_worker import (
     ApprovalRequest,
     ApprovalWorker,
 )
+from ...agents.git.repo_contract import RepoContract
+from ...agents.github_workos.issue_auto_create import (
+    AUDIT_TEMPLATE_FALLBACK,
+    IssueAutoCreateOutcome,
+    build_issue_auto_create_plan,
+)
 from ...agents.job_queue.github_work_order import (
     APPROVAL_KIND_GITHUB_WORK_ORDER,
     GitHubWorkOrder,
@@ -213,6 +219,9 @@ def build_github_work_order_proposal(
     proposal_id: Optional[str] = None,
     extra: Optional[Mapping[str, Any]] = None,
     summary_max_chars: int = 280,
+    repo_contract: Optional[RepoContract] = None,
+    issue_template_loader: Optional[Callable[[str], Optional[str]]] = None,
+    existing_issue_number: Optional[int] = None,
 ) -> Optional[GitHubWorkOrderProposal]:
     """Compose a :class:`GitHubWorkOrderProposal` for *session* / *request_text*,
     or ``None`` when the request should not flow through the GitHub
@@ -246,6 +255,33 @@ def build_github_work_order_proposal(
     selected, excluded = _resolve_roles_from_session(session)
     summary = _short_request_summary(request_text, max_chars=summary_max_chars)
 
+    # P0-S — Issue-less bootstrap. repo_contract 가 주어지면 그 자리에서
+    # issue auto-create plan 을 빌드해 proposal payload 에 stamp. existing
+    # issue 번호가 명시되면 plan 은 None — worker 가 existing anchor 로
+    # 전환. session.extra 가 이미 anchor 를 들고 있어도 동일하게 인식한다
+    # (이전 PR 후속 호출에서 한 번 stamp 된 경우).
+    issue_plan_payload: Optional[Mapping[str, Any]] = None
+    resolved_existing = _coerce_existing_issue(existing_issue_number, session)
+    if repo_contract is not None and not resolved_existing:
+        try:
+            outcome = build_issue_auto_create_plan(
+                repo_contract=repo_contract,
+                request_summary=summary,
+                template_loader=issue_template_loader,
+                session_id=str(getattr(session, "session_id", "") or ""),
+            )
+        except Exception:  # noqa: BLE001 - never block the proposal on plan failure
+            outcome = None
+        if outcome is not None and outcome.plan is not None:
+            issue_plan_payload = outcome.plan.to_dict()
+            # audit 흔적을 extras_payload 에도 남김 — operator 가 카드를
+            # 볼 때 어떤 audit_reason 으로 plan 이 만들어졌는지 확인 가능
+            extras_payload.setdefault(
+                "issue_auto_create_audit_reason", outcome.audit_reason
+            )
+            if outcome.plan.needs_operator_decision:
+                extras_payload.setdefault("issue_auto_create_needs_decision", True)
+
     pid = (proposal_id or "").strip() or _new_proposal_id()
     return GitHubWorkOrderProposal(
         proposal_id=pid,
@@ -267,7 +303,41 @@ def build_github_work_order_proposal(
         dry_run_default=True,
         extra=extras_payload,
         created_at=_utc_now_iso(),
+        issue_auto_create_plan=issue_plan_payload,
+        existing_issue_number=resolved_existing,
     )
+
+
+def _coerce_existing_issue(
+    explicit: Optional[int], session: Any
+) -> Optional[int]:
+    """Caller-provided existing issue > session anchor > None.
+
+    The anchor key (``github_work_order_issue.issue_number``) is set by
+    a previous run of :class:`GitHubWorkOrderWorker` after a successful
+    auto-create. If the operator restarts the flow for the same session
+    (e.g. re-runs intake), we treat the existing anchor as the issue
+    number so a second issue isn't created.
+    """
+
+    if explicit is not None:
+        try:
+            value = int(explicit)
+        except (TypeError, ValueError):
+            value = 0
+        if value > 0:
+            return value
+    extra = getattr(session, "extra", None)
+    if not isinstance(extra, Mapping):
+        return None
+    anchor = extra.get("github_work_order_issue")
+    if not isinstance(anchor, Mapping):
+        return None
+    try:
+        value = int(anchor.get("issue_number") or 0)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
 
 
 def _resolve_roles_from_session(
@@ -400,6 +470,9 @@ async def enqueue_github_work_approval(
     proposal_id: Optional[str] = None,
     drive_consumer: bool = True,
     now: Optional[float] = None,
+    repo_contract: Optional[RepoContract] = None,
+    issue_template_loader: Optional[Callable[[str], Optional[str]]] = None,
+    existing_issue_number: Optional[int] = None,
 ) -> GitHubWorkApprovalOutcome:
     """Build a proposal + enqueue (and optionally post) the approval card.
 
@@ -427,6 +500,9 @@ async def enqueue_github_work_approval(
         base_branch=base_branch,
         proposal_id=proposal_id,
         extra=extra,
+        repo_contract=repo_contract,
+        issue_template_loader=issue_template_loader,
+        existing_issue_number=existing_issue_number,
     )
     if proposal is None:
         eligible, skipped_reason, _ = should_route_to_github_workos(

--- a/tests/discord/test_github_workos_adapter_issue_bootstrap.py
+++ b/tests/discord/test_github_workos_adapter_issue_bootstrap.py
@@ -1,0 +1,223 @@
+"""Adapter 의 issue-less bootstrap wiring 회귀 — P0-S 종단.
+
+contract:
+  - repo_contract + issue_template_loader 가 주어지면 proposal 의
+    issue_auto_create_plan 이 채워진다.
+  - session.extra 에 이미 anchor 가 있으면 plan 은 None, existing_issue
+    번호는 anchor 에서 가져온다 (중복 생성 금지).
+  - 명시적 existing_issue_number 가 더 우선한다.
+  - 카드 본문 extras 에 `issue_auto_create_audit_reason` 이 남는다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.git.repo_contract import RepoContract
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.discord.integrations.github_workos_adapter import (
+    build_github_work_order_proposal,
+    enqueue_github_work_approval,
+)
+
+
+_FEATURE_TEMPLATE = (
+    "---\n"
+    'name: "[Feature] Issue Template"\n'
+    'title: "[Feat]"\n'
+    'labels: "✨ Feature, 📃 Docs"\n'
+    "---\n"
+    "\n"
+    "## 어떤 기능인가요?\n"
+    "> 추가하려는 기능에 대해 간결하게 설명해주세요\n"
+)
+
+
+def _session(*, session_id="sess-x", extra: Optional[dict] = None):
+    base = {
+        "lifecycle_mode": "implementation",
+        "active_research_roles": ["tech-lead", "backend-engineer"],
+    }
+    if extra:
+        base.update(extra)
+    return SimpleNamespace(session_id=session_id, extra=base)
+
+
+class BuildProposalIssuePlanTests(unittest.TestCase):
+    def test_plan_stamped_when_no_existing_issue(self) -> None:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        proposal = build_github_work_order_proposal(
+            session=_session(),
+            request_text="Next.js + NestJS 회원가입 PR 올려줘",
+            repo="yule-studio/naver-search-clone",
+            repo_contract=rc,
+            issue_template_loader=lambda p: _FEATURE_TEMPLATE
+            if p.endswith("feature.md")
+            else None,
+        )
+        self.assertIsNotNone(proposal)
+        assert proposal is not None
+        self.assertIsNotNone(proposal.issue_auto_create_plan)
+        assert proposal.issue_auto_create_plan is not None
+        plan = proposal.issue_auto_create_plan
+        self.assertEqual(plan["audit_reason"], "template_used")
+        self.assertTrue(plan["title"].startswith("[Feat]"))
+        self.assertIn("✨ Feature", plan["labels"])
+        # extras 에 audit_reason 흔적
+        self.assertEqual(
+            proposal.extra.get("issue_auto_create_audit_reason"),
+            "template_used",
+        )
+
+    def test_explicit_existing_issue_short_circuits(self) -> None:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        proposal = build_github_work_order_proposal(
+            session=_session(),
+            request_text="issue #99 작업 진행 PR 올려",
+            repo="yule-studio/naver-search-clone",
+            repo_contract=rc,
+            issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+            existing_issue_number=99,
+        )
+        assert proposal is not None
+        self.assertEqual(proposal.existing_issue_number, 99)
+        self.assertIsNone(proposal.issue_auto_create_plan)
+
+    def test_session_anchor_is_reused_when_no_explicit(self) -> None:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        session = _session(
+            extra={"github_work_order_issue": {"issue_number": 42}}
+        )
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text="기존 작업 이어서 PR 올려",
+            repo="yule-studio/naver-search-clone",
+            repo_contract=rc,
+            issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+        )
+        assert proposal is not None
+        self.assertEqual(proposal.existing_issue_number, 42)
+        self.assertIsNone(proposal.issue_auto_create_plan)
+
+    def test_no_repo_contract_keeps_legacy_behavior(self) -> None:
+        # repo_contract 미주입 시 기존 호출 흐름과 호환 — plan 은 None
+        proposal = build_github_work_order_proposal(
+            session=_session(),
+            request_text="버그 고쳐서 PR 올려",
+            repo="yule-studio/naver-search-clone",
+        )
+        assert proposal is not None
+        self.assertIsNone(proposal.issue_auto_create_plan)
+        self.assertIsNone(proposal.existing_issue_number)
+
+    def test_ambiguous_template_marks_extra_flag(self) -> None:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(
+                ".github/ISSUE_TEMPLATE/feature.md",
+                ".github/ISSUE_TEMPLATE/bug.md",
+            ),
+        )
+        # 두 template 모두 매칭 0 점수 — LOW confidence + needs_operator_decision
+        proposal = build_github_work_order_proposal(
+            session=_session(),
+            request_text="zzz yyy xxx PR 올려",  # 매칭 키워드 없음
+            repo="yule-studio/naver-search-clone",
+            repo_contract=rc,
+            issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+        )
+        assert proposal is not None
+        # plan 은 생성 (LOW confidence 라도 filled), needs_decision 플래그가 extras 에 남음
+        self.assertIsNotNone(proposal.issue_auto_create_plan)
+        self.assertTrue(
+            proposal.extra.get("issue_auto_create_needs_decision") is True
+        )
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class EnqueueApprovalIssuePlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.db = Path(self._tmp.name) / "q.sqlite3"
+        self.queue = JobQueue(db_path=self.db)
+        self.heartbeats = HeartbeatStore(db_path=self.db)
+        self.posted: list = []
+
+        async def _post_fn(req, rendered):
+            self.posted.append((req, rendered))
+            return {"posted_message_id": 1234}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post_fn,
+            channel_resolver=lambda: 99,
+        )
+
+    def test_approval_card_carries_plan_in_extra(self) -> None:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        outcome = _run(
+            enqueue_github_work_approval(
+                session=_session(),
+                request_text="회원가입 구현 PR 올려",
+                approval_worker=self.approval_worker,
+                repo="yule-studio/naver-search-clone",
+                repo_contract=rc,
+                issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+            )
+        )
+        self.assertIsNotNone(outcome.proposal)
+        assert outcome.proposal is not None
+        # 카드 1 건이 게시됐고, payload extras 에 proposal 사본 + plan 포함
+        self.assertEqual(len(self.posted), 1)
+        request, _rendered = self.posted[0]
+        proposal_payload = request.extra.get("github_work_order_proposal") or {}
+        plan_payload = proposal_payload.get("issue_auto_create_plan")
+        self.assertIsNotNone(plan_payload)
+        assert plan_payload is not None
+        self.assertEqual(plan_payload["audit_reason"], "template_used")
+        self.assertIn("✨ Feature", plan_payload["labels"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/engineering/test_issueless_bootstrap_end_to_end.py
+++ b/tests/engineering/test_issueless_bootstrap_end_to_end.py
@@ -1,0 +1,311 @@
+"""Issue-less bootstrap end-to-end — P0-S 회사형 runtime 종단 회귀.
+
+다음 시나리오를 한 줄로 묶어 검증한다:
+
+1. operator 가 Discord 에 issue 가 없는 full-stack coding request 를 던짐.
+2. RepoContract 가 ISSUE_TEMPLATE 발견.
+3. adapter 가 issue_auto_create_plan 을 stamp 한 proposal 빌드.
+4. approval 카드가 `#승인-대기` 로 게시.
+5. operator 가 approve → handle_github_work_approval_reply 가 work_order
+   dispatch.
+6. GitHubWorkOrderWorker 가 work_order job 을 drain → writer.create_issue
+   호출 → 결과 issue number/url 을 session.extra 에 stamp.
+7. 같은 session 으로 다시 build_github_work_order_proposal 을 호출하면
+   anchor 가 재사용돼 중복 issue 가 생성되지 않음 (existing anchor 전환).
+
+이 테스트가 통과하면 "issue 없는 repo 에 업무 요청만 들어와도 agent 가
+스스로 issue 를 만들고 그것을 anchor 로 끝까지 이어가는" 종단의 핵심
+경로가 닫혀 있다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.git.repo_contract import RepoContract
+from yule_orchestrator.agents.github_workos.audit import OUTCOME_OK
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    APPROVAL_KIND_ENGINEERING_WRITE,
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.github_work_order import (
+    APPROVAL_KIND_GITHUB_WORK_ORDER,
+    GitHubWorkOrderProposal,
+)
+from yule_orchestrator.agents.job_queue.github_work_order_executor import (
+    CREATED_VIA_AUTO_CREATE,
+    CREATED_VIA_EXISTING_ANCHOR,
+    GitHubWorkOrderWorker,
+    SESSION_EXTRA_GITHUB_ISSUE_KEY,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.discord.integrations.github_workos_adapter import (
+    build_github_work_order_proposal,
+    enqueue_github_work_approval,
+    handle_github_work_approval_reply,
+)
+
+
+_FEATURE_TEMPLATE = (
+    "---\n"
+    'name: "[Feature] Issue Template"\n'
+    'title: "[Feat]"\n'
+    'labels: "✨ Feature, 📃 Docs"\n'
+    "---\n"
+    "\n"
+    "## 어떤 기능인가요?\n"
+    "> 추가하려는 기능에 대해 간결하게 설명해주세요\n"
+)
+
+
+@dataclass
+class _SessionStore:
+    sessions: Dict[str, Any] = field(default_factory=dict)
+
+    def make(self, session_id: str) -> SimpleNamespace:
+        session = SimpleNamespace(
+            session_id=session_id,
+            extra={
+                "lifecycle_mode": "implementation",
+                "active_research_roles": ["tech-lead", "backend-engineer"],
+            },
+        )
+        self.sessions[session_id] = session
+        return session
+
+    def load(self, session_id: str):
+        return self.sessions.get(session_id)
+
+    def update(self, session, new_extra: Mapping[str, Any]):
+        session.extra = dict(new_extra)
+        self.sessions[session.session_id] = session
+        return session
+
+
+@dataclass
+class _WriterCall:
+    title: str
+    body: str
+    labels: Tuple[str, ...]
+    assignees: Tuple[str, ...]
+
+
+class _StubIssueWriter:
+    """Minimal writer Protocol — captures create_issue calls."""
+
+    def __init__(self) -> None:
+        self.calls: List[_WriterCall] = []
+        self._next_number = 77
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels=(),
+        assignees=(),
+        autonomy_level: str = "L2",
+        session_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+    ):
+        self.calls.append(
+            _WriterCall(
+                title=title,
+                body=body,
+                labels=tuple(labels),
+                assignees=tuple(assignees),
+            )
+        )
+        number = self._next_number
+        self._next_number += 1
+        result = SimpleNamespace(
+            ok=True,
+            outcome=OUTCOME_OK,
+            succeeded=True,
+            body={
+                "number": number,
+                "html_url": f"https://github.com/{repo}/issues/{number}",
+                "url": f"https://api.github.com/repos/{repo}/issues/{number}",
+            },
+        )
+        return result
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class IssuelessBootstrapEndToEndTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db_path = Path(self._tmp.name) / "q.sqlite3"
+        self.queue = JobQueue(db_path=db_path)
+        self.heartbeats = HeartbeatStore(db_path=db_path)
+        self.posted: List[Tuple[ApprovalRequest, str]] = []
+
+        async def _post(req, rendered):
+            self.posted.append((req, rendered))
+            return {"posted_message_id": 9999}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post,
+            channel_resolver=lambda: 4242,
+        )
+        self.sessions = _SessionStore()
+        self.writer = _StubIssueWriter()
+        self.worker = GitHubWorkOrderWorker(
+            queue=self.queue,
+            writer_factory=lambda _wo: (self.writer, "L2"),
+            load_session_fn=lambda sid: self.sessions.load(sid),
+            update_session_fn=lambda s, e: self.sessions.update(s, e),
+        )
+
+    def test_issueless_request_flows_to_real_issue_anchor(self) -> None:
+        session = self.sessions.make("sess-end-to-end")
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+
+        # 1. approval card 게시 + proposal 에 plan stamp
+        outcome = _run(
+            enqueue_github_work_approval(
+                session=session,
+                request_text=(
+                    "Next.js + NestJS + PostgreSQL 회원가입/로그인/검색 PR 올려"
+                ),
+                approval_worker=self.approval_worker,
+                repo="yule-studio/naver-search-clone",
+                source_message_id=12345,
+                repo_contract=rc,
+                issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+                requested_by="masterway",
+            )
+        )
+        self.assertIsNotNone(outcome.proposal)
+        self.assertEqual(len(self.posted), 1)
+        approval_request, _rendered = self.posted[0]
+        proposal_payload = approval_request.extra.get(
+            "github_work_order_proposal"
+        )
+        self.assertIsInstance(proposal_payload, Mapping)
+        plan = proposal_payload.get("issue_auto_create_plan")
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertTrue(plan["title"].startswith("[Feat]"))
+
+        # 2. operator 승인 → work order dispatch
+        dispatch_outcome = handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-e2e",
+            approved_by="masterway",
+            approved_at="2026-05-15T11:00:00+00:00",
+            dry_run=False,
+        )
+        self.assertIsNone(dispatch_outcome.skipped_reason)
+        self.assertIsNotNone(dispatch_outcome.dispatched_job_id)
+
+        # 3. worker drain → 실제 issue 생성
+        exec_outcome = self.worker.run_one()
+        self.assertIsNotNone(exec_outcome)
+        assert exec_outcome is not None
+        self.assertEqual(exec_outcome.created_via, CREATED_VIA_AUTO_CREATE)
+        self.assertEqual(exec_outcome.issue_number, 77)
+        self.assertTrue(
+            exec_outcome.issue_url
+            and "yule-studio/naver-search-clone/issues/77" in exec_outcome.issue_url
+        )
+
+        # 4. session.extra 에 anchor stamp 됐는지
+        anchor = session.extra.get(SESSION_EXTRA_GITHUB_ISSUE_KEY)
+        self.assertIsInstance(anchor, dict)
+        assert isinstance(anchor, dict)
+        self.assertEqual(anchor["issue_number"], 77)
+        self.assertEqual(anchor["created_via"], CREATED_VIA_AUTO_CREATE)
+        self.assertEqual(anchor["approval_id"], "approval-e2e")
+
+        # 5. 같은 session 으로 다시 proposal 만들면 anchor 재사용
+        again = build_github_work_order_proposal(
+            session=session,
+            request_text="추가 PR 올려줘 — 검색 결과 페이지 보강 구현",
+            repo="yule-studio/naver-search-clone",
+            repo_contract=rc,
+            issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+        )
+        self.assertIsNotNone(again)
+        assert again is not None
+        self.assertEqual(again.existing_issue_number, 77)
+        self.assertIsNone(again.issue_auto_create_plan)
+
+    def test_existing_issue_number_in_request_skips_plan_creation(self) -> None:
+        """operator 가 명시한 issue 번호가 있으면 plan 빌드 자체를 건너뜀."""
+
+        session = self.sessions.make("sess-explicit")
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        outcome = _run(
+            enqueue_github_work_approval(
+                session=session,
+                request_text="이슈 #15 작업 PR 올려",
+                approval_worker=self.approval_worker,
+                repo="yule-studio/naver-search-clone",
+                repo_contract=rc,
+                issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+                existing_issue_number=15,
+            )
+        )
+        self.assertIsNotNone(outcome.proposal)
+        assert outcome.proposal is not None
+        self.assertEqual(outcome.proposal.existing_issue_number, 15)
+        self.assertIsNone(outcome.proposal.issue_auto_create_plan)
+        approval_request, _ = self.posted[-1]
+        # approval → dispatch → worker
+        handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-explicit",
+            approved_by="masterway",
+            approved_at="2026-05-15T12:00:00+00:00",
+            dry_run=False,
+        )
+        exec_outcome = self.worker.run_one()
+        self.assertIsNotNone(exec_outcome)
+        assert exec_outcome is not None
+        # writer 호출 안 됨
+        self.assertEqual(self.writer.calls, [])
+        self.assertEqual(exec_outcome.created_via, CREATED_VIA_EXISTING_ANCHOR)
+        self.assertEqual(exec_outcome.issue_number, 15)
+        anchor = session.extra.get(SESSION_EXTRA_GITHUB_ISSUE_KEY)
+        assert isinstance(anchor, dict)
+        self.assertEqual(anchor["issue_number"], 15)
+        self.assertEqual(anchor["created_via"], CREATED_VIA_EXISTING_ANCHOR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_github_work_order_executor.py
+++ b/tests/job_queue/test_github_work_order_executor.py
@@ -1,0 +1,381 @@
+"""GitHubWorkOrderWorker — issue auto-create 종단 회귀 핀.
+
+contract:
+  - existing_issue_number 가 있으면 issue 생성 안 함, session.extra 에
+    existing_anchor 로 stamp + 큐 SAVED.
+  - issue_auto_create_plan 이 있으면 writer.create_issue 호출, 결과
+    issue number/url 을 session.extra 에 stamp.
+  - writer 가 dry_run → succeeded=False → ``created_via='dry_run_plan'``
+    + SAVED (요청은 실패가 아니라 plan-only 결정).
+  - repo 가 비어있으면 failed_retryable + SKIPPED_NO_REPO.
+  - plan 도 existing 도 없으면 failed_retryable + SKIPPED_MISSING_PLAN.
+  - run_one 이 queue 에서 한 건만 drain, 다른 session 의 job 은 lease
+    되돌림.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.github_workos.audit import (
+    OUTCOME_DRY_RUN,
+    OUTCOME_OK,
+)
+from yule_orchestrator.agents.job_queue.github_work_order import (
+    GitHubWorkOrder,
+    JOB_TYPE_GITHUB_WORK_ORDER,
+    dispatch_github_work_order,
+)
+from yule_orchestrator.agents.job_queue.github_work_order_executor import (
+    CREATED_VIA_AUTO_CREATE,
+    CREATED_VIA_DRY_RUN,
+    CREATED_VIA_EXISTING_ANCHOR,
+    GitHubWorkOrderWorker,
+    SESSION_EXTRA_GITHUB_ISSUE_KEY,
+    SKIPPED_MISSING_PLAN,
+    SKIPPED_NO_REPO,
+    SKIPPED_NO_WRITER,
+)
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SessionFake:
+    session_id: str
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+class _FakeSessionStore:
+    def __init__(self) -> None:
+        self.sessions: Dict[str, _SessionFake] = {}
+
+    def add(self, session_id: str) -> _SessionFake:
+        s = _SessionFake(session_id=session_id, extra={})
+        self.sessions[session_id] = s
+        return s
+
+    def load(self, session_id: str):
+        return self.sessions.get(session_id)
+
+    def update(self, session, new_extra: Mapping[str, Any]):
+        session.extra = dict(new_extra)
+        self.sessions[session.session_id] = session
+        return session
+
+
+@dataclass
+class _WriterResult:
+    ok: bool
+    outcome: str
+    body: Mapping[str, Any] = field(default_factory=dict)
+    succeeded: bool = False
+
+
+class _RecordingWriter:
+    def __init__(self, *, response: Optional[Mapping[str, Any]] = None, succeeded: bool = True) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+        self._response = response or {
+            "number": 77,
+            "html_url": "https://github.com/yule-studio/naver-search-clone/issues/77",
+            "url": "https://api.github.com/.../issues/77",
+        }
+        self._succeeded = succeeded
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels=(),
+        assignees=(),
+        autonomy_level: str = "L2",
+        session_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+    ):
+        self.calls.append(
+            (
+                "create_issue",
+                {
+                    "repo": repo,
+                    "title": title,
+                    "body": body,
+                    "labels": tuple(labels),
+                    "assignees": tuple(assignees),
+                    "autonomy_level": autonomy_level,
+                    "session_id": session_id,
+                    "decision_id": decision_id,
+                },
+            )
+        )
+        if self._succeeded:
+            return _WriterResult(
+                ok=True,
+                outcome=OUTCOME_OK,
+                body=dict(self._response),
+                succeeded=True,
+            )
+        return _WriterResult(
+            ok=True,
+            outcome=OUTCOME_DRY_RUN,
+            body={},
+            succeeded=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.queue = JobQueue(db_path=Path(self._tmp.name) / "q.sqlite3")
+        self.sessions = _FakeSessionStore()
+        self.writer = _RecordingWriter()
+
+        def _writer_factory(_wo):
+            return self.writer, "L2"
+
+        self.worker = GitHubWorkOrderWorker(
+            queue=self.queue,
+            writer_factory=_writer_factory,
+            load_session_fn=lambda sid: self.sessions.load(sid),
+            update_session_fn=lambda s, e: self.sessions.update(s, e),
+        )
+
+    def _enqueue(self, wo: GitHubWorkOrder):
+        outcome = dispatch_github_work_order(self.queue, wo)
+        self.assertIsNotNone(outcome.job)
+        return outcome.job
+
+    def _sample_plan(self, audit_reason: str = "template_used") -> Mapping[str, Any]:
+        return {
+            "title": "[Feat] 회원가입/검색 구현",
+            "body": "## 어떤 기능인가요?\n> 본문\n",
+            "labels": ["✨ Feature", "📃 Docs"],
+            "assignees": [],
+            "template_path": ".github/ISSUE_TEMPLATE/feature.md",
+            "confidence": "high",
+            "audit_reason": audit_reason,
+            "needs_operator_decision": False,
+            "template_score": 2,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Auto-create branch
+# ---------------------------------------------------------------------------
+
+
+class AutoCreateBranchTests(_Fixture):
+    def test_creates_issue_and_stamps_session(self) -> None:
+        self.sessions.add("sess-1")
+        wo = GitHubWorkOrder(
+            proposal_id="p1",
+            session_id="sess-1",
+            approval_id="approval-1",
+            approved_by="masterway",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="full-stack 구현",
+            repo="yule-studio/naver-search-clone",
+            dry_run=False,
+            issue_auto_create_plan=self._sample_plan(),
+        )
+        job = self._enqueue(wo)
+        outcome = self.worker.run_one(now=None)
+        assert outcome is not None
+        self.assertEqual(outcome.created_via, CREATED_VIA_AUTO_CREATE)
+        self.assertEqual(outcome.issue_number, 77)
+        self.assertTrue(outcome.issue_url and "issues/77" in outcome.issue_url)
+        # writer called with plan content
+        self.assertEqual(len(self.writer.calls), 1)
+        _, call_kwargs = self.writer.calls[0]
+        self.assertTrue(call_kwargs["title"].startswith("[Feat]"))
+        self.assertIn("✨ Feature", call_kwargs["labels"])
+        # session extra anchor
+        anchor = self.sessions.sessions["sess-1"].extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]
+        self.assertEqual(anchor["issue_number"], 77)
+        self.assertEqual(anchor["created_via"], CREATED_VIA_AUTO_CREATE)
+        self.assertEqual(anchor["approval_id"], "approval-1")
+        self.assertEqual(anchor["repo"], "yule-studio/naver-search-clone")
+        # queue row SAVED
+        refreshed = self.queue.get(job.job_id)
+        self.assertEqual(refreshed.state, JobState.SAVED)
+        self.assertEqual(refreshed.result.get("issue_number"), 77)
+        self.assertEqual(refreshed.result.get("created_via"), CREATED_VIA_AUTO_CREATE)
+
+    def test_dry_run_writer_falls_back_to_plan_only(self) -> None:
+        self.writer = _RecordingWriter(succeeded=False)
+
+        def _writer_factory(_wo):
+            return self.writer, "L2"
+
+        self.worker = GitHubWorkOrderWorker(
+            queue=self.queue,
+            writer_factory=_writer_factory,
+            load_session_fn=lambda sid: self.sessions.load(sid),
+            update_session_fn=lambda s, e: self.sessions.update(s, e),
+        )
+        self.sessions.add("sess-dry")
+        wo = GitHubWorkOrder(
+            proposal_id="p2",
+            session_id="sess-dry",
+            approval_id="approval-2",
+            approved_by="m",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="x",
+            repo="yule-studio/naver-search-clone",
+            dry_run=True,
+            issue_auto_create_plan=self._sample_plan(),
+        )
+        self._enqueue(wo)
+        outcome = self.worker.run_one()
+        assert outcome is not None
+        self.assertEqual(outcome.created_via, CREATED_VIA_DRY_RUN)
+        self.assertIsNone(outcome.issue_number)
+        anchor = self.sessions.sessions["sess-dry"].extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]
+        self.assertEqual(anchor["created_via"], CREATED_VIA_DRY_RUN)
+        self.assertIsNone(anchor["issue_number"])
+
+
+# ---------------------------------------------------------------------------
+# Existing anchor branch
+# ---------------------------------------------------------------------------
+
+
+class ExistingAnchorTests(_Fixture):
+    def test_existing_issue_skips_writer(self) -> None:
+        self.sessions.add("sess-reuse")
+        wo = GitHubWorkOrder(
+            proposal_id="p3",
+            session_id="sess-reuse",
+            approval_id="approval-3",
+            approved_by="m",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="이미 있는 #42",
+            repo="yule-studio/naver-search-clone",
+            existing_issue_number=42,
+        )
+        self._enqueue(wo)
+        outcome = self.worker.run_one()
+        assert outcome is not None
+        self.assertEqual(outcome.created_via, CREATED_VIA_EXISTING_ANCHOR)
+        self.assertEqual(outcome.issue_number, 42)
+        # writer 호출 안 됨
+        self.assertEqual(self.writer.calls, [])
+        # session stamp 확인
+        anchor = self.sessions.sessions["sess-reuse"].extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]
+        self.assertEqual(anchor["issue_number"], 42)
+        self.assertEqual(anchor["created_via"], CREATED_VIA_EXISTING_ANCHOR)
+        self.assertEqual(anchor["audit_reason"], "existing_issue_reused")
+
+
+# ---------------------------------------------------------------------------
+# Failure / skip branches
+# ---------------------------------------------------------------------------
+
+
+class FailureBranchTests(_Fixture):
+    def test_missing_repo_fails_retryable(self) -> None:
+        self.sessions.add("sess-no-repo")
+        wo = GitHubWorkOrder(
+            proposal_id="p4",
+            session_id="sess-no-repo",
+            approval_id="a4",
+            approved_by="m",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="x",
+            repo=None,
+            issue_auto_create_plan=self._sample_plan(),
+        )
+        job = self._enqueue(wo)
+        outcome = self.worker.run_one()
+        assert outcome is not None
+        self.assertEqual(outcome.skipped_reason, SKIPPED_NO_REPO)
+        refreshed = self.queue.get(job.job_id)
+        self.assertEqual(refreshed.state, JobState.FAILED_RETRYABLE)
+        self.assertEqual(refreshed.result.get("error"), SKIPPED_NO_REPO)
+        # session 은 anchor 안 만듦
+        self.assertNotIn(
+            SESSION_EXTRA_GITHUB_ISSUE_KEY,
+            self.sessions.sessions["sess-no-repo"].extra,
+        )
+
+    def test_missing_plan_and_no_existing_fails(self) -> None:
+        self.sessions.add("sess-no-plan")
+        wo = GitHubWorkOrder(
+            proposal_id="p5",
+            session_id="sess-no-plan",
+            approval_id="a5",
+            approved_by="m",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="x",
+            repo="yule-studio/naver-search-clone",
+            # 둘 다 비어있음
+        )
+        job = self._enqueue(wo)
+        outcome = self.worker.run_one()
+        assert outcome is not None
+        self.assertEqual(outcome.skipped_reason, SKIPPED_MISSING_PLAN)
+        refreshed = self.queue.get(job.job_id)
+        self.assertEqual(refreshed.state, JobState.FAILED_RETRYABLE)
+
+    def test_missing_writer_fails(self) -> None:
+        # writer_factory 가 None 을 반환 — production env 미준비 시뮬레이션
+        self.worker = GitHubWorkOrderWorker(
+            queue=self.queue,
+            writer_factory=lambda _wo: (None, "L2"),
+            load_session_fn=lambda sid: self.sessions.load(sid),
+            update_session_fn=lambda s, e: self.sessions.update(s, e),
+        )
+        self.sessions.add("sess-nw")
+        wo = GitHubWorkOrder(
+            proposal_id="p6",
+            session_id="sess-nw",
+            approval_id="a6",
+            approved_by="m",
+            approved_at="2026-05-15T10:00:00+00:00",
+            request_summary="x",
+            repo="yule-studio/naver-search-clone",
+            issue_auto_create_plan=self._sample_plan(),
+        )
+        job = self._enqueue(wo)
+        outcome = self.worker.run_one()
+        assert outcome is not None
+        self.assertEqual(outcome.skipped_reason, SKIPPED_NO_WRITER)
+        refreshed = self.queue.get(job.job_id)
+        self.assertEqual(refreshed.state, JobState.FAILED_RETRYABLE)
+        self.assertEqual(refreshed.result.get("error"), SKIPPED_NO_WRITER)
+
+
+# ---------------------------------------------------------------------------
+# Queue drain semantics
+# ---------------------------------------------------------------------------
+
+
+class QueueDrainTests(_Fixture):
+    def test_run_one_returns_none_when_queue_empty(self) -> None:
+        outcome = self.worker.run_one()
+        self.assertIsNone(outcome)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #167

## ✨ 과제 내용

issue 가 없는 repo 에 업무 요청만 들어와도 engineering-agent 가 스스로 issue 를 만들고, **그것을 anchor 로 끝까지 구현 흐름을 이어가는** 종단을 닫는다.

### 직전 PR #166 까지 닫혀 있던 것
- `IssueAutoCreatePlan` model + template parser/selector/filler
- `LiveGithubAppClient.create_issue` + `GithubWriter.create_issue` capability
- `GitHubWorkOrder.issue_auto_create_plan` / `existing_issue_number` 1급 필드
- `RepoContract.tag_policy` 4 분류

### 본 PR 이 닫은 것 (마지막 빈 자리)
1. **`GitHubWorkOrderWorker`** (신설) — `github_work_order` 큐 job 을 실제 drain 하는 consumer. 4 분기 명시:
   - `existing_issue_number` 있음 → issue 생성 skip + anchor stamp
   - `issue_auto_create_plan` 있음 → `GithubWriter.create_issue` 호출 → 결과 stamp
   - repo 없음 → SKIPPED_NO_REPO failed_retryable
   - plan 도 existing 도 없음 → SKIPPED_MISSING_PLAN failed_retryable
2. **`session.extra["github_work_order_issue"]`** anchor SSoT — downstream (branch / commit / PR / progress / Obsidian) 가 일관되게 읽을 단일 키. 본 키는 오직 `GitHubWorkOrderWorker` 만 stamp 한다.
3. **adapter wiring** — `build_github_work_order_proposal` 이 `repo_contract` + `issue_template_loader` + `existing_issue_number` 파라미터를 받아 호출 시점에 plan 을 proposal 에 직접 stamp. session.extra anchor 가 이미 있으면 existing_anchor 로 자동 전환 (중복 생성 방지).
4. **end-to-end 회귀** — 한 줄로 묶은 시나리오 테스트.

### 3 commit 구성
1. **🚀 GitHubWorkOrderWorker 신설 — issue create 종단 consumer** — worker + payload schema + 7 회귀 테스트
2. **🔧 adapter 가 issue auto-create plan 을 proposal 에 직접 stamp** — `build_github_work_order_proposal` / `enqueue_github_work_approval` 시그니처 확장 + 6 회귀 테스트
3. **✅ Issue-less bootstrap end-to-end 회귀 + docs §1.4 갱신** — Discord intake → approval → 승인 → worker drain → anchor stamp → 재사용 한 줄 검증 (2 시나리오) + docs

### 실제 사용자 경험 (이 PR 후)

```
Discord 입력:
  "approval_required, full_stack_single_repo. repo: ...naver-search-clone.git
   목표: Next.js + NestJS + PG 회원가입/로그인/검색"

agent:
  1. ✅ RepoContract 발견 (ISSUE_TEMPLATE / PR_TEMPLATE / tag_policy)
  2. ✅ build_issue_auto_create_plan 으로 template 채움
  3. ✅ #승인-대기 카드 게시 (proposal payload 에 plan 보존)
  4. operator: "승인"
  5. ✅ handle_github_work_approval_reply → work_order dispatch
  6. ✅ GitHubWorkOrderWorker.run_one → GithubWriter.create_issue 호출
  7. ✅ session.extra["github_work_order_issue"] = {issue_number, html_url, ...}
  8. ✅ 같은 session 으로 추가 요청 → anchor 자동 재사용, 중복 issue 생성 안 됨
  9. ⏸ branch / commit / push / draft PR (후속 PR — anchor 만 읽으면 됨)
```

operator 가 실제로 개입해야 하는 지점:
- **승인 카드 1회** (`#승인-대기` 에서 "승인")
- INFO / ACCESS / SECRET / DECISION 카드가 떴을 때만 (외부 사실 / 권한 / secret 값 / 정책)

승인 후 자동 이어지는 단계:
- work_order dispatch → worker drain → issue create → session anchor stamp

### 남은 명시적 deferred (본 PR 에서 닫지 않은 부분)
1. **Branch / commit / push / draft PR wiring** — issue anchor 가 SSoT 로 land 됐으므로 다음 PR 은 anchor 를 읽기만 한다. base SHA discovery, tree build, ref move 등 추가 작업 필요해 분리.
2. **Tag/release 자동 발행** — 별 worker + L3 승인 카드 시스템 필요.
3. **engineering_channel_router → adapter 통합** — adapter API 는 `repo_contract` / `issue_template_loader` 를 keyword arg 로 받음. router 측에서 실제 호출 시 이 두 값을 주입하는 통합은 repo_contract 발견 위치 (router vs background loop) 결정 후 별 PR.

이 한계는 fake success 가 아니라 **명시적 deferred scope** — master plan §3 에 명시.

### 회귀
- 전체 회귀: **4828 pass / 1 skip** (직전 PR #166 의 4813 + 신규 15: worker 7 + adapter 6 + e2e 2)
- 기존 classification / status / operator-action / approval / pr-merge / governance 전부 그대로 통과
- 직전 PR 의 회귀 라인 (`test_github_work_order_issue_plan` / `test_writer_create_issue` / `test_repo_contract_tag_policy` / `test_issue_auto_create` / `test_issue_autocreate_end_to_end` / `test_knowledge_note_hollow_guard`) 모두 통과

## 📚 레퍼런스
- `src/yule_orchestrator/agents/job_queue/github_work_order_executor.py` (신규 consumer)
- `src/yule_orchestrator/discord/integrations/github_workos_adapter.py` (adapter wiring)
- `tests/engineering/test_issueless_bootstrap_end_to_end.py` (종단 회귀)
- `docs/github-agent-workos.md` §1.4
- `docs/engineering-company-runtime-master-plan.md` §3 (2026-05-15 P0-S 종단)
- `docs/approval-matrix.md` §6 (operator action inbox)