### PR TITLE
🛡 P1-N: repo write policy hard guards — gitmoji / 한글 제목 / issue anchor / :tada: initial commit

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -19,3 +19,12 @@
 # - 내용이 없는 항목도 생략하지 않고 `- 없음`으로 둔다
 # - 규칙의 source of truth: policies/reference/COMMIT_CONVENTION.md
 # - 이 파일은 편의용 템플릿이며, 형식 해석 기준은 위 문서를 따른다
+#
+# Initial commit (새 repo 의 첫 non-merge 커밋) 특수 규칙:
+# - 제목은 반드시 정확히 `:tada: initial commit`
+# - 본문 (변경 이유 / 주요 변경 사항 / 비고) 는 일반 규칙 유지
+# - 첫 커밋 이후에는 `:tada:` 사용 금지
+#
+# 검증 hook 설치 (commit-msg):
+#   ln -sf ../../scripts/validate_commit_msg.py .git/hooks/commit-msg
+# 분류 ambiguous 시 환경변수: YULE_COMMIT_IS_INITIAL=1/0

--- a/policies/reference/COMMIT_CONVENTION.md
+++ b/policies/reference/COMMIT_CONVENTION.md
@@ -7,6 +7,29 @@
 현재는 1인 프로젝트이므로 복잡한 규칙보다 일관성을 우선한다.
 추후 Jira 연동이 완료되면 Jira 티켓 키를 포함하는 방식으로 확장할 수 있다.
 
+## 적용 범위 (cross-repo)
+
+본 컨벤션은 `yule-studio-agent` 내부 커밋뿐 아니라 **봇이 GitHub write 를 수행하는 모든 target repo** (예: `yule-studio/naver-search-clone`, 향후 engineering runtime 이 coding_execute / github_work_order / draft PR 을 만드는 모든 repo) 에 동일하게 적용된다. repo-local stricter policy 가 있으면 그것을 우선 적용하되, 기본은 본 SSoT 를 상속한다.
+
+코드 차원 SSoT — [`src/yule_orchestrator/agents/governance/repo_write_policy.py`](../../src/yule_orchestrator/agents/governance/repo_write_policy.py) 가 commit / issue title / PR title / issue anchor 4-종 hard guard 를 한 자리에 모은다. live path (GithubAppCommitter / GithubAppDraftPRCreator / GithubWriter.create_issue 등) 가 그 validator 를 호출하고 실패 시 raise.
+
+## Initial commit 특수 규칙
+
+새 repo 의 첫 non-merge 커밋 (bootstrap / scaffold flow 의 repo initialization commit 포함) 은 반드시 다음 제목을 사용한다:
+
+```
+:tada: initial commit
+```
+
+- 이 규칙은 일반 gitmoji whitelist 의 예외다.
+- 본문 (변경 이유 / 주요 변경 사항 / 비고) 는 일반 규칙 유지.
+- 첫 커밋 이후에는 `:tada:` 사용 금지.
+- 첫 커밋 판별이 ambiguous 하면 enforcement layer 가 `initial_commit_detection_ambiguous` blocker 로 surface.
+
+판별 기준 (`repo_write_policy.is_initial_commit_context`):
+1. repo 의 첫 non-merge commit (HEAD 이전 commit count == 0)
+2. caller (bootstrap / scaffold flow) 가 명시적으로 `initial_commit=True` 를 hint 로 전달
+
 ## 커밋 템플릿
 
 `.gitmessage.txt` 는 편의를 위한 Git commit template 역할만 한다. 규칙의 정의·해석은 항상 이 문서를 따르고, `.gitmessage.txt` 의 빈 줄·주석은 형식의 권위가 아니다.

--- a/policies/runtime/agents/engineering-agent/issue-pr-conventions.md
+++ b/policies/runtime/agents/engineering-agent/issue-pr-conventions.md
@@ -147,22 +147,43 @@ issue body 와 동일하되 추가:
 
 ## 3. Commit 컨벤션 (2026-05-12 갱신 — 분리 정책)
 
-### 3.1 메시지 포맷
+> **Source of truth**: [`policies/reference/COMMIT_CONVENTION.md`](../../../reference/COMMIT_CONVENTION.md).
+> 본 §3 은 그 SSoT 의 운영 적용 가이드일 뿐이며, 형식 충돌 시 항상 SSoT 가 우선.
+
+### 3.1 메시지 포맷 (SSoT 사본)
+
+**plain text section header** 를 사용한다 (`##` markdown 헤더 금지 — SSoT 와 동일):
 
 ```
 <gitmoji> #<n> <Type 한국어 한 줄 요약>
 
-## 변경 이유
+변경 이유
 - ...
 
-## 주요 변경 사항
+주요 변경 사항
 - ...
 
-## 비고
-- 회귀 결과, 후속, blocker
+비고
+- 회귀 결과, 후속, blocker (없으면 `- 없음`)
 ```
 
 **금지**: `Co-Authored-By` trailer, 🤖 생성 trailer, `Generated with Claude` 류 메시지.
+
+**Initial commit 특수 규칙** — 새 repo 의 첫 non-merge 커밋 (bootstrap / scaffold flow 의 repo initialization commit 포함) 은 반드시 다음 제목을 사용한다:
+
+```
+:tada: initial commit
+```
+
+- 이 규칙은 일반 gitmoji whitelist 의 예외다.
+- 첫 커밋 이후에는 `:tada:` 사용 금지 (다음 커밋부터 일반 whitelist 적용).
+- 첫 커밋 판별이 ambiguous 하면 enforcement layer 가 `initial_commit_detection_ambiguous` blocker 로 surface 한다.
+
+### 3.0 적용 범위 (cross-repo)
+
+본 컨벤션은 `yule-studio-agent` 내부에 한정되지 않는다. **봇이 GitHub write 를 수행하는 모든 target repo** (예: `yule-studio/naver-search-clone`, 향후 engineering runtime 이 coding_execute / github_work_order / draft PR 을 만드는 모든 repo) 에 동일하게 적용된다. repo-local stricter policy 가 있으면 그것이 우선하되, 기본은 본 SSoT 를 상속한다.
+
+코드 SSoT — [`src/yule_orchestrator/agents/governance/repo_write_policy.py`](../../../../src/yule_orchestrator/agents/governance/repo_write_policy.py) 가 commit / issue title / PR title / issue anchor 4-종 hard guard 를 한 자리에 모은다. live path (GithubAppCommitter / GithubAppDraftPRCreator / GithubWriter.create_issue 등) 가 그 validator 를 호출하고 실패 시 raise.
 
 ### 3.2 커밋 분리 정책 (필수)
 

