### PR TITLE
🎚 P1-M: 세션 mode 영속 / backlog seeder / 한글 PR 제목 / non-greenfield blocker / recovery CLI

### DIFF
--- a/src/yule_orchestrator/agents/coding/coding_backlog_seed.py
+++ b/src/yule_orchestrator/agents/coding/coding_backlog_seed.py
@@ -1,0 +1,241 @@
+"""P1-M C — deterministic ``coding_backlog`` seeder.
+
+배경 — merge 후 자동 continuation 은 ``session.extra["coding_backlog"]``
+가 채워져 있어야 동작. 옛 intake 경로는 backlog 를 절대 만들지 않아서
+첫 merge 후 항상 session done 으로 마감됐다.
+
+본 모듈은 두 가지 시점에 호출된다:
+  * 새 intake (`/engineer_intake` slash 또는 채널 router) 직후
+  * 옛 session recovery 시 (operator CLI)
+
+backlog 가 이미 있으면 절대 덮어쓰지 않음 — idempotent. full-stack
+single-repo + greenfield 의도 (또는 naver-search-clone 같은 known canary)
+면 deterministic 8-slice 를 stamp. 그 외에는 빈 list 만 보장 (operator
+가 수동으로 채울 수도 있게).
+
+slice spec 포맷 (각 항목은 dict):
+  * ``title``       — 사람이 한눈에 보는 제목 (한국어)
+  * ``summary``     — 한 줄 요약
+  * ``area``        — auth / search / blog / mail / runtime / polish 등
+  * ``executor_role`` — backend-engineer | frontend-engineer | platform-engineer
+  * ``prompt``      — coding executor 에게 넘길 한국어 프롬프트
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence
+
+from ..lifecycle.session_mode import (
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_SINGLE,
+)
+
+
+EXTRA_CODING_BACKLOG: str = "coding_backlog"
+EXTRA_CODING_BACKLOG_SEEDED_BY: str = "coding_backlog_seeded_by"
+EXTRA_CODING_BACKLOG_SEEDED_AT: str = "coding_backlog_seeded_at"
+
+
+# canonical 8-slice plan for naver-search-clone 류 full-stack 검색 MVP.
+# 각 slice 는 1 commit / 1 PR 단위로 굴러갈 수 있도록 좁게 끊었다.
+FULL_STACK_SEARCH_MVP_PLAN: tuple = (
+    {
+        "title": "인증 백엔드 — 회원가입/로그인 API + 세션",
+        "summary": "auth backend: 회원가입/로그인/세션 + 비밀번호 해시",
+        "area": "auth",
+        "executor_role": "backend-engineer",
+        "prompt": (
+            "네이버 검색 풀스택 MVP 의 인증 백엔드를 구현해줘. "
+            "회원가입 / 로그인 API + 세션 (httpOnly cookie) + bcrypt 비밀번호 해시. "
+            "Next.js + NestJS + Postgres 스택 가정. "
+            "기존 scaffold 위에 services/auth 디렉터리에 추가."
+        ),
+    },
+    {
+        "title": "인증 프론트엔드 — 로그인/회원가입 화면 + 클라이언트 세션",
+        "summary": "auth frontend: 로그인/회원가입 form + 세션 hooks",
+        "area": "auth",
+        "executor_role": "frontend-engineer",
+        "prompt": (
+            "네이버 검색 풀스택 MVP 의 인증 프론트엔드를 구현해줘. "
+            "Next.js 페이지: /login, /signup. "
+            "useSession hook + form validation. "
+            "백엔드 API 와 fetch 연동."
+        ),
+    },
+    {
+        "title": "검색 홈 UI — 네이버 검색창 레퍼런스 (1:1 복제 금지)",
+        "summary": "search home: 검색창 + 자동완성 placeholder",
+        "area": "search",
+        "executor_role": "frontend-engineer",
+        "prompt": (
+            "검색 홈 화면을 구현해줘. 네이버 검색 홈을 강하게 참고하되 로고/"
+            "상표/문구의 1:1 복제는 피한다. 중앙 검색창 + 검색 버튼 + "
+            "최근 검색어 placeholder. /search 페이지로 라우팅."
+        ),
+    },
+    {
+        "title": "검색 결과 탭 + 통합 검색 API",
+        "summary": "search results: 통합/블로그/카페/이미지 탭 + API",
+        "area": "search",
+        "executor_role": "backend-engineer",
+        "prompt": (
+            "검색 결과 페이지와 통합 검색 API 를 구현해줘. /search?q=... "
+            "탭: 통합 / 블로그 / 카페 / 이미지. "
+            "백엔드 API: GET /api/search?q=&tab= → 모의 데이터 반환 (DB seed). "
+            "다음 slice 의 블로그/메일 모듈 데이터와 호환되는 schema."
+        ),
+    },
+    {
+        "title": "블로그 코어 — 글 작성/조회/검색 노출",
+        "summary": "blog core: 글 CRUD + 검색 결과 노출",
+        "area": "blog",
+        "executor_role": "backend-engineer",
+        "prompt": (
+            "블로그 코어 모듈을 구현해줘. 글 작성 / 조회 / 목록 / 단일 글. "
+            "프론트엔드: /blog, /blog/[id], /blog/write. "
+            "검색 결과 페이지의 '블로그' 탭이 본 모듈의 글을 노출하도록 연결."
+        ),
+    },
+    {
+        "title": "메일 코어 — 보낸 메일/받은 메일 + 작성",
+        "summary": "mail core: 받은 메일함 + 작성",
+        "area": "mail",
+        "executor_role": "backend-engineer",
+        "prompt": (
+            "메일 코어 모듈을 구현해줘. 받은 메일함 / 보낸 메일함 / 메일 작성. "
+            "API + 프론트엔드 /mail, /mail/compose. "
+            "인증된 사용자만 접근. 외부 SMTP 없이 내부 DB 만 사용 (MVP)."
+        ),
+    },
+    {
+        "title": "Docker / dev runtime 안정화",
+        "summary": "docker-compose up → 전체 스택 한 번에 기동",
+        "area": "runtime",
+        "executor_role": "platform-engineer",
+        "prompt": (
+            "docker-compose 와 dev runtime 안정화. "
+            "docker-compose up 한 번으로 Postgres / NestJS / Next.js 모두 기동. "
+            ".env.example 만 보존 (.env 는 hard-forbidden). "
+            "README 에 로컬 개발 실행 절차 추가."
+        ),
+    },
+    {
+        "title": "테스트 커버리지 + 폴리시",
+        "summary": "tests + polish: 핵심 흐름 회귀 + UX 다듬기",
+        "area": "polish",
+        "executor_role": "backend-engineer",
+        "prompt": (
+            "핵심 흐름 (인증 / 검색 / 블로그 / 메일) 회귀 테스트 추가. "
+            "프론트엔드 UX 작은 폴리시 (loading state, error toast). "
+            "마무리 PR."
+        ),
+    },
+)
+
+
+def detect_backlog_plan(
+    session_extra: Optional[Mapping[str, Any]],
+    *,
+    prompt: Optional[str] = None,
+) -> Sequence[Mapping[str, Any]]:
+    """session 상태에 맞는 deterministic backlog plan 반환.
+
+    full_stack_single_repo + 검색/포털 류 키워드 → FULL_STACK_SEARCH_MVP_PLAN.
+    그 외에는 빈 tuple (의도가 명확하지 않으면 backlog 생성 안 함).
+    """
+
+    extra = session_extra or {}
+    scope = str(extra.get(EXTRA_SCOPE) or "").strip()
+    topology = str(extra.get(EXTRA_TOPOLOGY) or "").strip()
+    text_lower = str(prompt or "").lower()
+
+    full_stack_signal = scope == SCOPE_FULL_STACK and topology == TOPOLOGY_SINGLE
+    search_signal = any(
+        token in text_lower
+        for token in (
+            "네이버", "naver", "검색", "search",
+            "포털", "portal", "blog", "블로그",
+        )
+    )
+
+    if full_stack_signal and search_signal:
+        return FULL_STACK_SEARCH_MVP_PLAN
+    return ()
+
+
+def seed_coding_backlog(
+    *,
+    session_id: Optional[str],
+    force: bool = False,
+    explicit_plan: Optional[Sequence[Mapping[str, Any]]] = None,
+    seeded_by: str = "intake",
+) -> Optional[Sequence[Mapping[str, Any]]]:
+    """session.extra 에 ``coding_backlog`` stamp — idempotent.
+
+    *force* 가 False (기본) 이면 backlog 가 이미 있고 비어있지 않으면 보존.
+    *explicit_plan* 을 주면 detect 무시. 그 외에는 ``detect_backlog_plan``.
+
+    Returns: stamp 된 backlog (없으면 None).
+    """
+
+    if not session_id:
+        return None
+
+    try:
+        from dataclasses import replace as _replace
+        from datetime import datetime, timezone
+        from ..workflow_state import load_session, update_session
+    except Exception:  # noqa: BLE001 - partial install
+        return None
+
+    try:
+        session = load_session(session_id)
+    except Exception:  # noqa: BLE001
+        return None
+    if session is None:
+        return None
+
+    extra = dict(getattr(session, "extra", None) or {})
+    existing = extra.get(EXTRA_CODING_BACKLOG)
+    if (
+        not force
+        and isinstance(existing, list)
+        and len(existing) > 0
+    ):
+        return tuple(existing)
+
+    if explicit_plan is not None:
+        plan = tuple(dict(item) for item in explicit_plan)
+    else:
+        prompt_text = str(getattr(session, "prompt", "") or "")
+        plan = tuple(dict(item) for item in detect_backlog_plan(extra, prompt=prompt_text))
+
+    if not plan:
+        # backlog 자체를 만들 의도가 없으면 stamp 도 하지 않음
+        return None
+
+    now_iso = datetime.now(tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    extra[EXTRA_CODING_BACKLOG] = [dict(item) for item in plan]
+    extra[EXTRA_CODING_BACKLOG_SEEDED_BY] = seeded_by
+    extra[EXTRA_CODING_BACKLOG_SEEDED_AT] = now_iso
+    try:
+        updated = _replace(session, extra=extra)
+        update_session(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        return None
+    return plan
+
+
+__all__ = (
+    "EXTRA_CODING_BACKLOG",
+    "EXTRA_CODING_BACKLOG_SEEDED_AT",
+    "EXTRA_CODING_BACKLOG_SEEDED_BY",
+    "FULL_STACK_SEARCH_MVP_PLAN",
+    "detect_backlog_plan",
+    "seed_coding_backlog",
+)

--- a/src/yule_orchestrator/agents/coding/human_titles.py
+++ b/src/yule_orchestrator/agents/coding/human_titles.py
@@ -1,0 +1,179 @@
+"""P1-M D — Issue / PR 제목 한국어 humanizer.
+
+배경 — 옛 wiring 은 PR 제목을 ``"📝 #3 coding-executor draft"`` 같이
+기계형으로 만들었다. 사람이 GitHub timeline 만 보면 무엇을 하는 PR 인지
+알 수 없다.
+
+본 모듈은 모든 issue / PR 제목을 **명확한 한국어 + 카테고리 prefix +
+slice 영역** 으로 만든다. 같은 helper 를 issue creator (work_order) /
+PR creator (coding executor) 가 공유.
+
+규칙
+  * Issue 제목: ``[기능] <세션 prompt 요약> — <slice 영역>``
+  * PR 제목:    ``[구현][<영역>] <slice title>``  (slice 가 있을 때)
+                 ``[구현] <세션 prompt 요약>``    (slice 없을 때)
+  * 100자 cap (GitHub UI truncation 방지) + 줄바꿈 제거.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+
+_TITLE_MAX_LEN: int = 100
+_AREA_LABEL: Mapping[str, str] = {
+    "auth": "인증",
+    "search": "검색",
+    "blog": "블로그",
+    "mail": "메일",
+    "runtime": "런타임",
+    "polish": "마무리",
+    "backend": "백엔드",
+    "frontend": "프론트엔드",
+    "platform": "플랫폼",
+}
+
+
+def _strip_to_summary(text: str, *, max_len: int = 60) -> str:
+    """프롬프트에서 첫 줄 + 한 문장 추출, 줄바꿈 / URL 제거."""
+
+    if not text:
+        return ""
+    first_line = text.strip().splitlines()[0].strip()
+    # URL / github 토큰 제거
+    first_line = re.sub(r"https?://\S+", "", first_line)
+    first_line = re.sub(r"github\.com\S+", "", first_line)
+    # 모드 토큰 제거 (autonomous_merge / approval_required / single_repo / full_stack_single_repo)
+    first_line = re.sub(
+        r"\b(autonomous_merge|approval_required|single_repo|multi_repo"
+        r"|full_stack_single_repo|single_scope|layer_scoped|cross_repo_program)\b",
+        "",
+        first_line,
+        flags=re.IGNORECASE,
+    )
+    # 첫 문장만
+    first_line = re.split(r"[.。!?\n]", first_line, maxsplit=1)[0]
+    cleaned = re.sub(r"\s+", " ", first_line).strip(" ,，·-")
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 1].rstrip() + "…"
+    return cleaned
+
+
+def _resolve_area(slice_spec: Optional[Mapping[str, Any]]) -> str:
+    if not slice_spec:
+        return ""
+    area = str(slice_spec.get("area") or "").strip().lower()
+    if area in _AREA_LABEL:
+        return _AREA_LABEL[area]
+    role = str(slice_spec.get("executor_role") or "").strip().lower()
+    if role.startswith("frontend"):
+        return _AREA_LABEL["frontend"]
+    if role.startswith("backend"):
+        return _AREA_LABEL["backend"]
+    if role.startswith("platform"):
+        return _AREA_LABEL["platform"]
+    return area or ""
+
+
+def build_issue_title(
+    *,
+    session_prompt: Optional[str],
+    slice_spec: Optional[Mapping[str, Any]] = None,
+    fallback_short_purpose: Optional[str] = None,
+) -> str:
+    """Issue 제목 — ``[기능] <요약> — <영역>`` 한국어.
+
+    slice_spec 이 있으면 slice 의 title 을 우선 사용.
+    """
+
+    if slice_spec:
+        title = str(slice_spec.get("title") or "").strip()
+        if title:
+            area = _resolve_area(slice_spec)
+            if area and area not in title:
+                composed = f"[기능][{area}] {title}"
+            else:
+                composed = f"[기능] {title}"
+            return composed[:_TITLE_MAX_LEN]
+
+    summary = _strip_to_summary(session_prompt or "")
+    if not summary:
+        summary = (fallback_short_purpose or "코딩 작업").strip()
+    return f"[기능] {summary}"[:_TITLE_MAX_LEN]
+
+
+def build_pr_title(
+    *,
+    session_prompt: Optional[str],
+    slice_spec: Optional[Mapping[str, Any]] = None,
+    branch_hint: Optional[str] = None,
+    issue_number: Optional[int] = None,
+    fallback_short_purpose: Optional[str] = None,
+) -> str:
+    """PR 제목 — ``[구현][영역] <slice title>`` 또는
+    ``[구현] <요약>`` (slice 없을 때).
+
+    issue_number 가 있으면 끝에 `(#N)` 추가 — GitHub 가 자동으로 PR 을
+    issue 에 link 하지만 시각 단서로도 노출.
+    """
+
+    if slice_spec:
+        slice_title = str(slice_spec.get("title") or "").strip()
+        if slice_title:
+            area = _resolve_area(slice_spec)
+            prefix = f"[구현][{area}]" if area else "[구현]"
+            base = f"{prefix} {slice_title}"
+            if issue_number:
+                base = f"{base} (#{int(issue_number)})"
+            return base[:_TITLE_MAX_LEN]
+
+    summary = _strip_to_summary(session_prompt or "")
+    if not summary:
+        summary = (fallback_short_purpose or "코딩 작업").strip()
+    if not summary and branch_hint:
+        summary = branch_hint.split("/")[-1]
+    base = f"[구현] {summary}"
+    if issue_number:
+        base = f"{base} (#{int(issue_number)})"
+    return base[:_TITLE_MAX_LEN]
+
+
+def build_pr_body_intro(
+    *,
+    session_id: Optional[str],
+    repo_full_name: Optional[str],
+    work_mode: Optional[str],
+    slice_spec: Optional[Mapping[str, Any]] = None,
+    branch: Optional[str] = None,
+    backlog_remaining: Optional[int] = None,
+) -> str:
+    """PR body 상단의 한국어 메타 블록 — operator 가 첫 눈에 단계/모드 파악."""
+
+    lines = ["## 🧭 현재 단계", ""]
+    if slice_spec:
+        lines.append(f"- slice: **{slice_spec.get('title') or '(no title)'}**")
+        if slice_spec.get("summary"):
+            lines.append(f"- 요약: {slice_spec.get('summary')}")
+        area = _resolve_area(slice_spec)
+        if area:
+            lines.append(f"- 영역: {area}")
+    if session_id:
+        lines.append(f"- session_id: `{session_id}`")
+    if repo_full_name:
+        lines.append(f"- repo: `{repo_full_name}`")
+    if work_mode:
+        lines.append(f"- work_mode: `{work_mode}`")
+    if branch:
+        lines.append(f"- branch: `{branch}`")
+    if backlog_remaining is not None:
+        lines.append(f"- 남은 slice: **{int(backlog_remaining)} 개**")
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = (
+    "build_issue_title",
+    "build_pr_body_intro",
+    "build_pr_title",
+)

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
@@ -584,6 +584,27 @@ def build_coding_execute_request(
         list(coding_job.get("review_roles") or ()),
     )
 
