### PR TITLE
🐛 P1-O: merge_executor=no silent regression — import bug fix + 4-stage diagnostic

### DIFF
--- a/src/yule_orchestrator/agents/governance/code_audit.py
+++ b/src/yule_orchestrator/agents/governance/code_audit.py
@@ -159,6 +159,11 @@ SPLIT_NOW_PENDING: Mapping[str, Dict[str, str]] = {
         "owner": "codwithyc",
         "axes": "process_job pipeline, reason classification, progress stamping",
     },
+    "src/yule_orchestrator/runtime/coding_executor_runner.py": {
+        "deadline": "2026-06-21",
+        "owner": "codwithyc",
+        "axes": "background loops (producer / target_repo / pr_merge_continuation) + executor builders (live merge + approval enqueuer + next slice dispatcher) + recovery sweeps",
+    },
 }
 
 

--- a/src/yule_orchestrator/runtime/coding_executor_runner.py
+++ b/src/yule_orchestrator/runtime/coding_executor_runner.py
@@ -471,34 +471,134 @@ def _persist_session_extra(session_id: str, new_extra: Mapping[str, Any]) -> Non
         return
 
 
-def _maybe_build_live_pr_merge_executor():
-    """env 가 갖춰지면 live ``PRMergeExecutor`` 반환. 아니면 None.
+# P1-O — autonomous_merge live executor 의 opt-in env contract.  본
+# 모듈에서 직접 정의 — 옛 wiring 은 ``coding_executor_live`` 에서
+# import 하려다 silent ImportError 로 떨어져 ``merge_executor=no`` 라는
+# 거짓 신호를 startup log 에 노출했다.  이제 SSoT 가 본 모듈이고, bot
+# helper (`_build_pr_merge_executor_for_bot`) 도 본 함수를 재사용하므로
+# wiring 이 한 자리에서 보장된다.
+ENV_GITHUB_APP_MERGE_OPT_IN: str = "YULE_GITHUB_APP_MERGE_OPT_IN"
 
-    ``GitHubAppConfigError`` 면 None — env 미설정 환경에서는 autonomous
-    merge 가 동작하지 않을 뿐 loop 자체는 죽지 않는다.
-    """
 
-    try:
-        from ..agents.job_queue.coding_executor_live import (
-            ENV_GITHUB_APP_MERGE_OPT_IN,
-        )
-        from ..github_app.live_client import build_live_client_from_env
-        from ..github_app.pr_merge_executor import build_pr_merge_executor
-    except Exception:  # noqa: BLE001
-        return None
-    # merge opt-in env 가 없으면 안전을 위해 None — autonomous merge 가
-    # placeholder 단계에서 실수로 raise 하지 않게.
-    if (os.environ.get(ENV_GITHUB_APP_MERGE_OPT_IN) or "").strip().lower() not in (
+# diagnostic — 4 stage 중 어디서 None 으로 떨어졌는지 표면화.
+MERGE_EXEC_STAGE_IMPORT_FAILED: str = "import_failed"
+MERGE_EXEC_STAGE_OPT_IN_OFF: str = "opt_in_off"
+MERGE_EXEC_STAGE_CONFIG_ERROR: str = "github_app_config_error"
+MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED: str = "live_client_build_failed"
+MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED: str = "pr_merge_executor_build_failed"
+MERGE_EXEC_STAGE_OK: str = "ok"
+
+
+def _opt_in_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    src = env if env is not None else os.environ
+    return (src.get(ENV_GITHUB_APP_MERGE_OPT_IN) or "").strip().lower() in (
         "1",
         "true",
         "yes",
-    ):
-        return None
+        "on",
+    )
+
+
+def _maybe_build_live_pr_merge_executor(
+    *, log: bool = True
+) -> Optional[Any]:
+    """env 가 갖춰지면 live ``PRMergeExecutor`` 반환. 아니면 None.
+
+    P1-O harden — 옛 broad ``except Exception: return None`` 이 import
+    bug 와 env 미설정을 구분 못 해서 operator 가 startup log 만 보고는
+    원인을 알 수 없었다.  본 함수는 4 stage 로 명확히 분기해서 log
+    warning + reason 으로 surface한다.
+
+    Returns the executor callable when ``stage == ok``, otherwise None.
+    별도 stage 정보가 필요하면 :func:`build_live_pr_merge_executor_with_stage`
+    를 사용 — 본 함수는 backwards-compat shim.
+    """
+
+    executor, _stage = build_live_pr_merge_executor_with_stage(log=log)
+    return executor
+
+
+def build_live_pr_merge_executor_with_stage(
+    *, env: Optional[Mapping[str, str]] = None, log: bool = True
+) -> tuple:
+    """4 stage diagnostic — (executor or None, stage_token).
+
+    Stage tokens:
+      * ``import_failed`` — 모듈 import 자체가 실패.  P1-O 이전의 silent
+        regression 회귀 차단을 위한 explicit stage.
+      * ``opt_in_off`` — ``YULE_GITHUB_APP_MERGE_OPT_IN`` 가 truthy 가 아님.
+      * ``github_app_config_error`` — GitHubAppConfig.from_env 실패 (보통
+        env contract 누락).
+      * ``live_client_build_failed`` — config 는 통과했지만 live client
+        construction 에서 raise.
+      * ``pr_merge_executor_build_failed`` — live client 까지 OK 인데
+        ``build_pr_merge_executor`` 가 raise.
+      * ``ok`` — executor callable 반환.
+    """
+
     try:
-        live_client = build_live_client_from_env()
+        from ..github_app.config import GitHubAppConfigError
+        from ..github_app.live_client import build_live_client_from_env
+        from ..github_app.pr_merge_executor import build_pr_merge_executor
     except Exception:  # noqa: BLE001
-        return None
-    return build_pr_merge_executor(client=live_client)
+        if log:
+            logger.warning(
+                "pr_merge_continuation: live merge executor build skipped "
+                "(stage=%s) — github_app imports unavailable",
+                MERGE_EXEC_STAGE_IMPORT_FAILED,
+                exc_info=True,
+            )
+        return None, MERGE_EXEC_STAGE_IMPORT_FAILED
+
+    if not _opt_in_enabled(env):
+        if log:
+            logger.info(
+                "pr_merge_continuation: live merge executor skipped "
+                "(stage=%s) — set %s=1 to enable",
+                MERGE_EXEC_STAGE_OPT_IN_OFF,
+                ENV_GITHUB_APP_MERGE_OPT_IN,
+            )
+        return None, MERGE_EXEC_STAGE_OPT_IN_OFF
+
+    try:
+        live_client = build_live_client_from_env(env)
+    except GitHubAppConfigError as exc:
+        if log:
+            logger.warning(
+                "pr_merge_continuation: live merge executor skipped "
+                "(stage=%s) — GitHubAppConfig invalid: %s",
+                MERGE_EXEC_STAGE_CONFIG_ERROR,
+                exc,
+            )
+        return None, MERGE_EXEC_STAGE_CONFIG_ERROR
+    except Exception:  # noqa: BLE001
+        if log:
+            logger.warning(
+                "pr_merge_continuation: live merge executor skipped "
+                "(stage=%s) — live client build raised",
+                MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED,
+                exc_info=True,
+            )
+        return None, MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED
+
+    try:
+        executor = build_pr_merge_executor(client=live_client)
+    except Exception:  # noqa: BLE001
+        if log:
+            logger.warning(
+                "pr_merge_continuation: live merge executor skipped "
+                "(stage=%s) — build_pr_merge_executor raised",
+                MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED,
+                exc_info=True,
+            )
+        return None, MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED
+
+    if log:
+        logger.info(
+            "pr_merge_continuation: live merge executor wired (stage=%s)",
+            MERGE_EXEC_STAGE_OK,
+        )
+    return executor, MERGE_EXEC_STAGE_OK
 
 
 def _maybe_build_approval_enqueuer():