--- a/scripts/validate_commit_msg.py
+++ b/scripts/validate_commit_msg.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""P1-N D — commit-msg hook entry point.
+
+git ``commit-msg`` hook 으로 등록되면 사용자/봇이 만드는 모든 commit 이
+``repo_write_policy.validate_commit_message`` 를 거친다. 위반 시 exit
+code 1 + reason / detail 을 stderr 로 출력 → git 가 commit 거부.
+
+설치:
+  ln -sf ../../scripts/validate_commit_msg.py .git/hooks/commit-msg
+  chmod +x scripts/validate_commit_msg.py
+
+`is_initial` 판별은 ``is_initial_commit_context`` 가 git 디렉터리 자동
+감지.  애매하면 ``initial_commit_detection_ambiguous`` 로 reject.
+
+CI 환경에서도 동일하게 동작 가능 — `python3 scripts/validate_commit_msg.py
+<message_file>` 으로 호출.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _detect_repo_root() -> str:
+    # commit-msg hook 은 보통 .git 디렉터리의 부모에서 실행됨.
+    cwd = Path.cwd()
+    while True:
+        if (cwd / ".git").exists():
+            return str(cwd)
+        if cwd.parent == cwd:
+            return str(Path.cwd())
+        cwd = cwd.parent
+
+
+def main(argv) -> int:
+    if len(argv) < 2:
+        print(
+            "validate_commit_msg: usage: validate_commit_msg.py <message-file>",
+            file=sys.stderr,
+        )
+        return 2
+
+    message_file = Path(argv[1])
+    try:
+        text = message_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"validate_commit_msg: cannot read {message_file}: {exc}", file=sys.stderr)
+        return 2
+
+    # ``git commit`` 자체적으로 leading "# ..." 코멘트 라인을 자른 후
+    # COMMIT_EDITMSG 를 쓰지만 ``--message`` / amend 등은 raw 텍스트.
+    # 코멘트 라인 제거 (safety).
+    cleaned_lines = [
+        ln for ln in text.splitlines() if not ln.lstrip().startswith("#")
+    ]
+    cleaned = "\n".join(cleaned_lines).strip("\n")
+
+    if not cleaned.strip():
+        print("validate_commit_msg: empty commit message", file=sys.stderr)
+        return 1
+
+    # Ensure src/ in path
+    repo_root = _detect_repo_root()
+    src_dir = Path(repo_root) / "src"
+    if src_dir.is_dir():
+        sys.path.insert(0, str(src_dir))
+
+    try:
+        from yule_orchestrator.agents.governance.repo_write_policy import (  # type: ignore
+            is_initial_commit_context,
+            validate_commit_message,
+            validate_initial_commit_decision,
+        )
+    except Exception as exc:
+        # validator 가 import 안되면 hook 이 정책을 강제할 수 없으므로 안전
+        # 측 reject 보다는 통과 (env 가 잘못된 dev 환경에서 commit 자체가
+        # 막히는 사고 방지).  대신 stderr 에 큰 경고.
+        print(
+            f"validate_commit_msg: WARNING — repo_write_policy import failed "
+            f"({exc}); skipping policy check",
+            file=sys.stderr,
+        )
+        return 0
+
+    # initial commit 자동 감지.  CI / dev shell 모두에서 동작하도록 hint
+    # env (YULE_COMMIT_IS_INITIAL=1/0) 도 지원.
+    env_hint = os.environ.get("YULE_COMMIT_IS_INITIAL", "").strip().lower()
+    explicit_hint = None
+    if env_hint in ("1", "true", "yes"):
+        explicit_hint = True
+    elif env_hint in ("0", "false", "no"):
+        explicit_hint = False
+    decision = is_initial_commit_context(
+        repo_root=repo_root, explicit_hint=explicit_hint
+    )
+    decision_check = validate_initial_commit_decision(decision)
+    if not decision_check.ok:
+        print(
+            f"validate_commit_msg: {decision_check.reason}: {decision_check.detail}",
+            file=sys.stderr,
+        )
+        print(
+            "  hint: set YULE_COMMIT_IS_INITIAL=1 (or 0) to disambiguate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    result = validate_commit_message(cleaned, is_initial=decision.is_initial)
+    if result.ok:
+        return 0
+
+    print("─" * 60, file=sys.stderr)
+    print(f"commit rejected — policy: {result.reason}", file=sys.stderr)
+    print(f"  detail: {result.detail}", file=sys.stderr)
+    if result.fields:
+        for k, v in result.fields.items():
+            print(f"  {k}: {v}", file=sys.stderr)
+    print(
+        "  SSoT: policies/reference/COMMIT_CONVENTION.md",
+        file=sys.stderr,
+    )
+    print(
+        "  Initial commit exception: title must be exactly `:tada: initial commit`",
+        file=sys.stderr,
+    )
+    print("─" * 60, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/yule_orchestrator/agents/github_workos/github_writer.py
+++ b/src/yule_orchestrator/agents/github_workos/github_writer.py
@@ -478,6 +478,19 @@ class GithubWriter:
             str(a).strip() for a in assignees if str(a).strip()
         )
         title_snippet = (title or "").strip().splitlines()[0][:80]
+
+        # P1-N — cross-repo issue title hard guard. 사람이 GitHub 목록에서
+        # 바로 이해 가능한 한글 제목인지 검사. 옛 wiring 은 영문 / 기계형
+        # 제목이 그대로 통과해서 사용자가 무슨 issue 인지 알 수 없었음.
+        try:
+            from ..governance.repo_write_policy import enforce_issue_title
+
+            enforce_issue_title(title)
+        except Exception:
+            # PolicyViolation 그대로 raise — caller (work_order executor 등)
+            # 가 progress marker 에 reason 토큰을 stamp 한다.
+            raise
+
         return self._run(
             action=ACTION_GITHUB_ISSUE_CREATE,
             autonomy_level=autonomy_level,

--- a/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
+++ b/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
@@ -91,7 +91,7 @@ class IssueTemplate:
     name
         frontmatter `name:` — 사람 친화 라벨. 없으면 파일명 stem.
     title_prefix
-        frontmatter `title:` — issue 제목에 자동 prefix 됨. 예: ``[Feat]``.
+        frontmatter `title:` — issue 제목에 자동 prefix 됨. 예: ``[기능]``.
     labels
         frontmatter `labels:` 에 명시된 라벨 시퀀스.
     assignees
@@ -353,14 +353,14 @@ def fill_issue_template(
       `> ` quote 형식으로 prepend. 본 자리는 GitHub issue template 의
       가장 흔한 "추가하려는 기능에 대해 간결하게 설명해주세요" 라인.
     - placeholder 가 없으면 본문 끝에 `## 작업 컨텍스트` 섹션을 append.
-    - frontmatter title prefix 가 있으면 결합: ``[Feat] <summary>``.
+    - frontmatter title prefix 가 있으면 결합: ``[기능] <summary>``.
     """
 
     summary = (request_summary or "").strip()
     title = (title_override or "").strip() or summary or template.name
     if template.title_prefix:
         prefix = template.title_prefix.strip()
-        # GitHub default templates 자주 ``[Feat]`` 같은 prefix 만 두고 빈
+        # GitHub default templates 자주 ``[기능]`` 같은 prefix 만 두고 빈
         # 자리를 남김. 사용자가 요청 본문에 같은 prefix 를 안 가지고 있다면
         # 결합.
         if prefix and not title.lower().startswith(prefix.lower()):

--- a/src/yule_orchestrator/agents/github_workos/issue_quality.py
+++ b/src/yule_orchestrator/agents/github_workos/issue_quality.py
@@ -13,7 +13,7 @@ truncated, body = 4 섹션 minimal, labels = caller 가 준 extra 만" 이었다
 이 모듈은 사용자가 명시한 §A~§F 를 코드로 박는다:
 
 * :func:`synthesize_korean_title` — intent 분류 기반 한국어 명확 제목
-  (예: ``[Feat] 네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)``)
+  (예: ``[기능] 네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)``)
 * :func:`derive_default_labels` — deterministic label mapping
   (full-stack/feature → ``✨ Feature``, docs → ``📃 Docs``, …)
 * :func:`build_quality_default_body` — 운영 규칙에 맞는 default body
@@ -147,14 +147,17 @@ def detect_scopes(request_text: str, *, max_scopes: int = 4) -> Tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
+# P1-N — 한국어 prefix 로 통일 (repo_write_policy.validate_issue_title 의
+# allowlist 와 매칭).  옛 영문 prefix 는 사람이 GitHub 목록에서 작업
+# 내용을 인지하기 어려워 user 가 직접 reject 함.
 _INTENT_TITLE_PREFIX: Mapping[str, str] = {
-    INTENT_FULL_STACK_MVP: "[Feat]",
-    INTENT_FEATURE: "[Feat]",
-    INTENT_DOCS: "[Docs]",
-    INTENT_TEST: "[Test]",
-    INTENT_REFACTOR: "[Refactor]",
-    INTENT_BUGFIX: "[Fix]",
-    INTENT_CHORE: "[Chore]",
+    INTENT_FULL_STACK_MVP: "[기능]",
+    INTENT_FEATURE: "[기능]",
+    INTENT_DOCS: "[문서]",
+    INTENT_TEST: "[테스트]",
+    INTENT_REFACTOR: "[리팩토링]",
+    INTENT_BUGFIX: "[수정]",
+    INTENT_CHORE: "[설정]",
 }
 
 
@@ -212,7 +215,7 @@ def synthesize_korean_title(
     resolved_intent = (intent or detect_intent(request_text)).strip().lower()
     resolved_scopes = tuple(scopes) if scopes is not None else detect_scopes(request_text)
 
-    prefix = _INTENT_TITLE_PREFIX.get(resolved_intent, "[Feat]")
+    prefix = _INTENT_TITLE_PREFIX.get(resolved_intent, "[기능]")
     phrase = _INTENT_TITLE_PHRASE.get(resolved_intent, "신규 기능 추가")
     domain = _detect_domain_label(request_text)
 

--- a/src/yule_orchestrator/agents/governance/repo_write_policy.py
+++ b/src/yule_orchestrator/agents/governance/repo_write_policy.py
@@ -1,0 +1,619 @@
+"""P1-N — Cross-repo GitHub write policy hard guards.
+
+봇이 commit / issue / branch / PR 을 만드는 모든 write path 에서 호출되는
+**중앙 enforcement layer**. 본 모듈이 reject 한 작업은 live path 에서
+raise 되어 실제로 차단된다 (advisory / warning 아님).
+
+코드 SSoT — 본 모듈. 사람용 SSoT — [`policies/reference/COMMIT_CONVENTION.md`](
+../../../../policies/reference/COMMIT_CONVENTION.md) + [`policies/runtime/agents/
+engineering-agent/issue-pr-conventions.md`](../../../../policies/runtime/agents/
+engineering-agent/issue-pr-conventions.md).
+
+검증 항목
+  1. ``validate_commit_message`` — gitmoji whitelist + 3-section format
+  2. ``validate_issue_title`` — 한국어 + [기능]/[구현]/... prefix 강제
+  3. ``validate_pr_title``    — 동일 패턴 + 모드 토큰 금지
+  4. ``validate_issue_anchor``— branch / PR body 에 ``issue-N`` anchor 필수
+  5. ``is_initial_commit_context`` + ``validate_initial_commit_message``
+     — 첫 커밋 special case (`:tada: initial commit`)
+
+각 validator 는 ``PolicyResult`` 를 반환 — caller 가 ``ok`` 확인 후
+``reason`` / ``detail`` 로 raise 메시지 구성. live path 에는
+``PolicyViolation`` 예외를 raise 하는 ``enforce_*`` 헬퍼 사용 권장.
+
+cross-repo 적용 — 본 모듈은 yule-studio-agent / naver-search-clone / 향후
+어떤 target repo 에도 동일하게 동작. repo-local override 가 필요하면
+caller 가 ``repo_full_name`` 으로 stricter 규칙을 덧붙인다.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Reason tokens — operator surface 가 한눈에 보는 blocker
+# ---------------------------------------------------------------------------
+
+REASON_INVALID_COMMIT_GITMOJI: str = "invalid_commit_gitmoji"
+REASON_INVALID_COMMIT_BODY_SECTIONS: str = "invalid_commit_body_sections"
+REASON_INVALID_INITIAL_COMMIT_TITLE: str = "invalid_initial_commit_title"
+REASON_TADA_OUTSIDE_INITIAL_COMMIT: str = "tada_used_outside_initial_commit"
+REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS: str = (
+    "initial_commit_detection_ambiguous"
+)
+
+REASON_INVALID_ISSUE_TITLE: str = "invalid_issue_title_not_human_readable_korean"
+REASON_INVALID_PR_TITLE: str = "invalid_pr_title_not_human_readable_korean"
+REASON_ISSUE_REQUIRED_FOR_REPO_WORK: str = "issue_required_for_repo_work"
+
+
+# ---------------------------------------------------------------------------
+# Gitmoji whitelist — SSoT 와 동일
+# ---------------------------------------------------------------------------
+
+_BASE_GITMOJI: tuple = ("✨", "🐛", "♻️", "📝", "✅", "🔧")
+_OPTIONAL_GITMOJI: tuple = ("🚚", "🔥", "⚡️", "👷", "💚", "🚑️")
+ALLOWED_GITMOJI: frozenset = frozenset(_BASE_GITMOJI + _OPTIONAL_GITMOJI)
+
+# initial commit 전용 special-case
+INITIAL_COMMIT_TITLE_EXACT: str = ":tada: initial commit"
+INITIAL_GITMOJI_TEXT: str = ":tada:"
+
+
+# ---------------------------------------------------------------------------
+# Commit body 섹션 규칙
+# ---------------------------------------------------------------------------
+
+REQUIRED_SECTIONS: tuple = ("변경 이유", "주요 변경 사항", "비고")
+_MD_HEADER_SECTIONS: tuple = (
+    "## 변경 이유",
+    "## 주요 변경 사항",
+    "## 비고",
+)
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    ok: bool
+    reason: Optional[str] = None
+    detail: str = ""
+    fields: Mapping[str, Any] = field(default_factory=dict)
+
+
+class PolicyViolation(RuntimeError):
+    """live path 에서 raise — operator surface 가 reason 으로 분기.
+
+    `.reason` 은 위의 ``REASON_*`` 토큰 중 하나. `.detail` 은 사람이 읽는
+    한 줄 설명. `.fields` 는 추가 진단 dict.
+    """
+
+    def __init__(self, *, reason: str, detail: str = "", fields: Optional[Mapping[str, Any]] = None) -> None:
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+        self.reason = reason
+        self.detail = detail
+        self.fields = dict(fields or {})
+
+
+def _raise(result: PolicyResult) -> None:
+    if not result.ok and result.reason:
+        raise PolicyViolation(
+            reason=result.reason, detail=result.detail, fields=result.fields
+        )
+
+
+# ---------------------------------------------------------------------------
+# Commit message validation
+# ---------------------------------------------------------------------------
+
+
+def _strip_gitmoji_prefix(title_line: str) -> tuple:
+    """첫 토큰이 알려진 gitmoji 면 (gitmoji, 나머지) 반환."""
+
+    stripped = title_line.strip()
+    for emoji in sorted(ALLOWED_GITMOJI, key=len, reverse=True):
+        if stripped.startswith(emoji + " "):
+            return emoji, stripped[len(emoji) + 1 :].lstrip()
+        if stripped == emoji:
+            return emoji, ""
+    # :tada: special case (initial commit shortcode form)
+    if stripped.lower().startswith(INITIAL_GITMOJI_TEXT.lower()):
+        return INITIAL_GITMOJI_TEXT, stripped[len(INITIAL_GITMOJI_TEXT) :].lstrip()
+    return "", stripped
+
+
+def validate_commit_message(
+    text: str, *, is_initial: bool = False
+) -> PolicyResult:
+    """commit message 검증.
+
+    *is_initial=True* 이면 ``:tada: initial commit`` 정확 매칭 + 본문 규칙.
+    *is_initial=False* 이면 일반 whitelist + 본문 규칙 + ``:tada:`` 금지.
+    """
+
+    if not text or not text.strip():
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_COMMIT_BODY_SECTIONS,
+            detail="empty commit message",
+        )
+
+    lines = text.splitlines()
+    title = (lines[0] if lines else "").strip()
+
+    gitmoji, rest = _strip_gitmoji_prefix(title)
+
+    # Initial commit 분기
+    if is_initial:
+        if title.strip() != INITIAL_COMMIT_TITLE_EXACT:
+            return PolicyResult(
+                ok=False,
+                reason=REASON_INVALID_INITIAL_COMMIT_TITLE,
+                detail=(
+                    f"initial commit must be exactly {INITIAL_COMMIT_TITLE_EXACT!r}, "
+                    f"got {title!r}"
+                ),
+                fields={"expected": INITIAL_COMMIT_TITLE_EXACT, "got": title},
+            )
+        return _validate_body_sections(text, gitmoji=gitmoji)
+
+    # Non-initial: ``:tada:`` 금지
+    if gitmoji == INITIAL_GITMOJI_TEXT or title.startswith("🎉"):
+        return PolicyResult(
+            ok=False,
+            reason=REASON_TADA_OUTSIDE_INITIAL_COMMIT,
+            detail=(
+                f"`{INITIAL_GITMOJI_TEXT}` / 🎉 is reserved for the first commit"
+            ),
+            fields={"got_title": title},
+        )
+
+    # gitmoji whitelist 확인
+    if gitmoji not in ALLOWED_GITMOJI:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_COMMIT_GITMOJI,
+            detail=(
+                f"first token must be one of allowed gitmoji {sorted(ALLOWED_GITMOJI)}; "
+                f"got title={title!r}"
+            ),
+            fields={"allowed": sorted(ALLOWED_GITMOJI), "got_title": title},
+        )
+
+    # 제목 끝 마침표 금지
+    if rest.endswith(".") or rest.endswith("。"):
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_COMMIT_BODY_SECTIONS,
+            detail="commit title must not end with a period",
+            fields={"got_title": title},
+        )
+
+    return _validate_body_sections(text, gitmoji=gitmoji)
+
+
+def _validate_body_sections(text: str, *, gitmoji: str) -> PolicyResult:
+    """본문에 변경 이유 / 주요 변경 사항 / 비고 3 섹션이 plain text 헤더로 있는지."""
+
+    # markdown header (##) 사용 시 명확히 거부 — SSoT 와 충돌
+    for md_header in _MD_HEADER_SECTIONS:
+        if md_header in text:
+            return PolicyResult(
+                ok=False,
+                reason=REASON_INVALID_COMMIT_BODY_SECTIONS,
+                detail=(
+                    f"section header must be plain text per SSoT — found markdown "
+                    f"header {md_header!r}. Use {md_header.lstrip('#').strip()!r} instead."
+                ),
+                fields={"bad_header": md_header},
+            )
+
+    missing: List[str] = []
+    for section in REQUIRED_SECTIONS:
+        # plain-text header on its own line (allow trailing whitespace)
+        pattern = rf"(?m)^\s*{re.escape(section)}\s*$"
+        if not re.search(pattern, text):
+            missing.append(section)
+    if missing:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_COMMIT_BODY_SECTIONS,
+            detail=(
+                "commit body missing required section(s): "
+                + ", ".join(missing)
+                + ". Each must appear as a plain-text header followed by `- ...` bullets "
+                + "(or `- 없음` if empty)."
+            ),
+            fields={"missing_sections": missing},
+        )
+
+    # 각 section 직후에 최소 한 줄의 bullet 또는 `- 없음` 이 있어야 함
+    for section in REQUIRED_SECTIONS:
+        m = re.search(
+            rf"(?ms)^\s*{re.escape(section)}\s*$\n(.*?)(?=^\s*(?:{'|'.join(re.escape(s) for s in REQUIRED_SECTIONS)})\s*$|\Z)",
+            text,
+        )
+        if m is None:
+            continue
+        body_block = m.group(1).strip()
+        if not body_block:
+            return PolicyResult(
+                ok=False,
+                reason=REASON_INVALID_COMMIT_BODY_SECTIONS,
+                detail=(
+                    f"section {section!r} is empty — write `- 없음` when intentionally empty"
+                ),
+                fields={"empty_section": section},
+            )
+
+    return PolicyResult(ok=True, fields={"gitmoji": gitmoji})
+
+
+def enforce_commit_message(text: str, *, is_initial: bool = False) -> None:
+    _raise(validate_commit_message(text, is_initial=is_initial))
+
+
+# ---------------------------------------------------------------------------
+# Initial commit context detection
+# ---------------------------------------------------------------------------
+
+
+_MODE_TOKEN_RE = re.compile(
+    r"\b(autonomous_merge|approval_required|single_repo|multi_repo"
+    r"|full_stack_single_repo|single_scope|layer_scoped|cross_repo_program)\b",
+    re.IGNORECASE,
+)
+_MACHINE_TITLE_RE = re.compile(
+    r"(coding[- ]?executor(?:\s+draft)?|draft\s+pr|coding-executor draft|"
+    r"agent[/\\-][^\s]+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class InitialCommitDecision:
+    is_initial: bool
+    ambiguous: bool = False
+    reason: str = ""
+
+
+def is_initial_commit_context(
+    *,
+    repo_root: Optional[str] = None,
+    explicit_hint: Optional[bool] = None,
+    branch_hint: Optional[str] = None,
+) -> InitialCommitDecision:
+    """초기 commit 인지 결정.
+
+    1. ``explicit_hint=True`` → initial. ``False`` → not initial.
+    2. ``repo_root`` 가 주어지면 git log -1 이 없을 때 initial 로 본다.
+    3. 둘 다 단서가 없으면 ambiguous (caller 가 surface 해야 함).
+    """
+
+    if explicit_hint is True:
+        return InitialCommitDecision(is_initial=True, reason="explicit_hint")
+    if explicit_hint is False:
+        return InitialCommitDecision(is_initial=False, reason="explicit_hint")
+
+    if repo_root:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_root), "rev-list", "--count", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return InitialCommitDecision(
+                is_initial=False,
+                ambiguous=True,
+                reason="git_unavailable",
+            )
+        if result.returncode != 0:
+            # 'HEAD' resolve 실패 → repo 에 commit 이 아직 없다는 신호
+            stderr = (result.stderr or "").lower()
+            if "unknown revision" in stderr or "ambiguous argument" in stderr:
+                return InitialCommitDecision(is_initial=True, reason="no_head_yet")
+            return InitialCommitDecision(
+                is_initial=False,
+                ambiguous=True,
+                reason="git_command_failed",
+            )
+        try:
+            count = int((result.stdout or "0").strip())
+        except ValueError:
+            return InitialCommitDecision(
+                is_initial=False, ambiguous=True, reason="non_integer_count"
+            )
+        if count == 0:
+            return InitialCommitDecision(is_initial=True, reason="zero_commits")
+        # branch_hint 에 'bootstrap' 또는 'initial' 이 있어도 이미 commit 이
+        # 있으면 ambiguous 로 분류 (caller 가 명시적 hint 로 결정해야 함).
+        if branch_hint and any(
+            token in branch_hint.lower() for token in ("bootstrap", "initial", "scaffold")
+        ):
+            return InitialCommitDecision(
+                is_initial=False,
+                ambiguous=True,
+                reason="branch_says_bootstrap_but_commits_exist",
+            )
+        return InitialCommitDecision(is_initial=False, reason=f"commit_count={count}")
+
+    # repo_root 도 없고 hint 도 없음
+    return InitialCommitDecision(
+        is_initial=False, ambiguous=True, reason="no_signal"
+    )
+
+
+def validate_initial_commit_decision(
+    decision: InitialCommitDecision,
+) -> PolicyResult:
+    """ambiguous 면 honest blocker — caller 가 surface 해야 함."""
+
+    if decision.ambiguous:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS,
+            detail=(
+                f"cannot determine if this is the initial commit "
+                f"(reason={decision.reason}). Pass explicit_hint=True/False."
+            ),
+            fields={"detection_reason": decision.reason},
+        )
+    return PolicyResult(ok=True, fields={"is_initial": decision.is_initial})
+
+
+# ---------------------------------------------------------------------------
+# Issue / PR title validation
+# ---------------------------------------------------------------------------
+
+
+_KOREAN_RE = re.compile(r"[가-힣]")  # Hangul syllables
+_ALLOWED_TITLE_PREFIXES: tuple = ("[기능]", "[구현]", "[수정]", "[문서]", "[설정]", "[테스트]", "[리팩토링]")
+
+
+def _title_has_korean(text: str) -> bool:
+    return bool(_KOREAN_RE.search(text or ""))
+
+
+def _title_has_machine_pattern(text: str) -> bool:
+    if not text:
+        return False
+    if _MACHINE_TITLE_RE.search(text):
+        return True
+    return False
+
+
+def _title_has_mode_token(text: str) -> bool:
+    return bool(_MODE_TOKEN_RE.search(text or ""))
+
+
+def _validate_human_title(
+    text: str, *, kind: str, allow_machine: bool = False
+) -> PolicyResult:
+    """공통 title 검증.
+
+    kind: 'issue' or 'pr' — reason 토큰 분기.
+    """
+
+    if not text or not text.strip():
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail="title is empty",
+        )
+    text = text.strip()
+    if len(text) > 100:
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail=f"title length {len(text)} > 100 — must be <= 100 chars",
+            fields={"title": text, "length": len(text)},
+        )
+
+    if _title_has_mode_token(text):
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail=(
+                "title contains mode tokens (autonomous_merge / single_repo / "
+                "full_stack_single_repo 등) — these are session metadata, not features"
+            ),
+            fields={"title": text},
+        )
+
+    if not allow_machine and _title_has_machine_pattern(text):
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail=(
+                "title is machine-like (e.g. 'coding-executor draft', 'agent/...') — "
+                "rewrite using the Korean humanizer (agents/coding/human_titles.py)"
+            ),
+            fields={"title": text},
+        )
+
+    # Korean 문자 갯수 — prefix 만 한국어이고 본문은 영문인 경우 reject.
+    # 예: `[구현] fix authentication bug` → 한국어 chars 2 (구현) 만 있으면
+    # 본문이 영문이므로 사람이 작업 내용을 한눈에 못 본다.
+    korean_chars = sum(1 for ch in text if _KOREAN_RE.match(ch))
+    if korean_chars < 4:
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail=(
+                f"title must contain at least 4 Korean (한국어) chars describing "
+                f"the work — got {korean_chars}. Move non-Korean implementation "
+                f"detail to the body."
+            ),
+            fields={"title": text, "korean_char_count": korean_chars},
+        )
+
+    if not any(text.startswith(p) for p in _ALLOWED_TITLE_PREFIXES):
+        return PolicyResult(
+            ok=False,
+            reason=(
+                REASON_INVALID_ISSUE_TITLE
+                if kind == "issue"
+                else REASON_INVALID_PR_TITLE
+            ),
+            detail=(
+                "title must start with one of "
+                + ", ".join(_ALLOWED_TITLE_PREFIXES)
+                + " (use agents/coding/human_titles.py to build correctly)"
+            ),
+            fields={"title": text, "allowed_prefixes": list(_ALLOWED_TITLE_PREFIXES)},
+        )
+
+    return PolicyResult(ok=True, fields={"title": text})
+
+
+def validate_issue_title(text: str) -> PolicyResult:
+    return _validate_human_title(text, kind="issue")
+
+
+def validate_pr_title(text: str) -> PolicyResult:
+    return _validate_human_title(text, kind="pr")
+
+
+def enforce_issue_title(text: str) -> None:
+    _raise(validate_issue_title(text))
+
+
+def enforce_pr_title(text: str) -> None:
+    _raise(validate_pr_title(text))
+
+
+# ---------------------------------------------------------------------------
+# Issue anchor validation
+# ---------------------------------------------------------------------------
+
+
+_BRANCH_ISSUE_RE = re.compile(r"\bissue[-/_](\d+)\b", re.IGNORECASE)
+_BODY_ISSUE_RE = re.compile(
+    r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|관련)\s*#(\d+)",
+    re.IGNORECASE,
+)
+_PLAIN_HASH_ISSUE_RE = re.compile(r"#(\d+)")
+
+
+# repo work 가 아니라고 인정할 narrow 경우 — docs-only 같은 small chore
+_NO_ISSUE_EXEMPT_PATHS: tuple = ("docs/", "README.md", "CLAUDE.md", "AGENTS.md")
+
+
+@dataclass(frozen=True)
+class IssueAnchorContext:
+    branch: Optional[str] = None
+    pr_body: Optional[str] = None
+    issue_number_hint: Optional[int] = None
+    is_docs_only: bool = False
+
+
+def validate_issue_anchor(ctx: IssueAnchorContext) -> PolicyResult:
+    """PR 또는 commit 작업에 issue anchor 가 붙어있는지.
+
+    1. ``issue_number_hint`` 가 양수면 OK (caller 가 이미 알고 있음).
+    2. branch name 에 ``issue-N`` 형식이 있으면 OK.
+    3. pr_body 에 ``close #N``, ``refs #N`` 또는 단순 ``#N`` 이 있으면 OK.
+    4. docs-only 변경이면 OK (caller 가 ``is_docs_only=True`` 로 표시).
+    그 외에는 fail.
+    """
+
+    if ctx.issue_number_hint and ctx.issue_number_hint > 0:
+        return PolicyResult(ok=True, fields={"issue_number": ctx.issue_number_hint})
+
+    if ctx.is_docs_only:
+        return PolicyResult(ok=True, fields={"docs_only": True})
+
+    if ctx.branch:
+        m = _BRANCH_ISSUE_RE.search(ctx.branch)
+        if m:
+            return PolicyResult(
+                ok=True,
+                fields={"issue_number": int(m.group(1)), "source": "branch"},
+            )
+
+    if ctx.pr_body:
+        m = _BODY_ISSUE_RE.search(ctx.pr_body)
+        if m:
+            return PolicyResult(
+                ok=True,
+                fields={"issue_number": int(m.group(1)), "source": "pr_body"},
+            )
+        m = _PLAIN_HASH_ISSUE_RE.search(ctx.pr_body)
+        if m:
+            return PolicyResult(
+                ok=True,
+                fields={"issue_number": int(m.group(1)), "source": "pr_body_plain"},
+            )
+
+    return PolicyResult(
+        ok=False,
+        reason=REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+        detail=(
+            "no issue anchor found in branch name OR PR body. "
+            "Create an issue first and reference it via `issue-<n>` in branch or "
+            "`close #<n>` / `refs #<n>` in PR body."
+        ),
+        fields={
+            "branch": ctx.branch,
+            "has_pr_body": bool(ctx.pr_body),
+        },
+    )
+
+
+def enforce_issue_anchor(ctx: IssueAnchorContext) -> None:
+    _raise(validate_issue_anchor(ctx))
+
+
+__all__ = (
+    "ALLOWED_GITMOJI",
+    "INITIAL_COMMIT_TITLE_EXACT",
+    "InitialCommitDecision",
+    "IssueAnchorContext",
+    "PolicyResult",
+    "PolicyViolation",
+    "REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS",
+    "REASON_INVALID_COMMIT_BODY_SECTIONS",
+    "REASON_INVALID_COMMIT_GITMOJI",
+    "REASON_INVALID_INITIAL_COMMIT_TITLE",
+    "REASON_INVALID_ISSUE_TITLE",
+    "REASON_INVALID_PR_TITLE",
+    "REASON_ISSUE_REQUIRED_FOR_REPO_WORK",
+    "REASON_TADA_OUTSIDE_INITIAL_COMMIT",
+    "REQUIRED_SECTIONS",
+    "enforce_commit_message",
+    "enforce_issue_anchor",
+    "enforce_issue_title",
+    "enforce_pr_title",
+    "is_initial_commit_context",
+    "validate_commit_message",
+    "validate_initial_commit_decision",
+    "validate_issue_anchor",
+    "validate_issue_title",
+    "validate_pr_title",
+)

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -995,6 +995,42 @@ class LocalGitCommitter:
             return replace(context, commit_sha="")
 
         message = _commit_message(request, context)
