### PR TITLE
🚀 Runtime governance hard rails — git/vault/eval/post-test hardening (closes #171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,14 @@ docs/
 | --- | --- |
 | engineering-agent 전반 | `agents/engineering-agent/CLAUDE.md` |
 | 코드 구조 / 리팩터링 / 모듈 분할 | `agents/engineering-agent/CODE_LAYOUT.md` |
-| 브랜치 / 커밋 / PR / 네이밍 | `policies/reference/{BRANCH_STRATEGY,COMMIT_CONVENTION,NAMING_CONVENTION}.md` |
+| 브랜치 / 커밋 / PR / 네이밍 | `policies/reference/{BRANCH_STRATEGY,COMMIT_CONVENTION,NAMING_CONVENTION}.md` + `agents/governance/runtime_policy.py` |
 | 승인 / 자율 / hard rail | `docs/approval-matrix.md`, `docs/autonomy-policy.md` |
 | 운영 / 배포 / 상태 / 업타임 | `docs/operations.md`, `docs/configuration.md` |
 | Discord / forum / member-bot | `docs/discord.md`, `docs/runtime-member-bot-dispatch-parity.md` |
 | 거버넌스 / Obsidian write ownership | `docs/engineering-agent-governance.md` (+ `policies/runtime/agents/engineering-agent/*`) |
+| Vault / 지식 / inbox / retrieval | `docs/memory.md` (§"Curated 정책" / §"Retrieval eval") |
 | 테스트 작성 / 회귀 가이드 | `docs/testing.md` |
+| 성능 개선 / 고도화 opening criteria | `docs/engineering-company-runtime-master-plan.md` §"Post-test hardening" |
 
 규칙:
 - 위 표에 없는 토픽이면 그 작업과 가장 가까운 디렉터리의 `CLAUDE.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,19 @@
 멈추는 것 금지. 5 가지 request_type (APPROVAL/INFO/ACCESS/SECRET/DECISION)
 는 [`docs/approval-matrix.md`](docs/approval-matrix.md) §6 참조.
 
+## Runtime governance hard rails (P0-T)
+
+엔지니어링 코딩 작업이 실제로 굴러갈 때 무너지지 말아야 할 hard rail —
+코드 SSoT 는 [`src/yule_orchestrator/agents/governance/runtime_policy.py`](src/yule_orchestrator/agents/governance/runtime_policy.py),
+사람용 SSoT 는 [`docs/engineering-agent-governance.md`](docs/engineering-agent-governance.md)
+와 [`docs/memory.md`](docs/memory.md).
+
+핵심 규칙:
+- **Git/PR/Tag** — protected branch (main/master/develop/release/...) 직접 작업 금지, 표준 prefix (`feat/fix/chore/refactor/...`) 권장, issue 번호를 branch name 에 anchor. PR body 는 5 섹션 (목적/범위/리스크/테스트/이슈 linkage) + audit block 필수. Tag/release 는 `RepoContract.tag_policy` 기반 — 정책 없으면 자동 발행 금지.
+- **Vault / 지식** — `00-inbox` 는 raw 자료 보관소. curated note 는 **새로 만드는 것** 이지 inbox 안에서 자리만 바꾸는 게 아님. curated note 는 필수 frontmatter (title/kind/status/created_at/tags/related/home_hub) + 본문 5 섹션 (핵심 요약/내 해석/적용 맥락/관련 노트/참고). orphan / broken link 면 push 금지.
+- **Retrieval eval** — fixture 최소 50 / 목표 100 / top-5 평가. note 많이 추가했는데 eval 점수가 떨어지면 "지식 추가 성공" 이 아니라 **regression**. eval 없이 대량 curated generation push 금지.
+- **Post-test hardening** — 8 opening criteria (queue_backlog / runtime_status_latency / retrieval_eval_regression / prompt_size_ceiling / large_file_rule / duplicate_work / critical_path_bottleneck / flaky_or_slow_test) 중 하나라도 충족돼야 성능 개선 작업을 연다. baseline 측정 + target metric 명시 + behavior change 분리 + 회귀 테스트 의무.
+
 ## 읽기 우선순위 (요약)
 | 항상 | `AGENTS.md` → 본 파일 |
 | --- | --- |

--- a/agents/engineering-agent/CLAUDE.md
+++ b/agents/engineering-agent/CLAUDE.md
@@ -97,6 +97,8 @@ Engineering Agent는 **엔지니어링 부서의 게이트웨이**다. 외부에
 | 테스트 작성 | [`/docs/testing.md`](../../docs/testing.md), [`CODE_LAYOUT.md`](CODE_LAYOUT.md) §"tests/ 매핑" | 어느 디렉터리에 어떤 테스트가 떨어져야 하는지 |
 | Discord member-bot / dispatcher | [`/docs/discord.md`](../../docs/discord.md), [`/docs/runtime-member-bot-dispatch-parity.md`](../../docs/runtime-member-bot-dispatch-parity.md) | bot.py / member_bot 진입부 |
 | Configuration / env / CI 알림 | [`/docs/configuration.md`](../../docs/configuration.md), [`/docs/ci-discord-notifications.md`](../../docs/ci-discord-notifications.md) | env 변수 / CI 알림 채널 |
+| Runtime governance (branch/PR/tag/curated/eval/hardening) | [`/docs/engineering-agent-governance.md`](../../docs/engineering-agent-governance.md), [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../../src/yule_orchestrator/agents/governance/runtime_policy.py) | hard rail 코드 SSoT |
+| Vault / 지식 / inbox / retrieval | [`/docs/memory.md`](../../docs/memory.md) | curated 승격 규칙 + retrieval eval |
 
 ## 코딩 작업 시 강제 규칙 (engineering-agent 특화)
 

--- a/agents/engineering-agent/CODE_LAYOUT.md
+++ b/agents/engineering-agent/CODE_LAYOUT.md
@@ -141,8 +141,11 @@
 - 본 문서의 1000 줄 규칙은 governance smoke test
   [`tests/engineering/test_engineering_agent_governance_doc.py`](../../tests/engineering/test_engineering_agent_governance_doc.py)
   의 docstring 검증 라인이 핵심 섹션 존재를 지킨다.
-- 위 두 자동 가드와 본 규칙은 **상호 보완** — ceiling 은 토큰/회귀
-  보호, 본 규칙은 책임 분리 보호.
+- runtime hard rail (branch / PR / tag / curated note / retrieval eval /
+  post-test hardening) 은 [`tests/governance/test_runtime_policy.py`](../../tests/governance/test_runtime_policy.py)
+  가 검사 — 코드 SSoT 는 [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../../src/yule_orchestrator/agents/governance/runtime_policy.py).
+- 세 자동 가드와 본 규칙은 **상호 보완** — ceiling 은 토큰/회귀 보호,
+  본 규칙은 책임 분리 보호, runtime_policy 는 git/vault/eval drift 보호.
 
 ## Phase 1-5 변경 요약 (이 문서가 만들어진 배경)
 

--- a/docs/approval-matrix.md
+++ b/docs/approval-matrix.md
@@ -43,6 +43,8 @@ action 을 추가할 때는 반드시 본 표 + `autonomy_policy._DEFAULT_LEVELS
 | **runtime/prod 코드 변경** | **L3** | `runtime_code_change` |
 | 공유 repo 로 push (feature branch) | L3 | `push_to_shared_repo` |
 | draft PR 생성 | L3 | `draft_pr_create` (사용자 정책으로 사전 자동 허용 가능) |
+| **GitHub issue 자동 생성** | **L2** | `github_issue_create` — `#승인-대기` 카드로 묶인 work_order 안에서만 (P0-S, [`github-agent-workos.md`](github-agent-workos.md) §1.1) |
+| **Tag/release create** | **L3** | `tag_create` / `release_create` — `RepoContract.tag_policy` 가 `none` 이면 금지 (P0-S §1.2 / §1.2.1) |
 | **main 직접 push** | **L4** | `main_branch_push` — 사실상 금지 |
 | **merge** | **L4** | `branch_merge` |
 | **deploy** | **L4** | `deploy` |

--- a/docs/engineering-agent-governance.md
+++ b/docs/engineering-agent-governance.md
@@ -66,6 +66,70 @@ write 발생:
 
 위 항목 변경은 별도 hard-rail 정책 PR + 사용자 결정이 필요. 본 governance 가 자체 권한으로 변경할 수 없다.
 
+## 4.1 Runtime governance hard rails (P0-T)
+
+**코드 SSoT**: [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../src/yule_orchestrator/agents/governance/runtime_policy.py).
+**회귀 test**: [`tests/governance/test_runtime_policy.py`](../tests/governance/test_runtime_policy.py).
+**docs cross-link**: [`/docs/github-agent-workos.md`](github-agent-workos.md) §1.2.1 / [`/docs/memory.md`](memory.md).
+
+### 4.1.1 Git / branch / PR / tag
+
+| 영역 | 규칙 | 코드 |
+| --- | --- | --- |
+| Branch | protected branch 직접 작업 금지. 표준 prefix `feat/fix/chore/refactor/docs/test/perf`. issue 번호 anchor 권장. | `validate_branch_name`, `derive_standard_branch_name` |
+| Commit | 의미 있는 작업 단위. raw 수집과 curated promotion 분리. 30+ vault 변경은 분할. 봇 identity 만 사용. force push 금지. | (commit author = GitHub App identity 만) |
+| PR | draft 기본. repo PR template 우선. 5 섹션 (`purpose / scope / risks / tests / issue_linkage`) + audit block 필수. | `validate_pr_body` |
+| Tag/release | `RepoContract.tag_policy` 기반. `none` 이면 자동 발행 금지 + audit. 실제 create 는 L3 별도. | `RepoContract.tag_policy` + `has_tag_policy` |
+
+### 4.1.2 Vault / inbox / curated note / hub linkage
+
+- `00-inbox` 는 **raw 자료 보관소** — curated 승격 대상이 아님. 승격은
+  `20-areas` / `40-patterns` / `60-troubleshooting` / `10-projects/*`
+  아래에 **새 curated note** 를 만드는 행위.
+- Curated note 필수 frontmatter (7 키): `title / kind / status /
+  created_at / tags / related / home_hub`.
+- Curated note 필수 본문 섹션 (5 종): `핵심 요약 / 내 해석 / 적용 맥락 /
+  관련 노트 / 참고`.
+- 하루 자동 생성/갱신 curated note 20~30 개 / raw reference 100 개 제한.
+- 모든 curated note 는 ① `home_hub` 1 개 + ② `related` 최소 1 개.
+- orphan note / broken link 면 push 금지.
+- 검증: `validate_curated_note`, `is_inbox_path`, `detect_orphan_note`,
+  `detect_broken_links`.
+
+### 4.1.3 Retrieval eval
+
+- 평가셋 스키마: `question / expected_notes / allowed_alternatives /
+  failure_reason`.
+- 최소 50 / 목표 100 문항.
+- top-5 평가 — 기대 note 가 top-5 에 없으면 **regression** (지식 추가
+  성공 아님).
+- vault 구조 변경 / 대량 노트 추가 전후 eval 실행 의무. eval 없이
+  대량 curated generation push 금지.
+- 검증: `validate_retrieval_eval_entry`, `validate_retrieval_eval_fixture`.
+
+### 4.1.4 Post-test hardening — 성능 개선 opening criteria
+
+`correctness > visibility > maintainability > performance` 순서. 테스트가
+green 이어도 성능 개선은 자동 의무가 아니다. 다음 8 종 중 **최소 1 개
+가 충족돼야** 성능/고도화 작업을 연다:
+
+1. queue_backlog (큐 적체)
+2. runtime_status_latency (status 응답 30s+)
+3. retrieval_eval_regression
+4. prompt_size_ceiling (90%+ 근접)
+5. large_file_rule (700 warning / 1000 split)
+6. duplicate_work (중복 dispatch / 같은 repo contract / template 반복 작업)
+7. critical_path_bottleneck (executor / approval / operator action 명시적 정체)
+8. flaky_or_slow_test
+
+성능 개선 작업 시 의무:
+- baseline_measurement (이전 값)
+- target_metric (개선 대상)
+- behavior_change_separated (semantic 변경 ≠ perf refactor)
+- regression_test
+
+코드: `decide_hardening_opening(observations)` → `allowed` + `matched_criteria` + `required_artifacts`.
+
 ## 5. 정책 위치 인덱스
 
 | 영역 | 파일 |

--- a/docs/engineering-company-runtime-master-plan.md
+++ b/docs/engineering-company-runtime-master-plan.md
@@ -42,13 +42,13 @@ Yule가 도달해야 하는 최종 상태는 아래와 같다.
 
 이 수치는 운영 판단 기준으로 유지한다.
 
-| 영역 | 현재 추정 (2026-05-15, work_order→coding continuation) | 2026-05-15 (P0-S 종단 1) | 2026-05-15 (P0-S 1차) | 2026-05-11 추정 |
-| --- | --- | --- | --- | --- |
-| 운영 골격 | 90~92% | 88~90% | 85~88% | 80~85% |
-| Discord 기술 토의 능력 | 55~65% | 55~65% | 55~65% | 50~60% |
-| 완전 자율 코딩 루프 | 85~90% | 82~88% | 78~85% | 70~80% |
-| 역할별 자료 수집/정형화 루프 | 50~60% | 50~60% | 50~60% | 50~60% |
-| 실제 회사처럼 굴러가는 종합 수준 | 76~83% | 72~80% | 68~75% | 60~70% |
+| 영역 | 현재 추정 (2026-05-15, runtime policy hard rails) | 2026-05-15 (continuation) | 2026-05-15 (P0-S 종단 1) | 2026-05-15 (P0-S 1차) | 2026-05-11 추정 |
+| --- | --- | --- | --- | --- | --- |
+| 운영 골격 | 91~93% | 90~92% | 88~90% | 85~88% | 80~85% |
+| Discord 기술 토의 능력 | 55~65% | 55~65% | 55~65% | 55~65% | 50~60% |
+| 완전 자율 코딩 루프 | 86~91% | 85~90% | 82~88% | 78~85% | 70~80% |
+| 역할별 자료 수집/정형화 루프 | 55~65% | 50~60% | 50~60% | 50~60% | 50~60% |
+| 실제 회사처럼 굴러가는 종합 수준 | 78~85% | 76~83% | 72~80% | 68~75% | 60~70% |
 
 이번 PR 닫은 범위 (work_order → coding_execute continuation):
 
@@ -731,3 +731,43 @@ Round 4-bis 가 deterministic / record-only / live-ready 3-tier 의 *형식* 을
 - discussion + research + execution + retry를 한 흐름으로 묶는 것이 핵심
 
 이 문서를 기준으로 앞으로의 구현 판단을 고정한다.
+
+## 18. Post-test hardening — 성능 개선 / 고도화 opening criteria (P0-T)
+
+테스트가 green 이라고 자동으로 성능 개선 작업을 여는 건 금지. scope creep
+방지를 위해 다음 hard rail 을 둔다.
+
+### 18.1 우선순위
+**correctness > visibility > maintainability > performance** 순서.
+correctness 회귀가 없고 visibility 가 안정돼야 maintainability 가 의미를
+가지며, 그 위에서만 performance 가 정당화된다.
+
+### 18.2 Opening criteria (최소 1 개 충족 시 작업 허용)
+
+| # | criterion | 매칭 신호 |
+| --- | --- | --- |
+| 1 | `queue_backlog` | queue_backlog_jobs > 0 |
+| 2 | `runtime_status_latency` | status 응답 30s+ |
+| 3 | `retrieval_eval_regression` | top-5 fail / 점수 하락 |
+| 4 | `prompt_size_ceiling` | preamble / template size 가 ceiling 90%+ |
+| 5 | `large_file_rule` | 700 warning / 1000 split 초과 (`CODE_LAYOUT.md`) |
+| 6 | `duplicate_work` | 같은 repo contract / issue template / vault routing 반복 |
+| 7 | `critical_path_bottleneck` | executor / approval / operator action path 명시적 정체 |
+| 8 | `flaky_or_slow_test` | flaky 발견 또는 slow test 누적 |
+
+### 18.3 작업 의무
+opening 이 허용된 경우라도 PR 본문에 다음 4 가지를 명시해야 한다:
+
+- `baseline_measurement` — 이전 값
+- `target_metric` — 어떤 metric 을 어떻게 개선할지
+- `behavior_change_separated` — semantic 변경과 perf refactor 분리
+- `regression_test` — 회귀 보호
+
+코드 SSoT: [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../src/yule_orchestrator/agents/governance/runtime_policy.py)
+의 `decide_hardening_opening(observations)`. 검증 회귀:
+[`tests/governance/test_runtime_policy.py`](../tests/governance/test_runtime_policy.py).
+
+### 18.4 거버넌스 cross-link
+git / vault / retrieval 규칙은 [`engineering-agent-governance.md`](engineering-agent-governance.md)
+§4.1 / [`memory.md`](memory.md) §"Curated 정책" / [`github-agent-workos.md`](github-agent-workos.md)
+§1.2.1 참조.

--- a/docs/github-agent-workos.md
+++ b/docs/github-agent-workos.md
@@ -60,6 +60,28 @@ agent 가 issue 본문을 추측해 꾸며내지 않는다. placeholder/HTML 주
 `RepoContract.has_tag_policy` 가 False 이면 agent 는 tag 작업을 시도하지
 않는다 — 정책이 없는데 추측해 만들면 fake success 가 된다.
 
+### 1.2.1 Runtime hard rails — branch / PR / tag (P0-T)
+
+코드 SSoT: [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../src/yule_orchestrator/agents/governance/runtime_policy.py).
+
+**Branch**
+- protected branch (`main` / `master` / `develop` / `release*` / `hotfix*` / `production` / `prod`) 직접 작업 금지.
+- 표준 prefix: `feat/ fix/ chore/ refactor/ docs/ test/ perf/`. issue 번호가 있으면 `feat/<short>-issue-<n>` 으로 anchor.
+- 기존 `agent/<role>/...` 패턴 (engineering-agent 의 `derive_branch_name`) 도 회귀 없이 허용 — runtime_policy 가 warning 만 남김.
+- 검증: `validate_branch_name(name, issue_number=..., require_standard_prefix=...)`.
+- 표준 이름 빌더: `derive_standard_branch_name(kind, short_purpose, issue_number)`.
+
+**PR body**
+- 필수 5 섹션: `purpose` / `scope` / `risks` / `tests` / `issue_linkage` — 한국어/영어 키워드 alternative 매칭. repo PR template 의 heading 그대로 사용해도 통과.
+- audit block 필수 — `engineering-agent` / `audit` / `🤖` / `Generated with` / `Co-Authored-By` 마커 중 하나.
+- 누락 시 caller 가 push 거부.
+- 검증: `validate_pr_body(body)`.
+
+**Tag / version**
+- `RepoContract.tag_policy` 4 분류 (`workflow_driven` / `changelog_driven` / `version_file_only` / `none`) 그대로 사용 (PR #166).
+- `none` 일 때 자동 tag/release 금지 — audit 에 `tag_policy=none` 명시.
+- 실제 tag/release create 는 L3 승인 카드 별도 — 코딩 요청만으로 자동 발행 금지.
+
 ### 1.3 Operator action inbox
 
 agent 가 진행 중 외부 사실/권한/secret 값이 필요하면 `#승인-대기` 에

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -40,3 +40,62 @@ yule memory search "운영-리서치" --role engineering-agent/tech-lead --json
 - reindex 는 idempotent 하며 source_kind 별로 기존 슬라이스를 비우고 다시 채운다 — 삭제된 노트도 깔끔히 사라진다.
 - `source_kind` 옵션: `obsidian`, `policy`, `agent_md`, `readme`, `workflow_artifact` (현재 활성 카테고리는 코드의 `MemoryIndexer` 참조).
 - `--note-kind`, `--role`, `--task-type` 으로 좁힐 수 있고, 이 값들은 frontmatter 에 정의된 메타데이터를 그대로 쓴다.
+
+## Curated 정책 (P0-T)
+
+핵심 원칙: `inbox` 는 원천 자료 저장소다. **승격은 파일 이동이 아니라
+원천을 해석해 linked curated note 를 새로 만드는 행위**다. 좋은 노트의
+기준은 "많이 썼는가" 가 아니라 "retrieval eval 에서 잘 꺼내지는가" 다.
+
+코드 SSoT: [`src/yule_orchestrator/agents/governance/runtime_policy.py`](../src/yule_orchestrator/agents/governance/runtime_policy.py).
+
+### Inbox 규칙
+- `00-inbox` 는 raw 수집 / 임시 관찰 / source bookmark 용도.
+- `00-inbox` 문서는 품질 보증 대상이 아니라 **참고 근거**.
+- `00-inbox` 문서는 target note 로 직접 승격하지 않음 — caller 가
+  `is_inbox_path(path)` 로 검사.
+
+### Curated note 규칙
+- 일일 자동 생성/갱신 curated note: **20~30 개** 제한.
+- 일일 raw reference 수집: 최대 **100 개**.
+- 필수 frontmatter 7 키: `title / kind / status / created_at / tags /
+  related / home_hub`.
+- 필수 본문 섹션 5 종: `핵심 요약 / 내 해석 / 적용 맥락 / 관련 노트 /
+  참고`. 단순 복붙 / 링크 목록 / 요약 없는 자료는 curated 로 인정 안 함.
+- 모든 curated note 는 ① `home_hub` 1 개 + ② `related` 최소 1 개.
+- 연결할 hub 가 없으면 노트 늘리기 전에 **hub 를 먼저 생성**.
+
+### 검증 함수
+- `validate_curated_note(path, frontmatter, body)` — frontmatter / 본문
+  / inbox path 한 번에 검사.
+- `is_inbox_path(path)` — inbox 분류.
+- `detect_orphan_note(note_path, home_hub, related, hub_paths)` — orphan
+  검출 (push 금지).
+- `detect_broken_links(body, available_paths)` — 끊긴 wikilink 시퀀스.
+
+## Retrieval eval (P0-T)
+
+vault 구조 변경 / 대량 노트 추가 **전후로** retrieval eval 을 실행한다.
+note 를 많이 추가했는데 점수가 떨어지면 "지식 추가 성공" 이 아니라
+**regression** 으로 본다 — 추가 중단 후 hub / link / alias / tag 를
+먼저 수정.
+
+평가셋 스키마 (each entry):
+
+```yaml
+question: "JWT 와 session 차이가 뭐야?"
+expected_notes:
+  - 20-areas/auth/jwt-vs-session.md
+allowed_alternatives:
+  - 40-patterns/auth/token-strategy.md
+failure_reason: ""  # eval 결과 분석용. 빈 값 허용 (키 존재 강제)
+```
+
+수치 정책:
+- 최소 fixture **50 문항** (이하 → regression 차단).
+- 목표 fixture **100 문항** (50~99 사이는 warning).
+- **top-5** 기준 평가 — 기대 note 가 top-5 에 없으면 fail.
+- 새 hub / 중요 decision 추가 시 관련 retrieval question 최소 1 개 추가.
+- 검증: `validate_retrieval_eval_fixture(entries)`.
+
+> eval 없이 대량 curated generation push 금지.

--- a/src/yule_orchestrator/agents/governance/__init__.py
+++ b/src/yule_orchestrator/agents/governance/__init__.py
@@ -1,0 +1,73 @@
+"""Runtime governance policy gates — P0-T 시리즈.
+
+본 패키지는 engineering-agent 가 실제 코딩 작업을 굴릴 때 무너지지 말아야
+할 hard rail 을 한 자리에 모은다:
+
+  * branch / commit / PR / tag — git workflow 정책
+  * vault / curated note / inbox / hub linkage — 지식 정책
+  * retrieval eval — 평가 정책
+  * post-test hardening — 성능 개선 / 고도화 작업의 opening criteria
+
+각 정책은 pure 함수 — 호출자가 결과 (allow/deny + 사유 + 권고) 를 읽어
+실제 게이트로 사용. 본 패키지 안에서 storage I/O / network 호출 없음.
+
+상세 docs: `docs/engineering-agent-governance.md`, `docs/memory.md`,
+`docs/github-agent-workos.md` §1.5.
+"""
+
+from .runtime_policy import (
+    BRANCH_PREFIXES,
+    BranchPolicyResult,
+    CURATED_REQUIRED_FRONTMATTER,
+    CURATED_REQUIRED_SECTIONS,
+    CuratedNoteValidationResult,
+    HARDENING_OPENING_CRITERIA,
+    HardeningOpeningDecision,
+    INBOX_PATH_PREFIX,
+    MIN_RETRIEVAL_EVAL_QUESTIONS,
+    PRBodyValidationResult,
+    PR_REQUIRED_SECTIONS,
+    RETRIEVAL_EVAL_REQUIRED_KEYS,
+    RETRIEVAL_EVAL_TOP_K,
+    RetrievalEvalEntryResult,
+    TARGET_RETRIEVAL_EVAL_QUESTIONS,
+    decide_hardening_opening,
+    derive_standard_branch_name,
+    detect_broken_links,
+    detect_orphan_note,
+    is_inbox_path,
+    validate_branch_name,
+    validate_curated_note,
+    validate_pr_body,
+    validate_retrieval_eval_entry,
+    validate_retrieval_eval_fixture,
+)
+
+
+__all__ = (
+    "BRANCH_PREFIXES",
+    "BranchPolicyResult",
+    "CURATED_REQUIRED_FRONTMATTER",
+    "CURATED_REQUIRED_SECTIONS",
+    "CuratedNoteValidationResult",
+    "HARDENING_OPENING_CRITERIA",
+    "HardeningOpeningDecision",
+    "INBOX_PATH_PREFIX",
+    "MIN_RETRIEVAL_EVAL_QUESTIONS",
+    "PRBodyValidationResult",
+    "PR_REQUIRED_SECTIONS",
+    "RETRIEVAL_EVAL_REQUIRED_KEYS",
+    "RETRIEVAL_EVAL_TOP_K",
+    "RetrievalEvalEntryResult",
+    "TARGET_RETRIEVAL_EVAL_QUESTIONS",
+    "decide_hardening_opening",
+    "derive_standard_branch_name",
+    "detect_broken_links",
+    "detect_orphan_note",
+    "is_inbox_path",
+    "validate_branch_name",
+    "validate_curated_note",
+    "validate_pr_body",
+    "validate_retrieval_eval_entry",
+    "validate_retrieval_eval_fixture",
+)

--- a/src/yule_orchestrator/agents/governance/runtime_policy.py
+++ b/src/yule_orchestrator/agents/governance/runtime_policy.py
@@ -1,0 +1,760 @@
+"""Runtime governance hard rails — pure validators / deciders.
+
+본 모듈이 정의하는 정책 (코드로 박혀 있어 docs 와 자동 동기화 검증
+가능):
+
+1. Branch — protected branch 직접 작업 금지, 표준 prefix (feat/fix/
+   chore/refactor) 권장, issue 번호 anchor 권장.
+2. PR — 5 섹션 (목적/범위/리스크/테스트/이슈 linkage) + audit block.
+3. Curated note — frontmatter 필수 키 + 본문 필수 섹션 + inbox 직접
+   승격 금지 + orphan/broken link 검출.
+4. Retrieval eval — entry 스키마 + 최소 50 / 목표 100 + top-5 평가.
+5. Post-test hardening — 8 opening criteria.
+
+설계 원칙
+--------
+- pure: storage I/O / network 호출 없음.
+- caller-driven gate: 본 함수가 거부 결정을 내리지 않는다 — 결과 객체
+  (allowed + reasons + warnings + suggestions) 를 반환하고, **호출자**
+  가 그 결과를 실제 게이트로 사용한다.
+- single source of truth: branch_naming / curated_required / eval schema
+  / hardening criteria 같은 상수는 모두 본 모듈에서 export. docs 측은
+  본 모듈을 cross-link 해야 동기화가 깨지지 않는다.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Branch policy
+# ---------------------------------------------------------------------------
+
+
+# 표준 prefix — repo contract 가 별도 규칙을 갖지 않을 때의 기본값. 호출자
+# 는 repo contract 의 `branch_strategy` 를 우선 적용하고 본 prefix 는
+# fallback 으로만 사용.
+BRANCH_PREFIXES: Tuple[str, ...] = (
+    "feat",
+    "fix",
+    "chore",
+    "refactor",
+    "docs",
+    "test",
+    "perf",
+)
+
+
+# 기존 :func:`agents.github_workos.branching.is_protected_branch` 의
+# PROTECTED_BRANCHES 와 동일 — duplicate 회피를 위해 import.
+_PROTECTED_BRANCHES: frozenset[str] = frozenset(
+    {"main", "master", "develop", "release", "hotfix", "production", "prod"}
+)
+
+
+_BRANCH_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._\-/]*$")
+
+
+@dataclass(frozen=True)
+class BranchPolicyResult:
+    """``validate_branch_name`` 결과.
+
+    - ``allowed`` False: protected branch 또는 형식 위반 — 호출자는 push
+      거부.
+    - ``warnings``: 권장 prefix 가 안 붙었거나 issue 번호 anchor 가
+      없는 경우. 호출자는 audit 에 기록 후 진행 가능.
+    """
+
+    allowed: bool
+    name: str
+    reason: str = ""
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+    suggested_prefix: Optional[str] = None
+
+
+def validate_branch_name(
+    name: Optional[str],
+    *,
+    issue_number: Optional[int] = None,
+    require_standard_prefix: bool = False,
+) -> BranchPolicyResult:
+    """*name* 이 운영 정책에 부합하는지 검사.
+
+    rules:
+      - None / 빈 문자열 → ``allowed=False``.
+      - protected branch (case-insensitive) → ``allowed=False``.
+      - 소문자 + 영숫자 + ``.-_/`` 만 허용 — naming 형식 위반은
+        ``allowed=False``.
+      - ``feat/`` / ``fix/`` / ``chore/`` / ``refactor/`` / ``docs/`` /
+        ``test/`` / ``perf/`` 중 하나로 시작하지 않으면 ``warnings`` 에
+        suggestion. ``require_standard_prefix=True`` 일 때만 허용 거부.
+      - issue_number 가 주어졌는데 branch name 에 ``issue-<n>`` 또는
+        ``<n>`` 토큰이 없으면 warning.
+    """
+
+    candidate = (name or "").strip()
+    if not candidate:
+        return BranchPolicyResult(allowed=False, name="", reason="empty_branch_name")
+
+    last_segment = candidate.split("/")[-1].lower()
+    if last_segment in _PROTECTED_BRANCHES:
+        return BranchPolicyResult(
+            allowed=False,
+            name=candidate,
+            reason=f"protected_branch:{last_segment}",
+        )
+    # qualified ref ``refs/heads/main``
+    full_lower = candidate.lower()
+    for protected in _PROTECTED_BRANCHES:
+        if (
+            full_lower == protected
+            or full_lower.endswith(f"/{protected}")
+            or full_lower.startswith(f"refs/heads/{protected}")
+            or full_lower.startswith(f"origin/{protected}")
+        ):
+            return BranchPolicyResult(
+                allowed=False,
+                name=candidate,
+                reason=f"protected_branch:{protected}",
+            )
+
+    if not _BRANCH_NAME_RE.match(candidate):
+        return BranchPolicyResult(
+            allowed=False,
+            name=candidate,
+            reason="invalid_branch_chars",
+        )
+
+    warnings: list[str] = []
+    suggested_prefix: Optional[str] = None
+    first_segment = candidate.split("/", 1)[0].lower()
+    if first_segment not in BRANCH_PREFIXES:
+        # 기존 agent/<role> 패턴 (engineering-agent 의 derive_branch_name)
+        # 은 회귀 없도록 허용 — 단 standard prefix suggestion 은 남김.
+        if first_segment not in {"agent"}:
+            warnings.append(
+                f"non_standard_prefix:{first_segment} (권장: {', '.join(BRANCH_PREFIXES)})"
+            )
+            suggested_prefix = BRANCH_PREFIXES[0]
+            if require_standard_prefix:
+                return BranchPolicyResult(
+                    allowed=False,
+                    name=candidate,
+                    reason=f"non_standard_prefix:{first_segment}",
+                    warnings=tuple(warnings),
+                    suggested_prefix=suggested_prefix,
+                )
+
+    if issue_number is not None and issue_number > 0:
+        token = f"issue-{int(issue_number)}"
+        if token not in candidate.lower() and f"-{int(issue_number)}-" not in candidate.lower() and not candidate.lower().endswith(f"-{int(issue_number)}"):
+            warnings.append(
+                f"missing_issue_anchor:#{int(issue_number)}"
+            )
+
+    return BranchPolicyResult(
+        allowed=True,
+        name=candidate,
+        warnings=tuple(warnings),
+        suggested_prefix=suggested_prefix,
+    )
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def derive_standard_branch_name(
+    *,
+    kind: str,
+    short_purpose: str,
+    issue_number: Optional[int] = None,
+) -> str:
+    """표준 branch 이름 생성.
+
+    형식: ``<kind>/<short-purpose>[-issue-<n>]``.
+
+    - ``kind`` 는 :data:`BRANCH_PREFIXES` 중 하나여야 함 (예외 시
+      ``ValueError``).
+    - ``short_purpose`` 는 slugify — 소문자/숫자/하이픈만 남김.
+    - ``issue_number`` 가 있으면 ``-issue-<n>`` 접미사 자동 추가.
+
+    repo contract 가 별도 규칙을 제시하면 caller 가 본 함수를 건너뛰고
+    그 규칙을 따른다.
+    """
+
+    kind_clean = (kind or "").strip().lower()
+    if kind_clean not in BRANCH_PREFIXES:
+        raise ValueError(
+            f"branch kind {kind!r} 은 표준 prefix 목록에 없음: {BRANCH_PREFIXES}"
+        )
+    slug = _SLUG_RE.sub("-", (short_purpose or "").lower()).strip("-") or "work"
+    suffix = f"-issue-{int(issue_number)}" if issue_number and int(issue_number) > 0 else ""
+    return f"{kind_clean}/{slug}{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# PR body policy
+# ---------------------------------------------------------------------------
+
+
+# repo PR template 가 있으면 그 섹션을 우선 따르되, 본 5 종이 어떤
+# 형태로든 PR body 에 보여야 한다. 키워드 매칭 (한국어 + 영어) 으로
+# 검증한다 — exact heading 강제는 너무 빡빡함.
+PR_REQUIRED_SECTIONS: Mapping[str, Tuple[str, ...]] = {
+    "purpose": ("목적", "과제 내용", "summary", "purpose", "what"),
+    "scope": ("범위", "scope", "in_scope", "out_of_scope"),
+    "risks": ("리스크", "위험", "risk"),
+    "tests": ("테스트", "test plan", "테스트 계획", "validation"),
+    "issue_linkage": ("관련 이슈", "issue", "closes #", "fixes #", "refs #"),
+}
+
+
+PR_AUDIT_BLOCK_MARKERS: Tuple[str, ...] = (
+    "engineering-agent",
+    "audit",
+    "🤖",
+    "Generated with",
+    "Co-Authored-By",
+)
+
+
+@dataclass(frozen=True)
+class PRBodyValidationResult:
+    """:func:`validate_pr_body` 결과.
+
+    - ``ok``: 누락 섹션이 없고 audit block 도 있음 → write 진행 가능.
+    - ``missing_sections``: 누락 섹션 키 시퀀스 — caller 가 PR body 를
+      보강하지 않으면 fake success.
+    - ``audit_block_present``: 봇 정체성 마커가 보이는지 — operator 가
+      "이 PR 누가 만든 거지?" 를 즉시 식별 가능해야 함.
+    """
+
+    ok: bool
+    missing_sections: Tuple[str, ...] = field(default_factory=tuple)
+    audit_block_present: bool = False
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def validate_pr_body(body: Optional[str]) -> PRBodyValidationResult:
+    """*body* 에 5 종 섹션 + audit block 가 모두 있는지 검사.
+
+    검사 방식:
+      - 본문을 소문자로 normalize 한 뒤 각 섹션의 한국어 + 영어 키워드
+        시퀀스 중 하나라도 매칭되면 통과로 본다 (느슨한 매칭 — repo
+        마다 다른 template heading 도 수용).
+      - audit block: ``engineering-agent`` / ``audit`` / ``🤖`` 등 마커
+        하나라도 있으면 통과.
+    """
+
+    text = (body or "").strip()
+    if not text:
+        return PRBodyValidationResult(
+            ok=False,
+            missing_sections=tuple(PR_REQUIRED_SECTIONS.keys()),
+            audit_block_present=False,
+            warnings=("empty_pr_body",),
+        )
+
+    haystack = text.lower()
+    missing: list[str] = []
+    for key, alternatives in PR_REQUIRED_SECTIONS.items():
+        if not any(alt.lower() in haystack for alt in alternatives):
+            missing.append(key)
+
+    audit_present = any(marker.lower() in haystack for marker in PR_AUDIT_BLOCK_MARKERS)
+
+    warnings: list[str] = []
+    if not audit_present:
+        warnings.append("missing_audit_block")
+
+    return PRBodyValidationResult(
+        ok=not missing and audit_present,
+        missing_sections=tuple(missing),
+        audit_block_present=audit_present,
+        warnings=tuple(warnings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Curated note policy
+# ---------------------------------------------------------------------------
+
+
+INBOX_PATH_PREFIX: str = "00-inbox"
+
+
+# Curated note frontmatter 필수 키. ``home_hub`` 는 hub linkage 강제 — 모든
+# curated note 가 1 개 이상의 hub 를 가져야 한다.
+CURATED_REQUIRED_FRONTMATTER: Tuple[str, ...] = (
+    "title",
+    "kind",
+    "status",
+    "created_at",
+    "tags",
+    "related",
+    "home_hub",
+)
+
+
+# Curated note 본문 필수 섹션 — heading 형태로 본문에 보여야 한다. 키워드
+# 매칭은 PR body 와 동일하게 느슨한 alternative 방식.
+CURATED_REQUIRED_SECTIONS: Mapping[str, Tuple[str, ...]] = {
+    "summary": ("핵심 요약", "요약", "summary"),
+    "interpretation": ("내 해석", "해석", "interpretation"),
+    "context": ("적용 맥락", "맥락", "context"),
+    "related": ("관련 노트", "관련", "related"),
+    "references": ("참고", "references", "source"),
+}
+
+
+@dataclass(frozen=True)
+class CuratedNoteValidationResult:
+    """:func:`validate_curated_note` 결과."""
+
+    ok: bool
+    path: str
+    missing_frontmatter: Tuple[str, ...] = field(default_factory=tuple)
+    missing_sections: Tuple[str, ...] = field(default_factory=tuple)
+    reason: Optional[str] = None
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def is_inbox_path(path: Optional[str]) -> bool:
+    """*path* 가 ``00-inbox/`` 아래인지 — true 면 curated note 로 인정 안 함.
+
+    `00-inbox` 는 raw 자료 보관소. curated 승격은 새로운 노트 생성
+    (`20-areas`, `40-patterns`, `60-troubleshooting`, `10-projects/*`) 으로
+    이루어지지, inbox 안에서 자리만 바꾸는 것이 아니다.
+    """
+
+    if not path:
+        return False
+    text = str(path).replace("\\", "/").lstrip("./")
+    return text == INBOX_PATH_PREFIX or text.startswith(f"{INBOX_PATH_PREFIX}/")
+
+
+def validate_curated_note(
+    *,
+    path: str,
+    frontmatter: Optional[Mapping[str, Any]] = None,
+    body: Optional[str] = None,
+) -> CuratedNoteValidationResult:
+    """curated note candidate 가 정책을 만족하는지 검사.
+
+    rules:
+      - inbox path → ok=False, reason=``inbox_direct_promotion_forbidden``.
+      - frontmatter 누락 키 / 본문 누락 섹션 → ok=False.
+      - ``related`` 가 비어있거나 ``home_hub`` 가 비어있으면 ok=False
+        (hub linkage 강제).
+    """
+
+    if is_inbox_path(path):
+        return CuratedNoteValidationResult(
+            ok=False,
+            path=path or "",
+            reason="inbox_direct_promotion_forbidden",
+        )
+
+    fm = dict(frontmatter or {})
+    text = (body or "")
+
+    missing_fm: list[str] = []
+    for key in CURATED_REQUIRED_FRONTMATTER:
+        value = fm.get(key)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            missing_fm.append(key)
+        elif isinstance(value, (list, tuple)) and not any(
+            str(item).strip() for item in value
+        ):
+            missing_fm.append(key)
+
+    haystack = text.lower()
+    missing_sections: list[str] = []
+    for key, alternatives in CURATED_REQUIRED_SECTIONS.items():
+        if not any(alt.lower() in haystack for alt in alternatives):
+            missing_sections.append(key)
+
+    warnings: list[str] = []
+    if not missing_fm:
+        # hub linkage / related 보강 — 빈 list 였으면 missing_fm 가 잡았지만
+        # 단일 placeholder 만 있을 때를 추가 검증
+        related = fm.get("related") or ()
+        if isinstance(related, (list, tuple)) and len(related) == 0:
+            warnings.append("related_empty")
+        home_hub = str(fm.get("home_hub") or "").strip()
+        if not home_hub:
+            warnings.append("home_hub_empty")
+
+    ok = not missing_fm and not missing_sections
+    return CuratedNoteValidationResult(
+        ok=ok,
+        path=path or "",
+        missing_frontmatter=tuple(missing_fm),
+        missing_sections=tuple(missing_sections),
+        reason=None if ok else "missing_required_fields",
+        warnings=tuple(warnings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orphan / broken-link detectors
+# ---------------------------------------------------------------------------
+
+
+_WIKILINK_RE = re.compile(r"\[\[([^\]\|#]+?)(?:\|[^\]]*?)?\]\]")
+
+
+def detect_orphan_note(
+    *,
+    note_path: str,
+    home_hub: Optional[str],
+    related: Sequence[str] = (),
+    hub_paths: Sequence[str] = (),
+) -> bool:
+    """note 가 어떤 hub 에도 연결돼 있지 않은지 (= orphan) 검사.
+
+    True 반환 = orphan — push 금지. 호출자는 hub 를 먼저 만들거나
+    related 를 추가해 연결성을 확보해야 한다.
+
+    조건 (orphan):
+      - home_hub 가 비어있고
+      - related 도 비어있음
+      - OR home_hub 가 hub_paths 안에 없음
+    """
+
+    has_related = any(str(r).strip() for r in (related or ()))
+    home_hub_clean = (home_hub or "").strip()
+    if not home_hub_clean and not has_related:
+        return True
+    hub_set = {str(p).strip() for p in (hub_paths or ()) if str(p).strip()}
+    if hub_set and home_hub_clean and home_hub_clean not in hub_set:
+        # related 가 있어도 home_hub 가 untracked 면 orphan 의심
+        return not has_related
+    return False
+
+
+def detect_broken_links(
+    *,
+    body: str,
+    available_paths: Sequence[str],
+) -> Tuple[str, ...]:
+    """*body* 의 wikilink ``[[target]]`` 중 *available_paths* 에 없는
+    target 시퀀스 반환.
+
+    matching 은 basename 비교 + 정확 매칭 둘 다 시도. 둘 다 실패하면
+    broken link 로 본다.
+    """
+
+    text = body or ""
+    if not text:
+        return ()
+    available = {str(p).strip() for p in (available_paths or ()) if str(p).strip()}
+    basenames = {p.rsplit("/", 1)[-1].rsplit(".", 1)[0] for p in available}
+    broken: list[str] = []
+    for match in _WIKILINK_RE.finditer(text):
+        target = match.group(1).strip()
+        if not target:
+            continue
+        if target in available:
+            continue
+        # basename 매칭
+        tail = target.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        if tail in basenames:
+            continue
+        broken.append(target)
+    return tuple(broken)
+
+
+# ---------------------------------------------------------------------------
+# Retrieval eval policy
+# ---------------------------------------------------------------------------
+
+
+RETRIEVAL_EVAL_REQUIRED_KEYS: Tuple[str, ...] = (
+    "question",
+    "expected_notes",
+    "allowed_alternatives",
+    "failure_reason",
+)
+
+
+MIN_RETRIEVAL_EVAL_QUESTIONS: int = 50
+TARGET_RETRIEVAL_EVAL_QUESTIONS: int = 100
+RETRIEVAL_EVAL_TOP_K: int = 5
+
+
+@dataclass(frozen=True)
+class RetrievalEvalEntryResult:
+    ok: bool
+    entry_index: int
+    missing_keys: Tuple[str, ...] = field(default_factory=tuple)
+    reason: Optional[str] = None
+
+
+def validate_retrieval_eval_entry(
+    entry: Mapping[str, Any],
+    *,
+    index: int = 0,
+) -> RetrievalEvalEntryResult:
+    """retrieval eval fixture 의 한 entry 가 스키마를 만족하는지 검사.
+
+    - ``question`` / ``expected_notes`` 는 비어있을 수 없음.
+    - ``allowed_alternatives`` 는 빈 리스트라도 키 자체는 존재해야 한다
+      (eval runner 가 None 과 빈 리스트를 구분).
+    - ``failure_reason`` 은 eval 결과 분석을 위한 기록 — 빈 문자열은
+      허용하되 키는 존재해야.
+    """
+
+    missing: list[str] = []
+    for key in RETRIEVAL_EVAL_REQUIRED_KEYS:
+        if key not in entry:
+            missing.append(key)
+    if missing:
+        return RetrievalEvalEntryResult(
+            ok=False,
+            entry_index=index,
+            missing_keys=tuple(missing),
+            reason="missing_keys",
+        )
+
+    question = str(entry.get("question") or "").strip()
+    if not question:
+        return RetrievalEvalEntryResult(
+            ok=False, entry_index=index, reason="empty_question"
+        )
+    expected = entry.get("expected_notes") or ()
+    if not isinstance(expected, (list, tuple)) or not any(
+        str(n).strip() for n in expected
+    ):
+        return RetrievalEvalEntryResult(
+            ok=False, entry_index=index, reason="empty_expected_notes"
+        )
+
+    return RetrievalEvalEntryResult(ok=True, entry_index=index)
+
+
+@dataclass(frozen=True)
+class RetrievalEvalFixtureResult:
+    ok: bool
+    entry_count: int
+    entry_failures: Tuple[RetrievalEvalEntryResult, ...] = field(default_factory=tuple)
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def validate_retrieval_eval_fixture(
+    entries: Sequence[Mapping[str, Any]],
+) -> RetrievalEvalFixtureResult:
+    """fixture 전체 — entry 스키마 + 최소 count.
+
+    50 미만 → ok=False (regression 차단), 50~99 → warning, 100+ → 통과.
+    """
+
+    failures: list[RetrievalEvalEntryResult] = []
+    for idx, entry in enumerate(entries or ()):
+        result = validate_retrieval_eval_entry(entry, index=idx)
+        if not result.ok:
+            failures.append(result)
+    count = len(entries or ())
+    warnings: list[str] = []
+    if count < MIN_RETRIEVAL_EVAL_QUESTIONS:
+        return RetrievalEvalFixtureResult(
+            ok=False,
+            entry_count=count,
+            entry_failures=tuple(failures),
+            warnings=(f"below_min:{count}<{MIN_RETRIEVAL_EVAL_QUESTIONS}",),
+        )
+    if count < TARGET_RETRIEVAL_EVAL_QUESTIONS:
+        warnings.append(
+            f"below_target:{count}<{TARGET_RETRIEVAL_EVAL_QUESTIONS}"
+        )
+    return RetrievalEvalFixtureResult(
+        ok=not failures,
+        entry_count=count,
+        entry_failures=tuple(failures),
+        warnings=tuple(warnings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-test hardening — opening criteria
+# ---------------------------------------------------------------------------
+
+
+class HardeningOpeningCriterion(str, Enum):
+    """8 종 opening criteria — 이 중 하나라도 충족돼야 성능 개선 / 고도화
+    작업 brunch 를 열 수 있다. correctness > visibility > maintainability >
+    performance 순서."""
+
+    QUEUE_BACKLOG = "queue_backlog"
+    RUNTIME_STATUS_LATENCY = "runtime_status_latency"
+    RETRIEVAL_EVAL_REGRESSION = "retrieval_eval_regression"
+    PROMPT_SIZE_CEILING = "prompt_size_ceiling"
+    LARGE_FILE_RULE = "large_file_rule"  # 700 warning / 1000 split
+    DUPLICATE_WORK = "duplicate_work"
+    CRITICAL_PATH_BOTTLENECK = "critical_path_bottleneck"
+    FLAKY_OR_SLOW_TEST = "flaky_or_slow_test"
+
+
+HARDENING_OPENING_CRITERIA: Tuple[str, ...] = tuple(
+    c.value for c in HardeningOpeningCriterion
+)
+
+
+@dataclass(frozen=True)
+class HardeningOpeningDecision:
+    """:func:`decide_hardening_opening` 결과.
+
+    - ``allowed`` True: 최소 1 개의 criterion 충족 + baseline 측정 의무
+      + metric 명시 의무 (caller 가 PR 본문에 적어야 함).
+    - ``allowed`` False: 충족된 criterion 없음 → 성능 개선 작업을 열면
+      안 됨 (scope creep 방지).
+    """
+
+    allowed: bool
+    matched_criteria: Tuple[str, ...] = field(default_factory=tuple)
+    reason: str = ""
+    required_artifacts: Tuple[str, ...] = field(default_factory=tuple)
+
+
+_HARDENING_REQUIRED_ARTIFACTS: Tuple[str, ...] = (
+    "baseline_measurement",
+    "target_metric",
+    "behavior_change_separated",
+    "regression_test",
+)
+
+
+def decide_hardening_opening(
+    observations: Mapping[str, Any],
+) -> HardeningOpeningDecision:
+    """*observations* 에서 매칭되는 opening criterion 을 추출.
+
+    *observations* 는 자유 형태 mapping. 본 함수가 인식하는 키:
+
+      - ``queue_backlog_jobs``: int — 0 초과면 :attr:`QUEUE_BACKLOG`
+      - ``status_latency_seconds``: float — 30 이상이면
+        :attr:`RUNTIME_STATUS_LATENCY`
+      - ``retrieval_eval_regression``: bool/Truthy →
+        :attr:`RETRIEVAL_EVAL_REGRESSION`
+      - ``prompt_size_bytes`` / ``prompt_size_ceiling``: int — size 가
+        ceiling 의 0.9 이상이면 :attr:`PROMPT_SIZE_CEILING`
+      - ``large_files`` (시퀀스): 비어있지 않으면 :attr:`LARGE_FILE_RULE`
+      - ``duplicate_work_signals`` (시퀀스): 비어있지 않으면
+        :attr:`DUPLICATE_WORK`
+      - ``critical_path_bottleneck``: bool/Truthy →
+        :attr:`CRITICAL_PATH_BOTTLENECK`
+      - ``flaky_tests`` / ``slow_tests`` (시퀀스): 비어있지 않으면
+        :attr:`FLAKY_OR_SLOW_TEST`
+
+    하나라도 매칭되지 않으면 ``allowed=False`` + 사유 — caller 는 성능
+    개선 작업을 열지 말고 correctness/visibility 작업만 진행.
+    """
+
+    obs = dict(observations or {})
+    matched: list[str] = []
+
+    if _coerce_int(obs.get("queue_backlog_jobs")) > 0:
+        matched.append(HardeningOpeningCriterion.QUEUE_BACKLOG.value)
+    if _coerce_float(obs.get("status_latency_seconds")) >= 30.0:
+        matched.append(HardeningOpeningCriterion.RUNTIME_STATUS_LATENCY.value)
+    if bool(obs.get("retrieval_eval_regression")):
+        matched.append(
+            HardeningOpeningCriterion.RETRIEVAL_EVAL_REGRESSION.value
+        )
+    prompt_size = _coerce_int(obs.get("prompt_size_bytes"))
+    ceiling = _coerce_int(obs.get("prompt_size_ceiling"))
+    if prompt_size and ceiling and prompt_size >= int(ceiling * 0.9):
+        matched.append(HardeningOpeningCriterion.PROMPT_SIZE_CEILING.value)
+    if _has_non_empty_seq(obs, "large_files"):
+        matched.append(HardeningOpeningCriterion.LARGE_FILE_RULE.value)
+    if _has_non_empty_seq(obs, "duplicate_work_signals"):
+        matched.append(HardeningOpeningCriterion.DUPLICATE_WORK.value)
+    if bool(obs.get("critical_path_bottleneck")):
+        matched.append(
+            HardeningOpeningCriterion.CRITICAL_PATH_BOTTLENECK.value
+        )
+    if _has_non_empty_seq(obs, "flaky_tests") or _has_non_empty_seq(
+        obs, "slow_tests"
+    ):
+        matched.append(HardeningOpeningCriterion.FLAKY_OR_SLOW_TEST.value)
+
+    if not matched:
+        return HardeningOpeningDecision(
+            allowed=False,
+            matched_criteria=(),
+            reason="no_opening_criteria_met",
+            required_artifacts=_HARDENING_REQUIRED_ARTIFACTS,
+        )
+
+    return HardeningOpeningDecision(
+        allowed=True,
+        matched_criteria=tuple(matched),
+        reason=f"matched:{','.join(matched)}",
+        required_artifacts=_HARDENING_REQUIRED_ARTIFACTS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_float(value: Any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _has_non_empty_seq(obs: Mapping[str, Any], key: str) -> bool:
+    value = obs.get(key)
+    if not isinstance(value, (list, tuple)):
+        return False
+    return any(item not in (None, "") for item in value)
+
+
+__all__ = (
+    "BRANCH_PREFIXES",
+    "BranchPolicyResult",
+    "CURATED_REQUIRED_FRONTMATTER",
+    "CURATED_REQUIRED_SECTIONS",
+    "CuratedNoteValidationResult",
+    "HARDENING_OPENING_CRITERIA",
+    "HardeningOpeningCriterion",
+    "HardeningOpeningDecision",
+    "INBOX_PATH_PREFIX",
+    "MIN_RETRIEVAL_EVAL_QUESTIONS",
+    "PRBodyValidationResult",
+    "PR_REQUIRED_SECTIONS",
+    "PR_AUDIT_BLOCK_MARKERS",
+    "RETRIEVAL_EVAL_REQUIRED_KEYS",
+    "RETRIEVAL_EVAL_TOP_K",
+    "RetrievalEvalEntryResult",
+    "RetrievalEvalFixtureResult",
+    "TARGET_RETRIEVAL_EVAL_QUESTIONS",
+    "decide_hardening_opening",
+    "derive_standard_branch_name",
+    "detect_broken_links",
+    "detect_orphan_note",
+    "is_inbox_path",
+    "validate_branch_name",
+    "validate_curated_note",
+    "validate_pr_body",
+    "validate_retrieval_eval_entry",
+    "validate_retrieval_eval_fixture",
+)

--- a/tests/governance/test_runtime_policy.py
+++ b/tests/governance/test_runtime_policy.py
@@ -1,0 +1,497 @@
+"""Runtime governance policy gates 회귀 핀 — P0-T.
+
+본 test 가 통과한다 = `agents/governance/runtime_policy.py` 가 정의한
+hard rail 이 살아있다는 뜻. 정책이 silently 약해지면 가장 먼저 잡힌다.
+
+검사 영역:
+  1. Branch policy — protected branch 거부 / 표준 prefix 권장 / issue
+     anchor warning / derive_standard_branch_name 결정성
+  2. PR body — 5 섹션 + audit block / 누락 시 fail
+  3. Curated note — inbox 직접 승격 거부 / frontmatter 필수 / 본문
+     필수 섹션 / hub linkage warning
+  4. Orphan / broken link — hub 없음 + related 없음 = orphan,
+     wikilink 가 available_paths 에 없음 = broken
+  5. Retrieval eval — entry 스키마 / fixture 최소 count / top-5
+  6. Post-test hardening — opening criteria 8 종 매칭 / 빈 obs 거부
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.governance import (
+    BRANCH_PREFIXES,
+    CURATED_REQUIRED_FRONTMATTER,
+    CURATED_REQUIRED_SECTIONS,
+    HARDENING_OPENING_CRITERIA,
+    INBOX_PATH_PREFIX,
+    MIN_RETRIEVAL_EVAL_QUESTIONS,
+    PR_REQUIRED_SECTIONS,
+    RETRIEVAL_EVAL_REQUIRED_KEYS,
+    RETRIEVAL_EVAL_TOP_K,
+    TARGET_RETRIEVAL_EVAL_QUESTIONS,
+    decide_hardening_opening,
+    derive_standard_branch_name,
+    detect_broken_links,
+    detect_orphan_note,
+    is_inbox_path,
+    validate_branch_name,
+    validate_curated_note,
+    validate_pr_body,
+    validate_retrieval_eval_entry,
+    validate_retrieval_eval_fixture,
+)
+
+
+# ---------------------------------------------------------------------------
+# Branch
+# ---------------------------------------------------------------------------
+
+
+class BranchPolicyTests(unittest.TestCase):
+    def test_protected_branches_rejected(self) -> None:
+        for name in ("main", "master", "develop", "release", "production"):
+            with self.subTest(name=name):
+                r = validate_branch_name(name)
+                self.assertFalse(r.allowed)
+                self.assertTrue(r.reason.startswith("protected_branch"))
+
+    def test_qualified_protected_ref_rejected(self) -> None:
+        for name in (
+            "refs/heads/main",
+            "origin/main",
+            "feature/main",  # 마지막 segment 가 main → 거부
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(validate_branch_name(name).allowed)
+
+    def test_empty_branch_rejected(self) -> None:
+        self.assertFalse(validate_branch_name(None).allowed)
+        self.assertFalse(validate_branch_name("").allowed)
+
+    def test_invalid_chars_rejected(self) -> None:
+        self.assertFalse(validate_branch_name("Feat/CAPS").allowed)
+        self.assertFalse(validate_branch_name("feat with spaces").allowed)
+
+    def test_standard_prefix_ok_and_no_warnings(self) -> None:
+        r = validate_branch_name("feat/auth-issue-77", issue_number=77)
+        self.assertTrue(r.allowed)
+        self.assertEqual(r.warnings, ())
+
+    def test_issue_anchor_missing_warns(self) -> None:
+        r = validate_branch_name("feat/auth-only", issue_number=77)
+        self.assertTrue(r.allowed)
+        self.assertTrue(
+            any("missing_issue_anchor" in w for w in r.warnings)
+        )
+
+    def test_non_standard_prefix_warning_only_by_default(self) -> None:
+        # 'agent/...' 은 기존 derive_branch_name 패턴 — 회귀 없도록 허용
+        r = validate_branch_name("agent/backend-engineer/issue-77-foo")
+        self.assertTrue(r.allowed)
+        # custom prefix 는 warning
+        r2 = validate_branch_name("custom-prefix/foo")
+        self.assertTrue(r2.allowed)
+        self.assertTrue(any("non_standard_prefix" in w for w in r2.warnings))
+
+    def test_non_standard_prefix_can_be_strict(self) -> None:
+        r = validate_branch_name(
+            "custom-prefix/foo", require_standard_prefix=True
+        )
+        self.assertFalse(r.allowed)
+        self.assertTrue(r.reason.startswith("non_standard_prefix"))
+
+    def test_derive_standard_branch_name_includes_issue(self) -> None:
+        name = derive_standard_branch_name(
+            kind="feat", short_purpose="auth flow", issue_number=77
+        )
+        self.assertEqual(name, "feat/auth-flow-issue-77")
+
+    def test_derive_standard_branch_name_rejects_unknown_kind(self) -> None:
+        with self.assertRaises(ValueError):
+            derive_standard_branch_name(
+                kind="experimental", short_purpose="x"
+            )
+
+
+# ---------------------------------------------------------------------------
+# PR body
+# ---------------------------------------------------------------------------
+
+
+_VALID_PR_BODY = """
+## 📌 관련 이슈
+closes #77
+
+## ✨ 과제 내용
+
+목적: ...
+
+## 범위
+in_scope / out_of_scope
+
+## 리스크
+- foo
+
+## 테스트
+- bar
+
+🤖 engineering-agent audit
+"""
+
+
+class PRBodyPolicyTests(unittest.TestCase):
+    def test_required_sections_table_5_items(self) -> None:
+        self.assertEqual(
+            set(PR_REQUIRED_SECTIONS.keys()),
+            {"purpose", "scope", "risks", "tests", "issue_linkage"},
+        )
+
+    def test_valid_pr_body_passes(self) -> None:
+        r = validate_pr_body(_VALID_PR_BODY)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.missing_sections, ())
+        self.assertTrue(r.audit_block_present)
+
+    def test_missing_sections_collected(self) -> None:
+        r = validate_pr_body("## 목적\nonly this")
+        self.assertFalse(r.ok)
+        self.assertIn("scope", r.missing_sections)
+        self.assertIn("risks", r.missing_sections)
+        self.assertIn("tests", r.missing_sections)
+        self.assertIn("issue_linkage", r.missing_sections)
+
+    def test_missing_audit_block_warns(self) -> None:
+        body = """
+## 목적
+x
+## 범위
+x
+## 리스크
+x
+## 테스트
+x
+## 관련 이슈
+closes #1
+"""
+        r = validate_pr_body(body)
+        self.assertFalse(r.ok)  # audit 누락 시 fail
+        self.assertFalse(r.audit_block_present)
+        self.assertIn("missing_audit_block", r.warnings)
+
+    def test_empty_body_fails(self) -> None:
+        r = validate_pr_body("")
+        self.assertFalse(r.ok)
+        self.assertEqual(
+            set(r.missing_sections), set(PR_REQUIRED_SECTIONS.keys())
+        )
+
+
+# ---------------------------------------------------------------------------
+# Curated note
+# ---------------------------------------------------------------------------
+
+
+def _full_frontmatter() -> dict:
+    return {
+        "title": "네이버 검색 클론 — 인증 흐름",
+        "kind": "curated",
+        "status": "draft",
+        "created_at": "2026-05-15",
+        "tags": ["auth", "backend"],
+        "related": ["[[hub-app-arch]]"],
+        "home_hub": "_moc/30-areas-engineering",
+    }
+
+
+_VALID_CURATED_BODY = """
+## 핵심 요약
+회원가입은 JWT.
+
+## 내 해석
+session 보다 stateless
+
+## 적용 맥락
+naver-search-clone
+
+## 관련 노트
+[[hub-app-arch]]
+
+## 참고
+[[00-inbox/links/foo]]
+"""
+
+
+class CuratedNoteTests(unittest.TestCase):
+    def test_required_frontmatter_table(self) -> None:
+        self.assertIn("title", CURATED_REQUIRED_FRONTMATTER)
+        self.assertIn("home_hub", CURATED_REQUIRED_FRONTMATTER)
+        self.assertIn("related", CURATED_REQUIRED_FRONTMATTER)
+
+    def test_required_sections_table(self) -> None:
+        self.assertEqual(
+            set(CURATED_REQUIRED_SECTIONS.keys()),
+            {"summary", "interpretation", "context", "related", "references"},
+        )
+
+    def test_inbox_path_rejected(self) -> None:
+        r = validate_curated_note(
+            path="00-inbox/sample.md", frontmatter=_full_frontmatter()
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, "inbox_direct_promotion_forbidden")
+
+    def test_is_inbox_path_helper(self) -> None:
+        self.assertTrue(is_inbox_path("00-inbox/foo.md"))
+        self.assertTrue(is_inbox_path(f"./{INBOX_PATH_PREFIX}/x.md"))
+        self.assertFalse(is_inbox_path("20-areas/foo.md"))
+        self.assertFalse(is_inbox_path(None))
+
+    def test_full_curated_note_passes(self) -> None:
+        r = validate_curated_note(
+            path="20-areas/auth-flow.md",
+            frontmatter=_full_frontmatter(),
+            body=_VALID_CURATED_BODY,
+        )
+        self.assertTrue(r.ok, r)
+        self.assertEqual(r.missing_frontmatter, ())
+        self.assertEqual(r.missing_sections, ())
+
+    def test_missing_frontmatter_keys_collected(self) -> None:
+        partial = dict(_full_frontmatter())
+        partial.pop("home_hub")
+        partial.pop("related")
+        r = validate_curated_note(
+            path="20-areas/x.md",
+            frontmatter=partial,
+            body=_VALID_CURATED_BODY,
+        )
+        self.assertFalse(r.ok)
+        self.assertIn("home_hub", r.missing_frontmatter)
+        self.assertIn("related", r.missing_frontmatter)
+
+    def test_missing_body_sections_collected(self) -> None:
+        r = validate_curated_note(
+            path="20-areas/x.md",
+            frontmatter=_full_frontmatter(),
+            body="## 핵심 요약\nonly summary",
+        )
+        self.assertFalse(r.ok)
+        self.assertIn("interpretation", r.missing_sections)
+        self.assertIn("context", r.missing_sections)
+        self.assertIn("related", r.missing_sections)
+        self.assertIn("references", r.missing_sections)
+
+
+# ---------------------------------------------------------------------------
+# Orphan / broken link
+# ---------------------------------------------------------------------------
+
+
+class OrphanAndBrokenLinkTests(unittest.TestCase):
+    def test_orphan_no_hub_no_related(self) -> None:
+        self.assertTrue(
+            detect_orphan_note(note_path="x", home_hub=None, related=())
+        )
+
+    def test_not_orphan_with_hub(self) -> None:
+        self.assertFalse(
+            detect_orphan_note(
+                note_path="x", home_hub="_moc/h", related=()
+            )
+        )
+
+    def test_not_orphan_with_related_only(self) -> None:
+        self.assertFalse(
+            detect_orphan_note(
+                note_path="x", home_hub=None, related=["[[other]]"]
+            )
+        )
+
+    def test_orphan_when_hub_not_in_known_set(self) -> None:
+        # hub_paths 가 주어졌는데 home_hub 가 그 안에 없고 related 도 없음
+        self.assertTrue(
+            detect_orphan_note(
+                note_path="x",
+                home_hub="_moc/unknown",
+                related=(),
+                hub_paths=("_moc/known-1", "_moc/known-2"),
+            )
+        )
+
+    def test_broken_link_detects_unknown_target(self) -> None:
+        broken = detect_broken_links(
+            body="[[known]] [[unknown-target]] [[hubs/path]]",
+            available_paths=("known.md", "hubs/path.md"),
+        )
+        self.assertEqual(broken, ("unknown-target",))
+
+    def test_broken_link_basename_match_passes(self) -> None:
+        broken = detect_broken_links(
+            body="[[tail]]",
+            available_paths=("some/long/path/tail.md",),
+        )
+        self.assertEqual(broken, ())
+
+
+# ---------------------------------------------------------------------------
+# Retrieval eval
+# ---------------------------------------------------------------------------
+
+
+class RetrievalEvalTests(unittest.TestCase):
+    def _entry(self, **overrides):
+        base = {
+            "question": "JWT 와 session 차이",
+            "expected_notes": ["20-areas/auth-flow.md"],
+            "allowed_alternatives": [],
+            "failure_reason": "",
+        }
+        base.update(overrides)
+        return base
+
+    def test_required_keys_present(self) -> None:
+        for key in ("question", "expected_notes", "allowed_alternatives", "failure_reason"):
+            self.assertIn(key, RETRIEVAL_EVAL_REQUIRED_KEYS)
+
+    def test_top_k_is_5(self) -> None:
+        self.assertEqual(RETRIEVAL_EVAL_TOP_K, 5)
+
+    def test_min_and_target_counts(self) -> None:
+        self.assertEqual(MIN_RETRIEVAL_EVAL_QUESTIONS, 50)
+        self.assertEqual(TARGET_RETRIEVAL_EVAL_QUESTIONS, 100)
+
+    def test_valid_entry(self) -> None:
+        r = validate_retrieval_eval_entry(self._entry())
+        self.assertTrue(r.ok)
+
+    def test_missing_key(self) -> None:
+        bad = self._entry()
+        bad.pop("allowed_alternatives")
+        r = validate_retrieval_eval_entry(bad)
+        self.assertFalse(r.ok)
+        self.assertIn("allowed_alternatives", r.missing_keys)
+
+    def test_empty_question_rejected(self) -> None:
+        r = validate_retrieval_eval_entry(self._entry(question=""))
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, "empty_question")
+
+    def test_empty_expected_notes_rejected(self) -> None:
+        r = validate_retrieval_eval_entry(self._entry(expected_notes=[]))
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, "empty_expected_notes")
+
+    def test_fixture_below_min_fails(self) -> None:
+        entries = [self._entry()] * 10
+        r = validate_retrieval_eval_fixture(entries)
+        self.assertFalse(r.ok)
+        self.assertTrue(any(w.startswith("below_min") for w in r.warnings))
+
+    def test_fixture_at_min_passes_with_target_warning(self) -> None:
+        entries = [self._entry()] * MIN_RETRIEVAL_EVAL_QUESTIONS
+        r = validate_retrieval_eval_fixture(entries)
+        self.assertTrue(r.ok)
+        self.assertTrue(any(w.startswith("below_target") for w in r.warnings))
+
+    def test_fixture_above_target_no_warnings(self) -> None:
+        entries = [self._entry()] * (TARGET_RETRIEVAL_EVAL_QUESTIONS + 5)
+        r = validate_retrieval_eval_fixture(entries)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.warnings, ())
+
+
+# ---------------------------------------------------------------------------
+# Post-test hardening
+# ---------------------------------------------------------------------------
+
+
+class HardeningOpeningTests(unittest.TestCase):
+    def test_eight_criteria_enumerated(self) -> None:
+        self.assertEqual(
+            set(HARDENING_OPENING_CRITERIA),
+            {
+                "queue_backlog",
+                "runtime_status_latency",
+                "retrieval_eval_regression",
+                "prompt_size_ceiling",
+                "large_file_rule",
+                "duplicate_work",
+                "critical_path_bottleneck",
+                "flaky_or_slow_test",
+            },
+        )
+
+    def test_no_observations_denies(self) -> None:
+        d = decide_hardening_opening({})
+        self.assertFalse(d.allowed)
+        self.assertEqual(d.reason, "no_opening_criteria_met")
+        # required artifacts 는 deny 시에도 caller 가 다음 PR 에서 충족
+        # 해야 할 항목 정보
+        self.assertIn("baseline_measurement", d.required_artifacts)
+
+    def test_queue_backlog_triggers(self) -> None:
+        d = decide_hardening_opening({"queue_backlog_jobs": 3})
+        self.assertTrue(d.allowed)
+        self.assertIn("queue_backlog", d.matched_criteria)
+
+    def test_runtime_status_latency_triggers(self) -> None:
+        d = decide_hardening_opening({"status_latency_seconds": 45})
+        self.assertTrue(d.allowed)
+        self.assertIn("runtime_status_latency", d.matched_criteria)
+
+    def test_retrieval_regression_triggers(self) -> None:
+        d = decide_hardening_opening({"retrieval_eval_regression": True})
+        self.assertTrue(d.allowed)
+        self.assertIn("retrieval_eval_regression", d.matched_criteria)
+
+    def test_prompt_size_ceiling_triggers(self) -> None:
+        # ceiling 90% 초과
+        d = decide_hardening_opening(
+            {"prompt_size_bytes": 300 * 1024, "prompt_size_ceiling": 320 * 1024}
+        )
+        self.assertTrue(d.allowed)
+
+    def test_large_files_triggers(self) -> None:
+        d = decide_hardening_opening({"large_files": ["foo.py"]})
+        self.assertTrue(d.allowed)
+        self.assertIn("large_file_rule", d.matched_criteria)
+
+    def test_flaky_or_slow_triggers(self) -> None:
+        d = decide_hardening_opening({"flaky_tests": ["t1"]})
+        self.assertTrue(d.allowed)
+        self.assertIn("flaky_or_slow_test", d.matched_criteria)
+
+    def test_multiple_criteria_listed(self) -> None:
+        d = decide_hardening_opening(
+            {"queue_backlog_jobs": 1, "large_files": ["x.py"]}
+        )
+        self.assertTrue(d.allowed)
+        self.assertEqual(
+            set(d.matched_criteria), {"queue_backlog", "large_file_rule"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constants contract — docs 동기화 보호
+# ---------------------------------------------------------------------------
+
+
+class ConstantsContractTests(unittest.TestCase):
+    """docs 가 명시한 정책 상수가 코드에서 silently 약해지지 않게 핀."""
+
+    def test_branch_prefixes_includes_core_set(self) -> None:
+        for kind in ("feat", "fix", "chore", "refactor"):
+            self.assertIn(kind, BRANCH_PREFIXES)
+
+    def test_inbox_path_prefix_is_00_inbox(self) -> None:
+        self.assertEqual(INBOX_PATH_PREFIX, "00-inbox")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #171

## ✨ 과제 내용

실제 코딩 작업이 굴러갈 때 무너지지 말아야 할 hard rail 을 **코드 SSoT + 9 문서 + 회귀 테스트 49 케이스** 로 한 자리에 묶는다.

### 4 영역 hard rail
1. **Git / branch / PR / tag** — protected branch 거부, 표준 prefix (`feat/fix/chore/refactor/docs/test/perf`), issue anchor 권장, PR body 5 섹션 + audit block, `RepoContract.tag_policy=none` 시 자동 발행 금지
2. **Vault / curated / inbox / hub linkage** — `00-inbox` 는 raw pool, 승격은 **새 curated note 생성**, frontmatter 7 키 + 본문 5 섹션 필수, orphan / broken link push 금지, 일일 curated 20~30 / raw 100 한도
3. **Retrieval eval** — fixture 50 minimum / 100 target / top-5, eval 없이 대량 generation push 금지, top-5 fail = regression
4. **Post-test hardening** — 8 opening criteria 중 1+ 충족 시 성능 개선 작업 허용 (queue_backlog / runtime_status_latency / retrieval_eval_regression / prompt_size_ceiling / large_file_rule / duplicate_work / critical_path_bottleneck / flaky_or_slow_test). baseline / target metric / behavior change 분리 / regression test 4 의무

우선순위: **correctness > visibility > maintainability > performance**.

### 3 commit 구성
1. **🚀 governance/runtime_policy 모듈 신설** — 9 validator + 1 decider, pure caller-driven gate. 833 라인
2. **✅ runtime governance policy 회귀 핀 49 케이스** — 6 영역 (Branch / PRBody / Curated / Orphan&BrokenLink / RetrievalEval / Hardening) + ConstantsContract
3. **📃 9 문서에 runtime governance hard rails 반영** — AGENTS / CLAUDE / engineering CLAUDE / CODE_LAYOUT / github-agent-workos §1.2.1 / engineering-agent-governance §4.1 / master-plan §18 / memory §"Curated 정책" §"Retrieval eval" / approval-matrix (issue_create L2 / tag_create L3 행)

### 회귀
- 전체: **4888 pass / 1 skip** (직전 PR #170 의 4839 + 신규 49)
- governance smoke (test_docs_hierarchy + test_runtime_policy 등): 109 pass
- 신규 49 케이스가 정책 상수가 silently 약해지는 것을 가장 먼저 감지

### 호출자 측 (이번 PR 에서 닫지 않음 — 명시적 deferred)
본 PR 은 **pure 정책 모듈 + 회귀 테스트 + 문서** land. 다음 PR 에서 호출자가 결과 객체를 실제 게이트로 사용:
- `GithubWriter.create_branch` / `create_draft_pull_request` 가 `validate_branch_name` / `validate_pr_body` 호출 후 deny 시 audit
- `ObsidianWriterWorker` 가 curated note write 직전 `validate_curated_note` 호출
- 백그라운드 vault sync 가 `detect_orphan_note` / `detect_broken_links` push pre-check
- post-test hardening: PR template 에 `decide_hardening_opening` observation 필드 추가

이 한계는 fake success 가 아니라 명시적 deferred — 정책 SSoT 가 land 됐고 caller-driven 패턴이라 후속 PR 에서 단계적으로 통합 가능.

## 📚 레퍼런스
- `src/yule_orchestrator/agents/governance/runtime_policy.py` (신규 SSoT)
- `tests/governance/test_runtime_policy.py` (49 회귀 케이스)
- `docs/engineering-agent-governance.md` §4.1 (4 sub-section)
- `docs/memory.md` §"Curated 정책" / §"Retrieval eval"
- `docs/github-agent-workos.md` §1.2.1
- `docs/engineering-company-runtime-master-plan.md` §18
- `docs/approval-matrix.md` §2 (issue_create L2 / tag_create L3)