+    # P1-M D — slice_spec + session_prompt + work_mode 도 forward 해서
+    # PR 생성 단계의 한국어 humanizer 가 사용. slice_spec 은 backlog 의
+    # 첫 항목 또는 coding_job 자체의 spec.
+    session_extra_meta = getattr(ready.session, "extra", None) or {}
+    if isinstance(session_extra_meta, Mapping):
+        slice_spec = (
+            coding_job.get("slice_spec")
+            if isinstance(coding_job, Mapping)
+            else None
+        )
+        if slice_spec is None:
+            slice_spec = session_extra_meta.get("current_coding_slice")
+        if isinstance(slice_spec, Mapping):
+            forwarded_metadata["slice_spec"] = dict(slice_spec)
+        prompt_for_title = str(getattr(ready.session, "prompt", "") or "")
+        if prompt_for_title:
+            forwarded_metadata["session_prompt"] = prompt_for_title
+        work_mode_val = session_extra_meta.get("work_mode")
+        if work_mode_val:
+            forwarded_metadata["work_mode"] = str(work_mode_val)
+
     return CodingExecuteRequest(
         session_id=ready.session_id,
         executor_role=ready.executor_role(),

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -510,6 +510,43 @@ class RecordOnlyCodeEditor:
 # P1-H — env-gated greenfield bootstrap.
 ENV_GREENFIELD_BOOTSTRAP_ENABLED: str = "YULE_CODING_EXECUTOR_GREENFIELD_BOOTSTRAP_ENABLED"
 
+# P1-M F — env-gated 정직한 blocker. 옛 wiring 은 non-greenfield 에
+# RecordOnlyCodeEditor 가 plan markdown 만 commit 하면 planning-only PR
+# 이 진짜 구현 PR 처럼 production main 까지 흘러갔다. 본 env 가 truthy
+# 면 worker 가 ``REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE`` 로 blocker
+# 노출 — operator 가 live editor wiring 한 뒤에야 다음 slice 굴러간다.
+ENV_PLANNING_ONLY_PR_FORBIDDEN: str = (
+    "YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN"
+)
+
+
+def _planning_only_pr_forbidden(
+    env: Optional[Mapping[str, str]] = None,
+) -> bool:
+    import os as _os
+
+    src = env if env is not None else _os.environ
+    return (src.get(ENV_PLANNING_ONLY_PR_FORBIDDEN) or "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+class NonGreenfieldRealEditUnavailable(RuntimeError):
+    """non-greenfield repo + record-only editor + env opt-in 시 raise.
+
+    worker 가 ``REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE`` 로 매핑.
+    """
+
+    def __init__(self, *, repo_full_name: Optional[str], worktree_path: str) -> None:
+        super().__init__(
+            f"non-greenfield repo {repo_full_name!r} requires real-edit "
+            f"capability. Set YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN=0 "
+            f"to allow planning-only PR (NOT recommended) OR wire a real LLM "
+            f"editor. worktree={worktree_path}"
+        )
+        self.repo_full_name = repo_full_name
+        self.worktree_path = worktree_path
+
 
 def _greenfield_bootstrap_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
     import os as _os
@@ -585,8 +622,23 @@ class GreenfieldBootstrapEditor:
             self.is_bootstrap_capable,
         )
         if mode is None:
-            # Not a greenfield case — keep ordinary record-only behaviour.
-            # Stamp audit so operator sees WHY scaffold didn't run.
+            # Not a greenfield case.
+            # P1-M F — env gate: planning-only PR 가 production main 까지
+            # 흘러가는 사고를 막기 위해 truthy 면 raise → worker 가
+            # ``REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE`` blocker stamp.
+            if _planning_only_pr_forbidden(self._env):
+                logger.warning(
+                    "GreenfieldBootstrapEditor.apply: non-greenfield repo "
+                    "blocked by ENV_PLANNING_ONLY_PR_FORBIDDEN — repo=%s "
+                    "worktree=%s",
+                    request.repo_full_name,
+                    context.worktree_path,
+                )
+                raise NonGreenfieldRealEditUnavailable(
+                    repo_full_name=request.repo_full_name,
+                    worktree_path=context.worktree_path,
+                )
+            # otherwise — record-only delegation 보존 (옛 동작).
             new_metadata = dict(context.metadata or {})
             new_metadata["bootstrap_apply"] = {
                 "mode": None,
@@ -598,6 +650,9 @@ class GreenfieldBootstrapEditor:
                 "worktree_path": context.worktree_path,
                 "repo_full_name": request.repo_full_name,
                 "bootstrap_enabled": self.is_bootstrap_capable,
+                "planning_only_pr_forbidden": _planning_only_pr_forbidden(
+                    self._env
+                ),
             }
             from dataclasses import replace as _replace
 
@@ -1068,11 +1123,34 @@ class GithubAppDraftPRCreator:
         repo = request.repo_full_name
         if not repo:
             raise ValueError("GithubAppDraftPRCreator requires repo_full_name")
-        title = (
-            f"📝 #{request.issue_number} coding-executor draft"
-            if request.issue_number
-            else f"📝 coding-executor draft — {context.branch}"
-        )
+        # P1-M D — 한국어 humanizer 가 slice/세션 정보로 명확한 제목 생성.
+        # slice_spec / session_prompt 는 dispatcher 가 request.metadata 에 stamp.
+        try:
+            from ..coding.human_titles import build_pr_title
+
+            metadata = request.metadata or {}
+            slice_spec = (
+                metadata.get("slice_spec")
+                if isinstance(metadata, Mapping)
+                else None
+            )
+            session_prompt = (
+                metadata.get("session_prompt")
+                if isinstance(metadata, Mapping)
+                else None
+            )
+            title = build_pr_title(
+                session_prompt=str(session_prompt or request.user_request or ""),
+                slice_spec=slice_spec if isinstance(slice_spec, Mapping) else None,
+                branch_hint=context.branch,
+                issue_number=request.issue_number,
+            )
+        except Exception:  # noqa: BLE001 — never block PR on title helper
+            title = (
+                f"📝 #{request.issue_number} coding-executor draft"
+                if request.issue_number
+                else f"📝 coding-executor draft — {context.branch}"
+            )
         body = _draft_pr_body(request, context)
 
         # P0-T: runtime governance policy gate — PR body 가 5 섹션 +

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
@@ -98,6 +98,12 @@ REASON_WORKTREE_FAILED: str = "worktree_provision_failed"
 # editor capability 정보까지 포함 (e.g.
 # ``bootstrap_required:empty_or_greenfield_repo+editor_record_only_insufficient``).
 REASON_BOOTSTRAP_REQUIRED: str = "bootstrap_required"
+# P1-M F — non-greenfield + record-only editor + ``YULE_CODING_EXECUTOR_
+# PLANNING_ONLY_PR_FORBIDDEN=1`` 일 때. planning-only PR 가 production 까지
+# 반복되는 회귀를 차단하기 위한 honest blocker.
+REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE: str = (
+    "non_greenfield_real_edit_unavailable"
+)
 
 
 _PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
@@ -649,6 +655,29 @@ class CodingExecutorWorker:
                         reason=f"{REASON_BOOTSTRAP_REQUIRED}:{sub_reason}",
                         branch=branch,
                     )