+
+        # P1-N — cross-repo commit convention hard guard.
+        # initial commit 여부는 worktree (target repo) 의 git log 로 판별 +
+        # caller (bootstrap flow) 가 ``metadata["initial_commit"]`` hint 를 줄
+        # 수 있다.  ambiguous 시 honest blocker raise.
+        try:
+            from ..governance.repo_write_policy import (
+                enforce_commit_message,
+                is_initial_commit_context,
+                PolicyViolation,
+                validate_initial_commit_decision,
+            )
+
+            explicit_hint = None
+            metadata = request.metadata or {}
+            if isinstance(metadata, Mapping):
+                if "initial_commit" in metadata:
+                    explicit_hint = bool(metadata.get("initial_commit"))
+            decision = is_initial_commit_context(
+                repo_root=wt,
+                explicit_hint=explicit_hint,
+                branch_hint=context.branch,
+            )
+            decision_result = validate_initial_commit_decision(decision)
+            if not decision_result.ok and decision_result.reason:
+                raise PolicyViolation(
+                    reason=decision_result.reason,
+                    detail=decision_result.detail,
+                    fields=decision_result.fields,
+                )
+            enforce_commit_message(message, is_initial=decision.is_initial)
+        except PolicyViolation as exc:
+            raise CodingCommitError(
+                f"commit policy violation: {exc.reason}: {exc.detail}"
+            ) from exc
+
         try:
             self._runner(
                 ["git", "-C", wt, "commit", "-m", message],
@@ -1152,6 +1188,31 @@ class GithubAppDraftPRCreator:
                 else f"📝 coding-executor draft — {context.branch}"
             )
         body = _draft_pr_body(request, context)
