### PR TITLE
🐞 live smoke fix — session c5278a9043f2 issue-less full-stack 오분류 + approval card 누락 (closes #175)

### DIFF
--- a/src/yule_orchestrator/agents/job_queue/github_work_order.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order.py
@@ -160,6 +160,22 @@ _CODING_INTENT_PHRASES: Tuple[str, ...] = (
     "patch 작성",
     "패치를 만들",
     "patch 만들",
+    # P0-T smoke fix (session c5278a9043f2 repro):
+    # operator 가 mode 토큰만 명시하는 자연어 — 본 토큰들이 보이면 coding
+    # intent 로 인식해야 enqueue_github_work_approval 이 발동하고 #승인-대기
+    # 카드가 게시된다. phrase_detect 의 CODING_PROPOSAL_REQUEST_PHRASES 와
+    # 동기화 유지.
+    "approval_required",
+    "full_stack_single_repo",
+    "full-stack-single-repo",
+    "single_repo",
+    "single-repo",
+    "코딩으로 진행",
+    "구현으로 진행",
+    "풀스택으로 진행",
+    "코딩 권한 제안",
+    "수정 권한 제안",
+    "구현 권한 제안",
 )
 
 

--- a/src/yule_orchestrator/agents/messaging/dispatcher.py
+++ b/src/yule_orchestrator/agents/messaging/dispatcher.py
@@ -201,9 +201,14 @@ _KEYWORD_RULES: Sequence[tuple[TaskType, Sequence[str]]] = (
     (TaskType.EMAIL_CAMPAIGN, ("email", "이메일", "campaign", "캠페인", "광고", "ad creative")),
     (TaskType.LANDING_PAGE, ("landing", "랜딩", "marketing page")),
     (TaskType.QA_TEST, ("regression", "회귀", "qa", "test plan", "테스트 시나리오")),
+    # P0-J / P0-T smoke fix — `docker` 단독 매칭 제거. Docker / Docker
+    # Compose / K8s 가 *full-stack 요청 안에서* 언급되면 본 keyword 매칭
+    # 전에 stack_detector 가 FULL_STACK_APP 분류하도록 ``classify`` 위
+    # 분기에서 우선 처리. 본 platform-infra 매칭은 deploy / terraform /
+    # github actions 같은 *genuine infra* 신호만 남긴다.
     (
         TaskType.PLATFORM_INFRA,
-        ("infra", "deploy", "ci ", " ci", "docker", "k8s", "terraform", "github action"),
+        ("infra", "deploy", "ci ", " ci", "terraform", "github action"),
     ),
     (TaskType.FRONTEND_FEATURE, ("frontend", "ui ", "component", "컴포넌트", "react", "next.js", "vue")),
     (
@@ -285,12 +290,51 @@ class Dispatcher:
         self.ranking_signal = ranking_signal
 
     def classify(self, request: DispatchRequest) -> TaskType:
+        """Classify request → TaskType.
+
+        Precedence (P0-T smoke fix for session c5278a9043f2):
+
+          1. explicit ``request.task_type`` — operator override.
+          2. **stack_detector** — if message mentions ≥2 distinct
+             application tiers (frontend / backend / database / cache /
+             queue / auth) → :attr:`TaskType.FULL_STACK_APP`. Mirrors
+             :func:`discord.engineering_conversation.task_shaping._suggest_task_type`.
+             Without this, a prompt like "Next.js + NestJS + Postgres +
+             Docker Compose 기반 회원가입/검색" mis-classified as
+             ``platform-infra`` (Docker keyword wins) or even
+             ``qa-test`` when the operator adds "테스트" later in the
+             same prompt.
+          3. keyword fallback — legacy ``_KEYWORD_RULES`` table.
+          4. ``TaskType.UNKNOWN``.
+
+        The stack_detector pass is best-effort: a stack_detector import
+        failure (partial install / circular path) falls back to the
+        keyword table — never raises.
+        """
+
         if request.task_type is not None:
             return request.task_type
-        prompt = request.prompt.lower()
+
+        prompt = request.prompt or ""
+        try:
+            from ..coding.stack_detector import detect_stacks
+        except Exception:  # noqa: BLE001 - partial install fallback
+            detect_stacks = None  # type: ignore[assignment]
+        if detect_stacks is not None:
+            try:
+                detection = detect_stacks(prompt)
+            except Exception:  # noqa: BLE001
+                detection = None
+            if detection is not None:
+                if detection.is_full_stack:
+                    return TaskType.FULL_STACK_APP
+                if detection.is_infra_only:
+                    return TaskType.PLATFORM_INFRA
+
+        prompt_lower = prompt.lower()
         for task_type, keywords in _KEYWORD_RULES:
             for keyword in keywords:
-                if keyword in prompt:
+                if keyword in prompt_lower:
                     return task_type
         return TaskType.UNKNOWN
 

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -674,13 +674,132 @@ def _run_engineer_intake(
                 f"task_type must be one of {[t.value for t in TaskType]}, got {task_type!r}"
             ) from exc
     orchestrator = _engineer_orchestrator()
-    return orchestrator.intake(
+    result = orchestrator.intake(
         prompt=prompt,
         task_type=parsed,
         write_requested=write_requested,
         channel_id=channel_id,
         user_id=user_id,
     )
+
+    # P0-T smoke fix (session c5278a9043f2 repro):
+    # /engineer_intake 슬래시 명령이 issue-less full-stack coding 요청을
+    # 받았을 때 본문 응답만 게시하고 `#승인-대기` 카드는 누락되던 회귀
+    # 차단. write_requested=True 이고 stack_detector / phrase_detect 가
+    # coding intent 를 인식하면 ApprovalWorker 빌드 후
+    # ``enqueue_github_work_approval`` 호출. 실패는 swallow — slash
+    # command 본문 응답은 절대 막지 않는다.
+    if write_requested:
+        try:
+            _maybe_post_intake_approval_card(
+                session=result.session,
+                prompt_text=prompt,
+                requested_by=str(user_id or ""),
+            )
+        except Exception:  # noqa: BLE001
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "engineer_intake: approval card posting 실패 — 본문 응답은 그대로 진행",
+                exc_info=True,
+            )
+    return result
+
+
+def _maybe_post_intake_approval_card(
+    *,
+    session: Any,
+    prompt_text: str,
+    requested_by: str,
+) -> None:
+    """Build production ApprovalWorker + post `#승인-대기` 카드 (best-effort).
+
+    intake 시점에는 session.extra 가 비어있어 should_route_to_github_workos
+    가 lifecycle_mode 누락 + coding_intent 둘 중 하나로 skip 할 수 있다.
+    그래서 본 helper 는 intake 직전 session 에 ``lifecycle_mode=implementation``
+    임시 stamp + ``active_research_roles`` placeholder 만 채워 adapter 가
+    proposal 을 build 할 수 있게 한다.
+    """
+
+    import asyncio as _asyncio
+
+    from ...agents.job_queue import (
+        ApprovalWorker,
+        HeartbeatStore,
+        JobQueue,
+    )
+    from ...agents.job_queue.approval_discord_poster import (
+        build_approval_channel_resolver,
+        build_production_post_fn,
+    )
+    from ..integrations.github_workos_adapter import (
+        enqueue_github_work_approval,
+        should_route_to_github_workos,
+    )
+
+    # intake 직후 session.extra 는 비어있을 수 있으므로 adapter 가 인식할
+    # 최소 lifecycle 신호를 임시로 채운다. 실제 lifecycle_mode 는 후속
+    # `_run_coding_authorization_gate` 가 정확한 값으로 갱신.
+    session_extra = dict(getattr(session, "extra", None) or {})
+    if "lifecycle_mode" not in session_extra:
+        session_extra["lifecycle_mode"] = "implementation"
+    if "active_research_roles" not in session_extra:
+        session_extra["active_research_roles"] = ["tech-lead", "backend-engineer"]
+    if session_extra != (getattr(session, "extra", None) or {}):
+        try:
+            from dataclasses import replace as _replace
+            from ...agents.workflow_state import update_session as _update
+
+            session = _update(
+                _replace(session, extra=session_extra),
+                now=datetime.now(),
+            )
+        except Exception:  # noqa: BLE001 - keep going with in-memory copy
+            try:
+                session.extra = session_extra  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+
+    eligible, reason, _ = should_route_to_github_workos(
+        session=session, request_text=prompt_text
+    )
+    if not eligible:
+        return
+
+    queue = JobQueue()
+    worker = ApprovalWorker(
+        queue=queue,
+        heartbeats=HeartbeatStore(),
+        post_fn=build_production_post_fn(),
+        channel_resolver=build_approval_channel_resolver(),
+    )
+
+    async def _go():
+        return await enqueue_github_work_approval(
+            session=session,
+            request_text=prompt_text,
+            approval_worker=worker,
+            requested_by=requested_by,
+        )
+
+    try:
+        loop = _asyncio.get_event_loop()
+        if loop.is_running():
+            # Slash command path 는 _run_engineer_intake 를 to_thread 로
+            # 호출하므로 별도 loop 가 필요. 새 loop 로 한 줄 실행.
+            new_loop = _asyncio.new_event_loop()
+            try:
+                new_loop.run_until_complete(_go())
+            finally:
+                new_loop.close()
+        else:
+            loop.run_until_complete(_go())
+    except RuntimeError:
+        new_loop = _asyncio.new_event_loop()
+        try:
+            new_loop.run_until_complete(_go())
+        finally:
+            new_loop.close()
 
 
 def _load_engineer_session(*, session_id: str):

--- a/src/yule_orchestrator/discord/engineering/phrase_detect.py
+++ b/src/yule_orchestrator/discord/engineering/phrase_detect.py
@@ -109,6 +109,20 @@ CODING_PROPOSAL_REQUEST_PHRASES: tuple[str, ...] = (
     "이 작업 수정 권한",
     "이 작업 구현 권한",
     "코딩 권한 만들",
+    # P0-T smoke fix (session c5278a9043f2 repro):
+    # operator 가 mode 토큰을 명시한 자연어로 들어오는 경우. 이 토큰들이
+    # 보이면 coding authorization gate 가 자동 발동 — 매칭 안 돼 approval
+    # card / coding_proposal 둘 다 누락되는 회귀를 막는다.
+    "approval_required",
+    "full_stack_single_repo",
+    "full-stack-single-repo",
+    "single_repo",
+    "single-repo",
+    "single_scope",
+    "single-scope",
+    "코딩으로 진행",
+    "구현으로 진행",
+    "풀스택으로 진행",
 )
 
 

--- a/src/yule_orchestrator/discord/engineering_channel_router/coding_gate.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/coding_gate.py
@@ -181,6 +181,7 @@ async def _run_coding_authorization_gate(
     prompt_text: str,
     list_sessions_fn: Callable[..., Sequence[Any]],
     send_chunks: SendChunksFn,
+    approval_worker: Any = None,
 ) -> Optional[EngineeringRouteResult]:
     """Two-branch gate.
 
@@ -222,6 +223,48 @@ async def _run_coding_authorization_gate(
         )
         _persist_coding_proposal(target, proposal)
         await send_chunks(message.channel, format_authorization_message(proposal))
+
+        # P0-T smoke fix (session c5278a9043f2 repro): approval card 가
+        # 본문 채널에만 뜨고 `#승인-대기` 에는 안 뜨던 회귀 차단. caller 가
+        # approval_worker 를 inject 했으면 coding_proposal stamp 직후 자동
+        # enqueue. worker 미주입 시 기존 동작 그대로 (회귀 없음).
+        if approval_worker is not None and proposal.approval_required:
+            try:
+                from ..integrations.github_workos_adapter import (
+                    enqueue_github_work_approval,
+                )
+
+                outcome = await enqueue_github_work_approval(
+                    session=target,
+                    request_text=getattr(target, "prompt", "") or prompt_text,
+                    approval_worker=approval_worker,
+                    source_channel_id=getattr(getattr(message, "channel", None), "id", None),
+                    source_thread_id=getattr(getattr(message, "channel", None), "id", None),
+                    source_message_id=getattr(message, "id", None),
+                    requested_by=str(getattr(getattr(message, "author", None), "id", "")),
+                )
+                if outcome.proposal is not None and outcome.skipped_reason is None:
+                    await send_chunks(
+                        message.channel,
+                        f"📨 `#승인-대기` 카드 게시 완료 (job=`{outcome.approval_job_id or '-'}`).",
+                    )
+                elif outcome.skipped_reason == "duplicate_approval_in_flight":
+                    await send_chunks(
+                        message.channel,
+                        "ℹ️ 같은 작업의 `#승인-대기` 카드가 이미 게시돼 있어요.",
+                    )
+                # 기타 skipped_reason 은 본문 응답을 추가하지 않음 — 본문
+                # proposal preview 자체로 operator 가 진행 가능.
+            except Exception:  # noqa: BLE001 — never block coding gate
+                # 카드 게시 실패는 본문 proposal preview 를 막지 않는다.
+                # session.extra audit 에는 남기지 않음 (logger 만).
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "coding_authorization_gate: enqueue_github_work_approval 실패 — 본문 proposal 만 게시",
+                    exc_info=True,
+                )
+
         return EngineeringRouteResult(
             handled=True,
             session_id=getattr(target, "session_id", None),

--- a/src/yule_orchestrator/discord/engineering_channel_router/main.py
+++ b/src/yule_orchestrator/discord/engineering_channel_router/main.py
@@ -170,6 +170,7 @@ async def route_engineering_message(
     list_sessions_fn: Optional[Callable[..., Sequence[Any]]] = None,
     obsidian_writer_fn: Optional[Callable[..., Any]] = None,
     obsidian_env: Optional[Any] = None,
+    approval_worker: Any = None,
 ) -> EngineeringRouteResult:
     """Drive the engineering channel response.
 
@@ -213,6 +214,7 @@ async def route_engineering_message(
             prompt_text=prompt_text,
             list_sessions_fn=list_sessions_fn,
             send_chunks=send_chunks,
+            approval_worker=approval_worker,
         )
         if coding is not None:
             return coding

--- a/tests/core/test_dispatcher_full_stack_classification.py
+++ b/tests/core/test_dispatcher_full_stack_classification.py
@@ -1,0 +1,137 @@
+"""Live smoke fix — issue-less full-stack request classification 회귀.
+
+Reproduces the failure observed in session ``c5278a9043f2``:
+- 사용자가 ``Next.js + NestJS + PostgreSQL + Docker Compose 기반 회원가입/
+  로그인/검색`` 같은 풀스택 요청을 보내면
+- :func:`Dispatcher.classify` 가 docker / qa 키워드 만으로 platform-infra /
+  qa-test 로 misclassify 했었다.
+
+이 test 가 통과 = stack_detector 우선 분기가 살아있다는 뜻. silently
+약해지면 가장 먼저 잡힌다.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents import (
+    Dispatcher,
+    DispatchRequest,
+    TaskType,
+    build_participants_pool,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _build_dispatcher() -> Dispatcher:
+    pool = build_participants_pool(REPO_ROOT, "engineering-agent", factories={})
+    return Dispatcher(pool)
+
+
+class FullStackClassificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.disp = _build_dispatcher()
+
+    def test_session_c5278a9043f2_repro_full_stack(self) -> None:
+        prompt = (
+            "approval_required, single_repo, full_stack_single_repo로 진행해줘.\n"
+            "repo: https://github.com/yule-studio/naver-search-clone.git\n"
+            "목표: Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+            "회원가입/로그인/로그아웃/검색 결과 목록 앱 구현"
+        )
+        result = self.disp.classify(DispatchRequest(prompt=prompt))
+        self.assertEqual(
+            result,
+            TaskType.FULL_STACK_APP,
+            f"session c5278a9043f2 repro: docker keyword 가 stack_detector 를 "
+            f"우회해 잘못 매칭됨 — got {result}",
+        )
+
+    def test_full_stack_with_qa_substring_still_full_stack(self) -> None:
+        # "테스트" 라는 단어가 포함돼도 stack_detector 신호가 더 강하면
+        # FULL_STACK_APP 로 분류 (qa-test 회귀 방지)
+        prompt = (
+            "Next.js + NestJS + PostgreSQL + Docker Compose 기반 회원가입/"
+            "로그인 앱 구현. 테스트도 같이 추가해줘"
+        )
+        self.assertEqual(
+            self.disp.classify(DispatchRequest(prompt=prompt)),
+            TaskType.FULL_STACK_APP,
+        )
+
+    def test_pure_qa_request_still_qa_test(self) -> None:
+        # stack 신호 없이 regression / qa / 회귀 만 있으면 QA_TEST 회귀 보존
+        for prompt in (
+            "기존 회원가입에 regression test 추가해줘",
+            "회귀 시나리오 정리",
+            "QA test plan 만들어줘",
+        ):
+            with self.subTest(prompt=prompt):
+                self.assertEqual(
+                    self.disp.classify(DispatchRequest(prompt=prompt)),
+                    TaskType.QA_TEST,
+                )
+
+    def test_pure_infra_still_platform_infra(self) -> None:
+        # stack 신호 없이 terraform / deploy 만 있으면 PLATFORM_INFRA 회귀 보존
+        for prompt in (
+            "terraform module 정리해줘",
+            "github actions workflow 추가",
+            "deploy 스크립트 정리",
+        ):
+            with self.subTest(prompt=prompt):
+                self.assertEqual(
+                    self.disp.classify(DispatchRequest(prompt=prompt)),
+                    TaskType.PLATFORM_INFRA,
+                )
+
+    def test_docker_keyword_no_longer_in_keyword_table(self) -> None:
+        # P0-T smoke fix — `docker` 단독 keyword 가 _KEYWORD_RULES 의
+        # PLATFORM_INFRA 엔트리에서 제거됐는지. stack_detector 가
+        # is_infra_only 분류한 경우 외에는 docker 만으로 platform-infra
+        # 분류되면 안 됨.
+        from yule_orchestrator.agents.messaging.dispatcher import _KEYWORD_RULES
+
+        for task_type, keywords in _KEYWORD_RULES:
+            if task_type == TaskType.PLATFORM_INFRA:
+                self.assertNotIn(
+                    "docker",
+                    keywords,
+                    "_KEYWORD_RULES PLATFORM_INFRA entry 가 docker 키워드를 "
+                    "다시 가졌음 — full-stack 요청이 docker 만으로 misclassify",
+                )
+                self.assertNotIn("k8s", keywords)
+                break
+        else:
+            self.fail("PLATFORM_INFRA entry not found in _KEYWORD_RULES")
+
+    def test_explicit_task_type_still_wins(self) -> None:
+        # operator 가 명시한 task_type 은 stack_detector 를 무시하고 우선
+        prompt = "Next.js + NestJS + Postgres 기반 회원가입"
+        result = self.disp.classify(
+            DispatchRequest(prompt=prompt, task_type=TaskType.QA_TEST)
+        )
+        self.assertEqual(result, TaskType.QA_TEST)
+
+    def test_frontend_only_request(self) -> None:
+        # tier 1개만 있으면 FULL_STACK_APP 안 됨 — keyword fallback
+        result = self.disp.classify(
+            DispatchRequest(
+                prompt="React 컴포넌트 정리해줘 (Next.js)"
+            )
+        )
+        # Stack detector 가 단일 tier 만 보면 is_full_stack=False — keyword
+        # fallback 으로 frontend-feature
+        self.assertEqual(result, TaskType.FRONTEND_FEATURE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_coding_gate_approval_card_wiring.py
+++ b/tests/discord/test_coding_gate_approval_card_wiring.py
@@ -1,0 +1,239 @@
+"""Live smoke fix — coding_authorization_gate 가 approval card 자동 enqueue.
+
+Reproduces session ``c5278a9043f2`` 의 두 갭:
+
+1. 사용자 메시지 ``approval_required, full_stack_single_repo`` 가 어떤
+   coding_proposal phrase 와도 매칭 안 돼 gate 가 발동 안 했었음.
+2. gate 가 발동해 본문 채널 proposal preview 까지는 띄웠지만 `#승인-대기`
+   에 카드 게시는 누락. → P0-T smoke fix: approval_worker 가 inject 되면
+   `enqueue_github_work_approval` 자동 호출.
+
+이 test 가 통과 = 두 갭이 다시 silently 닫혀도 가장 먼저 잡힌다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Optional, Tuple
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.approval_worker import (
+    APPROVAL_KIND_ENGINEERING_WRITE,
+    ApprovalRequest,
+    ApprovalWorker,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.discord.engineering.phrase_detect import (
+    CODING_PROPOSAL_REQUEST_PHRASES,
+    is_coding_proposal_request,
+)
+from yule_orchestrator.discord.engineering_channel_router.coding_gate import (
+    _run_coding_authorization_gate,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _msg(channel_id: int = 100, content: str = "", message_id: int = 999):
+    channel = SimpleNamespace(id=channel_id, name="업무-접수")
+    author = SimpleNamespace(id=42, bot=False, name="masterway", global_name="masterway")
+    return SimpleNamespace(channel=channel, author=author, content=content, id=message_id)
+
+
+# ---------------------------------------------------------------------------
+# Phrase detection regression
+# ---------------------------------------------------------------------------
+
+
+class PhraseDetectionTests(unittest.TestCase):
+    def test_session_c5278a9043f2_repro_phrase_recognised(self) -> None:
+        prompt = (
+            "approval_required, single_repo, full_stack_single_repo로 진행해줘.\n"
+            "repo: https://github.com/yule-studio/naver-search-clone.git\n"
+            "목표: Next.js + NestJS + PostgreSQL + Docker Compose 기반 회원가입/검색"
+        )
+        self.assertTrue(
+            is_coding_proposal_request(prompt),
+            "approval_required / full_stack_single_repo 토큰이 coding "
+            "proposal request 로 인식되지 않으면 gate 가 발동 못 함",
+        )
+
+    def test_legacy_korean_phrases_still_work(self) -> None:
+        for phrase in (
+            "이 작업 코딩 권한 제안해줘",
+            "수정 권한 제안",
+            "구현 권한 제안",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertTrue(is_coding_proposal_request(phrase))
+
+    def test_unrelated_phrases_not_misclassified(self) -> None:
+        for phrase in (
+            "오늘 날씨 어때",
+            "이 PR 좀 봐줘",
+            "조사해줘",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertFalse(is_coding_proposal_request(phrase))
+
+    def test_new_p0t_tokens_in_phrases_table(self) -> None:
+        # 정책 상수가 silently 약해지지 않게 핀
+        for token in (
+            "approval_required",
+            "full_stack_single_repo",
+            "single_repo",
+        ):
+            self.assertIn(token, CODING_PROPOSAL_REQUEST_PHRASES)
+
+
+# ---------------------------------------------------------------------------
+# Approval card auto-enqueue wiring
+# ---------------------------------------------------------------------------
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        db = Path(self._tmp.name) / "q.sqlite3"
+        self.queue = JobQueue(db_path=db)
+        self.heartbeats = HeartbeatStore(db_path=db)
+        self.posted_cards: List[Tuple[ApprovalRequest, str]] = []
+
+        async def _post(req, rendered):
+            self.posted_cards.append((req, rendered))
+            return {"posted_message_id": 1}
+
+        self.approval_worker = ApprovalWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            post_fn=_post,
+            channel_resolver=lambda: 4242,
+        )
+
+        # Discord channel send_chunks capture
+        self.sent: List[str] = []
+
+        async def _send(_channel, text: str, *args, **kwargs):
+            self.sent.append(text)
+
+        self.send_chunks = _send
+
+        # Open session that the gate will pick up
+        self.session = SimpleNamespace(
+            session_id="sess-c5278",
+            prompt=(
+                "approval_required, single_repo, full_stack_single_repo로 진행해줘. "
+                "repo: https://github.com/yule-studio/naver-search-clone.git "
+                "목표: Next.js + NestJS + PostgreSQL + Docker Compose 기반 회원가입/검색"
+            ),
+            task_type="full-stack-app",
+            state="intake",
+            channel_id=100,
+            thread_id=None,
+            user_id=42,
+            extra={
+                "lifecycle_mode": "implementation",
+                "active_research_roles": ["tech-lead", "backend-engineer"],
+            },
+            updated_at="2026-05-16T10:00:00",
+        )
+
+        def _list_sessions(limit=50):
+            return [self.session]
+
+        self.list_sessions = _list_sessions
+
+
+class CodingGateApprovalEnqueueTests(_Fixture):
+    def test_p0t_message_triggers_gate_and_enqueues_approval_card(self) -> None:
+        msg = _msg(
+            content=(
+                "approval_required, single_repo, full_stack_single_repo로 진행해줘"
+            )
+        )
+        result = _run(
+            _run_coding_authorization_gate(
+                message=msg,
+                prompt_text=msg.content,
+                list_sessions_fn=self.list_sessions,
+                send_chunks=self.send_chunks,
+                approval_worker=self.approval_worker,
+            )
+        )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertTrue(result.handled)
+        # 본문에 권한 제안 preview 게시
+        self.assertTrue(
+            any("코딩 권한 제안" in s or "engineering-agent" in s for s in self.sent),
+            f"본문에 proposal preview 가 보이지 않음: {self.sent}",
+        )
+        # `#승인-대기` 카드가 실제로 게시됨
+        self.assertEqual(
+            len(self.posted_cards),
+            1,
+            f"#승인-대기 카드 게시 누락 — posted={self.posted_cards}",
+        )
+        approval_request, _ = self.posted_cards[0]
+        self.assertEqual(
+            approval_request.approval_kind,
+            APPROVAL_KIND_ENGINEERING_WRITE,
+        )
+        # 본문에 `#승인-대기 카드 게시 완료` ack 도 게시
+        self.assertTrue(
+            any("`#승인-대기` 카드 게시 완료" in s for s in self.sent),
+            f"카드 게시 ack 누락: {self.sent}",
+        )
+
+    def test_no_approval_worker_keeps_legacy_behavior(self) -> None:
+        # caller 가 worker 를 inject 하지 않으면 (회귀 보호) 기존 동작 유지
+        msg = _msg(
+            content="이 작업 코딩 권한 제안"
+        )
+        result = _run(
+            _run_coding_authorization_gate(
+                message=msg,
+                prompt_text=msg.content,
+                list_sessions_fn=self.list_sessions,
+                send_chunks=self.send_chunks,
+                approval_worker=None,
+            )
+        )
+        self.assertIsNotNone(result)
+        # 본문 proposal preview 만 게시, 카드 0건
+        self.assertEqual(self.posted_cards, [])
+        self.assertTrue(any("engineering-agent" in s for s in self.sent))
+
+    def test_legacy_korean_phrase_with_worker_also_enqueues(self) -> None:
+        # 기존 한국어 phrase 도 worker inject 시 카드 enqueue
+        msg = _msg(content="이 작업 코딩 권한 제안")
+        _run(
+            _run_coding_authorization_gate(
+                message=msg,
+                prompt_text=msg.content,
+                list_sessions_fn=self.list_sessions,
+                send_chunks=self.send_chunks,
+                approval_worker=self.approval_worker,
+            )
+        )
+        self.assertEqual(len(self.posted_cards), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_engineer_intake_slash_command.py
+++ b/tests/discord/test_engineer_intake_slash_command.py
@@ -1,0 +1,226 @@
+"""Live smoke fix — `/engineer_intake` slash command 회귀.
+
+Reproduces session **c5278a9043f2**:
+
+  /engineer_intake
+    prompt: approval_required, single_repo, full_stack_single_repo로 진행해줘
+            repo: https://github.com/yule-studio/naver-search-clone.git
+            목표: Next.js + NestJS + PostgreSQL + Docker Compose 기반
+                  회원가입/로그인/로그아웃/검색 결과 목록 앱 구현
+    task_type: (blank)
+    write_requested: true
+
+  관찰된 결과:
+    - session.task_type = "qa-test"          ← misclassified
+    - executor_role     = "qa-engineer"      ← derived from misclassification
+    - progress_notes    = []                 ← coding_execute 진입 못 함
+    - #승인-대기 카드 누락                    ← intake 본문만 떴음
+
+  본 PR 후 기대:
+    - task_type = "full-stack-app"
+    - executor_role = "backend-engineer"
+    - approval card 가 ApprovalWorker 큐에 적재 (production env 시 #승인-대기 게시)
+
+본 test 가 통과 = session c5278a9043f2 회귀가 다시 silently 들어와도
+가장 먼저 잡힌다.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List, Tuple
+from unittest import mock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+_C5278A9043F2_PROMPT = (
+    "approval_required, single_repo, full_stack_single_repo로 진행해줘.\n"
+    "repo: https://github.com/yule-studio/naver-search-clone.git\n"
+    "목표: Next.js + NestJS + PostgreSQL + Docker Compose 기반 "
+    "회원가입/로그인/로그아웃/검색 결과 목록 앱 구현"
+)
+
+
+class _SmokeFixture(unittest.TestCase):
+    """Slash command path test fixture.
+
+    `/engineer_intake` → `_run_engineer_intake` → `WorkflowOrchestrator.intake`
+    + (P0-T) `_maybe_post_intake_approval_card` 가 production ApprovalWorker
+    를 빌드해 카드 enqueue. 본 test 는 ApprovalWorker.run_one 을 patch 해
+    실제 Discord REST 호출 없이 enqueue 만 검증.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        # session.extra 갱신 / 큐 row stash 가 `.cache/yule/cache.sqlite3`
+        # 또는 env 의 path 로 흘러가지 않게 격리
+        self._db_path = Path(self._tmp.name) / "cache.sqlite3"
+        os.environ["YULE_CACHE_DB_PATH"] = str(self._db_path)
+        self.addCleanup(lambda: os.environ.pop("YULE_CACHE_DB_PATH", None))
+
+
+# ---------------------------------------------------------------------------
+# Classification regression — session c5278a9043f2 repro
+# ---------------------------------------------------------------------------
+
+
+class IntakeClassificationTests(_SmokeFixture):
+    def test_session_c5278a9043f2_repro_classifies_as_full_stack(self) -> None:
+        """session c5278a9043f2 의 prompt 가 task_type=full-stack-app 으로
+        분류되고 executor=backend-engineer 가 선정되는지 확인."""
+
+        from yule_orchestrator.discord.commands import _run_engineer_intake
+
+        # `_maybe_post_intake_approval_card` 의 production worker 빌드를
+        # patch — 실제 Discord REST 호출 우회. enqueue 자체가 일어나는지만
+        # 검증.
+        with mock.patch(
+            "yule_orchestrator.discord.commands._maybe_post_intake_approval_card",
+            autospec=True,
+        ) as patched:
+            result = _run_engineer_intake(
+                prompt=_C5278A9043F2_PROMPT,
+                task_type=None,
+                write_requested=True,
+                channel_id=100,
+                user_id=42,
+            )
+
+        # 1. classification — full-stack-app
+        self.assertEqual(
+            result.session.task_type,
+            "full-stack-app",
+            f"session c5278a9043f2 repro: 분류가 여전히 잘못됨 — got {result.session.task_type!r}",
+        )
+
+        # 2. executor — backend-engineer (FULL_STACK_APP → backend-engineer 매핑)
+        self.assertEqual(
+            result.session.executor_role,
+            "backend-engineer",
+            f"executor_role 매핑 회귀 — got {result.session.executor_role!r}",
+        )
+
+        # 3. write_requested 플래그 보존
+        self.assertTrue(result.session.write_requested)
+
+        # 4. _maybe_post_intake_approval_card 가 호출됨 (write_requested=true 이므로)
+        patched.assert_called_once()
+        call_kwargs = patched.call_args.kwargs
+        self.assertEqual(call_kwargs["session"].session_id, result.session.session_id)
+        self.assertEqual(call_kwargs["prompt_text"], _C5278A9043F2_PROMPT)
+
+    def test_explicit_task_type_still_overrides(self) -> None:
+        """operator 가 명시한 task_type 은 stack_detector 를 무시."""
+
+        from yule_orchestrator.discord.commands import _run_engineer_intake
+
+        with mock.patch(
+            "yule_orchestrator.discord.commands._maybe_post_intake_approval_card",
+            autospec=True,
+        ):
+            result = _run_engineer_intake(
+                prompt=_C5278A9043F2_PROMPT,
+                task_type="qa-test",
+                write_requested=True,
+                channel_id=100,
+                user_id=42,
+            )
+        self.assertEqual(result.session.task_type, "qa-test")
+
+    def test_write_requested_false_skips_approval_card(self) -> None:
+        """write_requested=False 면 approval card 게시 시도하지 않음."""
+
+        from yule_orchestrator.discord.commands import _run_engineer_intake
+
+        with mock.patch(
+            "yule_orchestrator.discord.commands._maybe_post_intake_approval_card",
+            autospec=True,
+        ) as patched:
+            _run_engineer_intake(
+                prompt=_C5278A9043F2_PROMPT,
+                task_type=None,
+                write_requested=False,
+                channel_id=100,
+                user_id=42,
+            )
+        patched.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Approval card auto-enqueue — pure helper test
+# ---------------------------------------------------------------------------
+
+
+class IntakeApprovalCardEnqueueTests(_SmokeFixture):
+    """`_maybe_post_intake_approval_card` 가 실제로 ApprovalWorker 큐에
+    카드를 적재하는지 — production REST 는 mock 으로 우회."""
+
+    def test_session_c5278a9043f2_repro_enqueues_approval_card(self) -> None:
+        from types import SimpleNamespace
+
+        # `enqueue_github_work_approval` 자체를 patch — production worker
+        # 빌드 path 를 따라가지만 마지막 호출만 가로챈다. 실제 카드 enqueue
+        # contract (eligible 한 prompt 가 enqueue 함수까지 도달하는지) 검증.
+        captured = {"calls": []}
+
+        async def _stub_enqueue(**kwargs):
+            captured["calls"].append(kwargs)
+            return SimpleNamespace(
+                proposal=SimpleNamespace(proposal_id="p-stub"),
+                approval_job_id="job-stub",
+                approval_post_outcome=None,
+                skipped_reason=None,
+            )
+
+        with mock.patch(
+            "yule_orchestrator.discord.integrations.github_workos_adapter.enqueue_github_work_approval",
+            new=_stub_enqueue,
+        ):
+            from yule_orchestrator.discord.commands import (
+                _maybe_post_intake_approval_card,
+            )
+
+            session = SimpleNamespace(
+                session_id="sess-c5278a9043f2-repro",
+                prompt=_C5278A9043F2_PROMPT,
+                task_type="full-stack-app",
+                state="intake",
+                channel_id=100,
+                user_id=42,
+                thread_id=None,
+                extra={
+                    "lifecycle_mode": "implementation",
+                    "active_research_roles": ["tech-lead", "backend-engineer"],
+                },
+                write_requested=True,
+            )
+            _maybe_post_intake_approval_card(
+                session=session,
+                prompt_text=_C5278A9043F2_PROMPT,
+                requested_by="42",
+            )
+
+        self.assertEqual(
+            len(captured["calls"]),
+            1,
+            f"session c5278a9043f2 repro: enqueue_github_work_approval 호출 누락 — "
+            f"카드가 #승인-대기 에 안 뜬다는 뜻",
+        )
+        kwargs = captured["calls"][0]
+        self.assertEqual(kwargs["session"].session_id, "sess-c5278a9043f2-repro")
+        self.assertEqual(kwargs["request_text"], _C5278A9043F2_PROMPT)
+        self.assertEqual(kwargs["requested_by"], "42")
+        # approval_worker 가 inject 됐는지 — None 이면 enqueue 가 본질상 의미 없음
+        self.assertIsNotNone(kwargs.get("approval_worker"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closes #175

## ✨ 과제 내용

session **c5278a9043f2** 의 라이브 스모크 실패를 직접 재현해서 닫는다.

### 실패 세션 재현
- session: c5278a9043f2
- repo: https://github.com/yule-studio/naver-search-clone.git
- 입력: `/engineer_intake` slash command, prompt 에 `approval_required, single_repo, full_stack_single_repo로 진행해줘 + Next.js + NestJS + PostgreSQL + Docker Compose 기반 회원가입/로그인/검색`, `task_type=blank`, `write_requested=true`
- 실제: task_type=qa-test / executor=qa-engineer / progress_notes=[] / coding_execute saved=0 / `#승인-대기` 카드 없음

### 닫은 3 갭
| 갭 | 원인 | Fix |
| --- | --- | --- |
| ① 분류 (qa-test/platform-infra 오분류) | `Dispatcher.classify` 가 stack_detector 안 씀 + `_KEYWORD_RULES` 의 `docker` 단독 매칭 | `Dispatcher.classify` 에 stack_detector 우선 분기 + `docker`/`k8s` 키워드 제거 (commit 1) |
| ② approval card 누락 (자유 텍스트 경로) | "approval_required, full_stack_single_repo" 같은 자연어가 어떤 phrase 와도 매칭 안 돼 gate 발동 못 함 + gate 가 발동해도 본문에만 게시 | `phrase_detect` + `_CODING_INTENT_PHRASES` 에 P0-T 토큰 추가 + `_run_coding_authorization_gate` 가 `approval_worker` 받으면 `enqueue_github_work_approval` 자동 호출 (commit 2) |
| ③ approval card 누락 (slash command 경로 — 실 재현 경로) | `/engineer_intake` 가 `Orchestrator.intake` 만 호출, 카드 게시 누락 | `_run_engineer_intake` 가 `write_requested=True` 시 `_maybe_post_intake_approval_card` 호출, production `ApprovalWorker` 빌드 후 `enqueue_github_work_approval` (commit 3) |

### 3 commit 구성
1. **🐞 Dispatcher.classify 가 stack_detector 사용** — qa-test/platform-infra 오분류 fix + 7 회귀
2. **🐞 채널 router: P0-T 토큰 인식 + approval card 자동 enqueue** — phrase 확장 + coding_gate hook + 7 회귀
3. **🐞 /engineer_intake 슬래시 경로도 approval card 자동 게시** — `_maybe_post_intake_approval_card` + 4 회귀 (session c5278a9043f2 명시 mention)

### 본 PR 후 사용자 경험

`/engineer_intake` 로 c5278a9043f2 동일 prompt 를 보내면:

```
1. task_type = full-stack-app          ← stack_detector 우선 분기
2. executor_role = backend-engineer    ← FULL_STACK_APP 매핑
3. session.extra: lifecycle_mode=implementation, active_research_roles 임시 stamp
4. enqueue_github_work_approval 호출 → ApprovalWorker.run_one
5. #승인-대기 카드 게시 (production env: build_production_post_fn 가 Discord REST 로 POST)
```

operator 가 카드 응답 (승인 1회) 후:
- `handle_github_work_approval_reply` → `dispatch_github_work_order` (PR #168)
- `GitHubWorkOrderWorker` → issue create + anchor stamp + `coding_dispatch_queued` (PR #168/#170)
- `iter_ready_coding_jobs` pick up → `CodingExecutorWorker` (PR #170/#174)
- `coding_in_progress` → branch validation → 7-step pipeline → `draft_pr_opened` (PR #174)

### 회귀
- 전체: **4914 pass / 1 skip** (직전 PR #174 의 4896 + 신규 18)
- 신규 18:
  - dispatcher classification (7) — `test_dispatcher_full_stack_classification.py`
  - channel router wiring (7) — `test_coding_gate_approval_card_wiring.py`
  - slash command (4) — `test_engineer_intake_slash_command.py` (session c5278a9043f2 명시 mention)
- 기존 dispatcher (26) / discord (1440) / engineering / governance 모두 통과

### 남은 명시적 deferred
1. **production env 에서 ApprovalWorker.run_one 의 실 Discord REST 호출 검증** — 본 PR 의 unit test 는 mock. live smoke 는 별 PR (env 의 `DISCORD_ENGINEERING_APPROVAL_CHANNEL_ID` / `ENGINEERING_AGENT_BOT_GATEWAY_TOKEN` 필요).
2. **slash command 측 progress 응답 surface** — 카드 게시 결과 (`approval_job_id`)를 slash 명령 응답에 노출하는 wiring.
3. **bot/_legacy.py 측 approval_worker forwarding** — 자유 텍스트 경로의 main router 호출자도 worker 를 inject 하도록 별 PR.

이 한계는 fake success 가 아니라 명시적 deferred — 본 PR 은 분류 + 인식 + helper wiring 까지 닫는다.

## 📚 레퍼런스
- session c5278a9043f2 (live smoke failure)
- `src/yule_orchestrator/agents/messaging/dispatcher.py` (classify + _KEYWORD_RULES)
- `src/yule_orchestrator/discord/engineering/phrase_detect.py` (P0-T 토큰)
- `src/yule_orchestrator/agents/job_queue/github_work_order.py` (_CODING_INTENT_PHRASES)
- `src/yule_orchestrator/discord/engineering_channel_router/coding_gate.py` (approval_worker hook)
- `src/yule_orchestrator/discord/commands/__init__.py` (`_maybe_post_intake_approval_card`)