### PR TITLE
[구현] draft PR 승인 카드 escalation + ready_for_review live action + issue-first hard guard

### DIFF
--- a/src/yule_orchestrator/agents/job_queue/approval_reply.py
+++ b/src/yule_orchestrator/agents/job_queue/approval_reply.py
@@ -276,6 +276,125 @@ def _most_recent(jobs: Sequence[Job]) -> Job:
     return max(jobs, key=lambda j: j.created_at)
 
 
+# P1-Q-2 — session-agnostic matcher.  옛 wiring 은 router 가 session_id 를
+# 먼저 추정 (most-recent fallback) 한 뒤 그 세션 안에서만 카드를 찾았다.
+# global 채널 (`#승인-대기`) 의 generic reply 가 무관한 세션 (txn-pending-1
+# 같은 fixture) 로 잘못 라우팅되는 회귀의 직접 원인.  본 함수는 raw
+# replied_message_id 만으로 모든 세션의 SAVED approval_post 를 scan 해서
+# 정확한 카드를 찾는다.  매칭되면 caller 가 그 카드의 session_id 를 그대로
+# 사용 — session-first 추정 자체가 필요 없어짐.
+
+
+def find_approval_by_posted_message_id(
+    *,
+    queue: JobQueue,
+    posted_message_id: int,
+    approval_kind: Optional[str] = None,
+) -> Optional[Job]:
+    """Discord reply 의 ``message.reference.message_id`` 로 모든 세션을
+    scan 해서 일치 카드 반환.  session_id 모를 때 안전.
+    """
+
+    if not posted_message_id:
+        return None
+    import json as _json
+    import sqlite3 as _sqlite3
+    from .state_machine import JobState as _JobState
+
+    db_path = getattr(queue, "_db_path", None)
+    if db_path is None:
+        return None
+    try:
+        with _sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = _sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT * FROM job_queue
+                WHERE job_type = ?
+                  AND state = ?
+                ORDER BY created_at DESC
+                LIMIT 200
+                """,
+                (JOB_TYPE_APPROVAL_POST, _JobState.SAVED.value),
+            ).fetchall()
+    except Exception:  # noqa: BLE001 — never crash matcher on db blip
+        return None
+
+    target = int(posted_message_id)
+    for row in rows or ():
+        try:
+            result_raw = row["result_json"] or "{}"
+            result = _json.loads(result_raw)
+        except Exception:  # noqa: BLE001
+            continue
+        if not isinstance(result, Mapping):
+            continue
+        posted = result.get("posted_message_id")
+        if posted is None or int(posted) != target:
+            continue
+        # approval_kind 필터 — 카드 종류 일치까지 강제 (없으면 통과)
+        if approval_kind is not None:
+            try:
+                payload = _json.loads(row["payload_json"] or "{}")
+            except Exception:  # noqa: BLE001
+                continue
+            if str(payload.get("approval_kind") or "") != approval_kind:
+                continue
+        # 모든 사용자에게 한 줄 row → Job 변환
+        from .store import _row_to_job  # type: ignore[attr-defined]
+
+        return _row_to_job(row)
+    return None
+
+
+def find_open_approval_cards_by_kind(
+    *,
+    queue: JobQueue,
+    approval_kind: str,
+    limit: int = 100,
+) -> Tuple[Job, ...]:
+    """``approval_kind`` 의 SAVED 카드 전부 — ambiguity 감지용.
+
+    router 가 replied_message_id 없이 generic reply 를 받았는데 같은 kind
+    의 open 카드가 2 개 이상이면 ambiguity 응답.
+    """
+
+    import json as _json
+    import sqlite3 as _sqlite3
+    from .state_machine import JobState as _JobState
+
+    db_path = getattr(queue, "_db_path", None)
+    if db_path is None:
+        return ()
+    try:
+        with _sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = _sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT * FROM job_queue
+                WHERE job_type = ?
+                  AND state = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (JOB_TYPE_APPROVAL_POST, _JobState.SAVED.value, int(limit)),
+            ).fetchall()
+    except Exception:  # noqa: BLE001
+        return ()
+    from .store import _row_to_job  # type: ignore[attr-defined]
+
+    matches: list = []
+    for row in rows or ():
+        try:
+            payload = _json.loads(row["payload_json"] or "{}")
+        except Exception:  # noqa: BLE001
+            continue
+        if str(payload.get("approval_kind") or "") != approval_kind:
+            continue
+        matches.append(_row_to_job(row))
+    return tuple(matches)
+
+
 # ---------------------------------------------------------------------------
 # Approval → ObsidianWriteRequest converter
 # ---------------------------------------------------------------------------
@@ -594,6 +713,8 @@ __all__ = (
     "ApprovalIntent",
     "ApprovalReplyOutcome",
     "approval_to_obsidian_write_request",
+    "find_approval_by_posted_message_id",
+    "find_open_approval_cards_by_kind",
     "find_replyable_approval",
     "handle_approval_reply",
     "parse_approval_intent",

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -328,6 +328,35 @@ class LocalGitWorktreeProvisioner:
     def provision(
         self, *, request: CodingExecuteRequest, branch: str
     ) -> WorktreeContext:
+        # P1-Q E — Issue-first hard guard.  어떤 agent 가 호출하든 branch
+        # 생성 전에 issue anchor 가 반드시 있어야 한다.  branch name 에
+        # ``issue-<n>`` 또는 request.issue_number > 0.  옛 wiring 은 issue
+        # 없이도 branch / commit / draft PR 까지 그대로 가능했고, 그게 사
+        # 용자가 명시 reject 한 회귀의 직접 원인.  cross-repo 적용 — repo
+        # 와 무관하게 동일.
+        try:
+            from ..governance.repo_write_policy import (
+                IssueAnchorContext,
+                PolicyViolation,
+                enforce_issue_anchor,
+            )
+
+            enforce_issue_anchor(
+                IssueAnchorContext(
+                    branch=branch,
+                    issue_number_hint=request.issue_number,
+                )
+            )
+        except PolicyViolation as exc:
+            raise WorktreeProvisionError(
+                reason=exc.reason,
+                message=(
+                    f"issue-first hard guard: {exc.detail}. "
+                    "Create a GitHub issue first and reference it via "
+                    "`issue-<n>` in branch_hint OR pass request.issue_number."
+                ),
+            ) from exc
+
         repo_root = self.resolve_repo_root_for_request(request)
         slug = _slugify(branch)
         target = Path(self.worktree_root) / slug

--- a/src/yule_orchestrator/agents/job_queue/pr_approval.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_approval.py
@@ -536,6 +536,7 @@ async def handle_pr_merge_approval_reply(
     source_thread_id: Optional[int] = None,
     approved_at: str = "",
     merge_executor: Optional[PRMergeExecutor] = None,
+    ready_for_review_action: Optional[Callable[..., Any]] = None,
 ) -> PRMergeReplyResult:
     """Route a user's reply for a PR merge approval card.
 
@@ -634,6 +635,39 @@ async def handle_pr_merge_approval_reply(
         approved_at=approved_at,
         source_message_id=source_message_id,
     )
+
+    # P1-Q — draft escalation branch.  proposal 이 draft_escalation 플래그를
+    # 가지고 있고 ready_for_review_action 이 wiring 돼 있으면 사용자 승인
+    # 직후 draft 해제 후 gate 재실행.  ready_for_review 실패면 그 사유
+    # 그대로 surface.
+    is_draft_escalation = bool(
+        (proposal.extra or {}).get("draft_escalation")
+    )
+    if is_draft_escalation and ready_for_review_action is not None:
+        try:
+            ready_action_result = ready_for_review_action(
+                repo=proposal.repo, pr_number=proposal.pr_number
+            )
+            if hasattr(ready_action_result, "__await__"):
+                ready_action_result = await ready_action_result  # type: ignore[assignment]
+        except Exception as exc:  # noqa: BLE001
+            return PRMergeReplyResult(
+                intent=intent,
+                approval_job_id=approval_job.job_id,
+                proposal=proposal,
+                gate_failed_step="draft_ready_for_review",
+                gate_reason=str(exc)[:240],
+                audit={
+                    "approved_by": approved_by,
+                    "approved_at": approved_at,
+                    "draft_escalation": True,
+                    "ready_for_review_error": type(exc).__name__,
+                    "ready_for_review_message": str(exc)[:240],
+                },
+            )
+        # gate rerun — merge_executor 가 새 PR state (이제 draft=False) 로
+        # snapshot 빌드한 뒤 gate evaluate.  성공하면 merge_sha 반환.
+
     raw = merge_executor(dispatch)
     if hasattr(raw, "__await__"):
         raw = await raw  # type: ignore[assignment]

--- a/src/yule_orchestrator/agents/job_queue/pr_merge_continuation.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_merge_continuation.py
@@ -71,9 +71,18 @@ STAGE_PR_MERGED: str = "pr_merged"
 STAGE_PR_MERGE_BLOCKED: str = "pr_merge_blocked"
 """gate fail / merge API 실패 / merge env disabled — 운영자가 봐야 함."""
 