+
+        # P1-N — cross-repo PR title + issue anchor hard guard.
+        # 옛 wiring 은 "coding-executor draft #4" 같은 기계 제목 / issue
+        # 없는 PR 가 그대로 GitHub 로 흘러갔다. 본 가드가 PR 생성 직전
+        # raise 해서 다음 PR 부터는 위반 자체가 막힌다.
+        try:
+            from ..governance.repo_write_policy import (
+                IssueAnchorContext,
+                enforce_issue_anchor,
+                enforce_pr_title,
+            )
+
+            enforce_pr_title(title)
+            enforce_issue_anchor(
+                IssueAnchorContext(
+                    branch=context.branch,
+                    pr_body=body,
+                    issue_number_hint=request.issue_number,
+                )
+            )
+        except Exception as policy_exc:  # noqa: BLE001 — surface as RuntimeError
+            # Re-raise so worker maps to REASON_PR_FAILED with policy detail.
+            # PolicyViolation 의 reason/detail 이 그대로 worker progress
+            # marker 에 노출됨.
+            raise
 
         # P0-T: runtime governance policy gate — PR body 가 5 섹션 +
         # audit block 을 갖는지 검사. caller-driven gate 원칙: validation

--- a/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
@@ -27,7 +27,7 @@ session 갱신 키
 {
   "issue_number": 77,                          # 생성/재사용된 번호
   "html_url": "https://github.com/.../issues/77",
-  "title": "[Feat] 회원가입 ...",
+  "title": "[기능] 회원가입 ...",
   "labels": ["✨ Feature", "📃 Docs"],
   "approval_id": "approval-1",
   "approved_by": "masterway",

--- a/tests/discord/test_github_workos_adapter_issue_bootstrap.py
+++ b/tests/discord/test_github_workos_adapter_issue_bootstrap.py
@@ -39,7 +39,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[Feat]"\n'
+    'title: "[기능]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -80,7 +80,7 @@ class BuildProposalIssuePlanTests(unittest.TestCase):
         assert proposal.issue_auto_create_plan is not None
         plan = proposal.issue_auto_create_plan
         self.assertEqual(plan["audit_reason"], "template_used")
-        self.assertTrue(plan["title"].startswith("[Feat]"))
+        self.assertTrue(plan["title"].startswith("[기능]"))
         self.assertIn("✨ Feature", plan["labels"])
         # extras 에 audit_reason 흔적
         self.assertEqual(

--- a/tests/engineering/test_issue_autocreate_end_to_end.py
+++ b/tests/engineering/test_issue_autocreate_end_to_end.py
@@ -53,7 +53,7 @@ from yule_orchestrator.agents.job_queue.github_work_order import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[Feat]"\n'
+    'title: "[기능]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -207,7 +207,7 @@ class EndToEndIssueAutoCreateTests(unittest.TestCase):
         kind, kwargs = client.calls[0]
         self.assertEqual(kind, "create_issue")
         self.assertEqual(kwargs["repo"], "yule-studio/naver-search-clone")
-        self.assertTrue(kwargs["title"].startswith("[Feat]"))
+        self.assertTrue(kwargs["title"].startswith("[기능]"))
         self.assertIn("Next.js + NestJS", kwargs["title"])
         self.assertIn("✨ Feature", kwargs["labels"])
 

--- a/tests/engineering/test_issue_quality_and_repair.py
+++ b/tests/engineering/test_issue_quality_and_repair.py
@@ -92,8 +92,8 @@ class FallbackTitleQualityTests(unittest.TestCase):
             request_summary=_NAVER_PROMPT,
             session_id="sess-x",
         )
-        # 사용자가 명시한 기대 형태와 같은 골격: `[Feat] ... 풀스택 MVP 구축 (...)`
-        self.assertTrue(plan.title.startswith("[Feat]"))
+        # 사용자가 명시한 기대 형태와 같은 골격: `[기능] ... 풀스택 MVP 구축 (...)`
+        self.assertTrue(plan.title.startswith("[기능]"))
         self.assertIn("풀스택 MVP", plan.title)
         self.assertIn("(인증/검색/블로그/메일)", plan.title)
         # 도메인 토큰 (네이버 검색형) 도 들어감
@@ -211,7 +211,7 @@ class ObsidianFallbackTests(unittest.TestCase):
             "template_source: `obsidian_fallback`", plan.body
         )
         # title 은 여전히 Korean synthesizer 적용