+                if exc_name == "NonGreenfieldRealEditUnavailable":
+                    # P1-M F — planning-only PR 가 production main 까지
+                    # 흘러가는 사고 차단. live editor wiring 전까지는 다음
+                    # slice 가 굴러가지 않는다.
+                    self._stamp_progress(
+                        session_id=request.session_id,
+                        marker=PROGRESS_CODING_BLOCKED,
+                        detail={
+                            "job_id": in_progress.job_id,
+                            "reason": REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE,
+                            "branch": branch,
+                            "repo_full_name": request.repo_full_name,
+                            "worktree_path": getattr(exc, "worktree_path", ""),
+                            "code_editor": type(self._editor).__name__,
+                            "detail": _short(exc),
+                        },
+                    )
+                    return self._fail(
+                        in_progress,
+                        terminal=True,
+                        reason=REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE,
+                        branch=branch,
+                    )
                 if exc_name == "BootstrapApplyFailed":
                     # P1-J: BootstrapApplyFailed.sub_reason is one of
                     # ``scaffold_apply_failed`` (disk/perm) or
@@ -1152,6 +1181,7 @@ __all__ = (
     "REASON_PR_FAILED",
     "REASON_PROTECTED_BRANCH",
     "REASON_BOOTSTRAP_REQUIRED",
+    "REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE",
     "REASON_PUSH_FAILED",
     "REASON_TARGET_REPO_MISSING",
     "REASON_TEST_FAILED",

--- a/src/yule_orchestrator/agents/lifecycle/session_recovery.py
+++ b/src/yule_orchestrator/agents/lifecycle/session_recovery.py
@@ -1,0 +1,237 @@
+"""P1-M E — Session recovery 일반화 (특정 session 한정 패치 금지).
+
+특정 사고 session (canonical: ``fe5eedc65196``, ``11917bf1e75d``) 만 살리는
+hard-coded 해킹 대신, **모든 session 에 동일하게 동작하는** recovery
+함수를 제공.
+
+회복 항목:
+  1. ``work_mode`` / ``topology`` / ``scope`` / ``mode_decided_*``
+     — session.prompt 에서 explicit 토큰 재파싱.
+  2. ``coding_backlog`` — full-stack-single-repo + 검색 류 의도면
+     deterministic 8-slice seeding (idempotent).
+  3. ``pr_merge_*`` — operator 가 PR 메타 (repo / number / head_sha) 를
+     hint 로 주면 stamp. (안 주면 그대로 두고 audit 만 남김.)
+
+CLI (operator 가 한 줄로 실행):
+
+  python3 -m yule_orchestrator.cli.recover_session <session_id> \\
+       [--mode autonomous_merge|approval_required] \\
+       [--pr-number N --pr-url URL --head-sha SHA --repo owner/name]
+
+코드 SSoT — 본 모듈. recover_session_full 이 main entry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, List, Mapping, Optional
+
+from ..coding.coding_backlog_seed import (
+    EXTRA_CODING_BACKLOG,
+    seed_coding_backlog,
+)
+from .session_mode import (
+    EXTRA_DECIDED_AT,
+    EXTRA_DECIDED_BY,
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    SCOPE_DEFAULT,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_DEFAULT,
+    TOPOLOGY_SINGLE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+    WORK_MODE_DEFAULT,
+    DECIDED_BY_USER,
+    parse_mode_hints,
+)
+
+
+@dataclass(frozen=True)
+class RecoveryReport:
+    """recover_session_full 의 결과 — operator 가 한눈에 본다."""
+
+    session_id: str
+    found: bool = False
+    mode_persisted: bool = False
+    backlog_seeded_count: int = 0
+    pr_merge_stamped: bool = False
+    notes: tuple = field(default_factory=tuple)
+    work_mode: Optional[str] = None
+    topology: Optional[str] = None
+    scope: Optional[str] = None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def recover_session_full(
+    *,
+    session_id: str,
+    explicit_work_mode: Optional[str] = None,
+    explicit_topology: Optional[str] = None,
+    explicit_scope: Optional[str] = None,
+    pr_number: Optional[int] = None,
+    pr_url: Optional[str] = None,
+    head_sha: Optional[str] = None,
+    repo_full_name: Optional[str] = None,
+    base_branch: str = "main",
+) -> RecoveryReport:
+    """session.extra 를 새 wiring 호환 상태로 회복.
+
+    parse_mode_hints 를 session.prompt 에 실행 → explicit 토큰 추출.
+    explicit_* 인자 가 주어지면 그것이 우선. backlog 는
+    ``seed_coding_backlog`` (idempotent). PR 메타가 인자로 주어지면
+    pr_merge_stage = pr_merge_pending 으로 stamp.
+    """
+
+    try:
+        from dataclasses import replace as _replace
+        from ..workflow_state import load_session, update_session
+    except Exception:  # noqa: BLE001 - partial install
+        return RecoveryReport(
+            session_id=session_id, notes=("workflow_state import 실패",)
+        )
+
+    try:
+        session = load_session(session_id)
+    except Exception:  # noqa: BLE001
+        return RecoveryReport(
+            session_id=session_id, notes=("load_session raised",)
+        )
+    if session is None:
+        return RecoveryReport(
+            session_id=session_id, notes=("session not found",)
+        )
+
+    notes: List[str] = []
+    extra = dict(getattr(session, "extra", None) or {})
+    prompt = str(getattr(session, "prompt", "") or "")
+
+    # 1. work_mode / topology / scope 영속화 — explicit 인자 > prompt 파싱 > 기존값
+    hints = parse_mode_hints(prompt)
+
+    final_work_mode = (
+        explicit_work_mode
+        or hints.get("work_mode")
+        or extra.get(EXTRA_WORK_MODE)
+    )
+    final_topology = (
+        explicit_topology
+        or hints.get("topology")
+        or extra.get(EXTRA_TOPOLOGY)
+    )
+    final_scope = (
+        explicit_scope
+        or hints.get("scope")
+        or extra.get(EXTRA_SCOPE)
+    )
+
+    # explicit 또는 prompt 가 뭔가 알려줬으면 기록 (자동 default 로 빠지지
+    # 않게).  prompt 도 비어있으면 기존 값 보존 (덮어쓰기 금지).
+    new_extra = dict(extra)
+    mode_changed = False
+    if final_work_mode and final_work_mode != extra.get(EXTRA_WORK_MODE):
+        new_extra[EXTRA_WORK_MODE] = final_work_mode
+        mode_changed = True
+    if final_topology and final_topology != extra.get(EXTRA_TOPOLOGY):
+        new_extra[EXTRA_TOPOLOGY] = final_topology
+        mode_changed = True
+    if final_scope and final_scope != extra.get(EXTRA_SCOPE):
+        new_extra[EXTRA_SCOPE] = final_scope
+        mode_changed = True
+    if mode_changed:
+        new_extra[EXTRA_DECIDED_BY] = DECIDED_BY_USER
+        new_extra[EXTRA_DECIDED_AT] = _now_iso()
+        notes.append(
+            f"mode persist 보정 → work_mode={final_work_mode} "
+            f"topology={final_topology} scope={final_scope}"
+        )
+    else:
+        notes.append("mode 키 변경 없음 (이미 영속됨 또는 단서 부족)")
+
+    # 2. PR 메타 stamp — operator 가 hint 로 줬을 때만
+    pr_merge_stamped = False
+    if pr_number and pr_url and repo_full_name:
+        from ..job_queue.pr_merge_continuation import (
+            EXTRA_PR_MERGE_BASE_BRANCH,
+            EXTRA_PR_MERGE_DECIDED_AT,
+            EXTRA_PR_MERGE_HEAD_SHA,
+            EXTRA_PR_MERGE_PR_NUMBER,
+            EXTRA_PR_MERGE_PR_URL,
+            EXTRA_PR_MERGE_REASON,
+            EXTRA_PR_MERGE_REPO,
+            EXTRA_PR_MERGE_STAGE,
+            STAGE_PR_MERGE_PENDING,
+        )
+
+        new_extra[EXTRA_PR_MERGE_STAGE] = STAGE_PR_MERGE_PENDING
+        new_extra[EXTRA_PR_MERGE_PR_NUMBER] = int(pr_number)
+        new_extra[EXTRA_PR_MERGE_PR_URL] = str(pr_url)
+        new_extra[EXTRA_PR_MERGE_REPO] = str(repo_full_name)
+        new_extra[EXTRA_PR_MERGE_HEAD_SHA] = str(head_sha or "")
+        new_extra[EXTRA_PR_MERGE_BASE_BRANCH] = str(base_branch or "main")
+        new_extra[EXTRA_PR_MERGE_DECIDED_AT] = _now_iso()
+        new_extra[EXTRA_PR_MERGE_REASON] = (
+            f"recovered_for_{final_work_mode or WORK_MODE_DEFAULT}"
+        )
+        pr_merge_stamped = True
+        notes.append(f"pr_merge 메타 stamp 완료 (PR #{int(pr_number)})")
+
+    # 3. workflow_state persist (mode + pr_merge meta)
+    try:
+        updated = _replace(session, extra=new_extra)
+        update_session(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        notes.append("update_session 저장 실패")
+        return RecoveryReport(
+            session_id=session_id,
+            found=True,
+            mode_persisted=False,
+            pr_merge_stamped=False,
+            notes=tuple(notes),
+        )
+
+    # 4. coding_backlog seed (idempotent)
+    seeded = seed_coding_backlog(
+        session_id=session_id, seeded_by="recovery_cli"
+    )
+    seeded_count = len(seeded) if seeded else 0
+    if seeded_count > 0:
+        notes.append(f"coding_backlog {seeded_count} slice seed 완료")
+    else:
+        existing = new_extra.get(EXTRA_CODING_BACKLOG) or ()
+        if existing:
+            notes.append(
+                f"coding_backlog 이미 {len(existing)} slice — 보존"
+            )
+        else:
+            notes.append(
+                "coding_backlog seeding 안 함 (의도 detect 실패 — "
+                "operator 가 직접 채우거나 prompt 보강 필요)"
+            )
+
+    return RecoveryReport(
+        session_id=session_id,
+        found=True,
+        mode_persisted=mode_changed
+        or any(
+            new_extra.get(key)
+            for key in (EXTRA_WORK_MODE, EXTRA_TOPOLOGY, EXTRA_SCOPE)
+        ),
+        backlog_seeded_count=seeded_count,
+        pr_merge_stamped=pr_merge_stamped,
+        notes=tuple(notes),
+        work_mode=new_extra.get(EXTRA_WORK_MODE),
+        topology=new_extra.get(EXTRA_TOPOLOGY),
+        scope=new_extra.get(EXTRA_SCOPE),
+    )
+
+
+__all__ = (
+    "RecoveryReport",
+    "recover_session_full",
+)

--- a/src/yule_orchestrator/cli/recover_session.py
+++ b/src/yule_orchestrator/cli/recover_session.py
@@ -1,0 +1,104 @@
+"""P1-M E — `python3 -m yule_orchestrator.cli.recover_session <id>` CLI.
+
+특정 session 한정 해킹 금지 — 모든 session 에 동일하게 동작하는
+``recover_session_full`` 를 호출하는 얇은 wrapper.
+
+사용 예시:
+
+  # mode 만 prompt 에서 재파싱 + backlog seed
+  python3 -m yule_orchestrator.cli.recover_session fe5eedc65196
+
+  # mode + pr_merge 메타 같이 stamp (operator 가 PR 정보를 알 때)
+  python3 -m yule_orchestrator.cli.recover_session fe5eedc65196 \\
+      --mode autonomous_merge \\
+      --pr-number 4 \\
+      --pr-url https://github.com/yule-studio/naver-search-clone/pull/4 \\
+      --head-sha abc1234 \\
+      --repo yule-studio/naver-search-clone
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="yule-recover-session",
+        description=(
+            "Recover a session.extra to the latest wiring shape — re-parse "
+            "mode tokens from prompt, seed coding_backlog, optionally stamp "
+            "pr_merge_* metadata. Idempotent."
+        ),
+    )
+    p.add_argument("session_id", help="target session id")
+    p.add_argument(
+        "--mode",
+        choices=("autonomous_merge", "approval_required"),
+        default=None,
+        help="explicit work_mode override (prompt parse 결과 무시)",
+    )
+    p.add_argument(
+        "--topology",
+        choices=("single_repo", "multi_repo"),
+        default=None,
+    )
+    p.add_argument(
+        "--scope",
+        choices=(
+            "single_scope",
+            "full_stack_single_repo",
+            "layer_scoped",
+            "cross_repo_program",
+        ),
+        default=None,
+    )
+    p.add_argument("--pr-number", type=int, default=None)
+    p.add_argument("--pr-url", default=None)
+    p.add_argument("--head-sha", default=None)
+    p.add_argument("--repo", dest="repo_full_name", default=None)
+    p.add_argument("--base-branch", default="main")
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(list(argv) if argv is not None else None)
+
+    from ..agents.lifecycle.session_recovery import recover_session_full
+
+    report = recover_session_full(
+        session_id=args.session_id,
+        explicit_work_mode=args.mode,
+        explicit_topology=args.topology,
+        explicit_scope=args.scope,
+        pr_number=args.pr_number,
+        pr_url=args.pr_url,
+        head_sha=args.head_sha,
+        repo_full_name=args.repo_full_name,
+        base_branch=args.base_branch,
+    )
+
+    print(f"session_id: {report.session_id}")
+    print(f"found: {report.found}")
+    if report.found:
+        print(f"work_mode: {report.work_mode}")
+        print(f"topology: {report.topology}")
+        print(f"scope: {report.scope}")
+        print(f"mode_persisted: {report.mode_persisted}")
+        print(f"backlog_seeded_count: {report.backlog_seeded_count}")
+        print(f"pr_merge_stamped: {report.pr_merge_stamped}")
+        print("notes:")
+        for note in report.notes:
+            print(f"  - {note}")
+        return 0
+    else:
+        print("notes:")
+        for note in report.notes:
+            print(f"  - {note}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -725,6 +725,24 @@ def _run_engineer_intake(
         user_id=user_id,
     )
 