@@ -655,14 +755,20 @@ async def _pr_merge_continuation_loop(
     from ..agents.workflow_state import list_sessions
 
     approval_enqueuer = _maybe_build_approval_enqueuer()
-    pr_merge_executor = _maybe_build_live_pr_merge_executor()
+    pr_merge_executor, merge_stage = build_live_pr_merge_executor_with_stage(
+        log=False
+    )
     enqueue_slice, on_done = _build_next_slice_dispatcher()
 
+    # P1-O — silent None 금지. startup log 가 4 stage 중 정확히 어디서
+    # 떨어졌는지 보여준다 (env unset / config error / build failure).
     logger.info(
         "pr_merge_continuation loop wired: approval_enqueuer=%s "
-        "merge_executor=%s (env=YULE_GITHUB_APP_MERGE_OPT_IN)",
+        "merge_executor=%s merge_stage=%s (env=%s)",
         "yes" if approval_enqueuer is not None else "no",
         "yes" if pr_merge_executor is not None else "no",
+        merge_stage,
+        ENV_GITHUB_APP_MERGE_OPT_IN,
     )
 
     while not shutdown_event.is_set():
@@ -889,15 +995,23 @@ __all__ = (
     "DEFAULT_PR_MERGE_CONTINUATION_INTERVAL_SECONDS",
     "DEFAULT_PRODUCER_INTERVAL_SECONDS",
     "DEFAULT_TARGET_REPO_RECOVERY_INTERVAL_SECONDS",
+    "ENV_GITHUB_APP_MERGE_OPT_IN",
     "ENV_KEEPALIVE_INTERVAL",
     "ENV_PICK_LEASE_SECONDS",
     "ENV_PR_MERGE_CONTINUATION_INTERVAL",
     "ENV_PRODUCER_INTERVAL",
     "ENV_TARGET_REPO_RECOVERY_INTERVAL",
+    "MERGE_EXEC_STAGE_CONFIG_ERROR",
+    "MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED",
+    "MERGE_EXEC_STAGE_IMPORT_FAILED",
+    "MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED",
+    "MERGE_EXEC_STAGE_OK",
+    "MERGE_EXEC_STAGE_OPT_IN_OFF",
     "_build_next_slice_dispatcher",
     "_lease_keepalive_loop",
     "_maybe_build_approval_enqueuer",
     "_maybe_build_live_pr_merge_executor",
+    "build_live_pr_merge_executor_with_stage",
     "_persist_session_extra",
     "_pr_merge_continuation_loop",
     "_recover_lease_expired_rows",

--- a/tests/runtime/test_pr_merge_executor_wiring.py
+++ b/tests/runtime/test_pr_merge_executor_wiring.py
@@ -1,0 +1,273 @@
+"""P1-O — `merge_executor=no` silent regression 회귀.
+
+옛 wiring 은 ``_maybe_build_live_pr_merge_executor`` 가
+``coding_executor_live`` 에서 정의되지 않은 ``ENV_GITHUB_APP_MERGE_OPT_IN``
+를 import 하다 ``ImportError`` → broad ``except Exception: return None``
+로 빠져 startup log 에 거짓 ``merge_executor=no`` 만 노출했다.
+
+본 모듈은:
+  1. constant 가 runner 모듈에서 SSoT 로 정의되어 있음을 강제
+  2. 4-stage diagnostic 가 silent None 대신 정확한 stage 반환
+  3. runner / bot helper 양쪽이 동일 contract 로 동작
+  4. approval enqueuer path regression 없음
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Any
+from unittest import mock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.runtime.coding_executor_runner import (
+    ENV_GITHUB_APP_MERGE_OPT_IN,
+    MERGE_EXEC_STAGE_CONFIG_ERROR,
+    MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED,
+    MERGE_EXEC_STAGE_IMPORT_FAILED,
+    MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED,
+    MERGE_EXEC_STAGE_OK,
+    MERGE_EXEC_STAGE_OPT_IN_OFF,
+    _maybe_build_approval_enqueuer,
+    _maybe_build_live_pr_merge_executor,
+    build_live_pr_merge_executor_with_stage,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. SSoT constant exists at expected location (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class EnvConstantOwnershipTests(unittest.TestCase):
+    def test_env_constant_defined_in_runner_module(self) -> None:
+        """옛 회귀: ``coding_executor_live`` 에서 정의 없는 symbol 을
+        import 하다 silent fail.  본 가드는 SSoT 가 runner 모듈에 있고
+        값이 정확히 ``YULE_GITHUB_APP_MERGE_OPT_IN`` 임을 강제."""
+
+        self.assertEqual(ENV_GITHUB_APP_MERGE_OPT_IN, "YULE_GITHUB_APP_MERGE_OPT_IN")
+
+    def test_no_other_module_owns_constant(self) -> None:
+        """다른 모듈에 같은 이름의 constant 가 동시에 정의되어 있으면
+        SSoT 분기점이 모호해진다 — coding_executor_live 에는 없어야 함."""
+
+        from yule_orchestrator.agents.job_queue import coding_executor_live
+
+        self.assertFalse(
+            hasattr(coding_executor_live, "ENV_GITHUB_APP_MERGE_OPT_IN"),
+            "ENV_GITHUB_APP_MERGE_OPT_IN must NOT be defined in coding_executor_live "
+            "(its previous home was the import bug that silently produced merge_executor=no)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2-5. 4-stage diagnostic
+# ---------------------------------------------------------------------------
+
+
+class FourStageDiagnosticTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {
+            k: os.environ.get(k)
+            for k in (
+                ENV_GITHUB_APP_MERGE_OPT_IN,
+                "YULE_GITHUB_APP_ID",
+                "YULE_GITHUB_APP_INSTALLATION_ID",
+                "YULE_GITHUB_APP_PRIVATE_KEY_PATH",
+                "YULE_GITHUB_OWNER",
+                "YULE_GITHUB_REPO",
+            )
+        }
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_opt_in_off_returns_opt_in_off_stage(self) -> None:
+        os.environ.pop(ENV_GITHUB_APP_MERGE_OPT_IN, None)
+        executor, stage = build_live_pr_merge_executor_with_stage(log=False)
+        self.assertIsNone(executor)
+        self.assertEqual(stage, MERGE_EXEC_STAGE_OPT_IN_OFF)
+
+    def test_opt_in_on_but_no_config_returns_config_error(self) -> None:
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+        for k in (
+            "YULE_GITHUB_APP_ID",
+            "YULE_GITHUB_APP_INSTALLATION_ID",
+            "YULE_GITHUB_APP_PRIVATE_KEY_PATH",
+        ):
+            os.environ.pop(k, None)
+        executor, stage = build_live_pr_merge_executor_with_stage(log=False)
+        self.assertIsNone(executor)
+        self.assertEqual(stage, MERGE_EXEC_STAGE_CONFIG_ERROR)
+
+    def test_ok_stage_when_full_env_valid(self) -> None:
+        """env contract 충족 + live client build OK → callable executor."""
+
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+
+        # Fake live client / executor — 실제 GitHub 호출은 안 한다.
+        fake_live_client = object()
+
+        def fake_build_live_client_from_env(env=None, *, http=None):
+            return fake_live_client
+
+        fake_executor = lambda dispatch: {"merge_sha": "fake"}
+
+        def fake_build_pr_merge_executor(*, client, **_):
+            assert client is fake_live_client
+            return fake_executor
+
+        with mock.patch(
+            "yule_orchestrator.github_app.live_client.build_live_client_from_env",
+            fake_build_live_client_from_env,
+        ), mock.patch(
+            "yule_orchestrator.github_app.pr_merge_executor.build_pr_merge_executor",
+            fake_build_pr_merge_executor,
+        ):
+            executor, stage = build_live_pr_merge_executor_with_stage(log=False)
+        self.assertIs(executor, fake_executor)
+        self.assertEqual(stage, MERGE_EXEC_STAGE_OK)
+
+    def test_live_client_failure_returns_live_client_stage(self) -> None:
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+
+        def fake_build_live_client_from_env(env=None, *, http=None):
+            raise RuntimeError("network simulated failure")
+
+        with mock.patch(
+            "yule_orchestrator.github_app.live_client.build_live_client_from_env",
+            fake_build_live_client_from_env,
+        ):
+            executor, stage = build_live_pr_merge_executor_with_stage(log=False)
+        self.assertIsNone(executor)
+        self.assertEqual(stage, MERGE_EXEC_STAGE_LIVE_CLIENT_FAILED)
+
+    def test_executor_build_failure_returns_executor_stage(self) -> None:
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+
+        fake_live_client = object()
+
+        def fake_build_live_client_from_env(env=None, *, http=None):
+            return fake_live_client
+
+        def fake_build_pr_merge_executor(*, client, **_):
+            raise ValueError("executor wiring broken")
+
+        with mock.patch(
+            "yule_orchestrator.github_app.live_client.build_live_client_from_env",
+            fake_build_live_client_from_env,
+        ), mock.patch(
+            "yule_orchestrator.github_app.pr_merge_executor.build_pr_merge_executor",
+            fake_build_pr_merge_executor,
+        ):
+            executor, stage = build_live_pr_merge_executor_with_stage(log=False)
+        self.assertIsNone(executor)
+        self.assertEqual(stage, MERGE_EXEC_STAGE_EXECUTOR_BUILD_FAILED)
+
+
+# ---------------------------------------------------------------------------
+# 6. backwards-compat shim _maybe_build_live_pr_merge_executor
+# ---------------------------------------------------------------------------
+
+
+class BackwardsCompatShimTests(unittest.TestCase):
+    def test_legacy_shim_returns_callable_under_ok_path(self) -> None:
+        prev = os.environ.get(ENV_GITHUB_APP_MERGE_OPT_IN)
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+        try:
+            fake_live_client = object()
+            with mock.patch(
+                "yule_orchestrator.github_app.live_client.build_live_client_from_env",
+                lambda env=None, *, http=None: fake_live_client,
+            ), mock.patch(
+                "yule_orchestrator.github_app.pr_merge_executor.build_pr_merge_executor",
+                lambda *, client, **_: (lambda d: {"merge_sha": "x"}),
+            ):
+                executor = _maybe_build_live_pr_merge_executor()
+            self.assertIsNotNone(executor)
+            self.assertTrue(callable(executor))
+        finally:
+            if prev is None:
+                os.environ.pop(ENV_GITHUB_APP_MERGE_OPT_IN, None)
+            else:
+                os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = prev
+
+
+# ---------------------------------------------------------------------------
+# 7. bot helper parity (재사용 회귀)
+# ---------------------------------------------------------------------------
+
+
+class BotHelperParityTests(unittest.TestCase):
+    def test_bot_helper_delegates_to_runner_helper(self) -> None:
+        """`_build_pr_merge_executor_for_bot` 가 runner 의 helper 를 그대로
+        재사용하는지 source-grep 가드 — 다른 코드 경로가 같은 contract 를
+        두 번 구현해 분기되는 사고 차단."""
+
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/discord/bot/_legacy.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("_maybe_build_live_pr_merge_executor", src)
+
+    def test_bot_helper_runs_under_same_env_contract(self) -> None:
+        """runner helper 와 bot helper 가 동일 env 에서 동일 결과."""
+
+        from yule_orchestrator.discord.bot._legacy import (
+            _build_pr_merge_executor_for_bot,
+        )
+
+        prev = os.environ.get(ENV_GITHUB_APP_MERGE_OPT_IN)
+        os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = "1"
+        try:
+            fake_live_client = object()
+            fake_executor = lambda d: {"merge_sha": "x"}
+            with mock.patch(
+                "yule_orchestrator.github_app.live_client.build_live_client_from_env",
+                lambda env=None, *, http=None: fake_live_client,
+            ), mock.patch(
+                "yule_orchestrator.github_app.pr_merge_executor.build_pr_merge_executor",
+                lambda *, client, **_: fake_executor,
+            ):
+                bot_result = _build_pr_merge_executor_for_bot()
+                runner_result = _maybe_build_live_pr_merge_executor()
+            # 둘 다 callable
+            self.assertIsNotNone(bot_result)
+            self.assertIsNotNone(runner_result)
+            self.assertTrue(callable(bot_result))
+            self.assertTrue(callable(runner_result))
+        finally:
+            if prev is None:
+                os.environ.pop(ENV_GITHUB_APP_MERGE_OPT_IN, None)
+            else:
+                os.environ[ENV_GITHUB_APP_MERGE_OPT_IN] = prev
+
+
+# ---------------------------------------------------------------------------
+# 8. approval enqueuer regression 가드
+# ---------------------------------------------------------------------------
+
+
+class ApprovalEnqueuerRegressionGuard(unittest.TestCase):
+    def test_approval_enqueuer_still_yes(self) -> None:
+        """P1-M B 에서 고친 ApprovalWorker wiring 이 본 round 수정으로
+        깨지지 않는지 — local diagnostic 가 보여준 ``approval_enqueuer=yes``
+        contract 가 그대로 유지."""
+
+        enqueuer = _maybe_build_approval_enqueuer()
+        self.assertIsNotNone(enqueuer)
+        self.assertTrue(callable(enqueuer))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 Root cause

`.env.local` 에 모든 필수 값이 설정되어 있고 `_maybe_build_approval_enqueuer()` 는 `yes` 인데 `_maybe_build_live_pr_merge_executor()` 만 silent `None` 으로 떨어진 원인:

`runtime/coding_executor_runner.py` 가 `agents/job_queue/coding_executor_live` 에서 `ENV_GITHUB_APP_MERGE_OPT_IN` constant 를 import 하려 했지만, **그 constant 는 어디에도 정의되어 있지 않았다**. 결과:

```
ImportError → broad `except Exception: return None` → silent merge_executor=no
```

env 미설정과 코드 버그가 같은 None 으로 떨어져 operator 가 원인 구분 불가.

## ✨ 변경 (3 commits)

### 🐛 P1-O A+B — SSoT 정의 + 4-stage diagnostic (`69d9c68`)
- `ENV_GITHUB_APP_MERGE_OPT_IN = "YULE_GITHUB_APP_MERGE_OPT_IN"` 을 runner 모듈에 직접 정의 (SSoT).
- 6 stage 토큰: `import_failed` / `opt_in_off` / `github_app_config_error` / `live_client_build_failed` / `pr_merge_executor_build_failed` / `ok`.
- `build_live_pr_merge_executor_with_stage(env=, log=)` — `(executor or None, stage_token)` 반환. broad except 분해 — `ImportError` / `GitHubAppConfigError` / `RuntimeError` 별로 specific log.
- `_maybe_build_live_pr_merge_executor` 는 backwards-compat shim (기존 caller 무변경).
- startup log: `pr_merge_continuation loop wired: approval_enqueuer=yes merge_executor=yes merge_stage=ok (env=YULE_GITHUB_APP_MERGE_OPT_IN)`.

### 🔧 governance pending registration (`ae26772`)
- runner LOC 1020 (1000+ + 4 responsibilities) → `SPLIT_NOW_PENDING` 에 deadline 2026-06-21 등록.

### ✅ 11 회귀 (`a7f2951`)
- `EnvConstantOwnershipTests` (2) — SSoT 위치 강제 + 옛 잘못된 위치 (coding_executor_live) 에 없음 강제.
- `FourStageDiagnosticTests` (5) — 5 stage 분기 각각.
- `BackwardsCompatShimTests` (1) — `_maybe_build_live_pr_merge_executor` ok 경로.
- `BotHelperParityTests` (2) — bot helper 가 runner helper 재사용 + 같은 env 에서 동일 결과.
- `ApprovalEnqueuerRegressionGuard` (1) — P1-M B 의 ApprovalWorker wiring 깨지지 않음.

## 🧪 회귀

- **신규 11 케이스 모두 통과.**
- **전체 sweep**: 5304 tests / 5 pre-existing errors (digest_crawler locale + gateway_shutdown — P1-O 무관) / **0 새 regression**.
- **governance/code_audit**: 위반 0 유지 (split_now pending 신규 1 등록).
- **local smoke** (env unset): `stage=opt_in_off → None`.
- **local smoke** (env=1, App config missing): `stage=github_app_config_error → None` (옛 silent None 아님 — explicit log + token).

## 📦 머지 후 운영자 확인

1. main pull + 런타임 재기동.
2. startup log 한 줄:
   ```
   pr_merge_continuation loop wired: approval_enqueuer=yes merge_executor=yes merge_stage=ok (env=YULE_GITHUB_APP_MERGE_OPT_IN)
   ```
   - `approval_enqueuer=yes` + `merge_executor=yes` + `merge_stage=ok` 모두 보이면 정상.
   - `merge_stage=opt_in_off` → env 미설정 (`YULE_GITHUB_APP_MERGE_OPT_IN=1` 설정).
   - `merge_stage=github_app_config_error` → GitHub App env (`YULE_GITHUB_APP_ID` 등) 누락.
   - `merge_stage=import_failed` → 코드 import 회귀 (재발 시 본 PR 의 regression 가드가 stdlib unittest 로 잡음).

## 🧭 어떻게 다시 깨지는 것을 막았는지

`EnvConstantOwnershipTests.test_no_other_module_owns_constant` — `coding_executor_live` 에 `ENV_GITHUB_APP_MERGE_OPT_IN` symbol 이 다시 생기면 stdlib unittest 가 실패 → CI 가 막음. 옛 import 위치 회귀 (silent fail) 가 시스템적으로 차단.