-        self.assertTrue(plan.title.startswith("[Feat]"))
+        self.assertTrue(plan.title.startswith("[기능]"))
 
     def test_obsidian_loader_none_falls_through(self) -> None:
         """loader 가 빈 텍스트 / None 반환 → Yule default 로 fall through."""
@@ -255,7 +255,7 @@ class IssueRepairTests(unittest.TestCase):
         self.assertTrue(outcome.dry_run)
         self.assertEqual(outcome.skipped_reason, "no_client_wired")
         # plan 은 quality fallback 으로 생성
-        self.assertTrue(outcome.plan.title.startswith("[Feat]"))
+        self.assertTrue(outcome.plan.title.startswith("[기능]"))
         self.assertIn(LABEL_FULL_STACK, outcome.plan.labels)
 
     def test_live_update_calls_client(self) -> None:
@@ -291,7 +291,7 @@ class IssueRepairTests(unittest.TestCase):
         self.assertEqual(sent["repo"], "yule-studio/naver-search-clone")
         self.assertEqual(sent["issue_number"], 1)
         # 새 title 이 한국어 명확
-        self.assertTrue(sent["title"].startswith("[Feat]"))
+        self.assertTrue(sent["title"].startswith("[기능]"))
         self.assertIn("풀스택 MVP", sent["title"])
         # labels 가 비어있지 않음
         self.assertGreater(len(sent["labels"]), 0)
@@ -360,7 +360,7 @@ class IssueLessAutoCreateRegression(unittest.TestCase):
         # plan 생성 성공 + 새 quality 적용됨
         self.assertIsNotNone(outcome.plan)
         plan = outcome.plan
-        self.assertTrue(plan.title.startswith("[Feat]"))
+        self.assertTrue(plan.title.startswith("[기능]"))
         self.assertGreater(len(plan.labels), 0)
         self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_FALLBACK)
 

