### PR TITLE
🚀 work_order → coding_execute continuation — anchor 직후 자동 handoff (closes #169)

### DIFF
--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -42,13 +42,34 @@ Yule가 도달해야 하는 최종 상태는 아래와 같다.
 
 이 수치는 운영 판단 기준으로 유지한다.
 
-| 영역 | 현재 추정 (2026-05-15, P0-S 종단) | 2026-05-15 (P0-S 1차) | 2026-05-11 추정 |
-| --- | --- | --- | --- |
-| 운영 골격 | 88~90% | 85~88% | 80~85% |
-| Discord 기술 토의 능력 | 55~65% | 55~65% | 50~60% |
-| 완전 자율 코딩 루프 | 82~88% | 78~85% | 70~80% |
-| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% | 50~60% |
-| 실제 회사처럼 굴러가는 종합 수준 | 72~80% | 68~75% | 60~70% |
+| 영역 | 현재 추정 (2026-05-15, work_order→coding continuation) | 2026-05-15 (P0-S 종단 1) | 2026-05-15 (P0-S 1차) | 2026-05-11 추정 |
+| --- | --- | --- | --- | --- |
+| 운영 골격 | 90~92% | 88~90% | 85~88% | 80~85% |
+| Discord 기술 토의 능력 | 55~65% | 55~65% | 55~65% | 50~60% |
+| 완전 자율 코딩 루프 | 85~90% | 82~88% | 78~85% | 70~80% |
+| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% | 50~60% | 50~60% |
+| 실제 회사처럼 굴러가는 종합 수준 | 76~83% | 72~80% | 68~75% | 60~70% |
+
+이번 PR 닫은 범위 (work_order → coding_execute continuation):
+
+- **`promote_session_to_coding_ready`** — anchor 직후 `session.extra["coding_proposal"]` 을 읽어 `CodingJob(status=ready)` 빌드 후 `session.extra["coding_job"]` 에 stamp. metadata 에 anchor 정보 (issue_number / issue_url / repo / base_branch / dry_run / approval_id) 동기화. idempotent — 같은 anchor 로 재호출 시 `coding_job_already_ready_same_anchor` noop.
+- **`GitHubWorkOrderWorker` continuation hook** — auto_create / existing_anchor 양쪽 분기 모두 anchor stamp 직후 continuation 호출. queue row 의 `result.coding_dispatch_queued` / `coding_dispatch_noop_reason` 에 결과 audit.
+- **Progress markers SSoT** — `session.extra["github_work_order_progress"]` 가 5 단계 (issue_created / coding_dispatch_queued / coding_in_progress / draft_pr_opened / coding_blocked) 의 operator-visible timeline. 본 PR 은 앞 2 단계 stamp, 나머지 3 단계는 coding executor / operator action 측에서 누적.
+- **`build_coding_execute_request` anchor fallback** — coding_job metadata 에 issue_number / repo 가 비어 있어도 session.extra의 anchor 에서 자동 보충. legacy proposal builder 와 호환.
+
+이번 PR 후 operator 가 실제로 개입해야 하는 지점은 **승인 1회 + 외부 사실 (INFO/ACCESS/SECRET/DECISION) 카드 응답만**. 승인 후:
+
+1. work_order dispatch → worker drain (issue create / existing)
+2. continuation 자동 호출 → coding_job=ready
+3. `iter_ready_coding_jobs` 가 세션을 yield
+4. dispatcher 가 coding_execute 큐에 enqueue
+5. `CodingExecutorWorker` 가 branch / edit / test / commit / push / draft PR 까지
+
+남은 범위 (이 PR 의 명시적 deferred):
+
+- **CodingExecutorWorker live wiring** — 기존 dispatcher → executor 경로는 land 됐고 본 PR 이 그 경로 진입까지 자동 잇기. 실제 GitHub App 기반 commit/push/draft PR 의 live runner activation 은 `YULE_GITHUB_APP_*` 환경 설정 후 별 PR.
+- **Discord intake → adapter `repo_contract` 통합** — adapter API 는 keyword arg 로 받지만 router 측에서 실제 호출 시점에 어떻게 주입할지 (router 내부 discover vs background loop) 별 PR.
+- **Tag/release 자동 발행** — 별 worker + L3 카드.
 
 2026-05-15 갱신 근거 — P0-S 시리즈 (PR #162 Operator Action Inbox / PR #164 문서 계층 / PR #166 Issue auto-create plan + Tag policy / 본 PR Issue-less bootstrap end-to-end consumer).
 

--- a/docs/github-agent-workos.md
+++ b/docs/github-agent-workos.md
@@ -70,7 +70,7 @@ operator action 카드 (INFO/ACCESS/SECRET/DECISION) 가 올라간다. 흐름은
 ### 1.4 Issue-less bootstrap end-to-end (P0-S)
 
 "issue 가 없는 repo 에 업무 요청만 들어와도 agent 가 스스로 issue 를
-만들고 그것을 anchor 로 끝까지 이어가는" 종단은 다음 모듈이 묶는다:
+만들고 그것을 anchor 로 끝까지 이어가는" 종단:
 
 ```
 Discord intake
@@ -78,23 +78,50 @@ Discord intake
        └─ build_issue_auto_create_plan       ← #166 PR
        └─ session.extra.github_work_order_issue 이미 있으면 existing_anchor 로 전환
   └─ ApprovalRequest 카드 (#승인-대기)
-  └─ 승인 → handle_github_work_approval_reply
+  └─ 승인 1회 → handle_github_work_approval_reply
   └─ dispatch_github_work_order (queue)
-  └─ GitHubWorkOrderWorker.process_job        ← 이 PR 신설 consumer
+  └─ GitHubWorkOrderWorker.process_job        ← #168 신설 consumer
        └─ existing_issue_number 있으면 issue 생성 skip + anchor stamp
        └─ plan 있으면 GithubWriter.create_issue 호출 + anchor stamp
-       └─ session.extra[`github_work_order_issue`] = {issue_number, html_url, ...}
+       └─ session.extra["github_work_order_issue"] = {...}
+       └─ promote_session_to_coding_ready          ← 본 PR continuation
+              └─ session.extra["coding_job"] status="ready" + anchor metadata
+              └─ session.extra["github_work_order_progress"] = {
+                     "issue_created": ..., "coding_dispatch_queued": ...
+                 }
+  └─ iter_ready_coding_jobs (autonomy_producer / 운영 tick) 가 같은 세션 발견
+  └─ build_coding_execute_request 가 anchor 의 repo/issue_number 를 자동 fallback
+  └─ CodingExecutorWorker 가 branch / edit / test / commit / push / draft PR
 ```
 
-`session.extra["github_work_order_issue"]` 가 **issue-anchored continuity**
-의 SSoT. downstream (branch / commit / draft PR / progress comment /
-Obsidian work-report) 는 이 키를 anchor 로 읽는다. 본 키는 오직
-`GitHubWorkOrderWorker` 만 쓴다 — 다른 path 가 stamp 하지 않음.
+승인 **1회** 후 operator 추가 입력 없이 다음 단계가 자동 이어진다:
 
-dry_run / live 분기는 `work_order.dry_run` 을 따른다 (default True). True
-면 anchor 의 `created_via` 가 `dry_run_plan`, False 면 `auto_create` 또는
-`existing_anchor`. 잘못된 enqueue (repo 없음 / plan + existing 둘 다 없음)
-는 `failed_retryable` 로 떨어져 operator 가 status 에서 즉시 볼 수 있다.
+1. `GithubWriter.create_issue` 실제 호출 (`auto_create` 또는 `existing_anchor`)
+2. `session.extra["github_work_order_issue"]` anchor stamp
+3. `session.extra["coding_job"]` status=ready 로 promote + anchor metadata
+4. `iter_ready_coding_jobs` 가 세션을 yield
+5. `build_coding_execute_request` 가 anchor 의 repo/issue_number 를 자동 fallback
+6. dispatcher 가 `coding_execute` 큐에 enqueue
+7. `CodingExecutorWorker` 가 branch / edit / test / commit / push / draft PR
+
+`session.extra["github_work_order_progress"]` 가 operator-visible progress
+SSoT. 가능한 marker:
+
+| marker | 누가 stamp 하나 |
+| --- | --- |
+| `issue_created` | `GitHubWorkOrderWorker` (anchor stamp 직후) |
+| `coding_dispatch_queued` | `promote_session_to_coding_ready` (continuation) |
+| `coding_in_progress` | `CodingExecutorWorker` (작업 시작) |
+| `draft_pr_opened` | `CodingExecutorWorker` (draft PR 생성 완료) |
+| `coding_blocked` | `operator_action_reply` (외부 요인 대기) |
+
+idempotency:
+- 같은 anchor 로 두 번 promote 호출 → noop (`coding_job_already_ready_same_anchor`)
+- worker 재시작으로 같은 work_order 가 다시 drain → 이미 SAVED 라 queue 측에서 skip
+- coding_job 이 이미 다른 path (Discord chat phrase 승인) 로 ready 면 다시 build 안 함
+
+비표준 진입:
+- `coding_proposal` 이 session.extra 에 없으면 `promote_session_to_coding_ready` 가 noop 반환 + audit reason `no_coding_proposal` — operator 가 status diagnostic 으로 즉시 확인 가능 (Discord intake 가 proposal 을 stamp 안 한 경우).
 
 ## 2. 환경 contract
 

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
@@ -210,6 +210,7 @@ def _resolve_repo(coding_job: Mapping[str, Any], session: Any, env_repo: Optiona
     """Resolve repo_full_name with deterministic precedence.
 
     Order: ``coding_job.metadata['repo_full_name']`` →
+    ``session.extra['github_work_order_issue']['repo']`` (P0-S anchor) →
     ``session.extra['coding_repo_full_name']`` → env default. Empty
     string is acceptable — the worker only refuses to push when the
     GithubAppPusher is invoked on an empty repo, which the dry-run
@@ -223,6 +224,14 @@ def _resolve_repo(coding_job: Mapping[str, Any], session: Any, env_repo: Optiona
             return from_meta
     extra = getattr(session, "extra", None) or {}
     if isinstance(extra, Mapping):
+        # P0-S — issue anchor 가 stamp 한 repo 를 fallback 으로 사용. issue
+        # auto-create 후 같은 session 의 coding_job 이 metadata.repo_full_name
+        # 을 못 채운 경우 (legacy proposal 빌더) 에도 자연스럽게 연결.
+        anchor = extra.get("github_work_order_issue")
+        if isinstance(anchor, Mapping):
+            from_anchor = str(anchor.get("repo") or "").strip()
+            if from_anchor:
+                return from_anchor
         from_extra = str(extra.get("coding_repo_full_name") or "").strip()
         if from_extra:
             return from_extra
@@ -297,6 +306,16 @@ def build_coding_execute_request(
             else None
         )
     )
+    # P0-S — issue anchor fallback. coding_job.metadata 에 issue_number 가
+    # 없어도 session.extra["github_work_order_issue"]["issue_number"] 가
+    # 있으면 그쪽을 사용. issue-less bootstrap path 가 metadata 채움 직전에
+    # 호출되는 경우의 안전망.
+    if issue_number is None:
+        session_extra = getattr(ready.session, "extra", None) or {}
+        if isinstance(session_extra, Mapping):
+            anchor = session_extra.get("github_work_order_issue")
+            if isinstance(anchor, Mapping):
+                issue_number = _coerce_int(anchor.get("issue_number"))
 
     branch_hint = ""
     if isinstance(metadata_in, Mapping):

--- a/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
@@ -72,6 +72,10 @@ from .github_work_order import (
 from .heartbeat import HeartbeatStore
 from .state_machine import JobState
 from .store import Job, JobQueue
+from .work_order_coding_continuation import (
+    ContinuationOutcome,
+    promote_session_to_coding_ready,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -340,6 +344,14 @@ class GitHubWorkOrderWorker:
             "repo": work_order.repo,
         }
         self._write_session_anchor(work_order.session_id, anchor)
+        # P0-S continuation — anchor 가 안착되면 즉시 coding_job=ready 로
+        # promote. issue-less bootstrap 과 existing issue 둘 다 같은 downstream
+        # coding path 로 모인다.
+        continuation = self._continue_to_coding(
+            session_id=work_order.session_id,
+            work_order=work_order,
+            anchor=anchor,
+        )
         saved = self._queue.transition(
             job.job_id,
             JobState.SAVED,
@@ -347,6 +359,11 @@ class GitHubWorkOrderWorker:
                 "created_via": CREATED_VIA_EXISTING_ANCHOR,
                 "issue_number": anchor["issue_number"],
                 "skipped_reason": SKIPPED_EXISTING_ANCHOR,
+                "coding_dispatch_queued": continuation is not None
+                and continuation.promoted,
+                "coding_dispatch_noop_reason": continuation.noop_reason
+                if continuation is not None
+                else None,
             },
             clear_lease=True,
             now=now,
@@ -357,7 +374,15 @@ class GitHubWorkOrderWorker:
             issue_url=None,
             created_via=CREATED_VIA_EXISTING_ANCHOR,
             skipped_reason=SKIPPED_EXISTING_ANCHOR,
-            audit_summary={"anchor": anchor},
+            audit_summary={
+                "anchor": anchor,
+                "continuation_promoted": bool(
+                    continuation and continuation.promoted
+                ),
+                "continuation_noop": continuation.noop_reason
+                if continuation is not None
+                else None,
+            },
         )
 
     def _execute_auto_create(
@@ -431,6 +456,15 @@ class GitHubWorkOrderWorker:
         }
         self._write_session_anchor(work_order.session_id, anchor)
 
+        # P0-S continuation — anchor stamp 후 즉시 coding_job=ready 로 promote.
+        # dry_run plan-only 케이스도 같은 path 를 타고 dispatcher 가 dry_run
+        # 으로 자연스럽게 진행한다 (executor 가 자체 dry_run gate 보유).
+        continuation = self._continue_to_coding(
+            session_id=work_order.session_id,
+            work_order=work_order,
+            anchor=anchor,
+        )
+
         # Always SAVED — even dry_run / denied is a deterministic
         # outcome we want the operator to see in #봇-상태. failure means
         # the writer raised an exception, which is converted below.
@@ -443,6 +477,11 @@ class GitHubWorkOrderWorker:
                 "issue_url": issue_url,
                 "outcome": outcome_label,
                 "skipped_reason": skipped_reason,
+                "coding_dispatch_queued": continuation is not None
+                and continuation.promoted,
+                "coding_dispatch_noop_reason": continuation.noop_reason
+                if continuation is not None
+                else None,
             },
             clear_lease=True,
             now=now,
@@ -453,12 +492,63 @@ class GitHubWorkOrderWorker:
             issue_url=str(issue_url) if issue_url else None,
             created_via=created_via,
             skipped_reason=skipped_reason,
-            audit_summary={"anchor": anchor},
+            audit_summary={
+                "anchor": anchor,
+                "continuation_promoted": bool(
+                    continuation and continuation.promoted
+                ),
+                "continuation_noop": continuation.noop_reason
+                if continuation is not None
+                else None,
+            },
         )
 
     # ------------------------------------------------------------------
     # Session writer
     # ------------------------------------------------------------------
+
+    def _continue_to_coding(
+        self,
+        *,
+        session_id: str,
+        work_order: GitHubWorkOrder,
+        anchor: Mapping[str, Any],
+    ) -> Optional[ContinuationOutcome]:
+        """Anchor stamp 직후 같은 세션을 coding_job=ready 로 promote.
+
+        idempotent — 이미 같은 anchor 로 ready 상태면 noop. session 이
+        없거나 coding_proposal 이 없으면 noop (operator audit 에 noop
+        reason 남김).
+        """
+
+        if not session_id:
+            return None
+        try:
+            session = self._load_session(session_id)
+        except Exception:  # noqa: BLE001
+            return None
+        if session is None:
+            return None
+        existing_extra = getattr(session, "extra", None) or {}
+        if not isinstance(existing_extra, Mapping):
+            existing_extra = {}
+        outcome = promote_session_to_coding_ready(
+            session_extra=existing_extra,
+            anchor=anchor,
+            repo=work_order.repo,
+            base_branch=work_order.base_branch,
+            dry_run=bool(work_order.dry_run),
+            approval_id=work_order.approval_id or None,
+            approved_by=work_order.approved_by or None,
+            approved_at=work_order.approved_at or None,
+        )
+        if outcome.new_extra is None:
+            return outcome
+        try:
+            self._update_session(session, outcome.new_extra)
+        except Exception:  # noqa: BLE001 - best-effort
+            pass
+        return outcome
 
     def _write_session_anchor(
         self, session_id: str, anchor: Mapping[str, Any]

--- a/src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py
+++ b/src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py
@@ -1,0 +1,346 @@
+"""GitHub work_order → coding_execute continuation — P0-S 종단 마지막 다리.
+
+배경
+====
+PR #168 까지 닫힌 흐름:
+
+  Discord intake → approval card → 승인 → GitHubWorkOrderWorker → issue
+  create → ``session.extra["github_work_order_issue"]`` anchor stamp.
+
+여기서 멈추면 "issue 는 생겼는데 PR 이 안 나옴" 상태. 본 모듈이
+**anchor → coding_job=ready** continuation 을 담당한다.
+
+흐름
+====
+:func:`promote_session_to_coding_ready` 가 호출되면:
+
+1. session.extra 의 ``coding_proposal`` (engineering channel router 가
+   `_run_coding_authorization_gate` 에서 stamp 한 값) 을 읽는다.
+2. :func:`build_coding_job_from_proposal` 로 CodingJob 빌드.
+3. metadata 에 anchor 정보 (issue_number / issue_url / repo_full_name /
+   base_branch / dry_run / approval_id / approved_at) 를 stamp.
+4. status=ready 로 설정.
+5. session.extra["coding_job"] 가 이미 ready 이고 anchor 가 같으면 noop.
+
+이렇게 stamp 된 ready coding_job 은 기존 :func:`iter_ready_coding_jobs`
+가 자연스럽게 pick up — operator 가 추가 입력을 안 해도 dispatcher 가
+coding_execute 큐로 enqueue 한다.
+
+continuation marker
+-------------------
+``session.extra["github_work_order_progress"]`` 에 다음 단계 marker 가
+누적된다:
+
+  - ``issue_created`` — issue create 직후 (auto / existing 모두)
+  - ``coding_dispatch_queued`` — coding_job=ready 로 promote 됐을 때
+  - ``coding_in_progress`` — coding_executor 가 처리 시작 (이후 PR)
+  - ``draft_pr_opened`` — draft PR 생성 완료 (이후 PR)
+  - ``coding_blocked`` — operator action / 외부 요인으로 멈춤
+
+본 모듈은 ``issue_created`` 와 ``coding_dispatch_queued`` 만 stamp 한다.
+``in_progress`` / ``draft_pr_opened`` / ``blocked`` 는 coding executor /
+operator-action 핸들러가 stamp 한다.
+
+idempotency
+-----------
+- 같은 anchor 로 두 번 호출되면 두 번째는 noop 반환.
+- coding_proposal 이 없으면 noop ("Discord intake 측에서 proposal 을
+  stamp 안 한 비표준 진입" — operator 가 확인 가능하도록 audit 만 남김).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+from ..coding.authorization import proposal_from_dict
+from ..coding.job import (
+    STATUS_READY,
+    build_coding_job_from_proposal,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+SESSION_EXTRA_CODING_JOB_KEY: str = "coding_job"
+SESSION_EXTRA_CODING_PROPOSAL_KEY: str = "coding_proposal"
+SESSION_EXTRA_PROGRESS_KEY: str = "github_work_order_progress"
+
+
+# Progress markers — operator surface 에서 "어디까지 갔는지" 즉시 보이는 키.
+# 본 모듈은 처음 2 종만 stamp. 나머지는 후속 단계 (coding_executor,
+# operator_action_reply) 가 stamp.
+PROGRESS_ISSUE_CREATED: str = "issue_created"
+PROGRESS_CODING_DISPATCH_QUEUED: str = "coding_dispatch_queued"
+PROGRESS_CODING_IN_PROGRESS: str = "coding_in_progress"
+PROGRESS_DRAFT_PR_OPENED: str = "draft_pr_opened"
+PROGRESS_CODING_BLOCKED: str = "coding_blocked"
+
+
+PROGRESS_TIMELINE: tuple = (
+    PROGRESS_ISSUE_CREATED,
+    PROGRESS_CODING_DISPATCH_QUEUED,
+    PROGRESS_CODING_IN_PROGRESS,
+    PROGRESS_DRAFT_PR_OPENED,
+)
+
+
+CONTINUATION_NOOP_NO_PROPOSAL: str = "no_coding_proposal"
+CONTINUATION_NOOP_ALREADY_READY: str = "coding_job_already_ready_same_anchor"
+CONTINUATION_NOOP_BUILD_FAILED: str = "coding_job_build_failed"
+
+
+@dataclass(frozen=True)
+class ContinuationOutcome:
+    """:func:`promote_session_to_coding_ready` 결과.
+
+    ``coding_job`` 이 None 이면 promote 가 일어나지 않은 경우 (already
+    ready / no_proposal / build_failed). ``promoted`` True 면 session.extra
+    가 갱신되었음을 의미.
+    """
+
+    promoted: bool
+    coding_job: Optional[Mapping[str, Any]] = None
+    new_extra: Optional[Mapping[str, Any]] = None
+    noop_reason: Optional[str] = None
+    progress_markers: tuple = ()
+
+
+def promote_session_to_coding_ready(
+    *,
+    session_extra: Mapping[str, Any],
+    anchor: Mapping[str, Any],
+    repo: Optional[str],
+    base_branch: Optional[str],
+    dry_run: bool,
+    approval_id: Optional[str] = None,
+    approved_by: Optional[str] = None,
+    approved_at: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> ContinuationOutcome:
+    """*session_extra* 를 pure 하게 갱신해 coding_job=ready 상태로 promote.
+
+    return value 의 ``new_extra`` 를 caller 가 ``WorkflowSession.extra`` 에
+    persist 한다. 본 함수 자체는 storage I/O 없음.
+
+    idempotent 동작:
+      - coding_job 이 이미 ready 이고 그 metadata 의 ``issue_number`` /
+        ``approval_id`` 가 anchor 와 같으면 noop.
+      - coding_proposal 이 session.extra 에 없으면 noop ("비표준 진입").
+
+    progress markers:
+      - 항상 ``issue_created`` 를 추가 (anchor 가 존재한다는 사실 자체).
+      - promote 성공 시 ``coding_dispatch_queued`` 도 추가.
+    """
+
+    extra = dict(session_extra or {})
+    anchor_issue_number = _coerce_int(anchor.get("issue_number"))
+
+    # 1. progress marker — issue_created 는 anchor 가 있으면 무조건
+    progress_markers = _ensure_progress_marker(
+        extra,
+        marker=PROGRESS_ISSUE_CREATED,
+        at=_now_iso(now),
+        detail={
+            "issue_number": anchor_issue_number,
+            "html_url": anchor.get("html_url"),
+            "created_via": anchor.get("created_via"),
+        },
+    )
+
+    # 2. coding_proposal 없으면 promote 불가 — issue_created marker 만 반환
+    proposal_payload = extra.get(SESSION_EXTRA_CODING_PROPOSAL_KEY)
+    if not isinstance(proposal_payload, Mapping) or not proposal_payload:
+        return ContinuationOutcome(
+            promoted=False,
+            coding_job=None,
+            new_extra=extra,
+            noop_reason=CONTINUATION_NOOP_NO_PROPOSAL,
+            progress_markers=progress_markers,
+        )
+
+    # 3. 같은 anchor 로 이미 ready 인지 확인
+    existing_job = extra.get(SESSION_EXTRA_CODING_JOB_KEY)
+    if (
+        isinstance(existing_job, Mapping)
+        and str(existing_job.get("status") or "").lower() == STATUS_READY
+    ):
+        existing_metadata = existing_job.get("metadata") or {}
+        existing_anchor_issue = (
+            existing_metadata.get("issue_number")
+            if isinstance(existing_metadata, Mapping)
+            else None
+        )
+        if (
+            anchor_issue_number is not None
+            and _coerce_int(existing_anchor_issue) == anchor_issue_number
+        ):
+            return ContinuationOutcome(
+                promoted=False,
+                coding_job=existing_job,
+                new_extra=extra,
+                noop_reason=CONTINUATION_NOOP_ALREADY_READY,
+                progress_markers=progress_markers,
+            )
+
+    # 4. proposal → CodingJob (status=ready) + anchor metadata stamp
+    try:
+        proposal = proposal_from_dict(proposal_payload)
+        approved_at_dt = _coerce_dt(approved_at) or _coerce_dt(_now_iso(now))
+        job = build_coding_job_from_proposal(
+            proposal,
+            status=STATUS_READY,
+            approved_at=approved_at_dt,
+            now=now,
+        )
+    except Exception:  # noqa: BLE001 - keep continuation best-effort
+        logger.warning(
+            "promote_session_to_coding_ready: failed to build CodingJob — "
+            "anchor stamp 만 남기고 promote 건너뜀",
+            exc_info=True,
+        )
+        return ContinuationOutcome(
+            promoted=False,
+            coding_job=None,
+            new_extra=extra,
+            noop_reason=CONTINUATION_NOOP_BUILD_FAILED,
+            progress_markers=progress_markers,
+        )
+
+    job_payload = dict(job.to_dict())
+    metadata = dict(job_payload.get("metadata") or {})
+    if anchor_issue_number is not None:
+        metadata["issue_number"] = anchor_issue_number
+    issue_url = anchor.get("html_url")
+    if issue_url:
+        metadata["issue_url"] = str(issue_url)
+    if repo:
+        metadata["repo_full_name"] = str(repo)
+    if base_branch:
+        metadata["base_branch"] = str(base_branch)
+    metadata["dry_run"] = bool(dry_run)
+    if approval_id:
+        metadata["approval_id"] = str(approval_id)
+    if approved_by:
+        metadata["approved_by"] = str(approved_by)
+    if approved_at:
+        metadata["approved_at"] = str(approved_at)
+    # work order anchor 자체를 보존 — executor / 후속 단계가 audit 가능
+    metadata["github_work_order_anchor"] = dict(anchor)
+    job_payload["metadata"] = metadata
+
+    extra[SESSION_EXTRA_CODING_JOB_KEY] = job_payload
+
+    # 5. 두 번째 progress marker
+    progress_markers = _ensure_progress_marker(
+        extra,
+        marker=PROGRESS_CODING_DISPATCH_QUEUED,
+        at=_now_iso(now),
+        detail={
+            "issue_number": anchor_issue_number,
+            "executor_role": job_payload.get("executor_role"),
+            "repo_full_name": repo,
+        },
+    )
+
+    return ContinuationOutcome(
+        promoted=True,
+        coding_job=job_payload,
+        new_extra=extra,
+        noop_reason=None,
+        progress_markers=progress_markers,
+    )
+
+
+def stamp_progress_marker(
+    *,
+    session_extra: Mapping[str, Any],
+    marker: str,
+    at: Optional[str] = None,
+    detail: Optional[Mapping[str, Any]] = None,
+) -> Mapping[str, Any]:
+    """``session.extra`` 에 progress marker 한 줄 추가하고 새 dict 반환.
+
+    이미 같은 marker 가 있으면 detail 만 갱신 (timestamp 는 유지) — 같은
+    단계가 두 번 발생하지 않은 것으로 본다 (idempotent).
+
+    public helper — coding_executor / operator_action 측에서도 호출.
+    """
+
+    extra = dict(session_extra or {})
+    _ensure_progress_marker(
+        extra, marker=marker, at=at or _now_iso(None), detail=dict(detail or {})
+    )
+    return extra
+
+
+def _ensure_progress_marker(
+    extra: dict,
+    *,
+    marker: str,
+    at: str,
+    detail: Mapping[str, Any],
+) -> tuple:
+    bucket = extra.get(SESSION_EXTRA_PROGRESS_KEY)
+    if not isinstance(bucket, Mapping):
+        bucket = {}
+    bucket = dict(bucket)
+    existing = bucket.get(marker)
+    entry = {
+        "at": existing.get("at") if isinstance(existing, Mapping) and existing.get("at") else at,
+        "detail": {k: v for k, v in (detail or {}).items() if v is not None},
+    }
+    bucket[marker] = entry
+    extra[SESSION_EXTRA_PROGRESS_KEY] = bucket
+    return tuple(bucket.keys())
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_dt(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        text = str(value)
+        # GitHub-style ISO with Z suffix
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return datetime.fromisoformat(text)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _now_iso(now: Optional[datetime]) -> str:
+    dt = now or datetime.now(tz=timezone.utc)
+    return dt.replace(microsecond=0).isoformat()
+
+
+__all__ = (
+    "CONTINUATION_NOOP_ALREADY_READY",
+    "CONTINUATION_NOOP_BUILD_FAILED",
+    "CONTINUATION_NOOP_NO_PROPOSAL",
+    "ContinuationOutcome",
+    "PROGRESS_CODING_BLOCKED",
+    "PROGRESS_CODING_DISPATCH_QUEUED",
+    "PROGRESS_CODING_IN_PROGRESS",
+    "PROGRESS_DRAFT_PR_OPENED",
+    "PROGRESS_ISSUE_CREATED",
+    "PROGRESS_TIMELINE",
+    "SESSION_EXTRA_CODING_JOB_KEY",
+    "SESSION_EXTRA_CODING_PROPOSAL_KEY",
+    "SESSION_EXTRA_PROGRESS_KEY",
+    "promote_session_to_coding_ready",
+    "stamp_progress_marker",
+)

--- a/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
+++ b/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
@@ -1,0 +1,390 @@
+"""Work_order → coding_execute continuation 종단 회귀 (P0-S 마지막 단계).
+
+contract — 한 줄로 묶인 시나리오:
+  1. issue-less full-stack request
+  2. approval card + 승인
+  3. GitHubWorkOrderWorker drain → issue create + anchor stamp +
+     continuation 자동 호출 → coding_job=ready 로 promote
+  4. dispatcher (iter_ready_coding_jobs) 가 그 세션을 발견
+  5. build_coding_execute_request 가 anchor 의 issue_number / repo 를
+     CodingExecuteRequest 에 흘려보냄
+
+추가 회귀:
+  - existing_issue_number 만 있는 (template plan 없는) 케이스도 같은
+    downstream path
+  - 같은 work_order 가 두 번 drain 되면 두 번째는 coding_job=ready 가
+    이미 있어 promote noop
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.job import STATUS_READY
+from yule_orchestrator.agents.github_workos.audit import OUTCOME_OK
+from yule_orchestrator.agents.git.repo_contract import RepoContract
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    build_coding_execute_request,
+    iter_ready_coding_jobs,
+)
+from yule_orchestrator.agents.job_queue.github_work_order_executor import (
+    GitHubWorkOrderWorker,
+    SESSION_EXTRA_GITHUB_ISSUE_KEY,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.agents.job_queue.work_order_coding_continuation import (
+    PROGRESS_CODING_DISPATCH_QUEUED,
+    PROGRESS_ISSUE_CREATED,
+    SESSION_EXTRA_CODING_JOB_KEY,
+    SESSION_EXTRA_PROGRESS_KEY,
+)
+from yule_orchestrator.discord.integrations.github_workos_adapter import (
+    enqueue_github_work_approval,
+    handle_github_work_approval_reply,
+)
+
+
+_FEATURE_TEMPLATE = (
+    "---\n"
+    'name: "[Feature] Issue Template"\n'
+    'title: "[Feat]"\n'
+    'labels: "✨ Feature"\n'
+    "---\n"
+    "\n"
+    "## 어떤 기능인가요?\n"
+    "> 추가하려는 기능에 대해 간결하게 설명해주세요\n"
+)
+
+
+def _coding_proposal_payload(
+    session_id: str = "sess-e2e",
+    user_request: str = "Next.js + NestJS 회원가입 구현",
+) -> Mapping[str, Any]:
+    return {
+        "session_id": session_id,
+        "user_request": user_request,
+        "executor_role": "backend-engineer",
+        "review_roles": ["tech-lead", "qa-engineer"],
+        "participant_roles": ["backend-engineer", "tech-lead", "qa-engineer"],
+        "write_scope": ["src/api/auth", "web/src/app/login"],
+        "forbidden_scope": ["secret", ".env"],
+        "safety_rules": ["no force push"],
+        "reason": "full-stack 회원가입 — backend-engineer 가 auth 책임",
+        "approval_required": True,
+        "metadata": {},
+        "lifecycle_mode": "implementation",
+    }
+
+
+@dataclass
+class _SessionStore:
+    sessions: Dict[str, SimpleNamespace] = field(default_factory=dict)
+
+    def make(self, session_id: str, *, request: str, with_proposal: bool = True) -> SimpleNamespace:
+        extra = {
+            "lifecycle_mode": "implementation",
+            "active_research_roles": ["tech-lead", "backend-engineer"],
+        }
+        if with_proposal:
+            extra["coding_proposal"] = _coding_proposal_payload(
+                session_id=session_id, user_request=request
+            )
+        s = SimpleNamespace(session_id=session_id, extra=extra)
+        self.sessions[session_id] = s
+        return s
+
+    def load(self, session_id: str):
+        return self.sessions.get(session_id)
+
+    def update(self, session, new_extra: Mapping[str, Any]):
+        session.extra = dict(new_extra)
+        self.sessions[session.session_id] = session
+        return session
+
+
+@dataclass
+class _Call:
+    title: str
+    body: str
+    labels: Tuple[str, ...]
+
+
+class _StubIssueWriter:
+    def __init__(self) -> None:
+        self.calls: List[_Call] = []
+        self._next = 77
+
+    def create_issue(
+        self,
+        *,
+        repo,
+        title,
+        body,
+        labels=(),
+        assignees=(),
+        autonomy_level="L2",
+        session_id=None,
+        decision_id=None,
+    ):
+        self.calls.append(_Call(title=title, body=body, labels=tuple(labels)))
+        n = self._next
+        self._next += 1
+        return SimpleNamespace(
+            ok=True,
+            outcome=OUTCOME_OK,
+            succeeded=True,
+            body={
+                "number": n,
+                "html_url": f"https://github.com/{repo}/issues/{n}",
+                "url": f"https://api.github.com/repos/{repo}/issues/{n}",
+            },
+        )
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class ContinuationEndToEndTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db = Path(self._tmp.name) / "q.sqlite3"
+        self.queue = JobQueue(db_path=db)
+        self.heartbeats = HeartbeatStore(db_path=db)
+        self.posted: List[Tuple[ApprovalRequest, str]] = []
+
+        async def _post(req, rendered):
+            self.posted.append((req, rendered))
+            return {"posted_message_id": 1}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post,
+            channel_resolver=lambda: 99,
+        )
+        self.sessions = _SessionStore()
+        self.writer = _StubIssueWriter()
+        self.worker = GitHubWorkOrderWorker(
+            queue=self.queue,
+            writer_factory=lambda _wo: (self.writer, "L2"),
+            load_session_fn=lambda sid: self.sessions.load(sid),
+            update_session_fn=lambda s, e: self.sessions.update(s, e),
+        )
+
+    def _drive_intake(
+        self, *, session, request_text: str, existing_issue: Optional[int] = None
+    ) -> ApprovalRequest:
+        rc = RepoContract(
+            owner="yule-studio",
+            repo="naver-search-clone",
+            issue_templates=(".github/ISSUE_TEMPLATE/feature.md",),
+        )
+        outcome = _run(
+            enqueue_github_work_approval(
+                session=session,
+                request_text=request_text,
+                approval_worker=self.approval_worker,
+                repo="yule-studio/naver-search-clone",
+                base_branch="main",
+                repo_contract=rc,
+                issue_template_loader=lambda p: _FEATURE_TEMPLATE,
+                existing_issue_number=existing_issue,
+            )
+        )
+        self.assertIsNotNone(outcome.proposal)
+        return self.posted[-1][0]
+
+    def test_issueless_request_ends_with_coding_job_ready(self) -> None:
+        session = self.sessions.make(
+            "sess-issueless",
+            request="Next.js + NestJS 회원가입/검색 PR 올려",
+        )
+        approval_request = self._drive_intake(
+            session=session,
+            request_text="Next.js + NestJS 회원가입/검색 PR 올려",
+        )
+
+        # 승인 → work_order dispatch
+        dispatched = handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-e2e",
+            approved_by="masterway",
+            approved_at="2026-05-15T11:00:00+00:00",
+            dry_run=False,
+        )
+        self.assertIsNone(dispatched.skipped_reason)
+
+        # worker drain → issue create + continuation
+        exec_outcome = self.worker.run_one()
+        self.assertIsNotNone(exec_outcome)
+        assert exec_outcome is not None
+        self.assertEqual(exec_outcome.issue_number, 77)
+        # writer 호출 1건
+        self.assertEqual(len(self.writer.calls), 1)
+
+        # session.extra 에 anchor + coding_job + progress markers 모두 있음
+        s = self.sessions.sessions["sess-issueless"]
+        self.assertIn(SESSION_EXTRA_GITHUB_ISSUE_KEY, s.extra)
+        self.assertIn(SESSION_EXTRA_CODING_JOB_KEY, s.extra)
+        coding_job = s.extra[SESSION_EXTRA_CODING_JOB_KEY]
+        self.assertEqual(coding_job["status"], STATUS_READY)
+        meta = coding_job["metadata"]
+        self.assertEqual(meta["issue_number"], 77)
+        self.assertEqual(meta["repo_full_name"], "yule-studio/naver-search-clone")
+        self.assertEqual(meta["base_branch"], "main")
+        self.assertEqual(meta["approval_id"], "approval-e2e")
+        self.assertEqual(meta["approved_by"], "masterway")
+        # progress markers
+        progress = s.extra[SESSION_EXTRA_PROGRESS_KEY]
+        self.assertIn(PROGRESS_ISSUE_CREATED, progress)
+        self.assertIn(PROGRESS_CODING_DISPATCH_QUEUED, progress)
+        # work_order queue row 의 result 에 continuation 흔적
+        row = exec_outcome.job
+        assert row is not None
+        self.assertTrue(row.result.get("coding_dispatch_queued"))
+        self.assertIsNone(row.result.get("coding_dispatch_noop_reason"))
+
+    def test_dispatcher_picks_up_promoted_session(self) -> None:
+        """ready 로 promote 된 세션이 iter_ready_coding_jobs 의 pick 대상."""
+
+        session = self.sessions.make(
+            "sess-pick", request="full-stack 구현 PR 올려"
+        )
+        approval_request = self._drive_intake(
+            session=session, request_text="full-stack 구현 PR 올려"
+        )
+        handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-pick",
+            approved_by="m",
+            approved_at="2026-05-15T11:00:00+00:00",
+            dry_run=False,
+        )
+        self.worker.run_one()
+
+        # iter_ready_coding_jobs 가 그 세션을 yield
+        ready_jobs = list(
+            iter_ready_coding_jobs(
+                session_loader=lambda: list(self.sessions.sessions.values())
+            )
+        )
+        self.assertEqual(len(ready_jobs), 1)
+        ready = ready_jobs[0]
+        self.assertEqual(ready.session_id, "sess-pick")
+        self.assertEqual(ready.executor_role(), "backend-engineer")
+
+        # build_coding_execute_request 가 anchor 의 repo/issue_number 를
+        # CodingExecuteRequest 에 흘려보냄
+        request = build_coding_execute_request(ready, env={})
+        self.assertEqual(request.issue_number, 77)
+        self.assertEqual(
+            request.repo_full_name, "yule-studio/naver-search-clone"
+        )
+        self.assertEqual(request.base_branch, "main")
+        self.assertEqual(request.executor_role, "backend-engineer")
+        self.assertFalse(request.dry_run)
+
+    def test_existing_issue_continuation_uses_same_path(self) -> None:
+        session = self.sessions.make(
+            "sess-existing", request="issue #42 작업 PR 올려"
+        )
+        approval_request = self._drive_intake(
+            session=session,
+            request_text="issue #42 작업 PR 올려",
+            existing_issue=42,
+        )
+        handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-existing",
+            approved_by="m",
+            approved_at="2026-05-15T11:00:00+00:00",
+            dry_run=False,
+        )
+        exec_outcome = self.worker.run_one()
+        assert exec_outcome is not None
+        # writer 호출 없음 (existing anchor)
+        self.assertEqual(self.writer.calls, [])
+        self.assertEqual(exec_outcome.issue_number, 42)
+        # 하지만 coding_job=ready 는 똑같이 stamp
+        s = self.sessions.sessions["sess-existing"]
+        coding_job = s.extra[SESSION_EXTRA_CODING_JOB_KEY]
+        self.assertEqual(coding_job["status"], STATUS_READY)
+        self.assertEqual(coding_job["metadata"]["issue_number"], 42)
+        progress = s.extra[SESSION_EXTRA_PROGRESS_KEY]
+        self.assertIn(PROGRESS_CODING_DISPATCH_QUEUED, progress)
+
+    def test_same_work_order_drained_twice_does_not_repromote(self) -> None:
+        """idempotency: 같은 work_order job 이 두 번 drain (e.g., worker
+        restart) 되어도 coding_job 이 중복 promote 되지 않는다.
+
+        본 테스트는 queue 의 unique work_order job 자체는 한 번만 SAVED
+        되지만, anchor 가 있는 session.extra 에 promote 가 한 번 더 시도
+        되어도 continuation 이 already_ready_same_anchor 로 noop 반환하는
+        것을 핀.
+        """
+
+        from yule_orchestrator.agents.job_queue.work_order_coding_continuation import (
+            CONTINUATION_NOOP_ALREADY_READY,
+            promote_session_to_coding_ready,
+        )
+
+        session = self.sessions.make(
+            "sess-idem", request="PR 올려"
+        )
+        approval_request = self._drive_intake(
+            session=session, request_text="PR 올려"
+        )
+        handle_github_work_approval_reply(
+            queue=self.queue,
+            approval_request=approval_request,
+            approval_id="approval-idem",
+            approved_by="m",
+            approved_at="2026-05-15T11:00:00+00:00",
+            dry_run=False,
+        )
+        self.worker.run_one()
+
+        # 두 번째 promote 시도 — anchor 와 session.extra 가 이미 ready
+        s = self.sessions.sessions["sess-idem"]
+        anchor = s.extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]
+        outcome = promote_session_to_coding_ready(
+            session_extra=s.extra,
+            anchor=anchor,
+            repo="yule-studio/naver-search-clone",
+            base_branch="main",
+            dry_run=False,
+            approval_id="approval-idem",
+            approved_by="m",
+            approved_at="2026-05-15T11:00:00+00:00",
+        )
+        self.assertFalse(outcome.promoted)
+        self.assertEqual(outcome.noop_reason, CONTINUATION_NOOP_ALREADY_READY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_work_order_coding_continuation.py
+++ b/tests/job_queue/test_work_order_coding_continuation.py
@@ -1,0 +1,211 @@
+"""work_order_coding_continuation helper 회귀 — P0-S anchor → coding_job=ready.
+
+contract:
+  - coding_proposal 이 있으면 coding_job=ready 로 promote 되고 metadata
+    에 anchor 정보 (issue_number/issue_url/repo_full_name/base_branch/
+    dry_run/approval_id) 가 stamp 된다.
+  - progress markers (issue_created → coding_dispatch_queued) 가 누적
+    stamp.
+  - 같은 anchor 로 재호출 시 noop (idempotent).
+  - coding_proposal 이 없으면 promote 안 함 + audit reason 만 남김.
+  - proposal build 실패 시 NoopReason build_failed.
+  - stamp_progress_marker 가 추가 marker 를 idempotent 하게 누적.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.job import STATUS_READY
+from yule_orchestrator.agents.job_queue.work_order_coding_continuation import (
+    CONTINUATION_NOOP_ALREADY_READY,
+    CONTINUATION_NOOP_BUILD_FAILED,
+    CONTINUATION_NOOP_NO_PROPOSAL,
+    PROGRESS_CODING_DISPATCH_QUEUED,
+    PROGRESS_CODING_IN_PROGRESS,
+    PROGRESS_DRAFT_PR_OPENED,
+    PROGRESS_ISSUE_CREATED,
+    SESSION_EXTRA_CODING_JOB_KEY,
+    SESSION_EXTRA_PROGRESS_KEY,
+    promote_session_to_coding_ready,
+    stamp_progress_marker,
+)
+
+
+def _sample_proposal() -> Mapping[str, Any]:
+    return {
+        "session_id": "sess-x",
+        "user_request": "회원가입 구현",
+        "executor_role": "backend-engineer",
+        "review_roles": ["tech-lead", "qa-engineer"],
+        "participant_roles": ["backend-engineer", "tech-lead", "qa-engineer"],
+        "write_scope": ["src/api/auth"],
+        "forbidden_scope": ["secret", ".env"],
+        "safety_rules": ["no force push"],
+        "reason": "auth 흐름은 backend-engineer 책임",
+        "approval_required": True,
+        "metadata": {},
+        "lifecycle_mode": "implementation",
+    }
+
+
+def _anchor(issue_number: int = 77) -> Mapping[str, Any]:
+    return {
+        "issue_number": issue_number,
+        "html_url": f"https://github.com/yule-studio/naver-search-clone/issues/{issue_number}",
+        "title": "[Feat] 회원가입",
+        "created_via": "auto_create",
+        "approval_id": "a1",
+        "approved_by": "masterway",
+        "approved_at": "2026-05-15T11:00:00+00:00",
+        "dry_run": False,
+        "repo": "yule-studio/naver-search-clone",
+    }
+
+
+class PromoteTests(unittest.TestCase):
+    def test_promote_happy_path_stamps_metadata_and_progress(self) -> None:
+        extra = {"coding_proposal": _sample_proposal()}
+        outcome = promote_session_to_coding_ready(
+            session_extra=extra,
+            anchor=_anchor(),
+            repo="yule-studio/naver-search-clone",
+            base_branch="main",
+            dry_run=False,
+            approval_id="a1",
+            approved_by="masterway",
+            approved_at="2026-05-15T11:00:00+00:00",
+        )
+        self.assertTrue(outcome.promoted)
+        assert outcome.coding_job is not None
+        self.assertEqual(outcome.coding_job["status"], STATUS_READY)
+        meta = outcome.coding_job["metadata"]
+        self.assertEqual(meta["issue_number"], 77)
+        self.assertEqual(meta["repo_full_name"], "yule-studio/naver-search-clone")
+        self.assertEqual(meta["base_branch"], "main")
+        self.assertEqual(meta["approval_id"], "a1")
+        self.assertIn("github_work_order_anchor", meta)
+        # progress markers 누적
+        assert outcome.new_extra is not None
+        progress = outcome.new_extra[SESSION_EXTRA_PROGRESS_KEY]
+        self.assertIn(PROGRESS_ISSUE_CREATED, progress)
+        self.assertIn(PROGRESS_CODING_DISPATCH_QUEUED, progress)
+        self.assertEqual(
+            progress[PROGRESS_ISSUE_CREATED]["detail"]["issue_number"], 77
+        )
+
+    def test_idempotent_same_anchor(self) -> None:
+        extra = {"coding_proposal": _sample_proposal()}
+        first = promote_session_to_coding_ready(
+            session_extra=extra,
+            anchor=_anchor(),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        assert first.new_extra is not None
+        second = promote_session_to_coding_ready(
+            session_extra=first.new_extra,
+            anchor=_anchor(),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        self.assertFalse(second.promoted)
+        self.assertEqual(second.noop_reason, CONTINUATION_NOOP_ALREADY_READY)
+
+    def test_different_anchor_repromotes(self) -> None:
+        extra = {"coding_proposal": _sample_proposal()}
+        first = promote_session_to_coding_ready(
+            session_extra=extra,
+            anchor=_anchor(issue_number=10),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        assert first.new_extra is not None
+        # 다른 issue 번호의 anchor 가 들어오면 promote 가 다시 일어남
+        second = promote_session_to_coding_ready(
+            session_extra=first.new_extra,
+            anchor=_anchor(issue_number=11),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        self.assertTrue(second.promoted)
+        assert second.coding_job is not None
+        self.assertEqual(second.coding_job["metadata"]["issue_number"], 11)
+
+    def test_no_proposal_returns_noop(self) -> None:
+        outcome = promote_session_to_coding_ready(
+            session_extra={},
+            anchor=_anchor(),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        self.assertFalse(outcome.promoted)
+        self.assertEqual(outcome.noop_reason, CONTINUATION_NOOP_NO_PROPOSAL)
+        # 하지만 issue_created marker 는 여전히 stamp (anchor 자체는 존재)
+        assert outcome.new_extra is not None
+        self.assertIn(
+            PROGRESS_ISSUE_CREATED,
+            outcome.new_extra[SESSION_EXTRA_PROGRESS_KEY],
+        )
+
+    def test_research_only_proposal_build_failed(self) -> None:
+        proposal = dict(_sample_proposal())
+        proposal["lifecycle_mode"] = "research_only"
+        proposal["executor_role"] = ""
+        outcome = promote_session_to_coding_ready(
+            session_extra={"coding_proposal": proposal},
+            anchor=_anchor(),
+            repo="r",
+            base_branch="main",
+            dry_run=False,
+        )
+        self.assertFalse(outcome.promoted)
+        self.assertEqual(outcome.noop_reason, CONTINUATION_NOOP_BUILD_FAILED)
+
+
+class ProgressMarkerTests(unittest.TestCase):
+    def test_stamp_progress_marker_adds_and_does_not_overwrite_timestamp(self) -> None:
+        extra1 = stamp_progress_marker(
+            session_extra={},
+            marker=PROGRESS_CODING_IN_PROGRESS,
+            at="2026-05-15T12:00:00+00:00",
+            detail={"executor_role": "backend-engineer"},
+        )
+        self.assertIn(
+            PROGRESS_CODING_IN_PROGRESS,
+            extra1[SESSION_EXTRA_PROGRESS_KEY],
+        )
+        first_at = extra1[SESSION_EXTRA_PROGRESS_KEY][PROGRESS_CODING_IN_PROGRESS]["at"]
+        # 같은 marker 를 다시 stamp 하면 timestamp 는 유지
+        extra2 = stamp_progress_marker(
+            session_extra=extra1,
+            marker=PROGRESS_CODING_IN_PROGRESS,
+            at="2026-05-15T13:00:00+00:00",
+            detail={"new_field": "x"},
+        )
+        self.assertEqual(
+            extra2[SESSION_EXTRA_PROGRESS_KEY][PROGRESS_CODING_IN_PROGRESS]["at"],
+            first_at,
+        )
+
+    def test_stamp_progress_marker_does_not_mutate_input(self) -> None:
+        original = {"unrelated": True}
+        stamp_progress_marker(
+            session_extra=original, marker=PROGRESS_DRAFT_PR_OPENED
+        )
+        self.assertEqual(original, {"unrelated": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #169

## ✨ 과제 내용

직전 PR #168 까지 닫혀 있던 흐름:

```
Discord intake → approval card → 승인 → GitHubWorkOrderWorker →
  issue create → session.extra["github_work_order_issue"] anchor stamp
```

여기서 멈추면 "issue 는 생겼는데 PR 이 안 나옴" 정체. 본 PR 이 그 다리:

```
... anchor stamp → promote_session_to_coding_ready (continuation)
                     → session.extra["coding_job"] status=ready + anchor metadata
                     → session.extra["github_work_order_progress"] markers
  → iter_ready_coding_jobs 가 같은 세션 yield
  → build_coding_execute_request 가 anchor repo / issue_number fallback
  → dispatcher 가 coding_execute 큐 enqueue
  → CodingExecutorWorker → branch / edit / test / commit / push / draft PR
```

### 3 commit 구성
1. **🚀 anchor → coding_job=ready continuation helper** — `promote_session_to_coding_ready` pure 헬퍼 + progress timeline SSoT + 7 회귀 테스트
2. **🔧 GitHubWorkOrderWorker 가 anchor 직후 continuation 자동 호출** — auto_create / existing_anchor 양쪽 분기 모두 hook + dispatcher 의 anchor fallback
3. **✅ work_order → coding 종단 회귀 + docs §1.4 갱신** — 4 시나리오 end-to-end + docs

### 회귀
- 전체 **4839 pass / 1 skip** (직전 PR #168 의 4828 + 신규 11)
- 신규 11: continuation helper 7 + end-to-end 4

### Idempotency / progress markers
- 같은 anchor 로 promote 재시도 → `coding_job_already_ready_same_anchor` noop
- 같은 work_order 가 다시 drain → queue 측에서 SAVED 라 skip
- `session.extra["github_work_order_progress"]` 5 단계 timeline (issue_created / coding_dispatch_queued / coding_in_progress / draft_pr_opened / coding_blocked) — 본 PR 은 앞 2 단계 stamp, 나머지 3 단계는 coding executor / operator action 측에서 누적

### operator 가 실제 개입해야 하는 지점 (이 PR 후)
- **승인 1회** (`#승인-대기` 카드 응답)
- 외부 사실 카드 (INFO / ACCESS / SECRET / DECISION) 응답만

승인 후 자동 진행: work_order dispatch → worker drain (issue create) → continuation (coding_job=ready) → dispatcher pick up → CodingExecutorWorker.

### 남은 명시적 deferred (본 PR 에서 닫지 않음)
1. **CodingExecutorWorker live wiring** — 기존 dispatcher → executor 경로는 land 됐고 본 PR 이 그 진입까지 자동 잇기. 실제 GitHub App 기반 commit/push/draft PR 의 live runner activation 은 `YULE_GITHUB_APP_*` 환경 설정 후 별 PR (executor 자체는 RecordOnly 모드 가능).
2. **Discord intake → adapter `repo_contract` 통합** — adapter API 는 keyword arg 로 받지만 router 측에서 실제 호출 시점에 어떻게 주입할지 (router 내부 discover vs background loop) 별 PR.
3. **Tag/release 자동 발행** — 별 worker + L3 카드.
4. **coding_in_progress / draft_pr_opened / coding_blocked progress marker stamp** — `stamp_progress_marker` 공개 헬퍼는 land. coding executor 측에서 적절한 시점에 호출하는 wiring 은 별 PR.

이 한계는 fake success 가 아니라 명시적 deferred — master plan §3 에 명시.

## 📚 레퍼런스
- `src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py` (신규)
- `src/yule_orchestrator/agents/job_queue/github_work_order_executor.py` (hook 추가)
- `src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py` (anchor fallback)
- `tests/engineering/test_workorder_to_coding_continuation_end_to_end.py` (4 시나리오)
- `docs/github-agent-workos.md` §1.4
- `docs/engineering-company-runtime-master-plan.md` §3