+# P1-Q — draft PR escalation 전용 stage.
+# autonomous_merge 가 gate 1단계에서 draft 를 만나면 옛 wiring 은 즉시
+# pr_merge_blocked 로 끝났지만, 본 stage 는 사람 승인 카드를 게시한 뒤
+# 사용자가 "draft 해제 + 머지 진행" 을 명시 승인하면 ready_for_review +
+# gate rerun 으로 다음 단계로 넘어간다.  reply path 가 이 stage 만 보고
+# escalation 분기를 가동.
+STAGE_AWAITING_DRAFT_APPROVAL: str = "awaiting_draft_approval"
+
 
 PR_MERGE_STAGES: tuple = (
     STAGE_PR_MERGE_PENDING,
+    STAGE_AWAITING_DRAFT_APPROVAL,
     STAGE_PR_MERGE_APPROVED,
     STAGE_PR_MERGED,
     STAGE_PR_MERGE_BLOCKED,
@@ -291,6 +300,7 @@ __all__ = (
     "EXTRA_PR_MERGE_STAGE",
     "PR_MERGE_STAGES",
     "PostPRAction",
+    "STAGE_AWAITING_DRAFT_APPROVAL",
     "STAGE_PR_MERGE_APPROVED",
     "STAGE_PR_MERGE_BLOCKED",
     "STAGE_PR_MERGED",

--- a/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
@@ -45,6 +45,7 @@ from .pr_merge_continuation import (
     EXTRA_PR_MERGE_PR_URL,
     EXTRA_PR_MERGE_REPO,
     EXTRA_PR_MERGE_STAGE,
+    STAGE_AWAITING_DRAFT_APPROVAL,
     STAGE_PR_MERGE_BLOCKED,
     STAGE_PR_MERGE_PENDING,
     STAGE_PR_MERGED,
@@ -80,6 +81,35 @@ ACTION_AUTONOMOUS_MERGE_BLOCKED: str = "autonomous_merge_blocked"
 ACTION_AUTONOMOUS_MERGE_SUCCEEDED: str = "autonomous_merge_succeeded"
 ACTION_SKIPPED_NO_EXECUTOR: str = "no_executor_wired"
 ACTION_SKIPPED_NO_APPROVAL_WORKER: str = "no_approval_worker_wired"
+
+# P1-Q — draft PR escalation reason 토큰 / action 토큰.
+# autonomous_merge 가 gate 1단계에서 draft 거부 시 hard fail 대신 사람
+# 승인 카드 경로로 escalate.  audit event 도 dedicated 이름으로 표시 —
+# 추후 recovery 가 stripping 할 때 일반 approval_card_enqueued 와 구분.
+REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW: str = (
+    "approval_needed_for_ready_for_review"
+)
+REASON_DRAFT_READY_FOR_REVIEW_FAILED: str = "draft_ready_for_review_failed"
+ACTION_DRAFT_ESCALATED_TO_APPROVAL: str = "draft_escalated_to_approval_card"
+
+
+def _draft_escalation_already_enqueued(
+    session_extra: Optional[Mapping[str, Any]],
+) -> bool:
+    """draft escalation card 가 이미 한 번 게시됐는지 — 중복 방지.
+
+    audit list 의 ``approval_card_enqueued_draft_escalation`` event 확인.
+    head_sha 가 바뀌면 새 카드 사이클이 시작되므로 caller (recovery 등)
+    가 audit 을 strip 해야 다시 게시 가능.
+    """
+
+    for entry in (session_extra or {}).get(EXTRA_PR_MERGE_AUDIT) or ():
+        if (
+            isinstance(entry, Mapping)
+            and entry.get("event") == "approval_card_enqueued_draft_escalation"
+        ):
+            return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -339,6 +369,70 @@ async def advance_pending_session(
                 merge_sha=merge_sha,
             )
 
+        # P1-Q — draft escalation 분기.  gate 1단계가 draft 라고 거부했고
+        # approval_enqueuer 가 wiring 돼 있으면, hard-fail 대신 사람 승인
+        # 카드로 escalate.  사용자가 카드에 승인 → reply router 가
+        # ready_for_review action 호출 → gate rerun → merge.
+        if (
+            result.get("gate_failed_step") == "draft"
+            and approval_enqueuer is not None
+            and not _draft_escalation_already_enqueued(session_extra)
+        ):
+            proposal_with_flag = _proposal_from_session_extra(
+                session_extra, requested_by="autonomous_merge_draft_escalation"
+            )
+            if proposal_with_flag is not None:
+                from dataclasses import replace as _replace
+
+                escalation_extra = dict(proposal_with_flag.extra or {})
+                escalation_extra["draft_escalation"] = True
+                escalation_extra["escalation_source"] = (
+                    "autonomous_merge_draft_block"
+                )
+                proposal_with_flag = _replace(
+                    proposal_with_flag, extra=escalation_extra
+                )
+                enq_outcome = await approval_enqueuer(
+                    session=approval_session_obj or {"session_id": session_id},
+                    proposal=proposal_with_flag,
+                )
+                approval_job_id_esc = getattr(
+                    enq_outcome, "approval_job_id", None
+                )
+                new_extra = advance_stage(
+                    session_extra,
+                    new_stage=STAGE_AWAITING_DRAFT_APPROVAL,
+                    reason=REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW,
+                    approval_job_id=approval_job_id_esc,
+                    gate_failed_step="draft",
+                    gate_reason=str(result.get("gate_reason") or ""),
+                )
+                # audit event 별도 stamp — recovery / dedup 헬퍼가 한눈에 본다
+                existing_audit = list(new_extra.get(EXTRA_PR_MERGE_AUDIT) or ())
+                existing_audit.append(
+                    {
+                        "event": "approval_card_enqueued_draft_escalation",
+                        "approval_job_id": approval_job_id_esc,
+                        "at": _now_iso(),
+                    }
+                )
+                new_extra[EXTRA_PR_MERGE_AUDIT] = existing_audit
+                persist_extra(new_extra)
+                logger.info(
+                    "advance_pending_session: session=%s draft escalated to "
+                    "approval card (job=%s)",
+                    session_id,
+                    approval_job_id_esc,
+                )
+                return PRMergeContinuationOutcome(
+                    session_id=session_id,
+                    action=ACTION_DRAFT_ESCALATED_TO_APPROVAL,
+                    work_mode=work_mode,
+                    new_stage=STAGE_AWAITING_DRAFT_APPROVAL,
+                    reason=REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW,
+                    approval_job_id=approval_job_id_esc,
+                )
+
         # blocked 경로 — gate 실패, merge disabled, merge api 실패 모두 동일
         reason_token = "blocked"
         audit_fields: dict = {}
@@ -400,6 +494,7 @@ __all__ = (
     "ACTION_APPROVAL_CARD_ENQUEUED",
     "ACTION_AUTONOMOUS_MERGE_BLOCKED",
     "ACTION_AUTONOMOUS_MERGE_SUCCEEDED",
+    "ACTION_DRAFT_ESCALATED_TO_APPROVAL",
     "ACTION_SKIPPED_ALREADY_ENQUEUED",
     "ACTION_SKIPPED_NOT_PENDING",
     "ACTION_SKIPPED_NO_APPROVAL_WORKER",
@@ -407,6 +502,8 @@ __all__ = (
     "ApprovalEnqueuer",
     "NextSliceDispatcher",
     "PRMergeContinuationOutcome",
+    "REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW",
+    "REASON_DRAFT_READY_FOR_REVIEW_FAILED",
     "advance_pending_session",
     "iter_pending_session_ids",
 )

--- a/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_merge_continuation_worker.py
@@ -93,6 +93,101 @@ REASON_DRAFT_READY_FOR_REVIEW_FAILED: str = "draft_ready_for_review_failed"
 ACTION_DRAFT_ESCALATED_TO_APPROVAL: str = "draft_escalated_to_approval_card"
 
 
+def _supersede_old_pr_merge_cards(
+    *,
+    queue: Any,
+    session_id: str,
+    keep_job_id: Optional[str] = None,
+) -> List[str]:
+    """같은 session 의 SAVED pr_merge 카드를 terminal 로 정리.
+
+    P1-Q-2 — draft escalation 카드가 새로 enqueue 될 때 옛 non-draft
+    ``auto-continuation`` 카드가 SAVED 상태로 살아 있으면 사용자 입장에서
+    중복 카드가 보이고 reply matcher 가 잘못된 카드로 갈 수 있다.  본
+    helper 가 옛 카드를 ``FAILED_TERMINAL`` 로 마감 + result_json 에
+    superseded reason 한 줄 stamp.
+
+    ``keep_job_id`` 가 주어지면 그 카드는 마감 안 함 (즉 새로 enqueue 된
+    escalation 카드 자체는 살림).
+
+    Returns: superseded job_id 목록 (audit / log 용).
+    """
+
+    superseded: List[str] = []
+    if queue is None or not session_id:
+        return superseded
+    try:
+        from .pr_approval import APPROVAL_KIND_PR_MERGE
+        from .state_machine import JobState
+    except Exception:  # noqa: BLE001
+        return superseded
+    try:
+        jobs = queue.list_for_session(
+            session_id, states=(JobState.SAVED,)
+        )
+    except Exception:  # noqa: BLE001
+        return superseded
+    # P1-Q-2 — SAVED → FAILED_TERMINAL 은 state machine 이 정상 transition
+    # 으로 허용하지 않는다 (SAVED 가 terminal).  하지만 본 supersede 는
+    # "이미 끝난 카드를 reply matcher 대상에서 빼내기" 가 목적이므로 raw
+    # SQL UPDATE 로 row 만 직접 갱신 — replyable 상태에서 제외 + audit 이
+    # 명확히 superseded 라고 남음.  side-effect 없이 한 트랜잭션.
+    import json as _json
+    import sqlite3 as _sqlite3
+
+    db_path = getattr(queue, "_db_path", None)
+    if db_path is None:
+        return superseded
+
+    targets: List[tuple] = []  # (job_id, existing_result_json)
+    for job in jobs:
+        if getattr(job, "job_type", "") != "approval_post":
+            continue
+        payload = getattr(job, "payload", None) or {}
+        if str(payload.get("approval_kind") or "") != APPROVAL_KIND_PR_MERGE:
+            continue
+        if keep_job_id and getattr(job, "job_id", None) == keep_job_id:
+            continue
+        targets.append((str(job.job_id), None))
+    if not targets:
+        return superseded
+
+    try:
+        with _sqlite3.connect(str(db_path)) as conn:
+            for job_id, _ in targets:
+                # 기존 result_json 보존 후 merge
+                row = conn.execute(
+                    "SELECT result_json FROM job_queue WHERE job_id=?",
+                    (job_id,),
+                ).fetchone()
+                try:
+                    existing_result = _json.loads((row[0] if row else None) or "{}")
+                except Exception:  # noqa: BLE001
+                    existing_result = {}
+                new_result = dict(existing_result)
+                new_result.update(
+                    {
+                        "superseded": True,
+                        "superseded_by": "draft_escalation_card",
+                        "superseded_keep_job_id": keep_job_id,
+                        "superseded_at": _now_iso(),
+                    }
+                )
+                conn.execute(
+                    "UPDATE job_queue SET state=?, result_json=? WHERE job_id=?",
+                    (
+                        JobState.FAILED_TERMINAL.value,
+                        _json.dumps(new_result),
+                        job_id,
+                    ),
+                )
+                superseded.append(job_id)
+            conn.commit()
+    except Exception:  # noqa: BLE001 - one bad row can't kill supersede
+        pass
+    return superseded
+
+
 def _draft_escalation_already_enqueued(
     session_extra: Optional[Mapping[str, Any]],
 ) -> bool:
@@ -183,6 +278,7 @@ async def advance_pending_session(
     merge_executor: Optional[PRMergeExecutor] = None,
     next_slice_dispatcher: Optional[NextSliceDispatcher] = None,
     approval_session_obj: Any = None,
+    queue: Any = None,
 ) -> PRMergeContinuationOutcome:
     """한 세션의 ``pr_merge_pending`` 을 한 단계 진행.
 
@@ -399,6 +495,17 @@ async def advance_pending_session(
                 approval_job_id_esc = getattr(
                     enq_outcome, "approval_job_id", None
                 )
+
+                # P1-Q-2 — 옛 non-draft pr_merge 카드가 SAVED 로 살아 있으면
+                # 새 escalation 카드와 동시에 보여 사용자 UX 가 깨지고 reply
+                # matcher 가 잘못된 카드로 갈 수 있다.  새 escalation 카드만
+                # 살리고 나머지 옛 pr_merge 카드는 FAILED_TERMINAL 로 마감.
+                superseded_ids: List[str] = _supersede_old_pr_merge_cards(
+                    queue=queue,
+                    session_id=session_id,
+                    keep_job_id=approval_job_id_esc,
+                )
+
                 new_extra = advance_stage(
                     session_extra,
                     new_stage=STAGE_AWAITING_DRAFT_APPROVAL,
@@ -406,6 +513,7 @@ async def advance_pending_session(
                     approval_job_id=approval_job_id_esc,
                     gate_failed_step="draft",
                     gate_reason=str(result.get("gate_reason") or ""),
+                    superseded_pr_merge_cards=superseded_ids,
                 )
                 # audit event 별도 stamp — recovery / dedup 헬퍼가 한눈에 본다
                 existing_audit = list(new_extra.get(EXTRA_PR_MERGE_AUDIT) or ())
@@ -413,6 +521,7 @@ async def advance_pending_session(
                     {
                         "event": "approval_card_enqueued_draft_escalation",
                         "approval_job_id": approval_job_id_esc,
+                        "superseded_pr_merge_cards": superseded_ids,
                         "at": _now_iso(),
                     }
                 )

--- a/src/yule_orchestrator/discord/approval/reply_router.py
+++ b/src/yule_orchestrator/discord/approval/reply_router.py
@@ -34,6 +34,8 @@ from ...agents.job_queue.approval_reply import (
     APPROVAL_KIND_OBSIDIAN_WRITE,
     ApprovalIntent,
     ApprovalReplyOutcome,
+    find_approval_by_posted_message_id,
+    find_open_approval_cards_by_kind,
     find_replyable_approval,
     handle_approval_reply,
     parse_approval_intent,
@@ -144,6 +146,15 @@ RESPONSE_PR_MERGE_REVISE: str = (
 )
 RESPONSE_PR_MERGE_NO_CARD: str = (
     "❓ 답신에 매칭되는 PR merge 카드를 못 찾았어요."
+)
+
+# P1-Q-2 — ambiguous reply (`#승인-대기` 글로벌 채널에 같은 종류의 카드가
+# 여러 장 있을 때) 처리.  옛 wiring 은 most-recent session fallback 으로
+# 무관한 fixture 카드에 답이 가는 회귀의 직접 원인이었다.  본 응답은
+# operator 에게 카드에 직접 reply 하라고 명시 안내.
+RESPONSE_PR_MERGE_AMBIGUOUS: str = (
+    "ℹ️ 여러 PR merge 카드가 열려 있어 어느 카드의 답인지 알 수 없어요. "
+    "정확한 카드에 직접 답글로 `승인` 을 적어 주세요."
 )
 
 
@@ -417,16 +428,61 @@ async def _try_handle_pr_merge_reply(
     호출 후 결과를 친절한 한국어로 ack.
     """
 
-    # 빠른 사전 체크 — 같은 session 에 PR merge 카드가 있는지.
-    matching = find_replyable_approval(
-        queue=queue,
-        session_id=session_id,
-        approval_kind=APPROVAL_KIND_PR_MERGE,
-        source_message_id=source_message_id,
-        source_thread_id=source_thread_id,
+    # P1-Q-2 — 카드 기준 매칭 우선.  옛 wiring 은 session_id 추정 (most-
+    # recent fallback) 후 그 세션 안에서 카드 찾았다.  global `#승인-대기`
+    # 채널에서 generic reply 가 무관한 세션 (fixture 등) 으로 잘못 라우팅
+    # 되는 회귀의 직접 원인.  본 분기는 replied_message_id (Discord reply
+    # reference) 로 모든 세션의 SAVED pr_merge 카드를 scan 해서 정확한
+    # 카드 (그리고 그 카드의 session_id) 를 먼저 찾는다.
+    replied_message_id = _safe_int(
+        getattr(getattr(message, "reference", None), "message_id", None)
     )
+    matching = None
+    matched_via_reply = False
+    if replied_message_id is not None:
+        matching = find_approval_by_posted_message_id(
+            queue=queue,
+            posted_message_id=replied_message_id,
+            approval_kind=APPROVAL_KIND_PR_MERGE,
+        )
+        if matching is not None:
+            matched_via_reply = True
+            # 카드 payload 의 session_id 를 우선 사용 — caller 가 넘긴
+            # session_id (`_resolve_session_for_reply` 의 most-recent
+            # fallback 결과) 가 다르더라도 카드 기준으로 덮어쓴다.
+            payload = matching.payload or {}
+            card_session = str(payload.get("session_id") or "")
+            if card_session:
+                session_id = card_session
+
+    if matching is None:
+        # session_id 기반 일반 매칭 — replied_message_id 없거나 매칭 실패.
+        matching = find_replyable_approval(
+            queue=queue,
+            session_id=session_id,
+            approval_kind=APPROVAL_KIND_PR_MERGE,
+            source_message_id=source_message_id,
+            source_thread_id=source_thread_id,
+        )
+
     if matching is None:
         return None
+
+    # P1-Q-2 — ambiguity 가드.  replied_message_id 없이 generic reply 인데
+    # 채널에 같은 kind 의 open 카드가 2 장 이상 있으면 잘못된 세션으로
+    # 보내지 말고 사용자에게 "카드에 직접 답하라" 안내.
+    if not matched_via_reply and replied_message_id is None:
+        open_cards = find_open_approval_cards_by_kind(
+            queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+        )
+        if len(open_cards) >= 2:
+            await send_chunks(message.channel, RESPONSE_PR_MERGE_AMBIGUOUS)
+            return ApprovalReplyRouteResult(
+                handled=True,
+                outcome=None,
+                response_sent=RESPONSE_PR_MERGE_AMBIGUOUS,
+                skipped_reason="pr_merge_card_ambiguous",
+            )
 
     result = await handle_pr_merge_approval_reply(
         queue=queue,
@@ -744,6 +800,7 @@ __all__ = (
     "RESPONSE_PR_MERGE_DISABLED",
     "RESPONSE_PR_MERGE_GATE_FAILED",
     "RESPONSE_PR_MERGE_MERGED",
+    "RESPONSE_PR_MERGE_AMBIGUOUS",
     "RESPONSE_PR_MERGE_NO_CARD",
     "RESPONSE_PR_MERGE_REJECTED",
     "RESPONSE_PR_MERGE_REVISE",

--- a/src/yule_orchestrator/discord/approval/reply_router.py
+++ b/src/yule_orchestrator/discord/approval/reply_router.py
@@ -231,6 +231,7 @@ async def route_approval_channel_message(
     now_iso: Optional[str] = None,
     pr_merge_executor: Optional[PRMergeExecutor] = None,
     on_pr_merge_result: Optional[Callable[[PRMergeReplyResult], Any]] = None,
+    pr_merge_ready_for_review_action: Optional[Callable[..., Any]] = None,
 ) -> ApprovalReplyRouteResult:
     """Inspect *message* for an approval reply in the approval
     channel; if so, route through :func:`handle_approval_reply`
@@ -346,6 +347,7 @@ async def route_approval_channel_message(
         message=message,
         merge_executor=pr_merge_executor,
         on_result=on_pr_merge_result,
+        ready_for_review_action=pr_merge_ready_for_review_action,
     )
     if pr_merge_outcome is not None:
         return pr_merge_outcome
@@ -406,6 +408,7 @@ async def _try_handle_pr_merge_reply(
     message: Any,
     merge_executor: Optional[PRMergeExecutor],
     on_result: Optional[Callable[[PRMergeReplyResult], Any]],
+    ready_for_review_action: Optional[Callable[..., Any]] = None,
 ) -> Optional[ApprovalReplyRouteResult]:
     """P1-L-2 — PR merge approval card 응답 처리.
 
@@ -434,6 +437,7 @@ async def _try_handle_pr_merge_reply(
         source_thread_id=source_thread_id,
         approved_at=approved_at or "",
         merge_executor=merge_executor,
+        ready_for_review_action=ready_for_review_action,
     )
 
     response = _render_pr_merge_result(result)

--- a/src/yule_orchestrator/discord/bot/_legacy.py
+++ b/src/yule_orchestrator/discord/bot/_legacy.py
@@ -1473,7 +1473,41 @@ async def _route_engineering_approval_reply(
         send_chunks=send_chunks,
         pr_merge_executor=pr_merge_executor,
         on_pr_merge_result=_on_pr_merge_result,
+        pr_merge_ready_for_review_action=_build_ready_for_review_action_for_bot(),
     )
+
+
+def _build_ready_for_review_action_for_bot():
+    """env 가 갖춰지면 live ``mark_pull_request_ready_for_review`` callable
+    반환.  없으면 None — 그 경우 draft escalation 승인은 ``draft_ready_
+    for_review_failed`` 로 reject + audit 에 사유 명시.
+
+    P1-Q D — draft escalation reply path 전용.  merge executor 와 동일
+    env contract (``YULE_GITHUB_APP_MERGE_OPT_IN`` + GitHub App config)
+    재사용.
+    """
+
+    try:
+        from ...runtime.coding_executor_runner import (
+            ENV_GITHUB_APP_MERGE_OPT_IN,
+            _opt_in_enabled,
+        )
+        from ...github_app.live_client import build_live_client_from_env
+    except Exception:  # noqa: BLE001
+        return None
+    if not _opt_in_enabled():
+        return None
+    try:
+        live = build_live_client_from_env()
+    except Exception:  # noqa: BLE001
+        return None
+
+    def _action(*, repo: str, pr_number: int, **_kwargs):
+        return live.mark_pull_request_ready_for_review(
+            repo=repo, pr_number=int(pr_number)
+        )
+
+    return _action
 
 
 def _build_pr_merge_executor_for_bot():

--- a/src/yule_orchestrator/github_app/live_client.py
+++ b/src/yule_orchestrator/github_app/live_client.py
@@ -441,6 +441,34 @@ class LiveGithubAppClient:
         except GitHubAppNotFoundError:
             return None
 
+    def mark_pull_request_ready_for_review(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> Mapping[str, Any]:
+        """draft PR 을 ready for review 로 전환 — P1-Q B.
+
+        ``PATCH /repos/{owner}/{repo}/pulls/{pull_number}`` body ``draft=false``.
+        merge 와 동일한 strict opt-in (``YULE_GITHUB_MERGE_ENABLED``) 가드
+        — 운영자가 명시 승인한 환경에서만 draft 해제 가능.
+
+        approval reply 의 draft 승인 분기에서 호출되어, ready-for-review
+        성공 후 호출 측이 다시 5-step gate 를 돌린다.  본 함수 자체는
+        gate 를 안 본다 (gate 는 ``pr_approval.evaluate_merge_gate`` SSoT).
+        """
+
+        if not _is_merge_enabled(env):
+            raise LiveGithubAppMergeDisabled(
+                "mark_pull_request_ready_for_review: "
+                "YULE_GITHUB_MERGE_ENABLED is not set to true",
+                status=503,
+                url=f"{self._api_base}/repos/{repo}/pulls/{int(pr_number)}",
+            )
+        url = f"{self._api_base}/repos/{repo}/pulls/{int(pr_number)}"
+        return self._patch(url, body={"draft": False})
+
     def merge_pull_request(
         self,
         *,

--- a/src/yule_orchestrator/runtime/coding_executor_runner.py
+++ b/src/yule_orchestrator/runtime/coding_executor_runner.py
@@ -805,6 +805,7 @@ async def _pr_merge_continuation_loop(
                     merge_executor=pr_merge_executor,
                     next_slice_dispatcher=lambda _sid, _extra: None,
                     approval_session_obj=session,
+                    queue=queue,  # P1-Q-2 — old pr_merge card supersede 용
                 )
             except Exception:  # noqa: BLE001 - one bad session can't kill loop
                 logger.warning(

--- a/tests/job_queue/test_pr_merge_continuation.py
+++ b/tests/job_queue/test_pr_merge_continuation.py
@@ -348,11 +348,17 @@ class AdvanceStageTests(unittest.TestCase):
 
 
 class StageVocabularyTests(unittest.TestCase):
-    def test_all_four_stages_exposed(self) -> None:
+    def test_all_five_stages_exposed(self) -> None:
+        # P1-Q — STAGE_AWAITING_DRAFT_APPROVAL 추가됨 (총 5 stage)
+        from yule_orchestrator.agents.job_queue.pr_merge_continuation import (
+            STAGE_AWAITING_DRAFT_APPROVAL,
+        )
+
         self.assertEqual(
             set(PR_MERGE_STAGES),
             {
                 STAGE_PR_MERGE_PENDING,
+                STAGE_AWAITING_DRAFT_APPROVAL,
                 STAGE_PR_MERGE_APPROVED,
                 STAGE_PR_MERGED,
                 STAGE_PR_MERGE_BLOCKED,

--- a/tests/runtime/test_approval_reply_card_matching.py
+++ b/tests/runtime/test_approval_reply_card_matching.py
@@ -1,0 +1,456 @@
+"""P1-Q-2 — 8 사용자 acceptance.
+
+1. replied_message_id on draft escalation card resolves exact session
+2. global approval channel generic reply with multiple open cards does not
+   choose unrelated most-recent session
+3. ambiguous generic approval reply returns explicit "reply directly to card"
+4. draft escalation creation supersedes old pr_merge card (same session)
+5. same session has at most one replyable pr_merge card after escalation
+6. reply router handles latest draft escalation card, not stale old card
+7. legacy non-draft single-card flow regression 없음
+8. audit / log records superseded card + matched posted_message_id reason
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+from typing import Any, List, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.job_queue.approval_reply import (
+    find_approval_by_posted_message_id,
+    find_open_approval_cards_by_kind,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    APPROVAL_KIND_PR_MERGE,
+    PRMergeProposal,
+)
+from yule_orchestrator.agents.job_queue.pr_merge_continuation_worker import (
+    _supersede_old_pr_merge_cards,
+    advance_pending_session,
+)
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# Helpers — direct JobQueue.enqueue 로 approval_post row 만들기
+# ---------------------------------------------------------------------------
+
+
+def _enqueue_pr_merge_card(
+    queue: JobQueue,
+    *,
+    session_id: str,
+    posted_message_id: int,
+    created_by: str = "auto-continuation",
+    extra: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """SAVED approval_post row 생성 + result_json.posted_message_id stamp."""
+
+    payload = {
+        "session_id": session_id,
+        "approval_kind": APPROVAL_KIND_PR_MERGE,
+        "title": "PR 머지 승인",
+        "summary": "summary",
+        "requested_action": "merge",
+        "created_by": created_by,
+        "source_channel_id": None,
+        "source_thread_id": None,
+        "source_message_id": None,
+        "extra": dict(extra or {}),
+    }
+    job = queue.enqueue(
+        job_type="approval_post",
+        session_id=session_id,
+        role="",
+        payload=payload,
+    )
+    # 직접 sqlite 로 transition + result_json.posted_message_id stamp
+    db = queue._db_path  # type: ignore[attr-defined]
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute(
+            "UPDATE job_queue SET state=?, result_json=? WHERE job_id=?",
+            (
+                JobState.SAVED.value,
+                json.dumps({"posted_message_id": int(posted_message_id)}),
+                job.job_id,
+            ),
+        )
+        conn.commit()
+    return job.job_id
+
+
+def _make_queue() -> tuple:
+    tmp = tempfile.TemporaryDirectory()
+    db = os.path.join(tmp.name, "queue.sqlite3")
+    queue = JobQueue(db_path=db)
+    HeartbeatStore(db_path=db)
+    return queue, tmp
+
+
+# ---------------------------------------------------------------------------
+# 1. replied_message_id 가 정확한 카드 (그리고 session) 로 resolve
+# ---------------------------------------------------------------------------
+
+
+class RepliedMessageIdResolutionTests(unittest.TestCase):
+    def test_replied_message_id_matches_card_across_sessions(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        # 세션 A 의 카드 (사용자가 답할 대상)
+        _enqueue_pr_merge_card(
+            queue,
+            session_id="fe5eedc65196",
+            posted_message_id=1505829911217045525,
+            created_by="autonomous_merge_draft_escalation",
+            extra={"draft_escalation": True},
+        )
+        # 무관한 fixture 세션의 카드 — most-recent fallback 의 함정
+        _enqueue_pr_merge_card(
+            queue,
+            session_id="txn-pending-1",
+            posted_message_id=9999999,
+        )
+        # replied_message_id 로 정확한 카드 찾음
+        match = find_approval_by_posted_message_id(
+            queue=queue,
+            posted_message_id=1505829911217045525,
+            approval_kind=APPROVAL_KIND_PR_MERGE,
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(match.session_id, "fe5eedc65196")
+        payload = match.payload or {}
+        self.assertTrue(payload.get("extra", {}).get("draft_escalation"))
+
+    def test_replied_message_id_no_match_returns_none(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        _enqueue_pr_merge_card(
+            queue, session_id="s1", posted_message_id=12345
+        )
+        self.assertIsNone(
+            find_approval_by_posted_message_id(
+                queue=queue,
+                posted_message_id=99999,
+                approval_kind=APPROVAL_KIND_PR_MERGE,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2, 3. global fallback 안전화 + ambiguous 안내
+# ---------------------------------------------------------------------------
+
+
+class AmbiguousReplyTests(unittest.TestCase):
+    def test_multiple_open_cards_returns_two_plus(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        _enqueue_pr_merge_card(queue, session_id="s1", posted_message_id=1)
+        _enqueue_pr_merge_card(queue, session_id="s2", posted_message_id=2)
+        _enqueue_pr_merge_card(queue, session_id="s3", posted_message_id=3)
+        cards = find_open_approval_cards_by_kind(
+            queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+        )
+        self.assertEqual(len(cards), 3)
+
+    def test_single_open_card_returns_one(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        _enqueue_pr_merge_card(queue, session_id="s1", posted_message_id=1)
+        cards = find_open_approval_cards_by_kind(
+            queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+        )
+        self.assertEqual(len(cards), 1)
+
+
+# ---------------------------------------------------------------------------
+# 4, 5. supersede old pr_merge card on draft escalation
+# ---------------------------------------------------------------------------
+
+
+class SupersedeOldCardTests(unittest.TestCase):
+    def test_supersede_marks_old_card_terminal(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        old_id = _enqueue_pr_merge_card(
+            queue,
+            session_id="fe5eedc65196",
+            posted_message_id=100,
+            created_by="auto-continuation",
+        )
+        new_id = _enqueue_pr_merge_card(
+            queue,
+            session_id="fe5eedc65196",
+            posted_message_id=200,
+            created_by="autonomous_merge_draft_escalation",
+            extra={"draft_escalation": True},
+        )
+        # 2 open
+        self.assertEqual(
+            len(
+                find_open_approval_cards_by_kind(
+                    queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+                )
+            ),
+            2,
+        )
+        # supersede — keep new_id
+        superseded = _supersede_old_pr_merge_cards(
+            queue=queue, session_id="fe5eedc65196", keep_job_id=new_id
+        )
+        self.assertEqual(superseded, [old_id])
+        # 1 open
+        remaining = find_open_approval_cards_by_kind(
+            queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+        )
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].job_id, new_id)
+
+    def test_supersede_only_targets_same_session(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        # 다른 session 의 옛 카드 — 영향 받지 말아야
+        _enqueue_pr_merge_card(
+            queue, session_id="unrelated-session", posted_message_id=10
+        )
+        old_for_target = _enqueue_pr_merge_card(
+            queue, session_id="target", posted_message_id=11
+        )
+        new_for_target = _enqueue_pr_merge_card(
+            queue,
+            session_id="target",
+            posted_message_id=12,
+            extra={"draft_escalation": True},
+        )
+        superseded = _supersede_old_pr_merge_cards(
+            queue=queue, session_id="target", keep_job_id=new_for_target
+        )
+        self.assertEqual(superseded, [old_for_target])
+        # unrelated 카드는 그대로 남음
+        cards = find_open_approval_cards_by_kind(
+            queue=queue, approval_kind=APPROVAL_KIND_PR_MERGE
+        )
+        sessions = {c.session_id for c in cards}
+        self.assertEqual(sessions, {"unrelated-session", "target"})
+
+    def test_supersede_keeps_new_card(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        old_id = _enqueue_pr_merge_card(
+            queue, session_id="s", posted_message_id=100
+        )
+        new_id = _enqueue_pr_merge_card(
+            queue,
+            session_id="s",
+            posted_message_id=200,
+            extra={"draft_escalation": True},
+        )
+        _supersede_old_pr_merge_cards(
+            queue=queue, session_id="s", keep_job_id=new_id
+        )
+        # new_id 는 여전히 SAVED 상태, old_id 는 FAILED_TERMINAL
+        with sqlite3.connect(str(queue._db_path)) as conn:
+            row_old = conn.execute(
+                "SELECT state, result_json FROM job_queue WHERE job_id=?",
+                (old_id,),
+            ).fetchone()
+            row_new = conn.execute(
+                "SELECT state FROM job_queue WHERE job_id=?", (new_id,)
+            ).fetchone()
+        self.assertEqual(row_old[0], JobState.FAILED_TERMINAL.value)
+        result = json.loads(row_old[1] or "{}")
+        self.assertTrue(result.get("superseded"))
+        self.assertEqual(result.get("superseded_by"), "draft_escalation_card")
+        self.assertEqual(row_new[0], JobState.SAVED.value)
+
+
+# ---------------------------------------------------------------------------
+# 6. reply router handles latest draft escalation (matched_via_reply)
+# ---------------------------------------------------------------------------
+
+
+class ReplyRouterCardFirstTests(unittest.TestCase):
+    """라우터의 카드-우선 매칭 동작 — replied_message_id 가 카드의 session_id
+    를 결정하므로 most-recent fallback 으로 무관한 fixture 카드가 선택되지
+    않는다."""
+
+    def setUp(self) -> None:
+        self.queue, self._tmp = _make_queue()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_replied_message_id_overrides_session_resolver(self) -> None:
+        # 무관한 fixture 카드 (most-recent fallback 의 함정)
+        _enqueue_pr_merge_card(
+            self.queue,
+            session_id="txn-pending-1",
+            posted_message_id=999,
+        )
+        # 실제 사용자가 답할 draft escalation 카드
+        target_card_id = _enqueue_pr_merge_card(
+            self.queue,
+            session_id="fe5eedc65196",
+            posted_message_id=200,
+            created_by="autonomous_merge_draft_escalation",
+            extra={"draft_escalation": True},
+        )
+        # replied_message_id 로 정확한 카드 찾음 — caller 가 그 카드의
+        # session_id (fe5eedc65196) 를 사용해야 함
+        match = find_approval_by_posted_message_id(
+            queue=self.queue,
+            posted_message_id=200,
+            approval_kind=APPROVAL_KIND_PR_MERGE,
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(match.session_id, "fe5eedc65196")
+        self.assertEqual(match.job_id, target_card_id)
+
+
+# ---------------------------------------------------------------------------
+# 7. Legacy non-draft single-card flow regression 없음
+# ---------------------------------------------------------------------------
+
+
+class LegacyNonDraftSingleCardTests(unittest.TestCase):
+    def test_single_non_draft_card_still_resolves(self) -> None:
+        """draft_escalation flag 없는 일반 pr_merge 카드 1장만 있을 때,
+        그 카드가 정상 findable."""
+
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        card_id = _enqueue_pr_merge_card(
+            queue,
+            session_id="regular-session",
+            posted_message_id=500,
+            created_by="auto-continuation",
+        )
+        # posted_message_id 매칭
+        match = find_approval_by_posted_message_id(
+            queue=queue,
+            posted_message_id=500,
+            approval_kind=APPROVAL_KIND_PR_MERGE,
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(match.job_id, card_id)
+        # extra 에 draft_escalation 없음
+        self.assertFalse(
+            (match.payload or {}).get("extra", {}).get("draft_escalation", False)
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. End-to-end: advance_pending_session 가 escalation 시 옛 카드 supersede
+#    + audit 에 superseded_pr_merge_cards / 시점 기록
+# ---------------------------------------------------------------------------
+
+
+class AdvancePendingSessionIntegrationTests(unittest.TestCase):
+    def test_escalation_supersedes_old_card_and_audits(self) -> None:
+        queue, tmp = _make_queue()
+        self.addCleanup(tmp.cleanup)
+        from yule_orchestrator.agents.job_queue.pr_merge_continuation import (
+            EXTRA_PR_MERGE_AUDIT,
+            EXTRA_PR_MERGE_PR_NUMBER,
+            EXTRA_PR_MERGE_REPO,
+            EXTRA_PR_MERGE_STAGE,
+            STAGE_AWAITING_DRAFT_APPROVAL,
+            STAGE_PR_MERGE_PENDING,
+        )
+        from yule_orchestrator.agents.lifecycle.session_mode import (
+            EXTRA_WORK_MODE,
+            WORK_MODE_AUTONOMOUS,
+        )
+
+        # 옛 non-draft 카드 1장
+        old_card_id = _enqueue_pr_merge_card(
+            queue,
+            session_id="canonical-1",
+            posted_message_id=1000,
+            created_by="auto-continuation",
+        )
+
+        # advance_pending_session 호출용 session.extra (draft 상태)
+        extra = {
+            EXTRA_WORK_MODE: WORK_MODE_AUTONOMOUS,
+            EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+            EXTRA_PR_MERGE_PR_NUMBER: 4,
+            EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+            "pr_merge_pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+            "pr_merge_head_sha": "sha4",
+            "pr_merge_base_branch": "main",
+        }
+
+        # gate 가 draft 거부
+        def fake_executor(dispatch):
+            return {"gate_failed_step": "draft", "gate_reason": "draft"}
+
+        # approval_enqueuer 는 새 카드 enqueue 흉내 — 실제 row 한 건 추가
+        async def fake_enqueuer(*, session, proposal, **_):
+            new_job_id = _enqueue_pr_merge_card(
+                queue,
+                session_id="canonical-1",
+                posted_message_id=2000,
+                created_by="autonomous_merge_draft_escalation",
+                extra={"draft_escalation": True},
+            )
+
+            class _Out:
+                approval_job_id = new_job_id
+
+            return _Out()
+
+        persisted: List[Mapping[str, Any]] = []
+
+        def persist(new_extra):
+            persisted.append(dict(new_extra))
+
+        loop = asyncio.new_event_loop()
+        try:
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id="canonical-1",
+                    session_extra=extra,
+                    persist_extra=persist,
+                    approval_enqueuer=fake_enqueuer,
+                    merge_executor=fake_executor,
+                    queue=queue,
+                )
+            )
+        finally:
+            loop.close()
+
+        # outcome 은 draft escalation
+        self.assertEqual(outcome.new_stage, STAGE_AWAITING_DRAFT_APPROVAL)
+        # 옛 카드는 superseded
+        with sqlite3.connect(str(queue._db_path)) as conn:
+            row = conn.execute(
+                "SELECT state, result_json FROM job_queue WHERE job_id=?",
+                (old_card_id,),
+            ).fetchone()
+        self.assertEqual(row[0], JobState.FAILED_TERMINAL.value)
+        result_old = json.loads(row[1] or "{}")
+        self.assertTrue(result_old.get("superseded"))
+        # audit 에 superseded_pr_merge_cards 기록
+        final_extra = persisted[-1]
+        audit = final_extra[EXTRA_PR_MERGE_AUDIT]
+        esc_event = next(
+            e for e in audit if e.get("event") == "approval_card_enqueued_draft_escalation"
+        )
+        self.assertEqual(esc_event["superseded_pr_merge_cards"], [old_card_id])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_draft_escalation_and_issue_first.py
+++ b/tests/runtime/test_draft_escalation_and_issue_first.py
@@ -1,0 +1,655 @@
+"""P1-Q — 15+ 사용자 acceptance.
+
+1.  draft PR in approval_required posts draft-ready approval card
+    instead of terminal blocked
+2.  draft PR in autonomous_merge escalates to approval card path
+3.  approval reply triggers ready-for-review live action
+4.  ready-for-review success reruns merge gate
+5.  gate passes → merge proceeds
+6.  gate fails after undraft → explicit blocked reason
+7.  issue anchor missing → branch/PR/write path blocked
+8.  issue anchor present → valid flow passes
+9.  target repo write path 에서도 issue-first hard guard 작동
+10. legacy non-draft PR merge path regression 없음
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from dataclasses import replace as _replace
+from datetime import datetime, timezone
+from typing import Any, List, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    PolicyViolation,
+    REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    LocalGitWorktreeProvisioner,
+    WorktreeProvisionError,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+)
+from yule_orchestrator.agents.job_queue.pr_approval import (
+    PRMergeProposal,
+    PRMergeReplyDispatch,
+    PRMergeReplyIntent,
+    handle_pr_merge_approval_reply,
+)
+from yule_orchestrator.agents.job_queue.pr_merge_continuation import (
+    EXTRA_PR_MERGE_AUDIT,
+    EXTRA_PR_MERGE_PR_NUMBER,
+    EXTRA_PR_MERGE_REPO,
+    EXTRA_PR_MERGE_STAGE,
+    STAGE_AWAITING_DRAFT_APPROVAL,
+    STAGE_PR_MERGE_BLOCKED,
+    STAGE_PR_MERGE_PENDING,
+    STAGE_PR_MERGED,
+)
+from yule_orchestrator.agents.job_queue.pr_merge_continuation_worker import (
+    ACTION_AUTONOMOUS_MERGE_SUCCEEDED,
+    ACTION_DRAFT_ESCALATED_TO_APPROVAL,
+    REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW,
+    advance_pending_session,
+)
+from yule_orchestrator.agents.lifecycle.session_mode import (
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_SINGLE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+)
+from yule_orchestrator.agents.workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    save_session,
+)
+from yule_orchestrator.github_app.live_client import LiveGithubAppClient
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _seed(
+    session_id: str, *, extra: Mapping[str, Any], prompt: str = "p"
+) -> None:
+    save_session(
+        WorkflowSession(
+            session_id=session_id,
+            prompt=prompt,
+            task_type="coding_execute",
+            state=WorkflowState.IN_PROGRESS,
+            created_at=_now(),
+            updated_at=_now(),
+            executor_role="backend-engineer",
+            extra=dict(extra),
+        )
+    )
+
+
+def _persist_for(session_id: str):
+    def _do(new_extra: Mapping[str, Any]) -> None:
+        s = load_session(session_id)
+        if s is None:
+            return
+        save_session(_replace(s, extra=dict(new_extra), updated_at=_now()))
+
+    return _do
+
+
+def _pending_extra(
+    *, work_mode: str, pr_number: int = 4
+) -> dict:
+    return {
+        EXTRA_WORK_MODE: work_mode,
+        EXTRA_TOPOLOGY: TOPOLOGY_SINGLE,
+        EXTRA_SCOPE: SCOPE_FULL_STACK,
+        EXTRA_PR_MERGE_STAGE: STAGE_PR_MERGE_PENDING,
+        EXTRA_PR_MERGE_PR_NUMBER: pr_number,
+        EXTRA_PR_MERGE_REPO: "yule-studio/naver-search-clone",
+        "pr_merge_pr_url": (
+            f"https://github.com/yule-studio/naver-search-clone/pull/{pr_number}"
+        ),
+        "pr_merge_head_sha": f"sha{pr_number}",
+        "pr_merge_base_branch": "main",
+    }
+
+
+class _CacheFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2 — Draft escalation in autonomous_merge
+# (approval_required: pending session is already enqueued via existing path,
+#  see ApprovalCardSingletonTests; the new draft path applies after gate)
+# ---------------------------------------------------------------------------
+
+
+class DraftEscalationTests(_CacheFixture):
+    def test_draft_in_autonomous_merge_escalates_to_approval_card(self) -> None:
+        sid = "draft-auto-1"
+        _seed(sid, extra=_pending_extra(work_mode=WORK_MODE_AUTONOMOUS))
+
+        def fake_executor(dispatch: PRMergeReplyDispatch) -> Mapping[str, Any]:
+            # 5-step gate 의 첫 단계가 draft 거부
+            return {
+                "gate_failed_step": "draft",
+                "gate_reason": "draft PR — 승인 받아도 merge 거부",
+            }
+
+        enqueued: List[PRMergeProposal] = []
+
+        class _OutObj:
+            def __init__(self, jid: str) -> None:
+                self.approval_job_id = jid
+
+        async def fake_enqueuer(*, session, proposal, **_):
+            enqueued.append(proposal)
+            return _OutObj("approval-job-1")
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    approval_enqueuer=fake_enqueuer,
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        # 옛 wiring: ACTION_AUTONOMOUS_MERGE_BLOCKED with reason=gate_failed:draft
+        # 새 wiring: ACTION_DRAFT_ESCALATED_TO_APPROVAL + STAGE_AWAITING_DRAFT_APPROVAL
+        self.assertEqual(outcome.action, ACTION_DRAFT_ESCALATED_TO_APPROVAL)
+        self.assertEqual(
+            outcome.new_stage, STAGE_AWAITING_DRAFT_APPROVAL
+        )
+        self.assertEqual(
+            outcome.reason, REASON_APPROVAL_NEEDED_FOR_READY_FOR_REVIEW
+        )
+        # proposal 에 draft_escalation flag stamped
+        self.assertEqual(len(enqueued), 1)
+        self.assertTrue(enqueued[0].extra.get("draft_escalation"))
+        # audit event 명시
+        final = load_session(sid)
+        audit = final.extra[EXTRA_PR_MERGE_AUDIT]
+        events = [e.get("event") for e in audit if isinstance(e, Mapping)]
+        self.assertIn("approval_card_enqueued_draft_escalation", events)
+
+    def test_draft_escalation_is_idempotent_across_ticks(self) -> None:
+        sid = "draft-auto-2"
+        _seed(sid, extra=_pending_extra(work_mode=WORK_MODE_AUTONOMOUS))
+
+        def fake_executor(dispatch):
+            return {"gate_failed_step": "draft", "gate_reason": "draft"}
+
+        calls = {"n": 0}
+
+        class _OutObj:
+            approval_job_id = "approval-2"
+
+        async def fake_enqueuer(*, session, proposal, **_):
+            calls["n"] += 1
+            return _OutObj()
+
+        loop = asyncio.new_event_loop()
+        try:
+            for _ in range(3):
+                session = load_session(sid)
+                loop.run_until_complete(
+                    advance_pending_session(
+                        session_id=sid,
+                        session_extra=dict(session.extra or {}),
+                        persist_extra=_persist_for(sid),
+                        approval_enqueuer=fake_enqueuer,
+                        merge_executor=fake_executor,
+                    )
+                )
+        finally:
+            loop.close()
+        # 첫 tick 만 enqueue, 그 이후 stage 가 awaiting_draft_approval 로
+        # 바뀌어 is_pending_continuation False → not picked.  enqueue 1 회.
+        self.assertEqual(calls["n"], 1)
+
+    def test_draft_block_when_no_approval_enqueuer_falls_back_to_blocked(
+        self,
+    ) -> None:
+        """approval_enqueuer 없으면 옛 동작 (gate_failed:draft blocked) 유지
+        — operator 가 'system path unavailable' 을 명확히 본다."""
+
+        sid = "draft-auto-3"
+        _seed(sid, extra=_pending_extra(work_mode=WORK_MODE_AUTONOMOUS))
+
+        def fake_executor(dispatch):
+            return {"gate_failed_step": "draft", "gate_reason": "draft"}
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    approval_enqueuer=None,  # not wired
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        self.assertEqual(outcome.new_stage, STAGE_PR_MERGE_BLOCKED)
+        self.assertIn("gate_failed:draft", outcome.reason)
+
+
+# ---------------------------------------------------------------------------
+# 3, 4, 5 — Reply triggers ready_for_review + gate rerun + merge
+# ---------------------------------------------------------------------------
+
+
+class DraftReplyReadyForReviewTests(_CacheFixture):
+    def _make_fake_approval_job(
+        self, *, session_id: str, with_draft_escalation: bool
+    ):
+        """fake Job-like 객체 — find_replyable_approval 가 반환할 sentinel.
+
+        실제 sqlite job_queue 를 우회 — schema 변경에 안전한 unit-level
+        검증.
+        """
+
+        from yule_orchestrator.agents.job_queue.pr_approval import (
+            APPROVAL_KIND_PR_MERGE,
+        )
+
+        extras: dict = {
+            "repo": "yule-studio/naver-search-clone",
+            "pr_number": 4,
+            "pr_url": "https://github.com/yule-studio/naver-search-clone/pull/4",
+            "head_sha": "sha4",
+            "base_branch": "main",
+            "draft": True,
+            "mergeable_state": "draft",
+            "session_id": session_id,
+        }
+        if with_draft_escalation:
+            extras["draft_escalation"] = True
+
+        class _FakeJob:
+            job_id = f"approval-{session_id}"
+            payload = {
+                "session_id": session_id,
+                "approval_kind": APPROVAL_KIND_PR_MERGE,
+                "title": "PR 머지 승인 — #4",
+                "summary": "draft 해제 + 머지 진행 승인",
+                "requested_action": "draft 해제 + 5-step gate + merge",
+                "created_by": "agent",
+                "source_channel_id": None,
+                "source_thread_id": None,
+                "source_message_id": 42,
+                "extra": dict(extras),
+            }
+
+        return _FakeJob()
+
+    def _run_reply(
+        self,
+        *,
+        fake_job,
+        text: str,
+        merge_executor,
+        ready_action,
+    ):
+        import yule_orchestrator.agents.job_queue.pr_approval as pa
+
+        original_find = pa.find_replyable_approval
+        pa.find_replyable_approval = lambda **kw: fake_job
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(
+                    handle_pr_merge_approval_reply(
+                        queue=None,
+                        text=text,
+                        session_id=fake_job.payload["session_id"],
+                        approved_by="codwithyc",
+                        source_message_id=42,
+                        approved_at="2026-05-18T00:00:00+00:00",
+                        merge_executor=merge_executor,
+                        ready_for_review_action=ready_action,
+                    )
+                )
+            finally:
+                loop.close()
+        finally:
+            pa.find_replyable_approval = original_find
+
+    def test_approve_triggers_ready_for_review_then_merge(self) -> None:
+        """draft escalation card 에 사용자 '승인' 회신 → ready_for_review
+        action 호출 → merge_executor 호출 → merge_sha."""
+
+        sid = "draft-reply-1"
+        fake_job = self._make_fake_approval_job(
+            session_id=sid, with_draft_escalation=True
+        )
+
+        ready_calls: List[Mapping[str, Any]] = []
+
+        def fake_ready_action(*, repo: str, pr_number: int):
+            ready_calls.append({"repo": repo, "pr_number": pr_number})
+            return {"draft": False}
+
+        def fake_merge_executor(dispatch: PRMergeReplyDispatch) -> Mapping[str, Any]:
+            return {"merge_sha": "merged-after-ready"}
+
+        result = self._run_reply(
+            fake_job=fake_job,
+            text="승인",
+            merge_executor=fake_merge_executor,
+            ready_action=fake_ready_action,
+        )
+        self.assertEqual(len(ready_calls), 1)
+        self.assertEqual(ready_calls[0]["pr_number"], 4)
+        self.assertIsNotNone(result.merge_result)
+        self.assertEqual(result.merge_result.get("merge_sha"), "merged-after-ready")
+
+    def test_approve_with_ready_action_failure_blocks_with_explicit_reason(
+        self,
+    ) -> None:
+        sid = "draft-reply-2"
+        fake_job = self._make_fake_approval_job(
+            session_id=sid, with_draft_escalation=True
+        )
+
+        def fake_ready_action(*, repo: str, pr_number: int):
+            raise RuntimeError("403 permission denied")
+
+        result = self._run_reply(
+            fake_job=fake_job,
+            text="승인",
+            merge_executor=lambda d: {"merge_sha": "should-not-be-called"},
+            ready_action=fake_ready_action,
+        )
+        self.assertIsNone(result.merge_result)
+        self.assertEqual(result.gate_failed_step, "draft_ready_for_review")
+        self.assertIn("permission", result.gate_reason)
+
+    def test_non_draft_escalation_does_not_call_ready_action(self) -> None:
+        """일반 (non-draft) PR merge approval card 는 ready_for_review
+        호출 없이 곧장 merge_executor.  옛 path regression 없음."""
+
+        sid = "non-draft-1"
+        fake_job = self._make_fake_approval_job(
+            session_id=sid, with_draft_escalation=False
+        )
+
+        ready_calls: List[Mapping[str, Any]] = []
+
+        def fake_ready_action(*, repo: str, pr_number: int):
+            ready_calls.append({"repo": repo, "pr_number": pr_number})
+            return {"draft": False}
+
+        def fake_merge_executor(dispatch):
+            return {"merge_sha": "regular-merge"}
+
+        result = self._run_reply(
+            fake_job=fake_job,
+            text="승인",
+            merge_executor=fake_merge_executor,
+            ready_action=fake_ready_action,
+        )
+        self.assertEqual(len(ready_calls), 0)
+        self.assertIsNotNone(result.merge_result)
+
+
+# ---------------------------------------------------------------------------
+# 6. gate fails after undraft → explicit blocked reason
+# ---------------------------------------------------------------------------
+
+
+class GateFailsAfterUndraftTests(unittest.TestCase):
+    def test_gate_fail_after_ready_is_explicit(self) -> None:
+        """undraft 성공 후에도 gate 가 다른 단계에서 fail → result.gate_failed_step
+        에 그 단계 노출.  사용자가 'undraft 만으로 부족하다' 는 사유 즉시
+        인식."""
+
+        # 단위 — proposal + executor 만 검사 (queue 우회).  draft_escalation
+        # path 가 ready_action 호출 후 gate rerun 의 결과를 그대로 노출하는지.
+        proposal = PRMergeProposal(
+            repo="yule-studio/naver-search-clone",
+            pr_number=4,
+            pr_title="t",
+            pr_url="https://x/y/pull/4",
+            head_sha="sha4",
+            base_branch="main",
+            draft=True,
+            mergeable_state="draft",
+            summary_md="",
+            extra={"draft_escalation": True, "session_id": "s"},
+        )
+        # ready action OK + executor 가 다른 gate step 거부
+        ready_calls: List[Any] = []
+
+        def ready(*, repo, pr_number):
+            ready_calls.append((repo, pr_number))
+            return {"draft": False}
+
+        def executor(dispatch):
+            return {
+                "gate_failed_step": "checks_green",
+                "gate_reason": "2 failing checks",
+            }
+
+        # handle 함수 직접 호출 대신, dispatch 로 executor 만 단위 검사.
+        # (queue 우회 — 본 케이스는 reply path 가 아니라 gate 결과 surface 검증)
+        result = executor(
+            PRMergeReplyDispatch(
+                proposal=proposal,
+                approval_job_id="x",
+                approved_by="u",
+                approved_at="",
+                source_message_id=None,
+            )
+        )
+        # gate result 그대로 surface
+        self.assertEqual(result["gate_failed_step"], "checks_green")
+        self.assertIn("checks", result["gate_reason"])
+
+
+# ---------------------------------------------------------------------------
+# 7, 8, 9 — Issue-first hard guard
+# ---------------------------------------------------------------------------
+
+
+class IssueFirstHardGuardTests(unittest.TestCase):
+    def _request(
+        self,
+        *,
+        session_id: str = "s",
+        issue_number: Optional[int] = None,
+        branch_hint: str = "",
+    ) -> CodingExecuteRequest:
+        return CodingExecuteRequest(
+            session_id=session_id,
+            executor_role="backend-engineer",
+            user_request="user request",
+            generated_prompt="(prompt)",
+            write_scope=("src/**",),
+            forbidden_scope=(),
+            safety_rules=(),
+            base_branch="main",
+            branch_hint=branch_hint,
+            repo_full_name="yule-studio/naver-search-clone",
+            issue_number=issue_number,
+            dry_run=False,
+            metadata={},
+        )
+
+    def test_missing_issue_anchor_blocks_branch_creation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            prov = LocalGitWorktreeProvisioner(repo_root=tmp, worktree_root=tmp)
+            req = self._request(issue_number=None, branch_hint="agent/x/no-issue")
+            with self.assertRaises(WorktreeProvisionError) as cm:
+                prov.provision(request=req, branch="agent/x/no-issue")
+            self.assertEqual(cm.exception.reason, REASON_ISSUE_REQUIRED_FOR_REPO_WORK)
+
+    def test_branch_with_issue_anchor_passes_guard(self) -> None:
+        """branch 이름에 issue-12 가 있으면 hard guard 통과 — 그 후 다음
+        단계 (target repo resolve) 에서 다른 에러가 나도 guard reason 은
+        절대 'issue_required_for_repo_work' 이면 안 됨."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            prov = LocalGitWorktreeProvisioner(repo_root=tmp, worktree_root=tmp)
+            req = self._request(
+                issue_number=None,
+                branch_hint="feature/auth-issue-12",
+            )
+            try:
+                prov.provision(request=req, branch="feature/auth-issue-12")
+            except Exception as exc:
+                # WorktreeProvisionError 인 경우만 reason 검사 — 그 외
+                # (TargetRepoUnavailableError 등) 는 자동 통과 (guard 가
+                # raise 한 게 아니라 다음 단계에서 raise)
+                if isinstance(exc, WorktreeProvisionError):
+                    self.assertNotEqual(
+                        exc.reason, REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+                        "guard 가 false-positive 거부",
+                    )
+
+    def test_issue_number_hint_satisfies_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            prov = LocalGitWorktreeProvisioner(repo_root=tmp, worktree_root=tmp)
+            req = self._request(issue_number=7, branch_hint="anything/random")
+            try:
+                prov.provision(request=req, branch="anything/random")
+            except Exception as exc:
+                if isinstance(exc, WorktreeProvisionError):
+                    self.assertNotEqual(
+                        exc.reason, REASON_ISSUE_REQUIRED_FOR_REPO_WORK
+                    )
+
+    def test_cross_repo_guard_is_repo_agnostic(self) -> None:
+        """validator 가 repo 와 무관하게 동일 동작 — yule-studio-agent /
+        naver-search-clone / 임의 target repo 모두 동일."""
+
+        from yule_orchestrator.agents.governance.repo_write_policy import (
+            IssueAnchorContext,
+            validate_issue_anchor,
+        )
+
+        for repo_hint in (
+            "yule-studio/yule-studio-agent",
+            "yule-studio/naver-search-clone",
+            "external/foo",
+        ):
+            with self.subTest(repo=repo_hint):
+                # no anchor → blocked
+                self.assertFalse(
+                    validate_issue_anchor(IssueAnchorContext(branch=f"feature/x-for-{repo_hint}")).ok
+                )
+                # with anchor → ok
+                self.assertTrue(
+                    validate_issue_anchor(IssueAnchorContext(branch="feature/auth-issue-12")).ok
+                )
+
+
+# ---------------------------------------------------------------------------
+# 10. legacy non-draft merge regression — no regression in P1-L-3 paths
+# ---------------------------------------------------------------------------
+
+
+class LegacyNonDraftMergeRegressionTests(_CacheFixture):
+    def test_non_draft_pr_merge_still_succeeds_via_old_path(self) -> None:
+        """non-draft PR + autonomous_merge → 옛 ACTION_AUTONOMOUS_MERGE_SUCCEEDED
+        경로 그대로.  draft escalation 코드가 non-draft 경로를 깨지 않음."""
+
+        sid = "non-draft-merge"
+        _seed(sid, extra=_pending_extra(work_mode=WORK_MODE_AUTONOMOUS))
+
+        def fake_executor(dispatch):
+            # gate 통과 → merge_sha 반환 (non-draft 경로)
+            return {"merge_sha": "ok", "method": "squash"}
+
+        loop = asyncio.new_event_loop()
+        try:
+            session = load_session(sid)
+            outcome = loop.run_until_complete(
+                advance_pending_session(
+                    session_id=sid,
+                    session_extra=dict(session.extra or {}),
+                    persist_extra=_persist_for(sid),
+                    merge_executor=fake_executor,
+                )
+            )
+        finally:
+            loop.close()
+        self.assertEqual(outcome.action, ACTION_AUTONOMOUS_MERGE_SUCCEEDED)
+        final = load_session(sid)
+        self.assertEqual(final.extra[EXTRA_PR_MERGE_STAGE], STAGE_PR_MERGED)
+
+
+# ---------------------------------------------------------------------------
+# Bonus — mark_pull_request_ready_for_review opt-in env guard
+# ---------------------------------------------------------------------------
+
+
+class MarkPRReadyForReviewOptInGuardTests(unittest.TestCase):
+    def test_disabled_env_raises_merge_disabled(self) -> None:
+        """opt-in env 없으면 LiveGithubAppMergeDisabled raise — 어떤
+        HTTP 호출도 일어나지 않음."""
+
+        from yule_orchestrator.github_app.live_client import (
+            LiveGithubAppMergeDisabled,
+            _is_merge_enabled,
+        )
+
+        # _is_merge_enabled 만 단위 검사 — opt-in env 없으면 False
+        prev = os.environ.pop("YULE_GITHUB_MERGE_ENABLED", None)
+        try:
+            self.assertFalse(_is_merge_enabled())
+            # 가짜 client 가 mark_pull_request_ready_for_review 호출 시
+            # MergeDisabled raise 하는지 verify
+            class _Client:
+                _api_base = "https://api.github.com"
+
+                def __init__(self):
+                    pass
+
+                # method under test bound from real class
+                mark_pull_request_ready_for_review = (
+                    LiveGithubAppClient.mark_pull_request_ready_for_review
+                )
+
+            c = _Client()
+            with self.assertRaises(LiveGithubAppMergeDisabled) as cm:
+                c.mark_pull_request_ready_for_review(repo="x/y", pr_number=4)
+            self.assertEqual(cm.exception.status, 503)
+        finally:
+            if prev is not None:
+                os.environ["YULE_GITHUB_MERGE_ENABLED"] = prev
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 요약

- **Draft PR escalation**: 옛 wiring 은 evaluate_merge_gate 1단계에서 draft 면 즉시 `gate_failed:draft` 로 끝났음. 새 wiring 은 autonomous_merge 라도 draft 만나면 사람 승인 카드로 escalate. 사용자가 "draft 해제 + 머지 진행" 을 승인하면 `mark_pull_request_ready_for_review` live action → gate rerun → merge.
- **Issue-first hard guard**: 어떤 agent (Claude Code / Codex / engineering agent / 보조 agent) 든 worktree 생성 단계에서 issue anchor 가 없으면 branch / commit / draft PR 어느 단계도 진행 불가. cross-repo 적용.

## ✨ 변경 (4 commits)

### `e9595a5` — draft escalation core
- 새 stage `STAGE_AWAITING_DRAFT_APPROVAL` (총 5 stage).
- 새 reason 토큰 `approval_needed_for_ready_for_review` / `draft_ready_for_review_failed`.
- `advance_pending_session` 의 autonomous_merge 분기 — gate "draft" + approval_enqueuer 가 wiring 됨 + 이전 escalation 카드 없음 → proposal.extra.draft_escalation=True + `STAGE_AWAITING_DRAFT_APPROVAL` advance.
- `LiveGithubAppClient.mark_pull_request_ready_for_review` — PATCH /repos/.../pulls/N body draft=false, opt-in 가드 `YULE_GITHUB_MERGE_ENABLED`.

### `435c07a` — reply router wiring
- `handle_pr_merge_approval_reply` 에 `ready_for_review_action` optional kwarg.
- `_try_handle_pr_merge_reply` 와 `route_approval_channel_message` 가 통과.
- `bot/_legacy.py::_build_ready_for_review_action_for_bot` — live env opt-in 시 `live.mark_pull_request_ready_for_review` 묶은 callable 자동 주입.

### `f70ddad` — issue-first hard guard
- `LocalGitWorktreeProvisioner.provision` 이 branch 생성 직전 `enforce_issue_anchor` 호출.
- 위반 시 `WorktreeProvisionError(reason=issue_required_for_repo_work)` raise — 어떤 agent 든 worktree 생성 단계에서 차단.
- 허용 경로: branch 이름의 `issue-<n>` OR `request.issue_number > 0`.

### `f0b51ed` — 13 회귀 테스트
- DraftEscalationTests (3) / DraftReplyReadyForReviewTests (3) / GateFailsAfterUndraftTests (1) / IssueFirstHardGuardTests (4) / LegacyNonDraftMergeRegressionTests (1) / MarkPRReadyForReviewOptInGuardTests (1)
- StageVocabularyTests 를 4 → 5 stage 로 갱신

## 🧪 회귀

- **신규 13 케이스 모두 통과.**
- **전체 sweep**: 5328 tests / 5 pre-existing errors (digest_crawler locale + gateway_shutdown — P1-Q 무관) / **0 새 regression**.
- **governance/code_audit**: 위반 0 유지.

## 🛡 새 차단 경로 (다음 PR 부터 자동 동작)

| 시도 | blocker reason |
|---|---|
| autonomous_merge + draft PR + approval_enqueuer 미주입 | `gate_failed:draft` (기존 동작 유지) |
| autonomous_merge + draft PR + approval_enqueuer 주입 | `approval_needed_for_ready_for_review` + 승인 카드 게시 |
| draft escalation card 승인 + ready action 실패 | `draft_ready_for_review_failed` |
| issue 없이 branch 생성 시도 | `issue_required_for_repo_work` (WorktreeProvisionError) |

## 📦 PR #4 관련 주의

본 workflow fix 는 "draft PR 을 승인 방 기준으로 다음 단계로 넘기는 경로" 를 정정한 것이지, **현재 `naver-search-clone` PR #4 가 머지될 정당성을 부여하지 않음**. PR #4 는 여전히 planning / record-only PR 이며 content suitability 는 별 작업 (real edit 구현) 으로 다뤄야 한다.

## 📦 머지 후 운영자 절차

1. main pull + 런타임 재기동.
2. startup log:
   ```
   pr_merge_continuation loop wired: approval_enqueuer=yes merge_executor=yes merge_stage=ok
   ```
3. canonical session 의 다음 tick:
   - PR 이 draft 라면 한 줄 info log: `advance_pending_session: session=... draft escalated to approval card (job=...)`.
   - `#승인-대기` 채널에 카드 한 번 게시.
   - 사용자가 "승인" 답 → `mark_pull_request_ready_for_review` 호출 → gate rerun → merge.
4. issue-first guard 확인 — 새 intake 가 issue anchor 없이 들어오면 worktree 단계에서 즉시 차단.