--- a/tests/engineering/test_issueless_bootstrap_end_to_end.py
+++ b/tests/engineering/test_issueless_bootstrap_end_to_end.py
@@ -62,7 +62,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[Feat]"\n'
+    'title: "[기능]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -214,7 +214,7 @@ class IssuelessBootstrapEndToEndTests(unittest.TestCase):
         plan = proposal_payload.get("issue_auto_create_plan")
         self.assertIsNotNone(plan)
         assert plan is not None
-        self.assertTrue(plan["title"].startswith("[Feat]"))
+        self.assertTrue(plan["title"].startswith("[기능]"))
 
         # 2. operator 승인 → work order dispatch
         dispatch_outcome = handle_github_work_approval_reply(

--- a/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
+++ b/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
@@ -64,7 +64,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[Feat]"\n'
+    'title: "[기능]"\n'
     'labels: "✨ Feature"\n'
     "---\n"
     "\n"

--- a/tests/github_workos/test_issue_auto_create.py
+++ b/tests/github_workos/test_issue_auto_create.py
@@ -51,7 +51,7 @@ _REAL_FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
     'about: 모든 라벨 관리 이슈 템플릿\n'
-    'title: "[Feat]"\n'
+    'title: "[기능]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "assignees: ''\n"
     "---\n"
@@ -91,7 +91,7 @@ class TemplateParsingTests(unittest.TestCase):
             text=_REAL_FEATURE_TEMPLATE,
         )
         self.assertEqual(tpl.name, "[Feature] Issue Template")
-        self.assertEqual(tpl.title_prefix, "[Feat]")
+        self.assertEqual(tpl.title_prefix, "[기능]")
         self.assertEqual(tpl.labels, ("✨ Feature", "📃 Docs"))
         self.assertEqual(tpl.assignees, ())
         self.assertIn("어떤 기능인가요?", tpl.body)
@@ -167,7 +167,7 @@ class FillTemplateTests(unittest.TestCase):
             request_summary="회원가입/로그인 구현",
             session_id="sess-1",
         )
-        self.assertTrue(plan.title.startswith("[Feat]"))
+        self.assertTrue(plan.title.startswith("[기능]"))
         self.assertIn("회원가입/로그인 구현", plan.title)
         # quote 삽입 위치 검증
         self.assertIn("> 회원가입/로그인 구현", plan.body)

--- a/tests/github_workos/test_writer_create_issue.py
+++ b/tests/github_workos/test_writer_create_issue.py
@@ -83,7 +83,7 @@ class WriterCreateIssueDryRunTests(unittest.TestCase):
         writer = GithubWriter(client=client)
         result = writer.create_issue(
             repo="owner/repo",
-            title="[Feat] 회원가입",
+            title="[기능] 회원가입",
             body="요약",
             labels=("✨ Feature",),
             assignees=("codwithyc",),
@@ -104,8 +104,8 @@ class WriterCreateIssuePolicyTests(unittest.TestCase):
         )
         result = writer.create_issue(
             repo="owner/repo",
-            title="t",
-            body="b",
+            title="[기능] 정책 거부 회귀 테스트",
+            body="정책 거부 테스트 본문",
         )
         self.assertEqual(result.outcome, OUTCOME_DENIED_BY_POLICY)
         self.assertEqual(client.calls, [])
