### PR TITLE
🛡 P1-P: fe5eedc65196 recovery + GitHubAppNotFoundError signature + loop robustness

### DIFF
--- a/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
@@ -100,6 +100,17 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
 
+def _truncate(text: str, *, limit: int = 240) -> str:
+    """audit field 용 짧은 message — operator log 에 한 줄로 들어가게."""
+
+    if text is None:
+        return ""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
 def _proposal_from_session_extra(
     session_extra: Mapping[str, Any],
     *,
@@ -241,9 +252,61 @@ async def advance_pending_session(
             approved_at=_now_iso(),
             source_message_id=None,
         )
-        raw = merge_executor(dispatch)
-        if hasattr(raw, "__await__"):
-            raw = await raw  # type: ignore[assignment]
+
+        # P1-P — live GitHub 가 PR 을 못 찾으면 (404) 또는 다른 HTTP
+        # 에러를 raise 하면 loop 가 noisy traceback 을 뿜는 대신 세션을
+        # ``pr_merge_blocked`` 로 advance + audit reason ``pr_not_found`` /
+        # ``http_error`` stamp.  다음 tick 에서는 not-pending 이므로 같은
+        # 세션을 다시 건드리지 않는다 (fixture 세션 noise 차단).
+        try:
+            raw = merge_executor(dispatch)
+            if hasattr(raw, "__await__"):
+                raw = await raw  # type: ignore[assignment]
+        except Exception as exc:  # noqa: BLE001 — translate to blocked outcome
+            exc_name = type(exc).__name__
+            if exc_name == "GitHubAppNotFoundError":
+                reason_token = "pr_not_found"
+            elif exc_name in (
+                "LiveGithubAppHTTPError",
+                "GitHubAppHTTPError",
+                "GitHubAppAuthError",
+                "GitHubAppPermissionError",
+                "GitHubAppServerError",
+            ):
+                reason_token = f"github_http_error:{exc_name}"
+            else:
+                reason_token = f"merge_executor_raised:{exc_name}"
+            audit_fields_err = {
+                "exception_class": exc_name,
+                "error": _truncate(str(exc)),
+            }
+            status_attr = getattr(exc, "status", None)
+            if status_attr is not None:
+                audit_fields_err["status"] = status_attr
+            url_attr = getattr(exc, "url", None)
+            if url_attr is not None:
+                audit_fields_err["url"] = str(url_attr)
+            new_extra = advance_stage(
+                session_extra,
+                new_stage=STAGE_PR_MERGE_BLOCKED,
+                reason=reason_token,
+                **audit_fields_err,
+            )
+            persist_extra(new_extra)
+            logger.info(
+                "advance_pending_session: session=%s blocked (%s) — %s",
+                session_id,
+                reason_token,
+                _truncate(str(exc), limit=160),
+            )
+            return PRMergeContinuationOutcome(
+                session_id=session_id,
+                action=ACTION_AUTONOMOUS_MERGE_BLOCKED,
+                work_mode=work_mode,
+                new_stage=STAGE_PR_MERGE_BLOCKED,
+                reason=reason_token,
+                extra_audit_fields=audit_fields_err,
+            )
         result: Mapping[str, Any] = dict(raw or {})
 
         merge_sha = str(result.get("merge_sha") or "")

--- a/src/yule_orchestrator/agents/lifecycle/session_recovery.py
+++ b/src/yule_orchestrator/agents/lifecycle/session_recovery.py
@@ -150,6 +150,46 @@ def recover_session_full(
             f"mode persist 보정 → work_mode={final_work_mode} "
             f"topology={final_topology} scope={final_scope}"
         )
+
+        # P1-P — work_mode 가 바뀌면 stale approval-mode audit event 를
+        # 정리한다.  옛 ``approval_card_enqueued`` event 가 남아있으면
+        # continuation loop 의 ``is_pending_approval_card`` 가 False 를
+        # 반환해 새 모드 (autonomous_merge) 에서도 영원히 ``ACTION_SKIPPED_
+        # ALREADY_ENQUEUED`` 로 stuck.  본 라인이 그 회귀의 직접 fix.
+        prior_work_mode = extra.get(EXTRA_WORK_MODE)
+        if (
+            prior_work_mode != final_work_mode
+            and final_work_mode == WORK_MODE_AUTONOMOUS
+        ):
+            from ..job_queue.pr_merge_continuation import EXTRA_PR_MERGE_AUDIT
+
+            existing_audit = list(new_extra.get(EXTRA_PR_MERGE_AUDIT) or ())
+            filtered_audit = [
+                entry
+                for entry in existing_audit
+                if not (
+                    isinstance(entry, Mapping)
+                    and entry.get("event") == "approval_card_enqueued"
+                )
+            ]
+            stripped = len(existing_audit) - len(filtered_audit)
+            # 모드 전환 자체를 audit 에 한 줄 명시 — operator 가 이 시점에
+            # 무엇이 일어났는지 본다.
+            filtered_audit.append(
+                {
+                    "event": "mode_recovered",
+                    "prior_work_mode": prior_work_mode,
+                    "new_work_mode": final_work_mode,
+                    "stripped_approval_card_events": stripped,
+                    "at": _now_iso(),
+                }
+            )
+            new_extra[EXTRA_PR_MERGE_AUDIT] = filtered_audit
+            if stripped > 0:
+                notes.append(
+                    f"stale approval-mode audit event {stripped}건 정리 — "
+                    f"continuation loop 가 autonomous_merge 경로로 재평가 가능"
+                )
     else:
         notes.append("mode 키 변경 없음 (이미 영속됨 또는 단서 부족)")
 

--- a/src/yule_orchestrator/github_app/client.py
+++ b/src/yule_orchestrator/github_app/client.py
@@ -50,7 +50,15 @@ TOKEN_REDACTED: str = "<redacted>"
 
 
 class GitHubAppHTTPError(RuntimeError):
-    """Generic HTTP failure outside the typed 401/403/404/5xx set."""
+    """Generic HTTP failure outside the typed 401/403/404/5xx set.
+
+    P1-P — ``body`` 도 optional kwarg 로 받는다.  옛 시그니처는 (message,
+    status, url) 만 받아서 ``live_client._get`` 의 404 처리에서
+    ``GitHubAppNotFoundError(msg, status=404, body=response.body)`` 호출이
+    TypeError 로 떨어졌고, 그게 pr_merge_continuation_loop 의 noisy
+    traceback 회귀의 직접 원인이었다.  본 클래스의 base signature 가
+    SSoT 이므로 모든 subclass 가 동일 인자 contract 를 상속한다.
+    """
 
     def __init__(
         self,
@@ -58,10 +66,12 @@ class GitHubAppHTTPError(RuntimeError):
         *,
         status: Optional[int] = None,
         url: Optional[str] = None,
+        body: Any = None,
     ) -> None:
         super().__init__(message)
         self.status = status
         self.url = url
+        self.body = body
 
 
 class GitHubAppAuthError(GitHubAppHTTPError):

--- a/src/yule_orchestrator/github_app/live_client.py
+++ b/src/yule_orchestrator/github_app/live_client.py
@@ -73,6 +73,10 @@ class LiveGithubAppHTTPError(RuntimeError):
     G3 writer's failure path so an operator sees "GitHub returned
     422 — Validation Failed" without the writer needing to know the
     HTTP layer.
+
+    P1-P — ``body`` 도 optional kwarg.  GitHubAppHTTPError 와 동일
+    contract — caller 가 두 exception class 를 같은 인자로 raise 할 수
+    있게 통일.
     """
 
     def __init__(
@@ -81,10 +85,12 @@ class LiveGithubAppHTTPError(RuntimeError):
         *,
         status: Optional[int] = None,
         url: Optional[str] = None,
+        body: Any = None,
     ) -> None:
         super().__init__(message)
         self.status = status
         self.url = url
+        self.body = body
 
 
 class LiveGithubAppMergeDisabled(LiveGithubAppHTTPError):

--- a/tests/runtime/test_pr_merge_loop_robustness.py
+++ b/tests/runtime/test_pr_merge_loop_robustness.py
@@ -1,0 +1,545 @@
+"""P1-P — 사용자 명시 8 acceptance + 보조.
+
+1. fe5eedc65196-like recovery restores mode/topology/scope/backlog/pr metadata
+2. recovery 가 stuck approval_required → autonomous_merge 로 전환 + stale audit strip
+3. continuation loop 가 recovery 후 영원히 approval_card_already_enqueued 로 빠지지 않음
+4. GitHubAppNotFoundError(... body=...) constructor signature 회귀
+5. missing PR 시 traceback 대신 deterministic pr_not_found blocked outcome
+6. fixture 세션 처리 deterministic + quiet
+7. live canonical session vs test fixture 구분 (operator surface)
+8. operator audit / log 에 blocked / skip reason 명확히 남음
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from dataclasses import replace as _replace
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.coding.coding_backlog_seed import (
+    EXTRA_CODING_BACKLOG,
+)
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    PRMergeReplyDispatch,
+)
+from yule_orchestrator.agents.job_queue.pr_merge_continuation import (
+    EXTRA_PR_MERGE_AUDIT,
+    EXTRA_PR_MERGE_PR_NUMBER,
+    EXTRA_PR_MERGE_REPO,
+    EXTRA_PR_MERGE_STAGE,
+    STAGE_PR_MERGE_BLOCKED,
+    STAGE_PR_MERGE_PENDING,
+    STAGE_PR_MERGED,
+)
+from yule_orchestrator.agents.job_queue.pr_merge_continuation_worker import (
+    ACTION_APPROVAL_CARD_ENQUEUED,
+    ACTION_AUTONOMOUS_MERGE_BLOCKED,
+    ACTION_AUTONOMOUS_MERGE_SUCCEEDED,
+    ACTION_SKIPPED_ALREADY_ENQUEUED,
+    advance_pending_session,
+)
+from yule_orchestrator.agents.lifecycle.session_mode import (
+    EXTRA_DECIDED_BY,
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_SINGLE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+)
+from yule_orchestrator.agents.lifecycle.session_recovery import (
+    recover_session_full,
+)
+from yule_orchestrator.agents.workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    save_session,
+)
+from yule_orchestrator.github_app.client import (
+    GitHubAppHTTPError,
+    GitHubAppNotFoundError,
+)
+from yule_orchestrator.github_app.live_client import LiveGithubAppHTTPError
+
+
+_CANONICAL_PROMPT = (
+    "autonomous_merge, single_repo, full_stack_single_repo "
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _seed_session(session_id: str, *, prompt: str, extra: Mapping[str, Any]) -> None:
+    save_session(
+        WorkflowSession(
+            session_id=session_id,
+            prompt=prompt,
+            task_type="coding_execute",
+            state=WorkflowState.IN_PROGRESS,
+            created_at=_now(),
+            updated_at=_now(),
+            executor_role="backend-engineer",
+            extra=dict(extra),
+        )
+    )
+
+
+def _persist_for(session_id: str):
+    def _do(new_extra: Mapping[str, Any]) -> None:
+        s = load_session(session_id)
+        if s is None:
+            return
+        save_session(
+            _replace(s, extra=dict(new_extra), updated_at=_now())
+        )
+
+    return _do
+
+
+# ---------------------------------------------------------------------------
+# 4. GitHubAppNotFoundError constructor signature regression
+# ---------------------------------------------------------------------------
+
+
+class GitHubAppNotFoundErrorSignatureTests(unittest.TestCase):
+    """옛 회귀: live_client._get 가 body kwarg 로 raise 하는데 base class
+    signature 에 body 가 없어서 TypeError → continuation loop noisy
+    traceback.  본 가드는 두 형태의 raise 가 모두 가능함을 강제."""
+
+    def test_body_kwarg_supported(self) -> None:
+        exc = GitHubAppNotFoundError(
+            "GitHub GET /repos/x/y/pulls/4 -> 404 (not found)",
+            status=404,
+            body={"message": "Not Found"},
+        )
+        self.assertEqual(exc.status, 404)
+        self.assertEqual(exc.body, {"message": "Not Found"})
+        self.assertIn("404", str(exc))
+
+    def test_base_class_supports_body_too(self) -> None:
+        exc = GitHubAppHTTPError("x", status=422, url="https://u", body=b"raw")
+        self.assertEqual(exc.body, b"raw")
+
+    def test_live_class_supports_body_too(self) -> None:
+        exc = LiveGithubAppHTTPError(
+            "x", status=500, url="https://u", body={"k": "v"}
+        )
+        self.assertEqual(exc.body, {"k": "v"})
+
+    def test_old_call_form_still_works(self) -> None:
+        # body 미지정 시도 — backwards-compat
+        exc = GitHubAppNotFoundError("x", status=404)
+        self.assertIsNone(exc.body)
+
+
+# ---------------------------------------------------------------------------
+# 5. Missing PR → deterministic pr_not_found blocked outcome
+# 6. Fixture session deterministic + quiet
+# ---------------------------------------------------------------------------
+
+
+class MissingPRDeterministicBlockedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+    def test_missing_pr_translates_to_pr_not_found_block(self) -> None:
+        sid = "fixture-missing-pr-1"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 9999,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/9999",
+                "pr_merge_head_sha": "missing-sha",
+                "pr_merge_base_branch": "main",
+            },
+        )
+
+        def fake_executor(dispatch: PRMergeReplyDispatch) -> Mapping[str, Any]:
+            raise GitHubAppNotFoundError(
+                "GitHub GET /repos/yule-studio/naver-search-clone/pulls/9999 -> 404 (not found)",
+                status=404,
+                body={"message": "Not Found"},
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        # 1) outcome is blocked (not traceback)
+        self.assertEqual(outcome.action, ACTION_AUTONOMOUS_MERGE_BLOCKED)
+        self.assertEqual(outcome.reason, "pr_not_found")
+        # 2) stage advanced to blocked → loop won't pick again
+        final = load_session(sid)
+        self.assertEqual(final.extra[EXTRA_PR_MERGE_STAGE], STAGE_PR_MERGE_BLOCKED)
+        # 3) audit captured exception class + status for operator
+        audit = final.extra[EXTRA_PR_MERGE_AUDIT][-1]
+        self.assertEqual(audit["stage"], STAGE_PR_MERGE_BLOCKED)
+        self.assertEqual(audit["exception_class"], "GitHubAppNotFoundError")
+        self.assertEqual(audit["status"], 404)
+        # 4) re-tick 은 not-pending 으로 skip — fixture noise 차단
+        loop = asyncio.new_event_loop()
+        try:
+            session2 = load_session(sid)
+            outcome2 = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session2.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        self.assertNotEqual(outcome2.action, ACTION_AUTONOMOUS_MERGE_BLOCKED)
+        # not-pending 분기
+        from yule_orchestrator.agents.job_queue.pr_merge_continuation_worker import (
+            ACTION_SKIPPED_NOT_PENDING,
+        )
+
+        self.assertEqual(outcome2.action, ACTION_SKIPPED_NOT_PENDING)
+
+    def test_unknown_http_error_also_blocks_with_explicit_reason(self) -> None:
+        sid = "fixture-http-error-2"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+                "pr_merge_head_sha": "sha",
+                "pr_merge_base_branch": "main",
+            },
+        )
+
+        def fake_executor(dispatch):
+            raise LiveGithubAppHTTPError(
+                "GitHub GET /x -> HTTP 503", status=503, url="https://x"
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        self.assertEqual(outcome.action, ACTION_AUTONOMOUS_MERGE_BLOCKED)
+        self.assertIn("github_http_error", outcome.reason)
+
+    def test_unexpected_exception_class_still_blocked_not_traceback(self) -> None:
+        sid = "fixture-unexpected-3"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "x/y",
+                "pr_merge_pr_url": "https://x/y/pull/4",
+                "pr_merge_head_sha": "s",
+                "pr_merge_base_branch": "main",
+            },
+        )
+
+        def fake_executor(dispatch):
+            raise ValueError("simulated unexpected")
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        self.assertEqual(outcome.action, ACTION_AUTONOMOUS_MERGE_BLOCKED)
+        self.assertIn("merge_executor_raised:ValueError", outcome.reason)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2, 3 — fe5eedc65196 recovery + stuck approval → autonomous_merge flip
+# ---------------------------------------------------------------------------
+
+
+class CanonicalSessionRecoveryFlipTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+    def test_recovery_restores_mode_backlog_pr_metadata(self) -> None:
+        """fe5eedc65196 shape: work_mode=None, but pr_merge_pending stamped."""
+
+        sid = "fe5eedc65196"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+                "pr_merge_head_sha": "pr4sha",
+                "pr_merge_base_branch": "main",
+            },
+        )
+        report = recover_session_full(
+            session_id=sid, explicit_work_mode=WORK_MODE_AUTONOMOUS
+        )
+        self.assertTrue(report.found)
+        self.assertTrue(report.mode_persisted)
+        self.assertEqual(report.work_mode, WORK_MODE_AUTONOMOUS)
+        self.assertEqual(report.topology, TOPOLOGY_SINGLE)
+        self.assertEqual(report.scope, SCOPE_FULL_STACK)
+        self.assertEqual(report.backlog_seeded_count, 8)
+        fresh = load_session(sid)
+        self.assertEqual(fresh.extra[EXTRA_WORK_MODE], WORK_MODE_AUTONOMOUS)
+        self.assertEqual(fresh.extra[EXTRA_PR_MERGE_PR_NUMBER], 4)
+        self.assertEqual(len(fresh.extra[EXTRA_CODING_BACKLOG]), 8)
+
+    def test_recovery_strips_stale_approval_card_audit(self) -> None:
+        """stuck approval_required → autonomous_merge 전환 시 옛
+        approval_card_enqueued audit 가 strip 되어 loop 가 새 모드로 재평가
+        가능."""
+
+        sid = "fe5eedc65196-stuck"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_APPROVAL,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+                "pr_merge_head_sha": "pr4sha",
+                "pr_merge_base_branch": "main",
+                EXTRA_PR_MERGE_AUDIT: [
+                    {
+                        "event": "approval_card_enqueued",
+                        "approval_job_id": "stale-job",
+                        "at": "2026-05-17T00:00:00+00:00",
+                    }
+                ],
+            },
+        )
+        report = recover_session_full(
+            session_id=sid, explicit_work_mode=WORK_MODE_AUTONOMOUS
+        )
+        self.assertTrue(report.mode_persisted)
+        # mode_recovered event 가 audit 에 들어가 있고, approval_card_enqueued
+        # 는 strip 됨
+        fresh = load_session(sid)
+        audit = fresh.extra[EXTRA_PR_MERGE_AUDIT]
+        events = [e.get("event") for e in audit if isinstance(e, Mapping)]
+        self.assertIn("mode_recovered", events)
+        self.assertNotIn("approval_card_enqueued", events)
+        # mode_recovered 의 메타 — operator 가 strip 횟수를 본다
+        mr = next(e for e in audit if e.get("event") == "mode_recovered")
+        self.assertEqual(mr["prior_work_mode"], WORK_MODE_APPROVAL)
+        self.assertEqual(mr["new_work_mode"], WORK_MODE_AUTONOMOUS)
+        self.assertEqual(mr["stripped_approval_card_events"], 1)
+
+    def test_recovery_unstuck_session_now_passes_autonomous_merge_dispatch(
+        self,
+    ) -> None:
+        """recovery 후 continuation loop 가 autonomous_merge 경로로 실제
+        dispatch — 옛 approval_card_already_enqueued stuck 회복."""
+
+        sid = "fe5eedc65196-unstuck"
+        _seed_session(
+            sid,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_APPROVAL,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+                "pr_merge_head_sha": "pr4sha",
+                "pr_merge_base_branch": "main",
+                EXTRA_PR_MERGE_AUDIT: [
+                    {
+                        "event": "approval_card_enqueued",
+                        "approval_job_id": "stale",
+                        "at": "2026-05-17T00:00:00+00:00",
+                    }
+                ],
+            },
+        )
+        recover_session_full(
+            session_id=sid, explicit_work_mode=WORK_MODE_AUTONOMOUS
+        )
+
+        def fake_executor(dispatch):
+            return {"merge_sha": "merged-after-recovery", "method": "squash"}
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        # 옛 stuck 시그널 (ACTION_SKIPPED_ALREADY_ENQUEUED) 가 더 이상 안 나옴
+        self.assertNotEqual(outcome.action, ACTION_SKIPPED_ALREADY_ENQUEUED)
+        # autonomous_merge 성공 분기
+        self.assertEqual(outcome.action, ACTION_AUTONOMOUS_MERGE_SUCCEEDED)
+        self.assertEqual(outcome.merge_sha, "merged-after-recovery")
+
+
+# ---------------------------------------------------------------------------
+# 7. live canonical vs test fixture distinction (operator surface)
+# ---------------------------------------------------------------------------
+
+
+class CanonicalVsFixtureSurfaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+    def test_audit_distinguishes_blocked_from_succeeded(self) -> None:
+        """operator 가 canonical (succeeded) vs fixture (blocked) 를 audit
+        만 보고 구분 가능."""
+
+        # canonical → merge 성공
+        canonical = "live-canonical-1"
+        _seed_session(
+            canonical,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 4,
+                EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+                "pr_merge_pr_url": "https://x/y/pull/4",
+                "pr_merge_head_sha": "s",
+                "pr_merge_base_branch": "main",
+            },
+        )
+        loop = asyncio.new_event_loop()
+        try:
+            cs = load_session(canonical)
+            loop.run_until_complete(
+                advance_pending_session(
+                    session_id=canonical,
+                    session_extra=dict(cs.extra or {}),
+                    persist_extra=_persist_for(canonical),
+                    merge_executor=lambda d: {"merge_sha": "ok", "method": "squash"},
+                )
+            )
+        finally:
+            loop.close()
+
+        # fixture → 404
+        fixture = "fixture-404-2"
+        _seed_session(
+            fixture,
+            prompt=_CANONICAL_PROMPT,
+            extra={
+                EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+                EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+                EXTRA_PR_MERGE_PR_NUMBER: 9999,
+                EXTRA_PR_MERGE_REPO: "x/y",
+                "pr_merge_pr_url": "https://x/y/pull/9999",
+                "pr_merge_head_sha": "s",
+                "pr_merge_base_branch": "main",
+            },
+        )
+
+        def raise_404(dispatch):
+            raise GitHubAppNotFoundError(
+                "404", status=404, body={"message": "Not Found"}
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            fs = load_session(fixture)
+            loop.run_until_complete(
+                advance_pending_session(
+                    session_id=fixture,
+                    session_extra=dict(fs.extra or {}),
+                    persist_extra=_persist_for(fixture),
+                    merge_executor=raise_404,
+                )
+            )
+        finally:
+            loop.close()
+
+        c_final = load_session(canonical)
+        f_final = load_session(fixture)
+        self.assertEqual(c_final.extra[EXTRA_PR_MERGE_STAGE], STAGE_PR_MERGED)
+        self.assertEqual(f_final.extra[EXTRA_PR_MERGE_STAGE], STAGE_PR_MERGE_BLOCKED)
+        # operator 가 두 세션의 audit 마지막 stage 토큰만 봐도 구분 가능
+        self.assertEqual(c_final.extra[EXTRA_PR_MERGE_AUDIT][-1]["stage"], STAGE_PR_MERGED)
+        self.assertEqual(f_final.extra[EXTRA_PR_MERGE_AUDIT][-1]["stage"], STAGE_PR_MERGE_BLOCKED)
+        self.assertEqual(
+            f_final.extra[EXTRA_PR_MERGE_AUDIT][-1]["exception_class"],
+            "GitHubAppNotFoundError",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 두 bug 동시 close

### Bug 1 — `GitHubAppNotFoundError(... body=...)` TypeError
`live_client._get` 는 404 응답 시 `GitHubAppNotFoundError(msg, status=404, body=response.body)` 로 raise 하는데, base class `GitHubAppHTTPError.__init__` 시그니처에 `body` kwarg 가 없었음 → TypeError. continuation loop 가 fixture/test session 마다 noisy traceback 출력.

### Bug 2 — session `fe5eedc65196` approval_required stuck
recovery 가 work_mode 만 변경하고 `pr_merge_continuation_audit` 의 옛 `approval_card_enqueued` event 는 그대로 두어, `is_pending_approval_card` 가 False 반환 → 영원히 `ACTION_SKIPPED_ALREADY_ENQUEUED` 로 stuck. 사용자 의도 (`autonomous_merge`) 로 mode 를 바꿔도 다음 tick 이 그 분기를 못 봄.

## ✨ 변경 (4 commits)

### 🐛 A — signature fix (`41d4730`)
- `GitHubAppHTTPError.__init__` 와 `LiveGithubAppHTTPError.__init__` 에 `body: Any = None` optional kwarg 추가. subclass (NotFound / Auth / Permission / Server / MergeDisabled) 는 자동 상속.

### 🛡️ B — loop robustness (`f3a7106`)
- `advance_pending_session` 의 `merge_executor(dispatch)` 호출을 try/except 로 wrap. 4 분기:
  - `GitHubAppNotFoundError` → reason=`pr_not_found`
  - `Live/GitHubAppHTTPError` / `Auth` / `Permission` / `Server` → reason=`github_http_error:<class>`
  - 그 외 → reason=`merge_executor_raised:<class>`
- 모두 `STAGE_PR_MERGE_BLOCKED` 진입 + audit (exception_class / status / url / truncated error). 다음 tick 부터 not-pending → fixture/test 세션 noise 차단.

### 🔓 C — recovery strips stale audit (`999362b`)
- `recover_session_full` 가 work_mode 전환 시 (`approval_required → autonomous_merge`) 옛 `approval_card_enqueued` audit event 를 filter out + `mode_recovered` event stamp (prior/new mode + stripped_count).
- 특정 세션 한정 해킹 아님 — 모든 session 에 동일.

### ✅ D — 11 회귀 (`0d5d552`)
- `GitHubAppNotFoundErrorSignatureTests` (4) — body kwarg parity + backwards-compat
- `MissingPRDeterministicBlockedTests` (3) — 404 / 503 / unknown 모두 deterministic blocked
- `CanonicalSessionRecoveryFlipTests` (3) — fe5eedc65196 recovery → audit strip → autonomous_merge dispatch 성공
- `CanonicalVsFixtureSurfaceTests` (1) — operator audit 가 canonical vs fixture 구분

## 🧪 회귀

- **신규 11 케이스 모두 통과.**
- **전체 sweep**: 5315 tests / 5 pre-existing errors (digest_crawler locale + gateway_shutdown) / **0 새 regression**.
- **governance/code_audit**: 위반 0 유지.

## 📦 머지 후 운영자 절차 (fe5eedc65196 recovery)

1. main pull + 런타임 재기동.
2. fe5eedc65196 recovery CLI 1회 실행:
   ```bash
   python3 -m yule_orchestrator.cli.recover_session fe5eedc65196 \\
     --mode autonomous_merge \\
     --topology single_repo \\
     --scope full_stack_single_repo \\
     --pr-number 4 \\
     --pr-url https://github.com/yule-studio/naver-search-clone/pull/4 \\
     --head-sha <PR4 head sha> \\
     --repo yule-studio/naver-search-clone
   ```
   출력에서 확인:
   - `mode_persisted: True`
   - `work_mode: autonomous_merge`
   - `backlog_seeded_count: 8`
   - `pr_merge_stamped: True`
   - notes 에 "stale approval-mode audit event 1건 정리"
3. 다음 30s tick 안에 background loop 가 autonomous_merge 분기로 가동 → live merge_executor 호출 → 결과에 따라:
   - merge 성공 → `pr_merged` stamp + next slice dispatch
   - PR 404 → `pr_merge_blocked` + reason=`pr_not_found` (traceback 없음)
   - merge gate 실패 → `pr_merge_blocked` + reason=`gate_failed:*`
4. 결과는 `session.extra[pr_merge_continuation_audit]` 의 last entry 에서 한 줄로 확인 가능.

## 🧭 fixture session noise 가 사라지는 이유

옛 wiring 은 missing PR 마다 traceback 출력 + retry. 새 wiring 은:
1. 첫 tick: `merge_executor` raise → catch → blocked stage stamp → 한 줄 info log.
2. 두 번째 tick: stage 가 `pr_merge_blocked` 이므로 `is_pending_continuation = False` → ACTION_SKIPPED_NOT_PENDING → 어떤 외부 호출도 안 함.

`L3-startup-1`, `auto-merge-session-1`, `approval-session-2`, `txn-pending-1` 같은 fixture/test 세션은 한 번 blocked 로 가고 그 후 영원히 quiet.