+    # P1-M A — slash command path 도 session.extra 에 work_mode /
+    # topology / scope / mode_decided_* 를 영속해야 한다. 옛 wiring 은
+    # 채널 router path 만 ``prepare_coding_session_context`` 를 거쳤기
+    # 때문에 `/engineer_intake` 슬래시 세션은 work_mode=None 으로 떨어졌고,
+    # background pr_merge_continuation_loop 가 approval_required 로 fallback
+    # 됐다 (회귀: session fe5eedc65196).
+    try:
+        _persist_intake_mode_and_backlog(
+            session=result.session, prompt_text=prompt
+        )
+    except Exception:  # noqa: BLE001 - never block intake response
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "engineer_intake: mode/backlog 영속화 실패 — 본문 응답은 그대로 진행",
+            exc_info=True,
+        )
+
     # P0-T smoke fix (session c5278a9043f2 repro):
     # /engineer_intake 슬래시 명령이 issue-less full-stack coding 요청을
     # 받았을 때 본문 응답만 게시하고 `#승인-대기` 카드는 누락되던 회귀
@@ -747,6 +765,42 @@ def _run_engineer_intake(
                 exc_info=True,
             )
     return result
+
+
+def _persist_intake_mode_and_backlog(
+    *, session: Any, prompt_text: str
+) -> None:
+    """P1-M — slash command intake 직후 mode/backlog 영속화.
+
+    1. ``prepare_coding_session_context`` 로 work_mode/topology/scope
+       /mode_decided_* 계산 후 session.extra 머지.
+    2. full_stack_single_repo 의도면 ``seed_coding_backlog`` 호출해
+       backlog 8 개 slice 를 stamp (이미 있으면 보존).
+    """
+
+    if session is None:
+        return
+    try:
+        from ..engineering_channel_router.session_persistence import (
+            _persist_coding_session_context,
+        )
+    except Exception:  # noqa: BLE001 - partial install
+        return
+
+    refs = list(getattr(session, "references_user", None) or ())
+    user_links = tuple(str(r) for r in refs)
+    _persist_coding_session_context(
+        session,
+        message_text=prompt_text or "",
+        user_links=user_links,
+    )
+
+    try:
+        from ...agents.coding.coding_backlog_seed import seed_coding_backlog
+
+        seed_coding_backlog(session_id=getattr(session, "session_id", None))
+    except Exception:  # noqa: BLE001
+        return
 
 
 def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:

--- a/src/yule_orchestrator/runtime/coding_executor_runner.py
+++ b/src/yule_orchestrator/runtime/coding_executor_runner.py
@@ -504,29 +504,53 @@ def _maybe_build_live_pr_merge_executor():
 def _maybe_build_approval_enqueuer():
     """approval_required mode 에서 카드 게시용 ApprovalEnqueuer.
 
-    ApprovalWorker 가 활성화되어야만 동작. 없으면 None — 사용자에게
-    카드 게시 없이 stage 가 그대로 유지된다 (operator 가 보이는 진단:
-    ``no_approval_worker_wired`` action).
+    P1-M B 회귀 수정 — ``ApprovalWorker`` 가 ``post_fn`` + ``channel_resolver``
+    를 필수로 받는다. 옛 wiring 은 두 인자 모두 생략해 TypeError → silent
+    None 으로 떨어졌고 startup log 가 ``approval_enqueuer=no`` 로 나왔다.
+    본 helper 는 ``run_service`` 의 production wiring 과 동일하게
+    ``build_production_post_fn`` + ``build_approval_channel_resolver`` 를
+    재사용한다.
+
+    Discord/runtime 의존성이 빠진 env 에서는 두 헬퍼 중 하나가 raise →
+    None 반환 + log warning 으로 운영자에게 실패 사유 노출.
     """
 
     try:
         from ..agents.job_queue.approval_worker import ApprovalWorker