@@ -123,7 +123,7 @@ class WriterCreateIssueLiveTests(unittest.TestCase):
         )
         result = writer.create_issue(
             repo="owner/repo",
-            title="[Feat] 회원가입",
+            title="[기능] 회원가입",
             body="설명",
             labels=(" ✨ Feature ", "", "📃 Docs"),
             assignees=("codwithyc",),
@@ -227,7 +227,7 @@ class LiveGithubAppClientIssueTests(unittest.TestCase):
         client = _build_live_client(http)
         response = client.create_issue(
             repo="owner/repo",
-            title="[Feat] X",
+            title="[기능] X",
             body="body",
             labels=("✨ Feature", "📃 Docs"),
             assignees=("codwithyc",),
@@ -237,7 +237,7 @@ class LiveGithubAppClientIssueTests(unittest.TestCase):
         issue_reqs = [r for r in http.posted if r["url"].endswith("/repos/owner/repo/issues")]
         self.assertEqual(len(issue_reqs), 1)
         body = issue_reqs[0]["body"]
-        self.assertEqual(body["title"], "[Feat] X")
+        self.assertEqual(body["title"], "[기능] X")
         self.assertEqual(body["body"], "body")
         self.assertEqual(body["labels"], ["✨ Feature", "📃 Docs"])
         self.assertEqual(body["assignees"], ["codwithyc"])

--- a/tests/governance/test_repo_write_policy.py
+++ b/tests/governance/test_repo_write_policy.py
@@ -1,0 +1,421 @@
+"""P1-N — 15 사용자 명시 acceptance for hard guard layer.
+
+1.  허용되지 않은 gitmoji commit message reject
+2.  변경 이유 / 주요 변경 사항 / 비고 누락 commit reject
+3.  `## 변경 이유` (markdown header) reject (SSoT 통일 강제)
+4.  issue anchor 없는 PR 생성 시 block
+5.  issue title humanizer Korean readable
+6.  PR title humanizer Korean readable
+7.  machine-like PR title block
+8.  valid 조합 통과
+9.  coding executor / PR creator live path 에서 guard 호출 (단위 테스트로 guard 호출 가능성 확인)
+10. blocker reason status/audit/operator surface 명확
+11. cross-repo write path 가드 (validator 는 repo 와 무관하게 동일 동작)
+12. initial commit `:tada: initial commit` 정확 매칭
+13. non-initial 에서 `:tada: initial commit` reject
+14. initial 인데 다른 제목 reject
+15. ambiguous detection 시 honest blocker
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    ALLOWED_GITMOJI,
+    INITIAL_COMMIT_TITLE_EXACT,
+    InitialCommitDecision,
+    IssueAnchorContext,
+    PolicyViolation,
+    REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS,
+    REASON_INVALID_COMMIT_BODY_SECTIONS,
+    REASON_INVALID_COMMIT_GITMOJI,
+    REASON_INVALID_INITIAL_COMMIT_TITLE,
+    REASON_INVALID_ISSUE_TITLE,
+    REASON_INVALID_PR_TITLE,
+    REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+    REASON_TADA_OUTSIDE_INITIAL_COMMIT,
+    REQUIRED_SECTIONS,
+    enforce_commit_message,
+    enforce_issue_anchor,
+    enforce_issue_title,
+    enforce_pr_title,
+    is_initial_commit_context,
+    validate_commit_message,
+    validate_initial_commit_decision,
+    validate_issue_anchor,
+    validate_issue_title,
+    validate_pr_title,
+)
+
+
+_VALID_BODY = (
+    "변경 이유\n- 회원가입 부재\n\n"
+    "주요 변경 사항\n- 로그인 API\n\n"
+    "비고\n- 없음"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. gitmoji whitelist
+# ---------------------------------------------------------------------------
+
+
+class GitmojiWhitelistTests(unittest.TestCase):
+    def test_rejects_unlisted_gitmoji(self) -> None:
+        # 🎚 (recent 위반 케이스), 🔗, 🛡️, 🧪 모두 reject
+        for emoji in ("🎚", "🔗", "🛡️", "🧪", "🚀"):
+            with self.subTest(emoji=emoji):
+                r = validate_commit_message(f"{emoji} 제목\n\n{_VALID_BODY}")
+                self.assertFalse(r.ok, emoji)
+                self.assertEqual(r.reason, REASON_INVALID_COMMIT_GITMOJI)
+
+    def test_accepts_base_whitelist(self) -> None:
+        for emoji in ("✨", "🐛", "♻️", "📝", "✅", "🔧"):
+            with self.subTest(emoji=emoji):
+                r = validate_commit_message(f"{emoji} 제목\n\n{_VALID_BODY}")
+                self.assertTrue(r.ok, emoji)
+
+
+# ---------------------------------------------------------------------------
+# 2. body section enforcement
+# ---------------------------------------------------------------------------
+
+
+class BodySectionEnforcementTests(unittest.TestCase):
+    def test_rejects_missing_section(self) -> None:
+        for missing in REQUIRED_SECTIONS:
+            with self.subTest(missing=missing):
+                # rebuild body without the chosen section
+                body = "\n\n".join(
+                    f"{sec}\n- 내용" for sec in REQUIRED_SECTIONS if sec != missing
+                )
+                r = validate_commit_message(f"✨ 테스트 제목\n\n{body}")
+                self.assertFalse(r.ok)
+                self.assertEqual(r.reason, REASON_INVALID_COMMIT_BODY_SECTIONS)
+                self.assertIn(missing, r.detail)
+
+    def test_rejects_empty_section_body(self) -> None:
+        # section 헤더는 있지만 bullet 없는 경우
+        body = "변경 이유\n\n주요 변경 사항\n- 추가\n\n비고\n- 없음"
+        r = validate_commit_message(f"✨ 테스트\n\n{body}")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_COMMIT_BODY_SECTIONS)
+
+
+# ---------------------------------------------------------------------------
+# 3. markdown header reject (SSoT 통일)
+# ---------------------------------------------------------------------------
+
+
+class MarkdownHeaderRejectTests(unittest.TestCase):
+    def test_rejects_md_header_variant(self) -> None:
+        body = (
+            "## 변경 이유\n- a\n\n"
+            "## 주요 변경 사항\n- b\n\n"
+            "## 비고\n- 없음"
+        )
+        r = validate_commit_message(f"✨ 테스트\n\n{body}")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_COMMIT_BODY_SECTIONS)
+        self.assertIn("plain text", r.detail)
+
+
+# ---------------------------------------------------------------------------
+# 4. issue anchor required
+# ---------------------------------------------------------------------------
+
+
+class IssueAnchorRequiredTests(unittest.TestCase):
+    def test_missing_anchor_blocks(self) -> None:
+        ctx = IssueAnchorContext(
+            branch="feature/some-branch-no-issue",
+            pr_body="## 요약\n- 코드 추가",
+        )
+        r = validate_issue_anchor(ctx)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_ISSUE_REQUIRED_FOR_REPO_WORK)
+
+    def test_branch_issue_anchor_satisfies(self) -> None:
+        ctx = IssueAnchorContext(branch="feature/auth-issue-12")
+        r = validate_issue_anchor(ctx)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.fields["issue_number"], 12)
+
+    def test_body_close_anchor_satisfies(self) -> None:
+        ctx = IssueAnchorContext(
+            branch="feature/no-anchor", pr_body="close #42"
+        )
+        r = validate_issue_anchor(ctx)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.fields["issue_number"], 42)
+
+    def test_docs_only_exempt(self) -> None:
+        ctx = IssueAnchorContext(branch="docs/runbook", is_docs_only=True)
+        r = validate_issue_anchor(ctx)
+        self.assertTrue(r.ok)
+
+    def test_issue_number_hint_satisfies(self) -> None:
+        ctx = IssueAnchorContext(issue_number_hint=7)
+        r = validate_issue_anchor(ctx)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.fields["issue_number"], 7)
+
+
+# ---------------------------------------------------------------------------
+# 5, 6 — issue/PR title 한국어 humanizer
+# ---------------------------------------------------------------------------
+
+
+class HumanReadableTitleTests(unittest.TestCase):
+    def test_issue_title_valid_korean(self) -> None:
+        r = validate_issue_title("[기능] 네이버 검색 MVP - 인증/검색 홈 1차")
+        self.assertTrue(r.ok)
+
+    def test_pr_title_valid_korean(self) -> None:
+        r = validate_pr_title("[구현][검색] 검색 홈 화면 및 결과 탭 UI 1차 (#4)")
+        self.assertTrue(r.ok)
+
+    def test_pr_title_english_only_rejected(self) -> None:
+        r = validate_pr_title("[구현] fix authentication bug")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_PR_TITLE)
+
+    def test_issue_title_missing_prefix_rejected(self) -> None:
+        r = validate_issue_title("회원가입 API 추가")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_ISSUE_TITLE)
+
+
+# ---------------------------------------------------------------------------
+# 7. machine-like title block
+# ---------------------------------------------------------------------------
+
+
+class MachinelikeTitleBlockTests(unittest.TestCase):
+    def test_coding_executor_draft_pattern_blocked(self) -> None:
+        r = validate_pr_title("coding-executor draft #4")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_PR_TITLE)
+        self.assertIn("machine-like", r.detail)
+
+    def test_mode_token_in_title_blocked(self) -> None:
+        r = validate_pr_title("[구현] autonomous_merge 인증 추가")
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_PR_TITLE)
+
+
+# ---------------------------------------------------------------------------
+# 8. valid 조합 통과
+# ---------------------------------------------------------------------------
+
+
+class HappyPathTests(unittest.TestCase):
+    def test_valid_commit_issue_pr_anchor_all_pass(self) -> None:
+        # commit
+        commit = (
+            "✨ 회원가입 API 추가\n\n"
+            "변경 이유\n- 인증 부재\n\n"
+            "주요 변경 사항\n- POST /auth/signup\n- 비밀번호 해시\n\n"
+            "비고\n- 없음"
+        )
+        # All four validators pass
+        self.assertTrue(validate_commit_message(commit).ok)
+        self.assertTrue(validate_issue_title("[기능][인증] 회원가입 API 추가").ok)
+        self.assertTrue(
+            validate_pr_title("[구현][인증] 회원가입 API 1차 (#7)").ok
+        )
+        self.assertTrue(
+            validate_issue_anchor(
+                IssueAnchorContext(branch="feature/auth-issue-7")
+            ).ok
+        )
+
+    def test_enforce_helpers_dont_raise_on_valid(self) -> None:
+        enforce_commit_message(
+            "✨ 추가\n\n변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
+        )
+        enforce_issue_title("[기능] 인증 추가")
+        enforce_pr_title("[구현] 인증 API 추가")
+        enforce_issue_anchor(IssueAnchorContext(issue_number_hint=1))
+
+
+# ---------------------------------------------------------------------------
+# 9. live path 에서 guard 호출 (import-time wiring 가드)
+# ---------------------------------------------------------------------------
+
+
+class LiveWiringExistsTests(unittest.TestCase):
+    def test_committer_source_references_validator(self) -> None:
+        """coding_executor_live.GithubAppCommitter.commit 가 enforce_commit_message
+        를 실제 호출하는지 source-grep — 단위 테스트로 wiring 회귀 차단."""
+
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/agents/job_queue/coding_executor_live.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("enforce_commit_message", src)
+        self.assertIn("is_initial_commit_context", src)
+
+    def test_pr_creator_source_references_validators(self) -> None:
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/agents/job_queue/coding_executor_live.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("enforce_pr_title", src)
+        self.assertIn("enforce_issue_anchor", src)
+
+    def test_issue_creator_source_references_validator(self) -> None:
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/agents/github_workos/github_writer.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("enforce_issue_title", src)
+
+
+# ---------------------------------------------------------------------------
+# 10. blocker reason 노출
+# ---------------------------------------------------------------------------
+
+
+class PolicyViolationSurfaceTests(unittest.TestCase):
+    def test_violation_has_reason_and_fields(self) -> None:
+        try:
+            enforce_pr_title("[구현] english only title")
+        except PolicyViolation as exc:
+            self.assertEqual(exc.reason, REASON_INVALID_PR_TITLE)
+            self.assertIn("title", exc.fields)
+            return
+        self.fail("expected PolicyViolation")
+
+    def test_initial_ambiguous_violation_explicit(self) -> None:
+        decision = InitialCommitDecision(
+            is_initial=False, ambiguous=True, reason="no_signal"
+        )
+        check = validate_initial_commit_decision(decision)
+        self.assertFalse(check.ok)
+        self.assertEqual(check.reason, REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS)
+
+
+# ---------------------------------------------------------------------------
+# 11. cross-repo (validator 자체가 repo-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class CrossRepoApplicationTests(unittest.TestCase):
+    def test_validator_does_not_depend_on_repo_full_name(self) -> None:
+        # 같은 commit message 는 어떤 repo 든 동일 결과.
+        msg = (
+            "✨ 인증 추가\n\n변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
+        )
+        for repo in (
+            "yule-studio/yule-studio-agent",
+            "yule-studio/naver-search-clone",
+            "external/foo",
+        ):
+            with self.subTest(repo=repo):
+                self.assertTrue(validate_commit_message(msg).ok)
+        # 동일 PR title 도 어떤 repo 든 동일.
+        bad = validate_pr_title("coding-executor draft #4")
+        good = validate_pr_title("[구현][검색] 검색 홈 (#1)")
+        self.assertFalse(bad.ok)
+        self.assertTrue(good.ok)
+
+
+# ---------------------------------------------------------------------------
+# 12-14 — initial commit special case
+# ---------------------------------------------------------------------------
+
+
+class InitialCommitSpecialCaseTests(unittest.TestCase):
+    def test_exact_initial_title_accepted(self) -> None:
+        msg = (
+            ":tada: initial commit\n\n"
+            "변경 이유\n- 새 repo 시작\n\n"
+            "주요 변경 사항\n- 기본 scaffold\n\n"
+            "비고\n- 없음"
+        )
+        r = validate_commit_message(msg, is_initial=True)
+        self.assertTrue(r.ok, r.detail)
+
+    def test_tada_outside_initial_rejected(self) -> None:
+        msg = (
+            ":tada: 무언가 다른 제목\n\n"
+            "변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
+        )
+        r = validate_commit_message(msg, is_initial=False)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_TADA_OUTSIDE_INITIAL_COMMIT)
+
+    def test_initial_with_wrong_title_rejected(self) -> None:
+        msg = (
+            "✨ 첫 commit\n\n"
+            "변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
+        )
+        r = validate_commit_message(msg, is_initial=True)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_INITIAL_COMMIT_TITLE)
+        self.assertIn(INITIAL_COMMIT_TITLE_EXACT, r.detail)
+
+    def test_emoji_form_of_tada_also_rejected_outside_initial(self) -> None:
+        # 🎉 (unicode emoji form, not shortcode) 도 차단
+        msg = (
+            "🎉 축하 메시지\n\n변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
+        )
+        r = validate_commit_message(msg, is_initial=False)
+        self.assertFalse(r.ok)
+        # 🎉 는 whitelist 에도 없으므로 invalid_commit_gitmoji 또는
+        # tada_used_outside_initial_commit 중 하나로 reject — 둘 다 honest.
+        self.assertIn(r.reason, (
+            REASON_TADA_OUTSIDE_INITIAL_COMMIT,
+            REASON_INVALID_COMMIT_GITMOJI,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# 15. ambiguous detection
+# ---------------------------------------------------------------------------
+
+
+class AmbiguousInitialDetectionTests(unittest.TestCase):
+    def test_no_signal_returns_ambiguous(self) -> None:
+        decision = is_initial_commit_context(
+            repo_root=None, explicit_hint=None
+        )
+        self.assertTrue(decision.ambiguous)
+        self.assertFalse(decision.is_initial)
+        check = validate_initial_commit_decision(decision)
+        self.assertFalse(check.ok)
+        self.assertEqual(check.reason, REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS)
+
+    def test_explicit_hint_wins(self) -> None:
+        d_true = is_initial_commit_context(explicit_hint=True)
+        d_false = is_initial_commit_context(explicit_hint=False)
+        self.assertTrue(d_true.is_initial)
+        self.assertFalse(d_true.ambiguous)
+        self.assertFalse(d_false.is_initial)
+        self.assertFalse(d_false.ambiguous)
+
+    def test_zero_commits_returns_initial(self) -> None:
+        import tempfile, subprocess
+
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(
+                ["git", "init", "-q", tmp], check=True, capture_output=True
+            )
+            decision = is_initial_commit_context(repo_root=tmp)
+            self.assertTrue(decision.is_initial)
+            self.assertFalse(decision.ambiguous)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/job_queue/test_github_work_order_executor.py
+++ b/tests/job_queue/test_github_work_order_executor.py
@@ -168,7 +168,7 @@ class _Fixture(unittest.TestCase):
 
     def _sample_plan(self, audit_reason: str = "template_used") -> Mapping[str, Any]:
         return {
-            "title": "[Feat] 회원가입/검색 구현",
+            "title": "[기능] 회원가입/검색 구현",
             "body": "## 어떤 기능인가요?\n> 본문\n",
             "labels": ["✨ Feature", "📃 Docs"],
             "assignees": [],
@@ -208,7 +208,7 @@ class AutoCreateBranchTests(_Fixture):
         # writer called with plan content
         self.assertEqual(len(self.writer.calls), 1)
         _, call_kwargs = self.writer.calls[0]
-        self.assertTrue(call_kwargs["title"].startswith("[Feat]"))
+        self.assertTrue(call_kwargs["title"].startswith("[기능]"))
         self.assertIn("✨ Feature", call_kwargs["labels"])
         # session extra anchor
         anchor = self.sessions.sessions["sess-1"].extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]

--- a/tests/job_queue/test_github_work_order_issue_plan.py
+++ b/tests/job_queue/test_github_work_order_issue_plan.py
@@ -27,7 +27,7 @@ from yule_orchestrator.agents.job_queue.github_work_order import (
 
 def _sample_plan() -> dict:
     return {
-        "title": "[Feat] 회원가입/검색 기능",
+        "title": "[기능] 회원가입/검색 기능",
         "body": "## 어떤 기능인가요?\n> 본문\n",
         "labels": ["✨ Feature", "📃 Docs"],
         "assignees": [],

--- a/tests/job_queue/test_work_order_coding_continuation.py
+++ b/tests/job_queue/test_work_order_coding_continuation.py
@@ -60,7 +60,7 @@ def _anchor(issue_number: int = 77) -> Mapping[str, Any]:
     return {
         "issue_number": issue_number,
         "html_url": f"https://github.com/yule-studio/naver-search-clone/issues/{issue_number}",
-        "title": "[Feat] 회원가입",
+        "title": "[기능] 회원가입",
         "created_via": "auto_create",
         "approval_id": "a1",
         "approved_by": "masterway",

--- a/tests/job_queue/test_work_order_repo_recovery.py
+++ b/tests/job_queue/test_work_order_repo_recovery.py
@@ -136,7 +136,7 @@ class _Fixture(unittest.TestCase):
 
     def _sample_plan(self) -> Mapping[str, Any]:
         return {
-            "title": "[Feat] live recover",
+            "title": "[기능] live recover",
             "body": "## 어떤 기능인가요?\n> recover\n",
             "labels": ["✨ Feature"],
             "assignees": [],

--- a/tests/runtime/test_github_work_order_executor_runtime.py
+++ b/tests/runtime/test_github_work_order_executor_runtime.py
@@ -234,7 +234,7 @@ class RunUntilShutdownTests(unittest.TestCase):
             repo="yule-studio/naver-search-clone",
             dry_run=False,
             issue_auto_create_plan={
-                "title": "[Feat] 회원가입",
+                "title": "[기능] 회원가입",
                 "body": "## 어떤 기능인가요?\n> live\n",
                 "labels": ["✨ Feature"],
                 "assignees": [],


### PR DESCRIPTION
## 📌 요약

다음 PR 부터 정책 위반이 시스템적으로 막히도록 hard guard 4 종을 live path 에 wire.

1. **Gitmoji whitelist** — `✨ 🐛 ♻️ 📝 ✅ 🔧` 기본 + `🚚 🔥 ⚡️ 👷 💚 🚑️` 필요시. 옛 위반 (`🎚 🔗 🛡️ 🧪`) 모두 reject.
2. **3-section commit body** — plain text 헤더 `변경 이유 / 주요 변경 사항 / 비고` 필수. `## 변경 이유` markdown 변형 명시 reject.
3. **Issue anchor required** — branch `issue-N` OR PR body `close #N` OR docs-only.
4. **한국어 명확 title** — `[기능]/[구현]/[수정]/[문서]/[설정]/[테스트]/[리팩토링]` prefix + 본문 4+ chars + 모드 토큰 / 기계 패턴 reject.
5. **Initial commit 특수 규칙** — 첫 commit 만 `:tada: initial commit` 정확 매칭. ambiguous 시 honest blocker.

## ✨ 변경 (4 commits)

### 📝 P1-N A — doc SSoT 통일 (`292ae2b`)
- `COMMIT_CONVENTION.md` 에 cross-repo 적용 + initial commit 특수 규칙 추가.
- `issue-pr-conventions.md` §3.1 의 `## 변경 이유` markdown → plain text 로 normalize. SSoT cross-link.
- `.gitmessage.txt` 에 initial commit + hook 설치 안내.

### ✨ P1-N B+D — 중앙 validator + commit-msg hook (`1c28385`)
- `agents/governance/repo_write_policy.py` 신설 (4 validator + 1 helper, 8 reason 토큰).
- `scripts/validate_commit_msg.py` — git `commit-msg` hook entry point. `YULE_COMMIT_IS_INITIAL=1/0` env 로 ambiguous 분류.

### 🔗 P1-N C — live wiring (`65405e0`)
- `coding_executor_live.GithubAppCommitter.commit` — `is_initial_commit_context` + `enforce_commit_message`.
- `coding_executor_live.GithubAppDraftPRCreator.open` — `enforce_pr_title` + `enforce_issue_anchor`.
- `github_workos/github_writer.create_issue` — `enforce_issue_title`.
- `issue_quality._INTENT_TITLE_PREFIX` 영문 → 한국어 통일.
- 기존 test fixture 17 파일 `[Feat]` → `[기능]` 일괄 normalize.

### ✅ P1-N E — 31 회귀 (`911aedd`)
사용자 명시 15 acceptance 모두 cover + 16 보조.

## 🧪 회귀

- **stdlib unittest 누적**: 5293 / 5 pre-existing errors (digest_crawler locale + gateway_shutdown — P1-N 무관). 신규 31 모두 통과.
- **local commit-msg hook smoke**: `🎚 잘못된 gitmoji` exit=1 with rejection log; `✨ 회원가입 API 추가\n\n변경 이유\n- 없음\n\n주요 변경 사항\n- 추가\n\n비고\n- 없음` exit=0.
- **governance/code_audit**: 위반 0 유지.

## 📦 머지 후 운영자 절차

1. main pull.
2. commit-msg hook 활성화 (한 번만): `ln -sf ../../scripts/validate_commit_msg.py .git/hooks/commit-msg`.
3. runtime 재기동 — coding_executor 가 새 wiring 사용.
4. 다음 PR 시도해보고 위반 시 자동 차단됨을 확인. blocker reason 8 종 중 어느 것이 떴는지 progress marker 에서 즉시 식별 가능.

## 🛡 다음 PR 부터 막히는 시나리오

| 시도 | blocker reason |
|---|---|
| 🎚 같은 비허용 gitmoji 로 commit | `invalid_commit_gitmoji` |
| `## 변경 이유` markdown header | `invalid_commit_body_sections` |
| 본문 섹션 누락 | `invalid_commit_body_sections` |
| issue 없는 feature/fix PR | `issue_required_for_repo_work` |
| 영문-only / `coding-executor draft` PR title | `invalid_pr_title_not_human_readable_korean` |
| `autonomous_merge` 같은 모드 토큰 제목 노출 | `invalid_pr_title_not_human_readable_korean` |
| `[Feat]` 같은 영문 prefix issue title | `invalid_issue_title_not_human_readable_korean` |
| 첫 commit 인데 다른 제목 | `invalid_initial_commit_title` |
| 비-첫 commit 에 `:tada:` 사용 | `tada_used_outside_initial_commit` |
| 첫 commit 판별 모호 | `initial_commit_detection_ambiguous` |

위 모든 reason 은 `agents/governance/repo_write_policy.py` 의 상수로 정의됨 — operator surface (status / progress / mistake ledger candidate) 가 동일 token 으로 노출.