+        from ..agents.job_queue.approval_discord_poster import (
+            build_approval_channel_resolver,
+            build_production_post_fn,
+        )
         from ..agents.job_queue.heartbeat import HeartbeatStore
         from ..agents.job_queue.store import JobQueue
         from ..discord.integrations.pr_merge_adapter import (
             enqueue_pr_merge_approval,
         )
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "pr_merge_continuation: ApprovalEnqueuer build skipped "
+            "(imports unavailable)",
+            exc_info=True,
+        )
         return None
 
     queue = JobQueue()
     heartbeats = HeartbeatStore()
     try:
+        production_post_fn = build_production_post_fn()
+        channel_resolver = build_approval_channel_resolver()
         approval_worker = ApprovalWorker(
             queue=queue,
             heartbeats=heartbeats,
+            post_fn=production_post_fn,
+            channel_resolver=channel_resolver,
         )
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "pr_merge_continuation: ApprovalEnqueuer build skipped "
+            "(post_fn/channel_resolver/ApprovalWorker init failed)",
+            exc_info=True,
+        )
         return None
 
     async def _enqueue(*, session, proposal, **kwargs):

--- a/tests/agents/test_p1m_session_recovery_and_intake.py
+++ b/tests/agents/test_p1m_session_recovery_and_intake.py
@@ -1,0 +1,547 @@
+"""P1-M — 14 사용자 명시 acceptance.
+
+1.  현재 세션 recovery 시 mode/topology/scope 가 복구
+2.  현재 세션 recovery 시 coding_backlog 가 생성
+3.  현재 세션 recovery 후 PR #4 또는 후속 구현 PR 흐름이 실제 구현 경로
+4.  새 intake (autonomous_merge) persists mode/topology/scope
+5.  새 intake (approval_required) persists mode/topology/scope
+6.  새 intake + recovery 둘 다 seed coding_backlog
+7.  approval_required path 가 real pr_merge approval card 게시 (wiring 확인)
+8.  approval reply 가 real merge path 로 라우팅 (wiring 확인)
+9.  autonomous_merge path 가 real merge executor wiring 보유
+10. non-greenfield repo 가 더 이상 silent planning-only PR 로 빠지지 않음
+11. issue title 이 한국어 humanizer 거침
+12. PR title 이 한국어 humanizer 거침
+13. blocker 가 남았을 때 misleading "다음 tick" 메시지 제거
+14. duplicate branch replay / planning PR 가드
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from dataclasses import replace as _replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from unittest.mock import patch
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.coding.coding_backlog_seed import (
+    EXTRA_CODING_BACKLOG,
+    FULL_STACK_SEARCH_MVP_PLAN,
+    detect_backlog_plan,
+    seed_coding_backlog,
+)
+from yule_orchestrator.agents.coding.human_titles import (
+    build_issue_title,
+    build_pr_body_intro,
+    build_pr_title,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    ENV_PLANNING_ONLY_PR_FORBIDDEN,
+    GreenfieldBootstrapEditor,
+    NonGreenfieldRealEditUnavailable,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE,
+    WorktreeContext,
+)
+from yule_orchestrator.agents.lifecycle.session_mode import (
+    EXTRA_DECIDED_AT,
+    EXTRA_DECIDED_BY,
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_SINGLE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+    DECIDED_BY_USER,
+)
+from yule_orchestrator.agents.lifecycle.session_recovery import (
+    recover_session_full,
+)
+from yule_orchestrator.agents.workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    save_session,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _seed(session_id: str, *, prompt: str, extra: Mapping[str, Any]) -> WorkflowSession:
+    s = WorkflowSession(
+        session_id=session_id,
+        prompt=prompt,
+        task_type="coding_execute",
+        state=WorkflowState.IN_PROGRESS,
+        created_at=_now(),
+        updated_at=_now(),
+        executor_role="backend-engineer",
+        extra=dict(extra),
+    )
+    save_session(s)
+    return s
+
+
+_PROMPT_AUTONOMOUS = (
+    "autonomous_merge, single_repo, full_stack_single_repo "
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+_PROMPT_APPROVAL = (
+    "approval_required, single_repo, full_stack_single_repo "
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+
+
+class _CacheTmpFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2 — 현재 세션 recovery
+# ---------------------------------------------------------------------------
+
+
+class CurrentSessionRecoveryTests(_CacheTmpFixture):
+    def test_recovery_re_parses_mode_from_prompt(self) -> None:
+        # canonical 회귀 shape — work_mode=None 인데 PR 메타만 stamp 된 상태.
+        _seed(
+            "fe5eedc65196",
+            prompt=_PROMPT_AUTONOMOUS,
+            extra={
+                "pr_merge_stage": "pr_merge_pending",
+                "pr_merge_pr_number": 4,
+            },
+        )
+        report = recover_session_full(session_id="fe5eedc65196")
+        self.assertTrue(report.found)
+        self.assertEqual(report.work_mode, WORK_MODE_AUTONOMOUS)
+        self.assertEqual(report.topology, TOPOLOGY_SINGLE)
+        self.assertEqual(report.scope, SCOPE_FULL_STACK)
+        # workflow_state 에도 영속됨
+        fresh = load_session("fe5eedc65196")
+        self.assertEqual(fresh.extra[EXTRA_WORK_MODE], WORK_MODE_AUTONOMOUS)
+        self.assertEqual(fresh.extra[EXTRA_DECIDED_BY], DECIDED_BY_USER)
+        self.assertIn(EXTRA_DECIDED_AT, fresh.extra)
+
+    def test_recovery_seeds_coding_backlog(self) -> None:
+        _seed(
+            "rec-backlog",
+            prompt=_PROMPT_AUTONOMOUS,
+            extra={},
+        )
+        report = recover_session_full(session_id="rec-backlog")
+        # full_stack + 네이버 검색 키워드 → 8 slice
+        self.assertEqual(report.backlog_seeded_count, 8)
+        fresh = load_session("rec-backlog")
+        self.assertEqual(len(fresh.extra[EXTRA_CODING_BACKLOG]), 8)
+
+    def test_recovery_stamps_pr_merge_when_operator_hint_given(self) -> None:
+        _seed(
+            "rec-pr",
+            prompt=_PROMPT_AUTONOMOUS,
+            extra={},
+        )
+        report = recover_session_full(
+            session_id="rec-pr",
+            pr_number=4,
+            pr_url="https://github.com/yule-studio/naver-search-clone/pull/4",
+            head_sha="sha4",
+            repo_full_name="yule-studio/naver-search-clone",
+        )
+        self.assertTrue(report.pr_merge_stamped)
+        fresh = load_session("rec-pr")
+        self.assertEqual(fresh.extra["pr_merge_stage"], "pr_merge_pending")
+        self.assertEqual(fresh.extra["pr_merge_pr_number"], 4)
+        self.assertEqual(
+            fresh.extra["pr_merge_repo"], "yule-studio/naver-search-clone"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4, 5, 6 — 새 intake 일반 경로 + backlog seed
+# ---------------------------------------------------------------------------
+
+
+class NewIntakeModePersistenceTests(_CacheTmpFixture):
+    def test_explicit_autonomous_merge_persists(self) -> None:
+        from yule_orchestrator.agents.coding.coding_session_context import (
+            prepare_coding_session_context,
+        )
+
+        ctx = prepare_coding_session_context(
+            message_text=_PROMPT_AUTONOMOUS,
+            user_links=("https://github.com/yule-studio/naver-search-clone",),
+            existing_extra={},
+            discover_contract=False,
+        )
+        self.assertEqual(ctx.session_mode.work_mode, WORK_MODE_AUTONOMOUS)
+        self.assertEqual(ctx.session_mode.topology, TOPOLOGY_SINGLE)
+        self.assertEqual(ctx.session_mode.scope, SCOPE_FULL_STACK)
+        self.assertEqual(
+            ctx.extras_update[EXTRA_WORK_MODE], WORK_MODE_AUTONOMOUS
+        )
+
+    def test_explicit_approval_required_persists(self) -> None:
+        from yule_orchestrator.agents.coding.coding_session_context import (
+            prepare_coding_session_context,
+        )
+
+        ctx = prepare_coding_session_context(
+            message_text=_PROMPT_APPROVAL,
+            user_links=("https://github.com/yule-studio/naver-search-clone",),
+            existing_extra={},
+            discover_contract=False,
+        )
+        self.assertEqual(ctx.session_mode.work_mode, WORK_MODE_APPROVAL)
+        self.assertEqual(
+            ctx.extras_update[EXTRA_WORK_MODE], WORK_MODE_APPROVAL
+        )
+
+    def test_new_intake_path_seeds_backlog(self) -> None:
+        # intake 직후 호출되는 helper 와 동일 — session 만들고 seed_coding_backlog.
+        _seed(
+            "new-intake-1",
+            prompt=_PROMPT_AUTONOMOUS,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_TOPOLOGY: TOPOLOGY_SINGLE,
+                EXTRA_SCOPE: SCOPE_FULL_STACK,
+            },
+        )
+        plan = seed_coding_backlog(session_id="new-intake-1", seeded_by="intake")
+        self.assertIsNotNone(plan)
+        self.assertEqual(len(plan), 8)
+
+    def test_backlog_seed_is_idempotent(self) -> None:
+        _seed(
+            "new-intake-2",
+            prompt=_PROMPT_AUTONOMOUS,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_TOPOLOGY: TOPOLOGY_SINGLE,
+                EXTRA_SCOPE: SCOPE_FULL_STACK,
+            },
+        )
+        seed_coding_backlog(session_id="new-intake-2", seeded_by="intake")
+        # 두 번째 호출은 기존 plan 을 보존
+        seeded2 = seed_coding_backlog(session_id="new-intake-2", seeded_by="intake")
+        self.assertIsNotNone(seeded2)
+        fresh = load_session("new-intake-2")
+        self.assertEqual(len(fresh.extra[EXTRA_CODING_BACKLOG]), 8)
+
+
+# ---------------------------------------------------------------------------
+# 7, 8, 9 — production wiring (approval_enqueuer / merge_executor wiring)
+# ---------------------------------------------------------------------------
+
+
+class ProductionWiringTests(unittest.TestCase):
+    def test_approval_enqueuer_returns_callable_with_resolver(self) -> None:
+        """P1-M B 회귀 가드 — 옛 wiring 은 None 반환 (ApprovalWorker init 실패).
+        새 wiring 은 production post_fn + channel_resolver 주입."""
+
+        from yule_orchestrator.runtime.coding_executor_runner import (
+            _maybe_build_approval_enqueuer,
+        )
+
+        enqueuer = _maybe_build_approval_enqueuer()
+        # 함수 / 콜백 객체여야 함 (None 이면 wiring 회귀)
+        self.assertIsNotNone(enqueuer)
+        self.assertTrue(callable(enqueuer))
+
+    def test_merge_executor_respects_env_opt_in(self) -> None:
+        """live merge executor 는 env opt-in 시에만 wiring."""
+
+        from yule_orchestrator.runtime.coding_executor_runner import (
+            _maybe_build_live_pr_merge_executor,
+        )
+
+        # env unset 일 때 None
+        prev = os.environ.pop("YULE_GITHUB_APP_MERGE_OPT_IN", None)
+        try:
+            self.assertIsNone(_maybe_build_live_pr_merge_executor())
+        finally:
+            if prev is not None:
+                os.environ["YULE_GITHUB_APP_MERGE_OPT_IN"] = prev
+
+    def test_pr_merge_reply_routing_helper_exists(self) -> None:
+        """approval reply router 가 pr_merge 분기를 갖고 있는지."""
+
+        from yule_orchestrator.discord.approval.reply_router import (
+            _try_handle_pr_merge_reply,
+        )
+
+        self.assertTrue(callable(_try_handle_pr_merge_reply))
+
+
+# ---------------------------------------------------------------------------
+# 10 — non-greenfield real edit blocker
+# ---------------------------------------------------------------------------
+
+
+class NonGreenfieldBlockerTests(unittest.TestCase):
+    def test_planning_only_pr_forbidden_env_raises_on_non_greenfield(
+        self,
+    ) -> None:
+        """env=1 + non-greenfield repo → NonGreenfieldRealEditUnavailable.
+
+        옛 wiring 은 silent delegate 로 planning-only PR 을 생성했지만,
+        본 가드가 들어가면 worker 가 REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE
+        로 honest blocker stamp.
+        """
+
+        editor = GreenfieldBootstrapEditor(env={ENV_PLANNING_ONLY_PR_FORBIDDEN: "1"})
+        # non-greenfield worktree — 이미 코드가 있는 repo
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "package.json").write_text("{}")
+            (root / ".git").mkdir()
+            ctx = WorktreeContext(branch="b", worktree_path=str(root))
+            req = CodingExecuteRequest(
+                session_id="s-nongreen",
+                executor_role="backend-engineer",
+                user_request="실제 구현 추가",
+                generated_prompt="(p)",
+                write_scope=("src/**",),
+                forbidden_scope=(),
+                safety_rules=(),
+                base_branch="main",
+                branch_hint="agent/x",
+                repo_full_name="yule-studio/naver-search-clone",
+                issue_number=1,
+                dry_run=False,
+                metadata={},
+            )
+            with self.assertRaises(NonGreenfieldRealEditUnavailable):
+                editor.apply(request=req, context=ctx)
+
+    def test_default_env_allows_record_only_for_backwards_compat(self) -> None:
+        """env unset 이면 (default) 옛 동작 보존 — silent record-only.
+        이렇게 해서 operator 가 명시적 opt-in 전까지 회귀 0."""
+
+        editor = GreenfieldBootstrapEditor()  # env=None (real env, unset)
+        prev = os.environ.pop(ENV_PLANNING_ONLY_PR_FORBIDDEN, None)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                (root / "package.json").write_text("{}")
+                (root / ".git").mkdir()
+                ctx = WorktreeContext(branch="b", worktree_path=str(root))
+                req = CodingExecuteRequest(
+                    session_id="s-nongreen-2",
+                    executor_role="backend-engineer",
+                    user_request="실제 구현 추가",
+                    generated_prompt="(p)",
+                    write_scope=("src/**",),
+                    forbidden_scope=(),
+                    safety_rules=(),
+                    base_branch="main",
+                    branch_hint="agent/x",
+                    repo_full_name="yule-studio/naver-search-clone",
+                    issue_number=1,
+                    dry_run=False,
+                    metadata={},
+                )
+                new_ctx = editor.apply(request=req, context=ctx)
+                # delegate 동작 — plan 파일 한 개 추가됨
+                self.assertGreater(len(new_ctx.edited_files), 0)
+                # metadata audit 에 forbidden 플래그가 False 로 기록
+                audit = (new_ctx.metadata or {}).get("bootstrap_apply") or {}
+                self.assertFalse(audit.get("planning_only_pr_forbidden", True))
+        finally:
+            if prev is not None:
+                os.environ[ENV_PLANNING_ONLY_PR_FORBIDDEN] = prev
+
+
+# ---------------------------------------------------------------------------
+# 11, 12 — issue/PR title humanizer
+# ---------------------------------------------------------------------------
+
+
+class HumanTitleTests(unittest.TestCase):
+    def test_pr_title_for_slice_is_korean(self) -> None:
+        slice_spec = FULL_STACK_SEARCH_MVP_PLAN[0]  # 인증 백엔드
+        title = build_pr_title(
+            session_prompt=_PROMPT_AUTONOMOUS,
+            slice_spec=slice_spec,
+            branch_hint="agent/backend/auth",
+            issue_number=4,
+        )
+        self.assertIn("[구현]", title)
+        self.assertIn("인증", title)
+        self.assertIn("회원가입", title)
+        self.assertIn("(#4)", title)
+        # 옛 기계형 제목 패턴 금지
+        self.assertNotIn("coding-executor draft", title)
+
+    def test_pr_title_without_slice_uses_prompt_summary(self) -> None:
+        title = build_pr_title(
+            session_prompt=_PROMPT_AUTONOMOUS, slice_spec=None, issue_number=1
+        )
+        # 모드 토큰은 제거되고 한국어 요약만 남음
+        self.assertNotIn("autonomous_merge", title.lower())
+        self.assertNotIn("full_stack_single_repo", title.lower())
+        self.assertIn("[구현]", title)
+        self.assertIn("네이버", title)
+
+    def test_issue_title_for_slice_is_korean(self) -> None:
+        slice_spec = FULL_STACK_SEARCH_MVP_PLAN[2]  # 검색 홈 UI
+        title = build_issue_title(
+            session_prompt=_PROMPT_AUTONOMOUS, slice_spec=slice_spec
+        )
+        self.assertIn("[기능]", title)
+        self.assertIn("검색", title)
+        self.assertNotIn("autonomous_merge", title.lower())
+
+    def test_pr_body_intro_includes_session_meta(self) -> None:
+        body = build_pr_body_intro(
+            session_id="fe5eedc65196",
+            repo_full_name="yule-studio/naver-search-clone",
+            work_mode="autonomous_merge",
+            slice_spec=FULL_STACK_SEARCH_MVP_PLAN[0],
+            branch="agent/backend/auth",
+            backlog_remaining=7,
+        )
+        self.assertIn("fe5eedc65196", body)
+        self.assertIn("yule-studio/naver-search-clone", body)
+        self.assertIn("autonomous_merge", body)
+        self.assertIn("남은 slice", body)
+        self.assertIn("7", body)
+
+
+# ---------------------------------------------------------------------------
+# 13 — backlog detect 가 의도 없을 때 빈 plan 반환 (misleading skip)
+# ---------------------------------------------------------------------------
+
+
+class HonestBacklogDetectTests(unittest.TestCase):
+    def test_detect_plan_returns_empty_when_no_intent(self) -> None:
+        extra = {
+            EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+            EXTRA_TOPOLOGY: TOPOLOGY_SINGLE,
+            EXTRA_SCOPE: "single_scope",  # full_stack 아님
+        }
+        plan = detect_backlog_plan(extra, prompt="auth backend 하나만 추가해줘")
+        self.assertEqual(plan, ())
+
+    def test_seed_does_not_stamp_when_intent_absent(self) -> None:
+        # seed_coding_backlog 는 plan 이 비어있으면 None 반환 (silent stamp 안 함)
+        # → operator 가 status 에서 backlog 비어있음을 정직하게 본다.
+        import tempfile
+
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            os.environ["YULE_AGENT_CACHE_DIR"] = tmp.name
+            _seed(
+                "honest-1",
+                prompt="auth 만 추가",
+                extra={EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS},
+            )
+            seeded = seed_coding_backlog(session_id="honest-1")
+            self.assertIsNone(seeded)
+            fresh = load_session("honest-1")
+            self.assertNotIn(EXTRA_CODING_BACKLOG, fresh.extra)
+        finally:
+            os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+            tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# 14 — duplicate branch / planning PR 가드
+# ---------------------------------------------------------------------------
+
+
+class DuplicateReplayGuardTests(unittest.TestCase):
+    def test_backlog_pop_advances_pointer_no_replay(self) -> None:
+        """coding_backlog 첫 항목 pop 은 한 번만 동일 slice 를 반환.
+
+        dispatch_next_coding_slice 가 backlog 첫 항목을 pop 한 뒤 두 번째
+        호출은 다음 항목을 본다 → 같은 slice replay 없음.
+        """
+
+        import tempfile
+        from yule_orchestrator.agents.job_queue.next_slice_dispatcher import (
+            dispatch_next_coding_slice,
+        )
+        from yule_orchestrator.agents.job_queue.pr_merge_continuation import (
+            EXTRA_PR_MERGE_STAGE,
+            STAGE_PR_MERGED,
+        )
+
+        tmp = tempfile.TemporaryDirectory()
+        try:
+            os.environ["YULE_AGENT_CACHE_DIR"] = tmp.name
+            _seed(
+                "dup-1",
+                prompt=_PROMPT_AUTONOMOUS,
+                extra={
+                    EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                    EXTRA_TOPOLOGY: TOPOLOGY_SINGLE,
+                    EXTRA_SCOPE: SCOPE_FULL_STACK,
+                    EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGED,
+                    EXTRA_CODING_BACKLOG: [
+                        {"summary": "slice-1", "prompt": "first"},
+                        {"summary": "slice-2", "prompt": "second"},
+                    ],
+                },
+            )
+
+            slices: list = []
+
+            def enqueue(sid: str, spec: Mapping[str, Any]) -> None:
+                slices.append(dict(spec))
+
+            def persist(new_extra: Mapping[str, Any]) -> None:
+                session = load_session("dup-1")
+                save_session(
+                    _replace(session, extra=dict(new_extra), updated_at=_now())
+                )
+
+            # 첫 호출
+            session = load_session("dup-1")
+            dispatch_next_coding_slice(
+                session_id="dup-1",
+                session_extra=dict(session.extra or {}),
+                persist_extra=persist,
+                enqueue_slice=enqueue,
+            )
+            # 두 번째 호출 — backlog 한 칸 줄어든 상태에서 두 번째 slice 만 pop
+            session2 = load_session("dup-1")
+            dispatch_next_coding_slice(
+                session_id="dup-1",
+                session_extra=dict(session2.extra or {}),
+                persist_extra=persist,
+                enqueue_slice=enqueue,
+            )
+            self.assertEqual(len(slices), 2)
+            self.assertEqual(slices[0]["summary"], "slice-1")
+            self.assertEqual(slices[1]["summary"], "slice-2")
+        finally:
+            os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+            tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 요약

P1-L-3 deploy 후 발견된 3가지 회귀를 동시에 닫는 round.

1. **세션 mode 영속 회귀 (fe5eedc65196)** — `/engineer_intake` 슬래시 명령 경로가 `prepare_coding_session_context` 를 절대 호출하지 않아 work_mode/topology/scope 가 항상 None 으로 영속됐다. background pr_merge_continuation_loop 가 approval_required 로 잘못 fallback.
2. **`approval_enqueuer=no` 회귀** — `_maybe_build_approval_enqueuer` 가 `ApprovalWorker(queue, heartbeats)` 만 넘겨서 init TypeError → silent None. post_fn + channel_resolver 필수 인자 누락.
3. **planning-only PR 반복** — non-greenfield repo (naver-search-clone 같은) 에 RecordOnly editor 가 plan markdown 만 commit 해서 의미 없는 PR (`coding-executor draft #4`) 가 production 까지 흘러갔다.

## ✨ 변경 항목 (4 commits)

### 1. 새 모듈 3 개 + CLI 1 개 (`d3d2f44`)
- `agents/coding/coding_backlog_seed.py` — naver-search-clone 류 full-stack 검색 MVP 의 deterministic 8-slice plan + idempotent `seed_coding_backlog` helper.
- `agents/coding/human_titles.py` — `build_pr_title` / `build_issue_title` / `build_pr_body_intro` — `[구현][인증] 회원가입/로그인 API 1차 (#4)` 형 한국어 제목.
- `agents/lifecycle/session_recovery.py` — `recover_session_full` (특정 세션 한정 해킹 없음; 모든 session 동일 동작).
- `cli/recover_session.py` — `python3 -m yule_orchestrator.cli.recover_session <id>` operator CLI.

### 2. wiring (`d459d5d`)
- `/engineer_intake` slash 명령이 intake 직후 mode/backlog 영속화 호출.
- dispatcher 가 slice_spec / session_prompt / work_mode 를 forward.
- runner 의 `_maybe_build_approval_enqueuer` 가 `build_production_post_fn` + `build_approval_channel_resolver` 주입 — startup 시 `approval_enqueuer=yes`.

### 3. non-greenfield blocker + 한국어 PR 제목 wiring (`b97c019`)
- 새 env `YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN` (기본 off).
- `NonGreenfieldRealEditUnavailable` exception + `REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE` reason 토큰.
- `GithubAppDraftPRCreator.open` 가 `build_pr_title` 호출 (slice / session / branch / issue_number 정보 사용).

### 4. 회귀 19 케이스 (`8576c7e`)
사용자 명시 14 acceptance 모두 cover + 보조 5.

## 🧪 회귀

- **stdlib unittest 누적**: 5262 / 5 pre-existing errors (digest_crawler locale + gateway_shutdown — P1-M 무관). 신규 19 모두 통과.
- **local wiring smoke**: `approval_enqueuer=yes`, `merge_executor=no` (env 미설정 시 정상).
- **governance/code_audit**: 위반 0 유지.

## 📦 머지 후 운영자 절차

1. main pull + 런타임 재기동.
2. startup log 에 `approval_enqueuer=yes` 확인.
3. canonical session `fe5eedc65196` 복구:
   ```bash
   python3 -m yule_orchestrator.cli.recover_session fe5eedc65196 \\
     --mode autonomous_merge \\
     --pr-number 4 \\
     --pr-url https://github.com/yule-studio/naver-search-clone/pull/4 \\
     --head-sha <PR4 head sha> \\
     --repo yule-studio/naver-search-clone
   ```
   출력에서 `mode_persisted: True` + `backlog_seeded_count: 8` + `pr_merge_stamped: True` 확인.
4. 새 intake canary (slash): `autonomous_merge, single_repo, full_stack_single_repo 네이버 검색 풀스택 MVP 구현해줘 https://github.com/yule-studio/naver-search-clone`.
5. (선택) `YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN=1` 로 planning-only PR 차단.