### PR TITLE
[구현] 거버넌스 hard enforcement — Git Flow / tag / approval 카드 한국어 4섹션 / intake contract 확장

### DIFF
--- a/.github/ISSUE_TEMPLATE/-feature--issue-template.md
+++ b/.github/ISSUE_TEMPLATE/-feature--issue-template.md
@@ -1,7 +1,7 @@
 ---
 name: "[Feature] Issue Template"
 about: 모든 라벨 관리 이슈 템플릿
-title: "[Feat]"
+title: "[Feature]"
 labels: "\U0001F970 Accessibility, \U0001F4EC API, \U0001F41E BugFix, \U0001F4BB CrossBrowsing,
   \U0001F30F Deploy, \U0001F4C3 Docs, ✨ Feature, \U0001F3A8 Html&css, \U0001F64B‍♂️
   Question, \U0001F528 Refactor, ⚙ Setting, ✅ Test"

--- a/docs/engineering-governance-modes.md
+++ b/docs/engineering-governance-modes.md
@@ -1,0 +1,126 @@
+# Engineering governance modes — intake contract SSoT (P1-R)
+
+작업 시작 시점에 결정되는 6 + 1 governance 축.  intake 후 작업 도중에는 절대 바뀌지 않는다 (자율/승인 모드의 토글 금지 — ask-once contract).
+
+코드 SSoT — [`agents/lifecycle/session_mode.py`](../src/yule_orchestrator/agents/lifecycle/session_mode.py),
+[`agents/governance/repo_write_policy.py`](../src/yule_orchestrator/agents/governance/repo_write_policy.py).
+
+## 1. 축 (session.extra 키)
+
+| key | 값 | 기본값 | 의미 |
+|---|---|---|---|
+| `work_mode` | `approval_required` \| `autonomous_merge` | `approval_required` | 작업 중 사람 승인을 거치는지 여부 |
+| `topology` | `single_repo` \| `multi_repo` | `single_repo` | 작업 대상 repo 갯수 |
+| `scope` | `single_scope` \| `full_stack_single_repo` \| `layer_scoped` \| `cross_repo_program` | `single_scope` | 작업 깊이 |
+| `branch_strategy` | `git_flow` | `git_flow` | branch naming 규칙 |
+| `release_strategy` | `tagged_release` | `tagged_release` | release/hotfix 완료 시 tag 요구 |
+| `issue_policy` | `issue_required` | `issue_required` | branch / commit / PR 전에 issue anchor 필수 |
+| `mode_decided_by` | `user_explicit` \| `gateway_inferred` | 결정 |
+| `mode_decided_at` | iso8601 UTC | 결정 시점 |
+
+## 2. work_mode 의미
+
+### `approval_required` (기본)
+gateway 가 **중요한 write 단계마다** `#승인-대기` 카드를 게시.  사용자 승인 후 다음 단계로 진행.
+
+승인 카드 필수 한국어 4 섹션 (`repo_write_policy.validate_approval_card_quality`):
+- **작업 내용** — 무엇을 하는지
+- **목적** — 왜 필요한지
+- **영향 범위** — repo / branch / 위험도
+- **다음 단계** — 승인 후 바로 이어질 다음 동작
+
+vague / machine-like / 영문-only 카드는 enqueue 단계에서 차단.
+
+### `autonomous_merge`
+gateway 가 **end-to-end control** — intake → issue → branch (Git Flow) → coding → draft PR → ready_for_review → merge → 다음 slice continuation 까지 사람 개입 없이 진행.
+
+**예외 — 사람 승인 카드가 올라가는 경우**:
+1. **draft PR escalation** — gate 가 draft 거부 시 ready_for_review 전환 승인 카드
+2. **operator_action 카드** — secret / access / 외부 사실 / blocker 가 필요한 경우
+3. **HIGH risk 변경** — 보호 브랜치 정책 변경, secret 처리 변경 등
+
+**일반 진행 메시지는 최소화** — final completion summary 만 운영방에 게시.
+
+## 3. branch_strategy = git_flow
+
+허용 prefix (`repo_write_policy.GIT_FLOW_BRANCH_PREFIXES`):
+- `feature/` — 새 기능 (issue anchor 필수)
+- `bugfix/` / `fix/` — 버그 수정 (issue anchor 필수)
+- `hotfix/` — 긴급 수정 (issue 면제, tag 필수)
+- `release/` — 릴리즈 준비 (issue 면제, tag 필수)
+- `refactor/` — 리팩토링 (issue anchor 필수)
+- `chore/` / `docs/` / `test/` — 보조 작업
+- `agent/` — engineering-agent 가 만드는 branch
+
+**protected branch** (main/master/develop/dev/prod/production/release) 직접 작업 절대 금지 — worktree 생성 단계에서 차단.
+
+slug 부분: kebab-case lowercase + `_-.`만 허용.
+
+## 4. release_strategy = tagged_release
+
+`release/`, `hotfix/` branch 완료 시 **반드시** semver tag (`vMAJOR.MINOR.PATCH`, 선택 `-pre.1` 등) 를 남긴다.
+
+tag 없이 release/hotfix 머지 완료 처리는 `repo_write_policy.enforce_release_tag` 가 차단 — `missing_release_tag` reason 으로 surface.
+
+## 5. issue_policy = issue_required
+
+모든 agent (Claude Code / Codex / engineering / 보조) 가 작업 시작 전 GitHub issue 또는 유효한 기존 issue anchor 를 확보해야 한다.
+
+확보 방법 (적어도 하나):
+1. branch 이름의 `issue-<n>` (예: `feature/auth-issue-12`)
+2. `request.issue_number > 0` (work_order executor 등이 직접 지정)
+3. `is_docs_only=True` 명시 (제한 예외)
+
+확보 안 된 상태로 worktree 생성 시도 → `WorktreeProvisionError(reason=issue_required_for_repo_work)`.
+
+**cross-repo** — yule-studio-agent 본 repo 뿐 아니라 봇이 GitHub write 하는 모든 target repo (예: `naver-search-clone`) 에 동일 적용.
+
+## 6. intake prompt 예시
+
+명시적 intake (권장):
+
+```
+approval_required, git_flow, tagged_release, issue_required, single_repo, full_stack_single_repo
+네이버 검색 풀스택 MVP 구현해줘
+https://github.com/yule-studio/naver-search-clone
+```
+
+```
+autonomous_merge, git_flow, tagged_release, issue_required, single_repo, full_stack_single_repo
+네이버 검색 풀스택 MVP 끝까지 자율로 진행
+https://github.com/yule-studio/naver-search-clone
+```
+
+생략 토큰은 default 적용.  `parse_mode_hints` 가 한국어/영문 변형 모두 인식 (`자율 머지`, `승인 필요`, `git flow`, `tag release`, `issue required` 등).
+
+## 7. 모드별 operator 운영 절차
+
+| 시나리오 | approval_required | autonomous_merge |
+|---|---|---|
+| issue 생성 | gateway 가 카드 게시 → 사용자 승인 후 진행 | gateway 자동 생성 |
+| draft PR | 자동 생성 후 카드 게시 | 자동 생성 후 자동 ready_for_review → merge |
+| draft 가 gate 1단계 거부 | 카드에 `[draft 해제 + 머지 진행]` 한국어 4 섹션 | 동일 (escalation 시점에는 사람 승인 필요) |
+| merge 후 다음 slice | 다음 slice 도 승인 카드 | 다음 slice 자동 진행 |
+| 완료 보고 | 매 단계 카드 / 답신 | final completion 한 줄 |
+| secret / access / blocker | operator_action 카드 (둘 다 동일) | operator_action 카드 |
+
+## 8. 강제 위치 (live path hard guard)
+
+| 검증 | 호출 지점 | 위반 시 |
+|---|---|---|
+| Git Flow branch | `LocalGitWorktreeProvisioner.provision` | `WorktreeProvisionError(reason=invalid_git_flow_branch / protected_branch_direct_work)` |
+| issue anchor | `LocalGitWorktreeProvisioner.provision` | `WorktreeProvisionError(reason=issue_required_for_repo_work)` |
+| commit message | `GithubAppCommitter.commit` + `commit-msg` hook | `CodingCommitError(reason=invalid_commit_*)` |
+| PR title | `GithubAppDraftPRCreator.open` | `PolicyViolation(reason=invalid_pr_title_not_human_readable_korean)` |
+| issue title | `GithubWriter.create_issue` | `PolicyViolation(reason=invalid_issue_title_not_human_readable_korean)` |
+| approval card body | `pr_merge_adapter._approval_request_from_proposal` | `PolicyViolation(reason=approval_card_missing_sections)` |
+| release tag | (별도 release 마감 path — operator runbook) | `PolicyViolation(reason=missing_release_tag / invalid_release_tag)` |
+
+## 9. 관련 모듈
+
+- 검증 SSoT: [`agents/governance/repo_write_policy.py`](../src/yule_orchestrator/agents/governance/repo_write_policy.py)
+- 모드 영속화: [`agents/lifecycle/session_mode.py`](../src/yule_orchestrator/agents/lifecycle/session_mode.py)
+- intake 진입: [`agents/coding/coding_session_context.py`](../src/yule_orchestrator/agents/coding/coding_session_context.py)
+- slash command: [`discord/commands/__init__.py::_run_engineer_intake`](../src/yule_orchestrator/discord/commands/__init__.py)
+- branch 검증 live 호출: [`agents/job_queue/coding_executor_live.py::LocalGitWorktreeProvisioner.provision`](../src/yule_orchestrator/agents/job_queue/coding_executor_live.py)
+- approval 카드 quality: [`discord/integrations/pr_merge_adapter.py`](../src/yule_orchestrator/discord/integrations/pr_merge_adapter.py)

--- a/docs/engineering-governance-modes.md
+++ b/docs/engineering-governance-modes.md
@@ -75,23 +75,58 @@ tag 없이 release/hotfix 머지 완료 처리는 `repo_write_policy.enforce_rel
 
 **cross-repo** — yule-studio-agent 본 repo 뿐 아니라 봇이 GitHub write 하는 모든 target repo (예: `naver-search-clone`) 에 동일 적용.
 
-## 6. intake prompt 예시
+## 6. intake — slash option 권장 (P1-R-2)
 
-명시적 intake (권장):
+### 6.1 권장 방식 — `/engineer_intake` 명시 옵션
+
+운영자 UX 우선.  prompt 는 업무 내용 중심, governance 는 슬래시 옵션으로 선택:
+
+| option | choices |
+|---|---|
+| `work_mode` | `approval_required` / `autonomous_merge` |
+| `branch_strategy` | `git_flow` |
+| `release_strategy` | `tagged_release` |
+| `issue_policy` | `issue_required` |
+| `topology` | `single_repo` / `multi_repo` |
+| `scope` | `single_scope` / `full_stack_single_repo` / `layer_scoped` / `cross_repo_program` |
+
+예시:
+```
+/engineer_intake
+  prompt: 네이버 검색 풀스택 MVP 구현해줘 https://github.com/yule-studio/naver-search-clone
+  work_mode: autonomous_merge
+  branch_strategy: git_flow
+  release_strategy: tagged_release
+  issue_policy: issue_required
+  topology: single_repo
+  scope: full_stack_single_repo
+  write_requested: true
+```
+
+intake 직후 접수 메시지 끝에 `🛡 거버넌스 contract (intake 시점에 확정)` 블록이 자동 표시 — operator 가 6 키 + `mode_decided_by` 한눈에 확인.
+
+### 6.2 우선순위 (`slash option > prompt token > default`)
+
+slash option 이 prompt 토큰보다 강하다.  예:
+- option `work_mode=approval_required` + prompt `"autonomous_merge"` 포함 → 결과 `approval_required` (slash 우선).
+- option 생략 + prompt `"autonomous_merge"` → 결과 `autonomous_merge` (prompt fallback).
+- 둘 다 생략 → default `approval_required` (안전측).
+
+`mode_decided_by` 값:
+- `slash_option_explicit` — slash option 으로 결정
+- `user_explicit` — prompt 토큰으로 결정 (모든 3축 명시)
+- `gateway_inferred` — default 또는 일부만 명시
+
+### 6.3 prompt fallback (backward compatibility)
+
+slash option 없이도 옛 prompt 방식 그대로 동작:
 
 ```
 approval_required, git_flow, tagged_release, issue_required, single_repo, full_stack_single_repo
 네이버 검색 풀스택 MVP 구현해줘
-https://github.com/yule-studio/naver-search-clone
 ```
 
-```
-autonomous_merge, git_flow, tagged_release, issue_required, single_repo, full_stack_single_repo
-네이버 검색 풀스택 MVP 끝까지 자율로 진행
-https://github.com/yule-studio/naver-search-clone
-```
-
-생략 토큰은 default 적용.  `parse_mode_hints` 가 한국어/영문 변형 모두 인식 (`자율 머지`, `승인 필요`, `git flow`, `tag release`, `issue required` 등).
+`parse_mode_hints` 가 한국어/영문 변형 모두 인식 (`자율 머지`, `승인 필요`, `git flow`, `tag release`, `issue required` 등).
 
 ## 7. 모드별 operator 운영 절차
 

--- a/docs/engineering-governance-modes.md
+++ b/docs/engineering-governance-modes.md
@@ -139,6 +139,35 @@ approval_required, git_flow, tagged_release, issue_required, single_repo, full_s
 | 완료 보고 | 매 단계 카드 / 답신 | final completion 한 줄 |
 | secret / access / blocker | operator_action 카드 (둘 다 동일) | operator_action 카드 |
 
+## 7.5 Live LLM editor env contract (P1-T)
+
+Non-greenfield repo (이미 코드가 있는 target repo, 예: `naver-search-clone`) 에서 실제 product code 를 수정하려면 live LLM editor 를 명시 활성화해야 한다.  옛 wiring 은 `build_live_executor` 가 무조건 `GreenfieldBootstrapEditor` 만 선택해서 non-greenfield 에 record-only delegate 가 되는 회귀가 있었음.  P1-T 부터 다음 env 가 갖춰지면 `LiveCodeEditor` 가 우선 선택.
+
+| env | 의미 | 필수/권장/기본 |
+|---|---|---|
+| `YULE_LIVE_EDITOR_ENABLED` | live LLM editor 활성화 | **필수 (`true` 일 때만 동작)** |
+| `YULE_LIVE_EDITOR_PROVIDER` | LLM provider | **필수 — 현재 MVP 는 `claude-cli` 만 |
+| `YULE_LIVE_EDITOR_MODEL` | 모델 ID | 권장 (기본 `claude-sonnet-4-6`) |
+| `YULE_LIVE_EDITOR_MAX_RETRIES` | 재시도 횟수 | 기본 3 |
+| `claude` 바이너리 PATH 등록 | claude CLI 가 worktree 디렉터리 안에서 호출됨 | **필수** (`shutil.which("claude")` 가 찾아야 함) |
+| `YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN` | non-greenfield 에서 plan-only delegate 차단 | 권장 (`1`) — 위 live editor env 없이도 silent record-only 회귀를 잡아냄 |
+| `YULE_CODING_EXECUTOR_GREENFIELD_BOOTSTRAP_ENABLED` | 빈 repo scaffold (Next.js/NestJS/Postgres 기본) | live editor 가 있으면 불필요. greenfield 만 다루는 fallback 모드용 |
+
+선택 우선순위 (`build_live_executor`):
+1. live editor env 모두 충족 → `LiveCodeEditor(provider=claude-cli)` 선택
+2. live editor 부재 + `GREENFIELD_BOOTSTRAP_ENABLED=1` → greenfield 시 scaffold, non-greenfield 시 record-only delegate
+3. 둘 다 부재 → record-only delegate (기본 — `PLANNING_ONLY_PR_FORBIDDEN=1` 로 차단 권장)
+
+startup log 가 어느 분기를 탔는지 명시:
+```
+build_live_executor: live code editor selected — LiveCodeEditor(provider=claude-cli) (env=YULE_LIVE_EDITOR_ENABLED + YULE_LIVE_EDITOR_PROVIDER)
+```
+
+availability surface (`detect_live_executor_availability`) 도 같은 분기 반영:
+- `code_editor=live_llm(claude-cli)` (env on)
+- `code_editor=greenfield_bootstrap+record_only_delegate` (greenfield only)
+- `code_editor=greenfield_bootstrap (disabled — env off)` (어떤 env 도 없음)
+
 ## 8. 강제 위치 (live path hard guard)
 
 | 검증 | 호출 지점 | 위반 시 |

--- a/src/yule_orchestrator/agents/coding/authorization.py
+++ b/src/yule_orchestrator/agents/coding/authorization.py
@@ -323,6 +323,7 @@ def recommend_authorization(
     role_profile_loader: Optional[
         Mapping[str, Mapping[str, object]]
     ] = None,
+    implementation_strategy: Optional[Any] = None,
 ) -> CodingAuthorizationProposal:
     """Pick executor + review + participant roles for *user_request*.
 
@@ -399,10 +400,19 @@ def recommend_authorization(
             scored=scored,
         )
 
-    if top_score <= 0:
-        # No keyword matched — likely an under-specified request. Still
-        # return a tech-lead-led fallback so the gateway asks the user
-        # to specify the area instead of silently picking backend.
+    # P1-Z5 — strategy 가 resolved 면 keyword score 0 이라도 strategy 우선.
+    # tech-lead 가 repo layout + user request 로 이미 first_slice_owner 결정 →
+    # keyword scorer 가 모르더라도 strategy 가 source of truth.
+    strategy_resolved = bool(
+        implementation_strategy is not None
+        and getattr(implementation_strategy, "resolved", False)
+        and getattr(implementation_strategy, "first_slice_owner", None)
+        and getattr(implementation_strategy, "first_slice_scope", ())
+    )
+
+    if top_score <= 0 and not strategy_resolved:
+        # No keyword matched + 도 strategy 없음 — likely under-specified.
+        # tech-lead-led fallback 으로 gateway 가 사용자에게 영역 명시 요청.
         return _fallback_proposal(
             user_request=request_text,
             session_id=session_id,
@@ -413,8 +423,99 @@ def recommend_authorization(
         )
 
     executor_profile = profiles[top_role]
-    write_scope = tuple(_string_list(executor_profile.get("write_scope_candidates", ())))
-    forbidden_scope = tuple(_string_list(executor_profile.get("forbidden_scope", ())))
+    manifest_write_scope = tuple(_string_list(executor_profile.get("write_scope_candidates", ())))
+    manifest_forbidden_scope = tuple(_string_list(executor_profile.get("forbidden_scope", ())))
+
+    # P1-Z5 B — strategy 가 resolved 면 source of truth.  manifest scope 는
+    # fallback 으로만 사용.  옛 wiring 은 manifest 의 ``write_scope_candidates``
+    # (예: ``src/<service>/api/**``) 를 그대로 proposal 에 복사 → worktree
+    # 와 0 매칭일 때 ``write_scope_resolved_empty`` 로 종료되던 회귀.
+    strategy_audit: Mapping[str, Any] = {}
+    scope_source: str = "manifest_default"
+    if implementation_strategy is not None:
+        try:
+            strategy_audit = dict(implementation_strategy.to_audit())
+        except Exception:  # noqa: BLE001
+            strategy_audit = {}
+        if getattr(implementation_strategy, "resolved", False):
+            # strategy 가 first_slice_owner / first_slice_scope 를 결정
+            strategy_owner = getattr(implementation_strategy, "first_slice_owner", None)
+            strategy_scope = tuple(getattr(implementation_strategy, "first_slice_scope", ()) or ())
+            strategy_forbidden = tuple(
+                getattr(implementation_strategy, "first_slice_forbidden", ()) or ()
+            )
+            strategy_participants = tuple(
+                getattr(implementation_strategy, "participant_roles", ()) or ()
+            )
+            strategy_reviewers = tuple(
+                getattr(implementation_strategy, "review_roles", ()) or ()
+            )
+            if strategy_owner and strategy_scope:
+                top_role = strategy_owner
+                executor_profile = profiles.get(top_role) or executor_profile
+                # forbidden 은 strategy + manifest 합집합 (security 보강)
+                merged_forbidden = list(dict.fromkeys(
+                    list(strategy_forbidden) + list(manifest_forbidden_scope)
+                ))
+                write_scope = strategy_scope
+                forbidden_scope = tuple(merged_forbidden)
+                scope_source = "strategy"
+                # review/participant 는 strategy 가 명시했으면 사용
+                if strategy_reviewers:
+                    review_roles = strategy_reviewers
+                else:
+                    review_roles = _resolve_review_roles(
+                        executor_role=top_role,
+                        profiles=profiles,
+                        normalised=normalised,
+                    )
+                if strategy_participants:
+                    participant_roles = strategy_participants
+                else:
+                    participant_roles = _resolve_participant_roles(
+                        executor_role=top_role,
+                        review_roles=review_roles,
+                        profiles=profiles,
+                        normalised=normalised,
+                        scored=scored,
+                    )
+                domain_focus = str(executor_profile.get("domain_focus", "")).strip()
+                strategy_reason = (
+                    f"implementation_strategy={strategy_audit.get('strategy_id')} → "
+                    f"first_slice_owner={top_role} · "
+                    f"scope={list(write_scope)} · "
+                    f"rationale={strategy_audit.get('rationale', '')}"
+                )
+                return CodingAuthorizationProposal(
+                    session_id=session_id,
+                    user_request=request_text,
+                    executor_role=top_role,
+                    review_roles=review_roles,
+                    participant_roles=participant_roles,
+                    write_scope=write_scope,
+                    forbidden_scope=forbidden_scope,
+                    reason=strategy_reason,
+                    safety_rules=_DEFAULT_SAFETY_RULES,
+                    approval_required=True,
+                    metadata={
+                        "executor_score": top_score,
+                        "scored_roles": tuple(
+                            {"role": role, "score": score} for score, _, role in scored
+                        ),
+                        "implementation_strategy": strategy_audit,
+                        "scope_source": scope_source,
+                    },
+                )
+        else:
+            # strategy 는 있지만 unresolved — manifest fallback 으로 진입,
+            # 단 audit 에 unresolved 명시.
+            scope_source = "tech_lead_strategy_unresolved"
+
+    # Manifest fallback path (옛 동작) — strategy 미주입 또는 unresolved.
+    write_scope = manifest_write_scope
+    forbidden_scope = manifest_forbidden_scope
+    if scope_source == "manifest_default" and not implementation_strategy:
+        scope_source = "manifest_default"
 
     review_roles = _resolve_review_roles(
         executor_role=top_role,
@@ -454,6 +555,8 @@ def recommend_authorization(
             "scored_roles": tuple(
                 {"role": role, "score": score} for score, _, role in scored
             ),
+            "implementation_strategy": strategy_audit,
+            "scope_source": scope_source,
         },
     )
 

--- a/src/yule_orchestrator/agents/coding/coding_session_context.py
+++ b/src/yule_orchestrator/agents/coding/coding_session_context.py
@@ -122,6 +122,19 @@ def prepare_coding_session_context(
     )
     mode = decision.mode
 
+    # P1-R — intake governance contract 확장.  prompt 에 명시된 또는
+    # default 값으로 branch_strategy / release_strategy / issue_policy 도
+    # 영속.  ensure_session_mode 가 첫 _persist 에서 default 를 setdefault
+    # 했지만, prompt 에 explicit 값이 있으면 그것으로 덮어쓴다.
+    from ..lifecycle.session_mode import apply_governance_hints
+
+    apply_governance_hints(
+        extra_in,
+        branch_strategy=hints.get("branch_strategy"),
+        release_strategy=hints.get("release_strategy"),
+        issue_policy=hints.get("issue_policy"),
+    )
+
     mode_question = build_mode_question_text(decision) if decision.needs_question else None
 
     # 4. Coding handoff packet (always built; cheap).
@@ -147,6 +160,10 @@ def prepare_coding_session_context(
             "scope",
             "mode_decided_at",
             "mode_decided_by",
+            # P1-R — intake governance contract 확장
+            "branch_strategy",
+            "release_strategy",
+            "issue_policy",
         ):
             if key in extra_in:
                 extras_update[key] = extra_in[key]

--- a/src/yule_orchestrator/agents/coding/coding_session_context.py
+++ b/src/yule_orchestrator/agents/coding/coding_session_context.py
@@ -41,26 +41,68 @@ _ISSUE_ANCHOR_PATTERNS: tuple = (
     re.compile(r"(?<![\w/])#(\d+)\b"),
 )
 
+# P1-Z4 B — PR / pull request / pull_request / cross-repo reference 는
+# target repo 의 existing issue anchor 가 아니다.  prompt 안에 다음
+# disqualifier 가 ``#N`` 근처에 있으면 그 숫자를 무시한다.
+#
+# canonical session ``000f13fb121b`` 에서 prompt 안의 `PR #183 브랜치`
+# 가 target repo (naver-search-clone) 의 existing issue #183 anchor 로
+# 오인된 회귀를 영구 차단.
+_PR_DISQUALIFIER_PATTERNS: tuple = (
+    re.compile(r"\bPR\s*#?\s*(\d+)\b", re.IGNORECASE),
+    re.compile(r"\bpull\s*request\s*#?\s*(\d+)\b", re.IGNORECASE),
+    re.compile(r"\bpull[_\-]?request\s*#?\s*(\d+)\b", re.IGNORECASE),
+    # cross-repo reference: ``org/repo#N``
+    re.compile(r"\b[\w\-\.]+/[\w\-\.]+#(\d+)\b"),
+)
+
+
+def _disqualified_numbers_in_text(text: str) -> set:
+    """prompt 안의 PR / cross-repo / branch context 숫자 집합 반환.
+
+    P1-Z4 B — issue anchor 추출 시 본 집합에 들어간 숫자는 무시한다.
+    canonical session ``000f13fb121b`` 의 ``PR #183 브랜치`` 같은
+    문구가 issue #183 로 오인된 회귀 차단.
+    """
+
+    disqualified: set = set()
+    if not text:
+        return disqualified
+    for pattern in _PR_DISQUALIFIER_PATTERNS:
+        for match in pattern.finditer(text):
+            try:
+                value = int(match.group(1))
+            except (TypeError, ValueError, IndexError):
+                continue
+            if value > 0:
+                disqualified.add(value)
+    return disqualified
+
 
 def _extract_explicit_issue_number(text: str) -> Optional[int]:
     """prompt 안의 explicit issue anchor 숫자 추출.
 
     여러 패턴 중 첫 매칭만 사용.  URL 안에 이미 있으면 caller 가 그것
-    우선.  추출된 숫자가 > 0 일 때만 반환 (0 / "#000" 같은 의미 없는
-    값 무시).
+    우선.  추출된 숫자가 > 0 일 때만 반환.
+
+    P1-Z4 B — disqualified set (PR / cross-repo / pull_request 등) 에
+    포함되면 issue anchor 가 아니다.  ambiguous 면 None 반환 →
+    work_order builder 가 auto-create 경로로 떨어짐 (잘못된 reuse 보다
+    honest auto-create 가 낫다).
     """
 
     if not text:
         return None
+    disqualified = _disqualified_numbers_in_text(text)
     for pattern in _ISSUE_ANCHOR_PATTERNS:
-        match = pattern.search(text)
-        if match:
+        for match in pattern.finditer(text):
             try:
                 value = int(match.group(1))
             except (TypeError, ValueError):
                 continue
-            if value > 0:
-                return value
+            if value <= 0 or value in disqualified:
+                continue
+            return value
     return None
 from ..lifecycle.session_mode import (
     SessionMode,

--- a/src/yule_orchestrator/agents/coding/coding_session_context.py
+++ b/src/yule_orchestrator/agents/coding/coding_session_context.py
@@ -27,8 +27,41 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Sequence, Tuple
 
+import re
 from ..git.github_url import GithubTarget, parse_github_targets
 from ..git.repo_contract import RepoContract, discover_repo_contract
+
+
+# P1-U — prompt 안의 `#5` / `issue 5` / `이슈 5` 같은 explicit issue
+# anchor 패턴.  github URL 의 issue number 도 같이 잡지만 URL 은 이미
+# parse_github_targets 가 처리하므로 본 regex 는 plain-text 케이스 전용.
+_ISSUE_ANCHOR_PATTERNS: tuple = (
+    re.compile(r"이슈\s*#?\s*(\d+)", re.IGNORECASE),
+    re.compile(r"issue\s*#?\s*(\d+)", re.IGNORECASE),
+    re.compile(r"(?<![\w/])#(\d+)\b"),
+)
+
+
+def _extract_explicit_issue_number(text: str) -> Optional[int]:
+    """prompt 안의 explicit issue anchor 숫자 추출.
+
+    여러 패턴 중 첫 매칭만 사용.  URL 안에 이미 있으면 caller 가 그것
+    우선.  추출된 숫자가 > 0 일 때만 반환 (0 / "#000" 같은 의미 없는
+    값 무시).
+    """
+
+    if not text:
+        return None
+    for pattern in _ISSUE_ANCHOR_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            try:
+                value = int(match.group(1))
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                return value
+    return None
 from ..lifecycle.session_mode import (
     SessionMode,
     SessionModeDecision,
@@ -171,8 +204,24 @@ def prepare_coding_session_context(
         extras_update["github_target"] = dict(primary_target.to_dict())
         if primary_target.kind == "pull_request":
             extras_update["pull_request_number"] = primary_target.number
+        # P1-U — issue URL (예: github.com/.../issues/5) 의 number 도
+        # session.extra 에 영속해서 work_order 가 auto-create 대신 reuse.
+        # 옛 wiring 은 pull_request_number 만 추출하고 issue 번호는
+        # 흘려보냈고, 그게 사용자가 "기존 issue #5 사용" 명시했는데도
+        # auto-create issue #6 으로 떨어진 회귀의 직접 원인.
+        if primary_target.kind == "issue" and primary_target.number:
+            extras_update["existing_issue_number"] = int(primary_target.number)
+            extras_update["existing_issue_source"] = "prompt_url"
         if primary_target.branch_or_sha:
             extras_update["branch_name"] = primary_target.branch_or_sha
+
+    # P1-U — URL 외에도 prompt text 의 `#5` / `issue 5` / `이슈 5` 같은
+    # explicit anchor 도 추출.  URL 안에서 이미 잡혔으면 보존 (URL 우선).
+    if "existing_issue_number" not in extras_update:
+        text_issue = _extract_explicit_issue_number(message_text or "")
+        if text_issue is not None:
+            extras_update["existing_issue_number"] = text_issue
+            extras_update["existing_issue_source"] = "prompt_text"
     if repo_contract is not None:
         extras_update["repo_contract"] = dict(repo_contract.to_dict())
         extras_update["repo_contract_summary"] = repo_contract.summary_line()

--- a/src/yule_orchestrator/agents/coding/human_titles.py
+++ b/src/yule_orchestrator/agents/coding/human_titles.py
@@ -103,6 +103,35 @@ def build_issue_title(
     return f"[기능] {summary}"[:_TITLE_MAX_LEN]
 
 
+_KOREAN_RE_BUILDER = re.compile(r"[가-힣]")
+
+
+def _has_min_korean(text: str, *, min_chars: int = 4) -> bool:
+    """P1-S — validator (repo_write_policy.validate_pr_title) 와 동일
+    기준으로 한국어 문자 갯수 사전 검사.  builder 가 validator 와 정합."""
+
+    return sum(1 for ch in text or "" if _KOREAN_RE_BUILDER.match(ch)) >= min_chars
+
+
+def _korean_fallback_title(
+    *, issue_number: Optional[int], area: Optional[str] = None
+) -> str:
+    """P1-S — validator 통과를 보장하는 한국어 default title.
+
+    issue_number 있으면 issue 번호를 포함, area 있으면 area 라벨 포함.
+    어느 경우든 ``[구현]`` 또는 ``[구현][area]`` prefix + 4+ 한국어 chars +
+    branch / 영문 detail 없이 사람이 읽는 줄.
+    """
+
+    if area:
+        base = f"[구현][{area}] 작업 자동 진행"
+    else:
+        base = "[구현] 코딩 작업 자동 진행"
+    if issue_number:
+        return f"{base} (#{int(issue_number)})"
+    return base
+
+
 def build_pr_title(
     *,
     session_prompt: Optional[str],
@@ -114,29 +143,50 @@ def build_pr_title(
     """PR 제목 — ``[구현][영역] <slice title>`` 또는
     ``[구현] <요약>`` (slice 없을 때).
 
-    issue_number 가 있으면 끝에 `(#N)` 추가 — GitHub 가 자동으로 PR 을
-    issue 에 link 하지만 시각 단서로도 노출.
+    P1-S 강화 — builder 가 절대로 machine-like / 영문-only / 4-한국어-chars-미만
+    출력을 emit 하지 않음.  본 분기 결과가 validator 의 한국어 4 자 검사
+    불통이면 ``_korean_fallback_title`` 로 self-correct.
+
+    issue_number 가 있으면 끝에 ``(#N)`` 추가 — GitHub 가 자동으로 PR 을
+    issue 에 link 하지만 시각 단서로도 노출.  ``branch_hint`` 는 더 이상
+    fallback 출력 source 로 사용 안 함 (machine-like 회귀 차단).
     """
+
+    candidate: Optional[str] = None
+    area_label: Optional[str] = None
 
     if slice_spec:
         slice_title = str(slice_spec.get("title") or "").strip()
+        area_label = _resolve_area(slice_spec) or None
         if slice_title:
-            area = _resolve_area(slice_spec)
-            prefix = f"[구현][{area}]" if area else "[구현]"
+            prefix = f"[구현][{area_label}]" if area_label else "[구현]"
             base = f"{prefix} {slice_title}"
             if issue_number:
                 base = f"{base} (#{int(issue_number)})"
-            return base[:_TITLE_MAX_LEN]
+            candidate = base[:_TITLE_MAX_LEN]
 
-    summary = _strip_to_summary(session_prompt or "")
-    if not summary:
-        summary = (fallback_short_purpose or "코딩 작업").strip()
-    if not summary and branch_hint:
-        summary = branch_hint.split("/")[-1]
-    base = f"[구현] {summary}"
-    if issue_number:
-        base = f"{base} (#{int(issue_number)})"
-    return base[:_TITLE_MAX_LEN]
+    if candidate is None:
+        summary = _strip_to_summary(session_prompt or "")
+        if not summary:
+            summary = (fallback_short_purpose or "").strip()
+        # P1-S — branch_hint 기반 fallback 제거.  옛 wiring 은 branch
+        # 이름의 마지막 segment (e.g. ``issue-5-coding-execute``) 를
+        # 사용했지만 그 결과는 한국어 0 자라 validator reject 의 직접
+        # 원인이었다.  branch 정보는 PR body 의 메타 블록에서 노출.
+        if summary:
+            base = f"[구현] {summary}"
+            if issue_number:
+                base = f"{base} (#{int(issue_number)})"
+            candidate = base[:_TITLE_MAX_LEN]
+
+    # P1-S 정합성 강제 — 어떤 분기를 거쳐도 validator 와 동일 한국어 4 자
+    # 기준을 만족 못 하면 deterministic 한국어 fallback 으로 교체.
+    if candidate is None or not _has_min_korean(candidate):
+        candidate = _korean_fallback_title(
+            issue_number=issue_number, area=area_label
+        )
+
+    return candidate[:_TITLE_MAX_LEN]
 
 
 def build_pr_body_intro(

--- a/src/yule_orchestrator/agents/coding/human_titles.py
+++ b/src/yule_orchestrator/agents/coding/human_titles.py
@@ -9,7 +9,7 @@ slice 영역** 으로 만든다. 같은 helper 를 issue creator (work_order) /
 PR creator (coding executor) 가 공유.
 
 규칙
-  * Issue 제목: ``[기능] <세션 prompt 요약> — <slice 영역>``
+  * Issue 제목: ``[Feature] <세션 prompt 요약> — <slice 영역>``
   * PR 제목:    ``[구현][<영역>] <slice title>``  (slice 가 있을 때)
                  ``[구현] <세션 prompt 요약>``    (slice 없을 때)
   * 100자 cap (GitHub UI truncation 방지) + 줄바꿈 제거.
@@ -82,7 +82,7 @@ def build_issue_title(
     slice_spec: Optional[Mapping[str, Any]] = None,
     fallback_short_purpose: Optional[str] = None,
 ) -> str:
-    """Issue 제목 — ``[기능] <요약> — <영역>`` 한국어.
+    """Issue 제목 — ``[Feature] <요약> — <영역>`` 한국어.
 
     slice_spec 이 있으면 slice 의 title 을 우선 사용.
     """
@@ -92,15 +92,15 @@ def build_issue_title(
         if title:
             area = _resolve_area(slice_spec)
             if area and area not in title:
-                composed = f"[기능][{area}] {title}"
+                composed = f"[Feature][{area}] {title}"
             else:
-                composed = f"[기능] {title}"
+                composed = f"[Feature] {title}"
             return composed[:_TITLE_MAX_LEN]
 
     summary = _strip_to_summary(session_prompt or "")
     if not summary:
         summary = (fallback_short_purpose or "코딩 작업").strip()
-    return f"[기능] {summary}"[:_TITLE_MAX_LEN]
+    return f"[Feature] {summary}"[:_TITLE_MAX_LEN]
 
 
 _KOREAN_RE_BUILDER = re.compile(r"[가-힣]")

--- a/src/yule_orchestrator/agents/coding/implementation_strategy.py
+++ b/src/yule_orchestrator/agents/coding/implementation_strategy.py
@@ -200,6 +200,43 @@ def detect_repo_layout_signals(
 # ---------------------------------------------------------------------------
 
 
+def scan_toplevel_paths_from_workspace(
+    workspace_root: Optional[str],
+    *,
+    max_entries: int = 30,
+) -> Tuple[str, ...]:
+    """P1-Z6 C — local target repo checkout 의 toplevel 디렉터리 수집.
+
+    intake 시점에는 worktree provisioning 전이라 toplevel 신호가 없음.
+    하지만 target repo 의 local checkout (예:
+    ``/Users/masterway/local-dev/naver-search-clone``) 이 있으면 그
+    경로에서 즉시 toplevel 을 읽을 수 있다.
+
+    storage I/O 만 — pure helper.  exception 은 swallow (빈 튜플 반환) →
+    strategy 가 graceful 하게 unresolved/greenfield 로 떨어짐.
+    """
+
+    if not workspace_root:
+        return ()
+    try:
+        from pathlib import Path
+
+        root = Path(str(workspace_root))
+        if not root.is_dir():
+            return ()
+        entries: list[str] = []
+        for child in sorted(root.iterdir()):
+            name = child.name
+            if name.startswith(".") and name not in {".github", ".gitignore"}:
+                continue
+            entries.append(name)
+            if len(entries) >= max_entries:
+                break
+        return tuple(entries)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
 def synthesize_implementation_strategy(
     *,
     user_request: str,
@@ -208,6 +245,7 @@ def synthesize_implementation_strategy(
     task_type: Optional[str] = None,
     topology: str = "single_repo",
     explicit_first_slice_owner: Optional[str] = None,
+    workspace_root: Optional[str] = None,
 ) -> ImplementationStrategy:
     """tech-lead 가 구현 전략을 결정.
 
@@ -231,7 +269,16 @@ def synthesize_implementation_strategy(
         )
 
     request_signals = detect_request_signals(user_request)
-    repo_signals = detect_repo_layout_signals(toplevel_paths)
+    # P1-Z6 C — toplevel_paths 가 비어있어도 workspace_root 가 있으면
+    # local target repo checkout 에서 직접 scan.  canonical session
+    # ``6911f9d65e5d`` 가 toplevel=[] 로 greenfield_empty 잘못 분류된
+    # 회귀 차단.
+    effective_paths = list(toplevel_paths or ())
+    if not effective_paths and workspace_root:
+        scanned = scan_toplevel_paths_from_workspace(workspace_root)
+        if scanned:
+            effective_paths = list(scanned)
+    repo_signals = detect_repo_layout_signals(effective_paths)
 
     # 1) layout 결정
     strategy_id: str

--- a/src/yule_orchestrator/agents/coding/implementation_strategy.py
+++ b/src/yule_orchestrator/agents/coding/implementation_strategy.py
@@ -1,0 +1,461 @@
+"""P1-Z5 — full-stack-app / single_repo implementation strategy synthesizer.
+
+배경
+====
+canonical session ``000f13fb121b`` 가 노출한 설계 결함:
+
+  * role manifest 의 ``write_scope_candidates`` (예: ``src/<service>/api/**``)
+    가 그대로 proposal 의 ``write_scope`` 로 복사
+  * target repo ``naver-search-clone`` 은 ``apps/`` 중심 monorepo →
+    write_scope 가 worktree 와 0 매칭 →
+    ``write_scope_resolved_empty`` 로 종료
+  * full-stack-app / single_repo 요청에서 tech-lead 가 **구현 전략을
+    먼저 결정** 하는 단계가 없었음.  role keyword score → top executor →
+    manifest scope 복사 단순 pipeline 만
+
+본 모듈
+========
+tech-lead/orchestrator 의 책임을 코드로 명시:
+
+  1. target repo layout 신호 (``apps/`` / ``src/`` / ``frontend/+backend/``
+     ...) 수집
+  2. user request 의 영역 신호 (full-stack / auth / search / UI / DB ...)
+     수집
+  3. 두 신호의 조합으로 :class:`ImplementationStrategy` synthesis —
+     topology / frontend_root / backend_root / first_slice_owner /
+     first_slice_scope / participant_roles / review_roles 결정
+  4. 결과는 ``recommend_authorization`` 의 source of truth — manifest
+     write_scope 는 strategy unresolved 일 때만 fallback
+
+strategy 가 unresolved 면 placeholder scope 를 silently 내려보내지 않고
+``tech_lead_strategy_unresolved`` blocker 로 surface — operator 가 원인
+즉시 진단.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+
+# Strategy id 상수 — operator surface / regression test 에서 매칭.
+STRATEGY_MONOREPO_APPS: str = "monorepo_single_repo_apps"
+STRATEGY_MONOREPO_NEXT_NEST: str = "monorepo_single_repo_next_nest"
+STRATEGY_FRONTEND_BACKEND_SPLIT: str = "single_repo_frontend_backend_split"
+STRATEGY_CLASSIC_SRC_LAYOUT: str = "single_repo_classic_src_layout"
+STRATEGY_GREENFIELD_EMPTY: str = "single_repo_greenfield_empty"
+STRATEGY_UNRESOLVED: str = "tech_lead_strategy_unresolved"
+
+
+# scope_source 토큰 — operator 가 "왜 이 write_scope 가 만들어졌는지" 확인.
+SCOPE_SOURCE_STRATEGY: str = "strategy"
+SCOPE_SOURCE_MANIFEST_FALLBACK: str = "manifest_fallback"
+SCOPE_SOURCE_UNRESOLVED: str = "tech_lead_strategy_unresolved"
+
+
+# Role 토큰.
+ROLE_BACKEND: str = "backend-engineer"
+ROLE_FRONTEND: str = "frontend-engineer"
+ROLE_FULLSTACK: str = "fullstack-engineer"
+ROLE_DEVOPS: str = "devops-engineer"
+ROLE_QA: str = "qa-engineer"
+ROLE_TECH_LEAD: str = "tech-lead"
+
+
+@dataclass(frozen=True)
+class ImplementationStrategy:
+    """tech-lead 의 구현 전략 결과 (single_repo / full-stack 한정).
+
+    ``resolved == False`` 면 caller 는 placeholder scope 를 내려보내지
+    않고 ``tech_lead_strategy_unresolved`` 로 명시 blocker surface.
+
+    ``first_slice_scope`` 는 strategy 가 결정한 **실제 repo-aware path**
+    들.  placeholder literal (``<service>`` 등) 절대 포함 금지.
+    """
+
+    strategy_id: str
+    topology: str  # "single_repo" / "monorepo" 등 운영 용어
+    frontend_root: Optional[str] = None
+    backend_root: Optional[str] = None
+    shared_roots: Tuple[str, ...] = ()
+    first_slice_owner: Optional[str] = None
+    first_slice_scope: Tuple[str, ...] = ()
+    first_slice_forbidden: Tuple[str, ...] = ()
+    participant_roles: Tuple[str, ...] = ()
+    review_roles: Tuple[str, ...] = ()
+    rationale: str = ""
+    resolved: bool = False
+    repo_layout_signals: Mapping[str, Any] = field(default_factory=dict)
+    request_signals: Mapping[str, Any] = field(default_factory=dict)
+    fallback_reason: Optional[str] = None
+
+    def to_audit(self) -> dict:
+        return {
+            "strategy_id": self.strategy_id,
+            "topology": self.topology,
+            "frontend_root": self.frontend_root,
+            "backend_root": self.backend_root,
+            "shared_roots": list(self.shared_roots),
+            "first_slice_owner": self.first_slice_owner,
+            "first_slice_scope": list(self.first_slice_scope),
+            "first_slice_forbidden": list(self.first_slice_forbidden),
+            "participant_roles": list(self.participant_roles),
+            "review_roles": list(self.review_roles),
+            "rationale": self.rationale,
+            "resolved": self.resolved,
+            "repo_layout_signals": dict(self.repo_layout_signals),
+            "request_signals": dict(self.request_signals),
+            "fallback_reason": self.fallback_reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Request signal extraction
+# ---------------------------------------------------------------------------
+
+
+_BACKEND_FIRST_HINTS: Tuple[str, ...] = (
+    "인증", "로그인", "회원가입", "auth", "login", "sign up", "sign-up",
+    "검색", "search", "api", "REST", "endpoint", "db ", "데이터베이스",
+    "스키마", "migration", "마이그레이션", "백엔드 먼저", "백엔드부터",
+    "backend first", "backend-first",
+)
+_FRONTEND_FIRST_HINTS: Tuple[str, ...] = (
+    "ui 부터", "ui부터", "화면 부터", "화면부터", "프론트 먼저", "프론트엔드 먼저",
+    "frontend first", "frontend-first", "디자인 시스템", "design system",
+)
+_FULLSTACK_HINTS: Tuple[str, ...] = (
+    "풀스택", "fullstack", "full-stack", "full stack", "mvp", "monorepo",
+    "단일 repo", "단일레포",
+)
+
+
+def detect_request_signals(user_request: str) -> Mapping[str, Any]:
+    """user_request 에서 구현 전략 신호 추출.
+
+    Returns dict with: ``full_stack``, ``backend_first_hints``,
+    ``frontend_first_hints``, ``scope_hints``.
+    """
+
+    text = (user_request or "").lower()
+    backend_hits = [kw for kw in _BACKEND_FIRST_HINTS if kw in text]
+    frontend_hits = [kw for kw in _FRONTEND_FIRST_HINTS if kw in text]
+    fullstack_hits = [kw for kw in _FULLSTACK_HINTS if kw in text]
+    scope_hits: list[str] = []
+    for label, keywords in (
+        ("auth", ("인증", "회원가입", "로그인", "auth")),
+        ("search", ("검색", "search")),
+        ("blog", ("블로그", "blog")),
+        ("mail", ("메일", "mail", "inbox")),
+        ("ui", ("ui", "화면", "frontend", "디자인")),
+        ("db", ("db ", "스키마", "schema", "데이터베이스")),
+    ):
+        for kw in keywords:
+            if kw in text:
+                scope_hits.append(label)
+                break
+    return {
+        "full_stack": bool(fullstack_hits),
+        "fullstack_hits": fullstack_hits[:3],
+        "backend_first_hints": backend_hits[:3],
+        "frontend_first_hints": frontend_hits[:3],
+        "scope_hints": list(dict.fromkeys(scope_hits)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Repo layout signal extraction
+# ---------------------------------------------------------------------------
+
+
+def detect_repo_layout_signals(
+    toplevel_paths: Sequence[str] = (),
+) -> Mapping[str, Any]:
+    """toplevel directory 이름들로부터 repo 구조 신호 추출.
+
+    *toplevel_paths* 는 ``repo_contract.toplevel_paths`` / worktree
+    scan / 명시 hint 어느 source 든 받아들임 — caller 가 normalize.
+    """
+
+    norm = {str(p).strip("/").split("/")[0].lower() for p in (toplevel_paths or ()) if str(p).strip()}
+    return {
+        "toplevel": sorted(norm),
+        "has_apps_dir": "apps" in norm,
+        "has_packages_dir": "packages" in norm,
+        "has_src_dir": "src" in norm,
+        "has_frontend_dir": "frontend" in norm,
+        "has_backend_dir": "backend" in norm,
+        "has_server_dir": "server" in norm,
+        "has_client_dir": "client" in norm,
+        "has_web_dir": "web" in norm,
+        "has_api_dir": "api" in norm,
+        "has_migrations_dir": "migrations" in norm,
+        "has_tests_dir": "tests" in norm,
+        "is_empty_or_unknown": not norm,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strategy synthesizer
+# ---------------------------------------------------------------------------
+
+
+def synthesize_implementation_strategy(
+    *,
+    user_request: str,
+    toplevel_paths: Sequence[str] = (),
+    lifecycle_mode: str = "implementation",
+    task_type: Optional[str] = None,
+    topology: str = "single_repo",
+    explicit_first_slice_owner: Optional[str] = None,
+) -> ImplementationStrategy:
+    """tech-lead 가 구현 전략을 결정.
+
+    *user_request* + *toplevel_paths* + *task_type* + *topology* 신호를
+    조합해 ``ImplementationStrategy`` 산출.
+
+    full-stack-app / single_repo 가 아닌 경우 (research_only / 다른 task
+    type) 는 ``STRATEGY_UNRESOLVED`` 로 떨어져 caller 가 manifest fallback
+    또는 명시 blocker 로 처리.
+
+    *explicit_first_slice_owner* 가 주어지면 final first_slice_owner 결정에
+    우선 — operator 가 명시한 경우만 사용.
+    """
+
+    if lifecycle_mode == "research_only":
+        return ImplementationStrategy(
+            strategy_id=STRATEGY_UNRESOLVED,
+            topology=topology,
+            resolved=False,
+            fallback_reason="lifecycle_mode=research_only — no implementation strategy needed",
+        )
+
+    request_signals = detect_request_signals(user_request)
+    repo_signals = detect_repo_layout_signals(toplevel_paths)
+
+    # 1) layout 결정
+    strategy_id: str
+    frontend_root: Optional[str] = None
+    backend_root: Optional[str] = None
+    shared_roots: Tuple[str, ...] = ()
+    rationale_parts: list[str] = []
+
+    if repo_signals["has_apps_dir"]:
+        # apps/ monorepo — Next/Nest 또는 일반 monorepo
+        frontend_root = "apps/web"
+        backend_root = "apps/api"
+        shared_roots = ("packages/**",) if repo_signals["has_packages_dir"] else ()
+        # frontend/backend 의 정확한 폴더는 unknown — 일반 apps/ monorepo 로
+        strategy_id = STRATEGY_MONOREPO_APPS
+        rationale_parts.append("repo top-level 에 apps/ 발견 → monorepo")
+        if repo_signals["has_packages_dir"]:
+            rationale_parts.append("packages/ 도 발견 → 공유 영역 포함")
+    elif repo_signals["has_frontend_dir"] and repo_signals["has_backend_dir"]:
+        frontend_root = "frontend"
+        backend_root = "backend"
+        strategy_id = STRATEGY_FRONTEND_BACKEND_SPLIT
+        rationale_parts.append("frontend/ + backend/ top-level → 분리 split layout")
+    elif repo_signals["has_client_dir"] and repo_signals["has_server_dir"]:
+        frontend_root = "client"
+        backend_root = "server"
+        strategy_id = STRATEGY_FRONTEND_BACKEND_SPLIT
+        rationale_parts.append("client/ + server/ top-level → 분리 split layout")
+    elif repo_signals["has_src_dir"]:
+        # src/ 단일 — 가장 흔한 monolith
+        backend_root = "src"
+        frontend_root = None  # src 안에 다 들어있을 수도
+        strategy_id = STRATEGY_CLASSIC_SRC_LAYOUT
+        rationale_parts.append("repo top-level 에 src/ → classic monolith")
+    elif repo_signals["is_empty_or_unknown"]:
+        strategy_id = STRATEGY_GREENFIELD_EMPTY
+        rationale_parts.append("repo 비어있거나 미식별 → greenfield")
+    else:
+        # 미분류 → unresolved
+        return ImplementationStrategy(
+            strategy_id=STRATEGY_UNRESOLVED,
+            topology=topology,
+            resolved=False,
+            rationale="repo top-level 구조 미식별 — apps/src/frontend/backend 어느 hint 도 없음",
+            repo_layout_signals=dict(repo_signals),
+            request_signals=dict(request_signals),
+            fallback_reason="repo_layout_unclassified",
+        )
+
+    # 2) first_slice_owner 결정 — user-intent 우선
+    first_slice_owner: Optional[str]
+    if explicit_first_slice_owner:
+        first_slice_owner = explicit_first_slice_owner
+        rationale_parts.append(f"explicit first_slice_owner={explicit_first_slice_owner}")
+    elif request_signals["frontend_first_hints"]:
+        first_slice_owner = ROLE_FRONTEND
+        rationale_parts.append(
+            f"user 가 frontend first 신호 ({request_signals['frontend_first_hints'][0]})"
+        )
+    elif request_signals["backend_first_hints"]:
+        first_slice_owner = ROLE_BACKEND
+        rationale_parts.append(
+            f"user 가 backend-domain 신호 ({request_signals['backend_first_hints'][0]})"
+        )
+    elif backend_root:
+        # 기본 휴리스틱 — full-stack 일 때 backend 부터 (auth/DB/API 기반)
+        first_slice_owner = ROLE_BACKEND
+        rationale_parts.append("default: full-stack 첫 slice 는 backend (auth+API+DB)")
+    elif frontend_root:
+        first_slice_owner = ROLE_FRONTEND
+        rationale_parts.append("default: frontend-only repo 로 추정")
+    else:
+        first_slice_owner = ROLE_TECH_LEAD
+        rationale_parts.append("default: tech-lead 진단")
+
+    # 3) first_slice_scope 결정 — strategy + owner
+    first_slice_scope = _build_first_slice_scope(
+        strategy_id=strategy_id,
+        first_slice_owner=first_slice_owner,
+        backend_root=backend_root,
+        frontend_root=frontend_root,
+        shared_roots=shared_roots,
+        repo_signals=repo_signals,
+    )
+
+    # 4) participant + review roles — strategy 기반
+    participants, reviewers = _resolve_participants_and_reviewers(
+        first_slice_owner=first_slice_owner,
+        strategy_id=strategy_id,
+        request_signals=request_signals,
+    )
+
+    # forbidden — strategy 의 first_slice_owner 가 다른 영역 건드리지 않도록
+    first_slice_forbidden = _build_first_slice_forbidden(
+        first_slice_owner=first_slice_owner,
+        backend_root=backend_root,
+        frontend_root=frontend_root,
+    )
+
+    return ImplementationStrategy(
+        strategy_id=strategy_id,
+        topology=topology,
+        frontend_root=frontend_root,
+        backend_root=backend_root,
+        shared_roots=shared_roots,
+        first_slice_owner=first_slice_owner,
+        first_slice_scope=first_slice_scope,
+        first_slice_forbidden=first_slice_forbidden,
+        participant_roles=participants,
+        review_roles=reviewers,
+        rationale=" · ".join(rationale_parts),
+        resolved=bool(first_slice_owner) and bool(first_slice_scope),
+        repo_layout_signals=dict(repo_signals),
+        request_signals=dict(request_signals),
+        fallback_reason=None,
+    )
+
+
+def _build_first_slice_scope(
+    *,
+    strategy_id: str,
+    first_slice_owner: Optional[str],
+    backend_root: Optional[str],
+    frontend_root: Optional[str],
+    shared_roots: Tuple[str, ...],
+    repo_signals: Mapping[str, Any],
+) -> Tuple[str, ...]:
+    """strategy + owner 에 맞는 실제 repo-aware write_scope 생성."""
+
+    scope: list[str] = []
+    if strategy_id == STRATEGY_GREENFIELD_EMPTY:
+        # greenfield 면 모든 영역 — bootstrap editor 가 scaffold 의 path 결정
+        scope.extend(("apps/**", "packages/**", "**"))
+        return tuple(scope)
+
+    if first_slice_owner == ROLE_BACKEND and backend_root:
+        scope.append(f"{backend_root}/**")
+        # shared 도 backend 작업 시 함께
+        scope.extend(shared_roots)
+        # 일반적 backend artifact 영역 (있을 때만)
+        if repo_signals.get("has_migrations_dir"):
+            scope.append("migrations/**")
+        # tests — backend 영역
+        if repo_signals.get("has_tests_dir"):
+            if backend_root == "apps/api":
+                scope.append("tests/api/**")
+            elif backend_root == "backend":
+                scope.append("tests/backend/**")
+            elif backend_root == "server":
+                scope.append("tests/server/**")
+            else:
+                scope.append("tests/**")
+    elif first_slice_owner == ROLE_FRONTEND and frontend_root:
+        scope.append(f"{frontend_root}/**")
+        scope.extend(shared_roots)
+        if repo_signals.get("has_tests_dir"):
+            scope.append("tests/**")
+    elif first_slice_owner == ROLE_FULLSTACK:
+        # 전체
+        if backend_root:
+            scope.append(f"{backend_root}/**")
+        if frontend_root and frontend_root != backend_root:
+            scope.append(f"{frontend_root}/**")
+        scope.extend(shared_roots)
+    # placeholder literal 절대 안 들어감
+    return tuple(scope)
+
+
+def _build_first_slice_forbidden(
+    *,
+    first_slice_owner: Optional[str],
+    backend_root: Optional[str],
+    frontend_root: Optional[str],
+) -> Tuple[str, ...]:
+    """first slice 에 한해서 반대 영역 수정 금지 — slice 분리 강제."""
+
+    forbidden: list[str] = [".github/workflows/**"]
+    if first_slice_owner == ROLE_BACKEND and frontend_root and frontend_root != backend_root:
+        forbidden.append(f"{frontend_root}/**")
+    elif first_slice_owner == ROLE_FRONTEND and backend_root and backend_root != frontend_root:
+        forbidden.append(f"{backend_root}/**")
+    return tuple(forbidden)
+
+
+def _resolve_participants_and_reviewers(
+    *,
+    first_slice_owner: Optional[str],
+    strategy_id: str,
+    request_signals: Mapping[str, Any],
+) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """full-stack 이면 반대 영역 + devops + qa 가 살아있어야 함."""
+
+    participants: list[str] = []
+    if first_slice_owner == ROLE_BACKEND:
+        participants = [ROLE_FRONTEND, ROLE_DEVOPS]
+    elif first_slice_owner == ROLE_FRONTEND:
+        participants = [ROLE_BACKEND, ROLE_DEVOPS]
+    elif first_slice_owner == ROLE_FULLSTACK:
+        participants = [ROLE_DEVOPS]
+    else:
+        participants = [ROLE_BACKEND, ROLE_FRONTEND]
+
+    reviewers = [ROLE_TECH_LEAD, ROLE_QA]
+    return tuple(participants), tuple(reviewers)
+
+
+__all__ = (
+    "ImplementationStrategy",
+    "ROLE_BACKEND",
+    "ROLE_DEVOPS",
+    "ROLE_FRONTEND",
+    "ROLE_FULLSTACK",
+    "ROLE_QA",
+    "ROLE_TECH_LEAD",
+    "SCOPE_SOURCE_MANIFEST_FALLBACK",
+    "SCOPE_SOURCE_STRATEGY",
+    "SCOPE_SOURCE_UNRESOLVED",
+    "STRATEGY_CLASSIC_SRC_LAYOUT",
+    "STRATEGY_FRONTEND_BACKEND_SPLIT",
+    "STRATEGY_GREENFIELD_EMPTY",
+    "STRATEGY_MONOREPO_APPS",
+    "STRATEGY_MONOREPO_NEXT_NEST",
+    "STRATEGY_UNRESOLVED",
+    "detect_repo_layout_signals",
+    "detect_request_signals",
+    "synthesize_implementation_strategy",
+)

--- a/src/yule_orchestrator/agents/coding/tracking_refresh.py
+++ b/src/yule_orchestrator/agents/coding/tracking_refresh.py
@@ -1,0 +1,173 @@
+"""P1-Z4 C — anchor stamp 이후 tracking_validation 재평가 helper.
+
+배경
+----
+``tracking_validation`` 은 intake 시점에 ``session_persistence`` 에서
+한 번 계산되어 ``session.extra`` 에 stamp 된 뒤 갱신되지 않았다.
+이후 anchor (``github_work_order_issue``) 가 생기거나 coding_job 이
+ready 로 promote 돼도 ``tracking_validation.status = "needs_issue"`` 가
+stale 하게 남아 operator surface 가 "아직 issue 없어 멈춤" 처럼 보임.
+
+canonical session ``000f13fb121b`` 가 직접 사례: anchor stamp 됐고
+coding_execute 까지 dispatch 됐는데 tracking_validation 은 여전히
+needs_issue.
+
+본 모듈
+========
+* :func:`refresh_tracking_validation(session) -> RefreshResult` — pure
+  helper.  ``session.extra`` 를 다시 읽어 ``validate_tracking_chain``
+  으로 재평가, 결과를 dict 로 반환.  caller (worker / dispatcher) 가
+  ``session.extra`` 에 stamp + persist.
+* :func:`apply_tracking_refresh(session, *, update_session_fn)` —
+  편의 wrapper.  실제 storage 갱신까지 처리.
+
+trigger 지점 (caller 가 본 helper 호출):
+  - github_work_order_executor 가 anchor stamp 직후
+  - work_order_coding_continuation 가 coding_job ready promote 직후
+  - coding_execute_dispatcher 가 dispatch marker stamp 직후
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+SESSION_EXTRA_TRACKING_KEY: str = "tracking_validation"
+SESSION_EXTRA_TRACKING_REFRESH_AUDIT_KEY: str = "tracking_validation_refresh_audit"
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """:func:`refresh_tracking_validation` 결과.
+
+    ``changed`` 가 True 면 status 가 실제로 바뀜 (e.g., needs_issue → ok).
+    caller 가 audit 에 stamp 할 source 정보를 ``triggered_by`` 로 받는다.
+    """
+
+    changed: bool
+    previous_status: Optional[str]
+    new_status: Optional[str]
+    new_validation: Mapping[str, Any]
+    triggered_by: str
+
+
+def refresh_tracking_validation(
+    *,
+    session: Any,
+    triggered_by: str,
+) -> RefreshResult:
+    """Pure — session.extra 를 다시 평가해 갱신된 tracking_validation 반환.
+
+    storage I/O 없음.  caller 가 결과를 ``session.extra`` 에 stamp + persist.
+
+    *triggered_by* 는 caller 식별자 (예: ``"anchor_stamp"`` /
+    ``"coding_job_ready"`` / ``"dispatch_marker"``) — operator audit 에 노출.
+    """
+
+    extra_raw = getattr(session, "extra", None)
+    if not isinstance(extra_raw, Mapping):
+        return RefreshResult(
+            changed=False,
+            previous_status=None,
+            new_status=None,
+            new_validation={},
+            triggered_by=triggered_by,
+        )
+
+    from .tracking_enforcement import validate_tracking_chain
+
+    previous = extra_raw.get(SESSION_EXTRA_TRACKING_KEY)
+    previous_status = None
+    if isinstance(previous, Mapping):
+        previous_status = previous.get("status")
+
+    new_validation_obj = validate_tracking_chain(extra_raw)
+    new_validation = dict(new_validation_obj.to_dict())
+    new_status = new_validation.get("status")
+    changed = previous_status != new_status
+    return RefreshResult(
+        changed=changed,
+        previous_status=previous_status,
+        new_status=new_status,
+        new_validation=new_validation,
+        triggered_by=triggered_by,
+    )
+
+
+def apply_tracking_refresh(
+    *,
+    session: Any,
+    triggered_by: str,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+) -> Optional[RefreshResult]:
+    """편의 wrapper — refresh 결과를 session.extra 에 stamp + persist.
+
+    *update_session_fn* 이 주어지지 않으면 ``agents.workflow_state.update_session``
+    lazy import.  storage 실패는 warning 만 log — caller 흐름 안 깨뜨림.
+    """
+
+    result = refresh_tracking_validation(session=session, triggered_by=triggered_by)
+    if not result.new_validation:
+        return result
+
+    extra_raw = getattr(session, "extra", None)
+    extra = dict(extra_raw or {})
+    extra[SESSION_EXTRA_TRACKING_KEY] = dict(result.new_validation)
+
+    when = (now or datetime.now(tz=timezone.utc)).replace(microsecond=0).isoformat()
+    audit_bucket = extra.get(SESSION_EXTRA_TRACKING_REFRESH_AUDIT_KEY)
+    if not isinstance(audit_bucket, list):
+        audit_bucket = []
+    audit_bucket.append(
+        {
+            "triggered_by": triggered_by,
+            "previous_status": result.previous_status,
+            "new_status": result.new_status,
+            "at": when,
+        }
+    )
+    # bound — last 10 entries 만 보관 (operator surface 가 작아지도록)
+    if len(audit_bucket) > 10:
+        audit_bucket = audit_bucket[-10:]
+    extra[SESSION_EXTRA_TRACKING_REFRESH_AUDIT_KEY] = audit_bucket
+
+    try:
+        from dataclasses import replace as _replace
+
+        updated = _replace(session, extra=extra)
+    except Exception:  # noqa: BLE001
+        return result
+
+    persist = update_session_fn
+    if persist is None:
+        try:
+            from ..workflow_state import update_session as _update
+
+            persist = _update
+        except Exception:  # noqa: BLE001
+            return result
+    try:
+        persist(updated, now=(now or datetime.now(tz=timezone.utc)))
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "apply_tracking_refresh: persist failed (triggered_by=%s)",
+            triggered_by,
+            exc_info=True,
+        )
+    return result
+
+
+__all__ = (
+    "RefreshResult",
+    "SESSION_EXTRA_TRACKING_KEY",
+    "SESSION_EXTRA_TRACKING_REFRESH_AUDIT_KEY",
+    "apply_tracking_refresh",
+    "refresh_tracking_validation",
+)

--- a/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
+++ b/src/yule_orchestrator/agents/github_workos/issue_auto_create.py
@@ -91,7 +91,7 @@ class IssueTemplate:
     name
         frontmatter `name:` — 사람 친화 라벨. 없으면 파일명 stem.
     title_prefix
-        frontmatter `title:` — issue 제목에 자동 prefix 됨. 예: ``[기능]``.
+        frontmatter `title:` — issue 제목에 자동 prefix 됨. 예: ``[Feature]``.
     labels
         frontmatter `labels:` 에 명시된 라벨 시퀀스.
     assignees
@@ -353,14 +353,14 @@ def fill_issue_template(
       `> ` quote 형식으로 prepend. 본 자리는 GitHub issue template 의
       가장 흔한 "추가하려는 기능에 대해 간결하게 설명해주세요" 라인.
     - placeholder 가 없으면 본문 끝에 `## 작업 컨텍스트` 섹션을 append.
-    - frontmatter title prefix 가 있으면 결합: ``[기능] <summary>``.
+    - frontmatter title prefix 가 있으면 결합: ``[Feature] <summary>``.
     """
 
     summary = (request_summary or "").strip()
     title = (title_override or "").strip() or summary or template.name
     if template.title_prefix:
         prefix = template.title_prefix.strip()
-        # GitHub default templates 자주 ``[기능]`` 같은 prefix 만 두고 빈
+        # GitHub default templates 자주 ``[Feature]`` 같은 prefix 만 두고 빈
         # 자리를 남김. 사용자가 요청 본문에 같은 prefix 를 안 가지고 있다면
         # 결합.
         if prefix and not title.lower().startswith(prefix.lower()):

--- a/src/yule_orchestrator/agents/github_workos/issue_quality.py
+++ b/src/yule_orchestrator/agents/github_workos/issue_quality.py
@@ -13,7 +13,7 @@ truncated, body = 4 섹션 minimal, labels = caller 가 준 extra 만" 이었다
 이 모듈은 사용자가 명시한 §A~§F 를 코드로 박는다:
 
 * :func:`synthesize_korean_title` — intent 분류 기반 한국어 명확 제목
-  (예: ``[기능] 네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)``)
+  (예: ``[Feature] 네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)``)
 * :func:`derive_default_labels` — deterministic label mapping
   (full-stack/feature → ``✨ Feature``, docs → ``📃 Docs``, …)
 * :func:`build_quality_default_body` — 운영 규칙에 맞는 default body
@@ -147,17 +147,17 @@ def detect_scopes(request_text: str, *, max_scopes: int = 4) -> Tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
-# P1-N — 한국어 prefix 로 통일 (repo_write_policy.validate_issue_title 의
-# allowlist 와 매칭).  옛 영문 prefix 는 사람이 GitHub 목록에서 작업
-# 내용을 인지하기 어려워 user 가 직접 reject 함.
+# P1-N 후속 조정 — issue 제목 prefix 는 GitHub 목록 가독성을 위해 영어로
+# 통일하되, 본문은 여전히 한국어 설명을 유지한다. validate_issue_title 의
+# allowlist 와 반드시 정합해야 한다.
 _INTENT_TITLE_PREFIX: Mapping[str, str] = {
-    INTENT_FULL_STACK_MVP: "[기능]",
-    INTENT_FEATURE: "[기능]",
-    INTENT_DOCS: "[문서]",
-    INTENT_TEST: "[테스트]",
-    INTENT_REFACTOR: "[리팩토링]",
-    INTENT_BUGFIX: "[수정]",
-    INTENT_CHORE: "[설정]",
+    INTENT_FULL_STACK_MVP: "[Feature]",
+    INTENT_FEATURE: "[Feature]",
+    INTENT_DOCS: "[Docs]",
+    INTENT_TEST: "[Test]",
+    INTENT_REFACTOR: "[Refactor]",
+    INTENT_BUGFIX: "[Bug]",
+    INTENT_CHORE: "[Chore]",
 }
 
 
@@ -215,7 +215,7 @@ def synthesize_korean_title(
     resolved_intent = (intent or detect_intent(request_text)).strip().lower()
     resolved_scopes = tuple(scopes) if scopes is not None else detect_scopes(request_text)
 
-    prefix = _INTENT_TITLE_PREFIX.get(resolved_intent, "[기능]")
+    prefix = _INTENT_TITLE_PREFIX.get(resolved_intent, "[Feature]")
     phrase = _INTENT_TITLE_PHRASE.get(resolved_intent, "신규 기능 추가")
     domain = _detect_domain_label(request_text)
 

--- a/src/yule_orchestrator/agents/governance/code_audit.py
+++ b/src/yule_orchestrator/agents/governance/code_audit.py
@@ -164,6 +164,16 @@ SPLIT_NOW_PENDING: Mapping[str, Dict[str, str]] = {
         "owner": "codwithyc",
         "axes": "background loops (producer / target_repo / pr_merge_continuation) + executor builders (live merge + approval enqueuer + next slice dispatcher) + recovery sweeps",
     },
+    # P1-Z B — terminal session resurrection 차단 helper 분리 이후에도
+    # session iteration + marker validation + dispatch + audit persistence
+    # 가 한 파일에 남아있어 책임 2 종 (recovery_orchestration +
+    # state_persistence) 트리거.  다음 round 에서 producer loop /
+    # marker_validation / persistence 3 모듈로 추가 split 예정.
+    "src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py": {
+        "deadline": "2026-06-21",
+        "owner": "codwithyc",
+        "axes": "session iter + marker validation + dispatch + persistence",
+    },
 }
 
 

--- a/src/yule_orchestrator/agents/governance/repo_write_policy.py
+++ b/src/yule_orchestrator/agents/governance/repo_write_policy.py
@@ -590,30 +590,304 @@ def enforce_issue_anchor(ctx: IssueAnchorContext) -> None:
     _raise(validate_issue_anchor(ctx))
 
 
+# ---------------------------------------------------------------------------
+# P1-R — Git Flow branch validator + tag policy + approval card quality
+# ---------------------------------------------------------------------------
+
+REASON_INVALID_GIT_FLOW_BRANCH: str = "invalid_git_flow_branch"
+REASON_MISSING_RELEASE_TAG: str = "missing_release_tag"
+REASON_INVALID_RELEASE_TAG: str = "invalid_release_tag"
+REASON_APPROVAL_CARD_MISSING_SECTIONS: str = "approval_card_missing_sections"
+REASON_PROTECTED_BRANCH_DIRECT_WORK: str = "protected_branch_direct_work"
+
+# Git Flow whitelist — release / hotfix 는 issue-N anchor 면제 (release
+# branch 는 보통 여러 issue 묶음, hotfix 는 긴급 dispatch).
+GIT_FLOW_BRANCH_PREFIXES: tuple = (
+    "feature/",
+    "bugfix/",
+    "fix/",
+    "hotfix/",
+    "release/",
+    "refactor/",
+    "chore/",
+    "docs/",
+    "test/",
+    "agent/",  # engineering-agent 가 만드는 branch
+)
+
+# protected — direct 작업 절대 금지.  worktree 생성 자체를 거부.
+PROTECTED_BRANCHES: frozenset = frozenset(
+    {"main", "master", "develop", "dev", "prod", "production", "release"}
+)
+
+# release / hotfix 가 머지될 때 tag 요구.
+_RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:[-+][\w.\-+]+)?$")
+_BRANCH_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._\-]*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class GitFlowBranchContext:
+    branch: str
+    issue_number_hint: Optional[int] = None
+
+
+def validate_git_flow_branch(ctx: GitFlowBranchContext) -> PolicyResult:
+    """branch 이름이 Git Flow 규칙을 따르는지.
+
+    1. protected branch (main/master/develop/...) 직접 작업 금지.
+    2. 허용 prefix (feature/bugfix/hotfix/release/refactor/chore/...) 중 하나.
+    3. feature/bugfix/fix/refactor 는 issue-N anchor 가 필요 (issue-first 와 정합).
+    4. release/hotfix 는 issue anchor 면제 (그러나 release/hotfix 의 tag 요구는
+       별 validator 가 강제).
+    5. slug 부분이 kebab-case / lowercase 알파넘 + `_-.` 만.
+    """
+
+    branch = (ctx.branch or "").strip()
+    if not branch:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_GIT_FLOW_BRANCH,
+            detail="branch name is empty",
+        )
+
+    if branch.lower() in PROTECTED_BRANCHES or branch.lower().startswith(
+        ("release/", "hotfix/")
+    ) is False and branch.lower() in PROTECTED_BRANCHES:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_PROTECTED_BRANCH_DIRECT_WORK,
+            detail=(
+                f"branch {branch!r} is a protected branch — work must happen on "
+                f"a feature/bugfix/hotfix branch, never directly on protected"
+            ),
+            fields={"branch": branch},
+        )
+
+    if not any(
+        branch.startswith(prefix) for prefix in GIT_FLOW_BRANCH_PREFIXES
+    ):
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_GIT_FLOW_BRANCH,
+            detail=(
+                f"branch {branch!r} must start with one of {list(GIT_FLOW_BRANCH_PREFIXES)} "
+                f"(Git Flow / repo branching policy)"
+            ),
+            fields={"branch": branch, "allowed_prefixes": list(GIT_FLOW_BRANCH_PREFIXES)},
+        )
+
+    suffix = branch.split("/", 1)[1] if "/" in branch else ""
+    if not suffix:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_GIT_FLOW_BRANCH,
+            detail=f"branch {branch!r} missing slug after prefix",
+            fields={"branch": branch},
+        )
+
+    # release/hotfix 는 issue anchor 면제 — version slug 만 검증
+    if branch.startswith("release/") or branch.startswith("hotfix/"):
+        if not _BRANCH_SLUG_RE.match(suffix.replace("/", "-")):
+            return PolicyResult(
+                ok=False,
+                reason=REASON_INVALID_GIT_FLOW_BRANCH,
+                detail=(
+                    f"release/hotfix slug {suffix!r} must be kebab/version-like "
+                    f"(allowed chars: [A-Za-z0-9._-])"
+                ),
+                fields={"branch": branch},
+            )
+        return PolicyResult(
+            ok=True,
+            fields={"branch": branch, "kind": branch.split("/", 1)[0]},
+        )
+
+    # feature/bugfix/fix/refactor → issue anchor 필수
+    anchor_required_prefixes = ("feature/", "bugfix/", "fix/", "refactor/", "agent/")
+    if any(branch.startswith(p) for p in anchor_required_prefixes):
+        if not (
+            _BRANCH_ISSUE_RE.search(branch)
+            or (ctx.issue_number_hint and ctx.issue_number_hint > 0)
+        ):
+            return PolicyResult(
+                ok=False,
+                reason=REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+                detail=(
+                    f"branch {branch!r} requires `issue-<n>` anchor OR explicit "
+                    f"issue_number_hint (issue-first hard guard)"
+                ),
+                fields={"branch": branch},
+            )
+
+    return PolicyResult(
+        ok=True,
+        fields={"branch": branch, "kind": branch.split("/", 1)[0]},
+    )
+
+
+def enforce_git_flow_branch(ctx: GitFlowBranchContext) -> None:
+    _raise(validate_git_flow_branch(ctx))
+
+
+@dataclass(frozen=True)
+class ReleaseTagContext:
+    """release/hotfix branch 의 머지/배포 마감 시 tag 검증."""
+
+    branch: str
+    tag: Optional[str] = None  # None 이면 missing
+
+
+def validate_release_tag(ctx: ReleaseTagContext) -> PolicyResult:
+    """release/hotfix branch 면 tag (vX.Y.Z) 필수.  그 외 branch 는 no-op."""
+
+    branch = (ctx.branch or "").strip()
+    if not (
+        branch.startswith("release/") or branch.startswith("hotfix/")
+    ):
+        return PolicyResult(ok=True, fields={"applies": False})
+
+    if not ctx.tag:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_MISSING_RELEASE_TAG,
+            detail=(
+                f"release/hotfix branch {branch!r} 완료에 tag 가 필수 — vX.Y.Z "
+                f"(또는 그 변형) 을 명시한 뒤 완료 처리해야 합니다"
+            ),
+            fields={"branch": branch},
+        )
+    if not _RELEASE_TAG_RE.match(ctx.tag):
+        return PolicyResult(
+            ok=False,
+            reason=REASON_INVALID_RELEASE_TAG,
+            detail=(
+                f"tag {ctx.tag!r} 는 ``vMAJOR.MINOR.PATCH`` (선택 ``-suffix``) "
+                f"형식이어야 합니다 (semver)"
+            ),
+            fields={"branch": branch, "tag": ctx.tag},
+        )
+    return PolicyResult(ok=True, fields={"branch": branch, "tag": ctx.tag})
+
+
+def enforce_release_tag(ctx: ReleaseTagContext) -> None:
+    _raise(validate_release_tag(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Approval card quality — Korean 4 sections
+# ---------------------------------------------------------------------------
+
+
+_APPROVAL_CARD_REQUIRED_SECTIONS: tuple = (
+    "작업 내용",
+    "목적",
+    "영향 범위",
+    "다음 단계",
+)
+
+
+@dataclass(frozen=True)
+class ApprovalCardQualityContext:
+    """approval card body text — `#승인-대기` 카드의 summary 본문."""
+
+    body: str
+    approval_kind: Optional[str] = None
+    work_mode: Optional[str] = None  # autonomous_merge 등 분기용
+
+
+def validate_approval_card_quality(
+    ctx: ApprovalCardQualityContext,
+) -> PolicyResult:
+    """approval_required 모드 카드는 4 섹션 한국어 요약 필수.
+
+    autonomous_merge 모드는 본 enforcement 적용 X — autonomous 는 사람
+    승인 카드를 최소로 쓰는 모드 (operator_action 카드만).
+    """
+
+    if (ctx.work_mode or "").strip() == "autonomous_merge":
+        return PolicyResult(ok=True, fields={"applies": False})
+
+    body = ctx.body or ""
+    if not body.strip():
+        return PolicyResult(
+            ok=False,
+            reason=REASON_APPROVAL_CARD_MISSING_SECTIONS,
+            detail="approval card body is empty",
+        )
+
+    missing: List[str] = []
+    for section in _APPROVAL_CARD_REQUIRED_SECTIONS:
+        if section not in body:
+            missing.append(section)
+    if missing:
+        return PolicyResult(
+            ok=False,
+            reason=REASON_APPROVAL_CARD_MISSING_SECTIONS,
+            detail=(
+                "approval card body 가 한국어 요약 4 섹션 ("
+                + " / ".join(_APPROVAL_CARD_REQUIRED_SECTIONS)
+                + ") 중 일부 누락: "
+                + ", ".join(missing)
+                + ".  vague / machine-like 본문 금지 — operator 가 한눈에 이해 가능한 한국어 요약 강제."
+            ),
+            fields={"missing_sections": missing},
+        )
+    if not _KOREAN_RE.search(body):
+        return PolicyResult(
+            ok=False,
+            reason=REASON_APPROVAL_CARD_MISSING_SECTIONS,
+            detail=(
+                "approval card body 에 한국어가 전혀 없음 — 4 섹션 + Korean 요약 강제"
+            ),
+            fields={"missing_korean": True},
+        )
+    return PolicyResult(ok=True, fields={"sections_ok": True})
+
+
+def enforce_approval_card_quality(ctx: ApprovalCardQualityContext) -> None:
+    _raise(validate_approval_card_quality(ctx))
+
+
 __all__ = (
     "ALLOWED_GITMOJI",
+    "ApprovalCardQualityContext",
+    "GIT_FLOW_BRANCH_PREFIXES",
+    "GitFlowBranchContext",
     "INITIAL_COMMIT_TITLE_EXACT",
     "InitialCommitDecision",
     "IssueAnchorContext",
+    "PROTECTED_BRANCHES",
     "PolicyResult",
     "PolicyViolation",
+    "REASON_APPROVAL_CARD_MISSING_SECTIONS",
     "REASON_INITIAL_COMMIT_DETECTION_AMBIGUOUS",
     "REASON_INVALID_COMMIT_BODY_SECTIONS",
     "REASON_INVALID_COMMIT_GITMOJI",
+    "REASON_INVALID_GIT_FLOW_BRANCH",
     "REASON_INVALID_INITIAL_COMMIT_TITLE",
     "REASON_INVALID_ISSUE_TITLE",
     "REASON_INVALID_PR_TITLE",
+    "REASON_INVALID_RELEASE_TAG",
     "REASON_ISSUE_REQUIRED_FOR_REPO_WORK",
+    "REASON_MISSING_RELEASE_TAG",
+    "REASON_PROTECTED_BRANCH_DIRECT_WORK",
     "REASON_TADA_OUTSIDE_INITIAL_COMMIT",
     "REQUIRED_SECTIONS",
+    "ReleaseTagContext",
+    "enforce_approval_card_quality",
     "enforce_commit_message",
+    "enforce_git_flow_branch",
     "enforce_issue_anchor",
     "enforce_issue_title",
     "enforce_pr_title",
+    "enforce_release_tag",
     "is_initial_commit_context",
+    "validate_approval_card_quality",
     "validate_commit_message",
+    "validate_git_flow_branch",
     "validate_initial_commit_decision",
     "validate_issue_anchor",
     "validate_issue_title",
     "validate_pr_title",
+    "validate_release_tag",
 )

--- a/src/yule_orchestrator/agents/governance/repo_write_policy.py
+++ b/src/yule_orchestrator/agents/governance/repo_write_policy.py
@@ -11,7 +11,7 @@ engineering-agent/issue-pr-conventions.md).
 
 검증 항목
   1. ``validate_commit_message`` — gitmoji whitelist + 3-section format
-  2. ``validate_issue_title`` — 한국어 + [기능]/[구현]/... prefix 강제
+  2. ``validate_issue_title`` — 한국어 본문 + 영문 issue prefix 강제
   3. ``validate_pr_title``    — 동일 패턴 + 모드 토큰 금지
   4. ``validate_issue_anchor``— branch / PR body 에 ``issue-N`` anchor 필수
   5. ``is_initial_commit_context`` + ``validate_initial_commit_message``
@@ -373,7 +373,22 @@ def validate_initial_commit_decision(
 
 
 _KOREAN_RE = re.compile(r"[가-힣]")  # Hangul syllables
-_ALLOWED_TITLE_PREFIXES: tuple = ("[기능]", "[구현]", "[수정]", "[문서]", "[설정]", "[테스트]", "[리팩토링]")
+_ALLOWED_ISSUE_TITLE_PREFIXES: tuple = (
+    "[Feature]",
+    "[Bug]",
+    "[Docs]",
+    "[Chore]",
+    "[Test]",
+    "[Refactor]",
+)
+_ALLOWED_PR_TITLE_PREFIXES: tuple = (
+    "[구현]",
+    "[수정]",
+    "[문서]",
+    "[설정]",
+    "[테스트]",
+    "[리팩토링]",
+)
 
 
 def _title_has_korean(text: str) -> bool:
@@ -473,7 +488,12 @@ def _validate_human_title(
             fields={"title": text, "korean_char_count": korean_chars},
         )
 
-    if not any(text.startswith(p) for p in _ALLOWED_TITLE_PREFIXES):
+    allowed_prefixes = (
+        _ALLOWED_ISSUE_TITLE_PREFIXES
+        if kind == "issue"
+        else _ALLOWED_PR_TITLE_PREFIXES
+    )
+    if not any(text.startswith(p) for p in allowed_prefixes):
         return PolicyResult(
             ok=False,
             reason=(
@@ -483,10 +503,10 @@ def _validate_human_title(
             ),
             detail=(
                 "title must start with one of "
-                + ", ".join(_ALLOWED_TITLE_PREFIXES)
+                + ", ".join(allowed_prefixes)
                 + " (use agents/coding/human_titles.py to build correctly)"
             ),
-            fields={"title": text, "allowed_prefixes": list(_ALLOWED_TITLE_PREFIXES)},
+            fields={"title": text, "allowed_prefixes": list(allowed_prefixes)},
         )
 
     return PolicyResult(ok=True, fields={"title": text})

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
@@ -101,6 +101,17 @@ DEFAULT_BASE_BRANCH: str = "main"
 READY_STATUSES: frozenset[str] = frozenset({"ready"})
 
 
+# P1-Z B — terminal session resurrection 차단 — sibling module 위임.
+# helpers 본체는 ``coding_execute_terminal_skip`` 모듈에 있다 (dispatcher
+# 자체 LOC 를 1000 임계 안에 유지).  여기서는 re-export 만.
+from .coding_execute_terminal_skip import (
+    SESSION_EXTRA_TERMINAL_SKIP_KEY,
+    TERMINAL_SESSION_STATES,
+    is_terminal_session as _is_terminal_session,
+    stamp_terminal_session_skip as _stamp_terminal_session_skip_external,
+)
+
+
 # ---------------------------------------------------------------------------
 # Session iteration helpers
 # ---------------------------------------------------------------------------
@@ -408,6 +419,12 @@ def iter_ready_coding_jobs(
         return
 
     for session in sessions:
+        # P1-Z B — terminal session 은 marker self-heal 대상에서 제외.
+        # rejected/completed 인데 coding_job=ready 가 extra 에 남아있으면
+        # 옛 wiring 은 새 coding_execute row 를 만들었다.  operator 가
+        # 폐기한 세션이 runtime restart 후 살아나는 회귀의 직접 원인.
+        if _is_terminal_session(session):
+            continue
         coding_job = _read_coding_job(session)
         if not coding_job:
             continue
@@ -424,6 +441,8 @@ def iter_ready_coding_jobs(
         if not include_dispatched and ready.has_been_dispatched(queue=queue):
             continue
         yield ready
+
+
 
 
 def _default_session_loader() -> Sequence[Any]:
@@ -756,6 +775,24 @@ def _default_update_session(session: Any, *, now: datetime) -> Any:
     return update_session(session, now=now)
 
 
+def _stamp_terminal_session_skip(
+    *,
+    session_loader: Optional[Callable[[], Iterable[Any]]] = None,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+) -> int:
+    """본체는 ``coding_execute_terminal_skip`` 모듈에 — 본 함수는 thin wrapper."""
+
+    return _stamp_terminal_session_skip_external(
+        session_loader=session_loader,
+        update_session_fn=update_session_fn,
+        coding_job_reader=_read_coding_job,
+        dispatch_marker_key=SESSION_EXTRA_DISPATCH_KEY,
+        ready_statuses=READY_STATUSES,
+        now=now,
+    )
+
+
 def dispatch_ready_coding_jobs(
     *,
     worker: CodingExecutorWorker,
@@ -782,6 +819,15 @@ def dispatch_ready_coding_jobs(
 
     queue_for_validation = (
         getattr(worker, "_queue", None) if validate_marker_against_queue else None
+    )
+
+    # P1-Z B — pre-pass: rejected/completed session 에 ready coding_job 또는
+    # dispatch marker 가 남아있으면 operator surface 에 ``terminal_session_skip``
+    # audit 를 한 번 stamp 하고 넘어간다.  re-enqueue 는 absolutely 안 함.
+    _stamp_terminal_session_skip(
+        session_loader=session_loader,
+        update_session_fn=update_session_fn,
+        now=now,
     )
 
     out: list[DispatchedCodingJob] = []

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py
@@ -752,6 +752,24 @@ def _persist_dispatch_marker(
         }
         extra[SESSION_EXTRA_PROGRESS_KEY] = bucket
 
+    # P1-Z4 C — dispatch marker stamp 직후 tracking_validation 재평가.
+    # anchor + coding_job=ready + dispatch marker 가 다 있으면
+    # needs_issue 가 stale 로 남으면 안 됨.
+    try:
+        from ..coding.tracking_refresh import (
+            SESSION_EXTRA_TRACKING_KEY,
+            refresh_tracking_validation,
+        )
+
+        refresh_result = refresh_tracking_validation(
+            session=_replace(session, extra=extra),
+            triggered_by="dispatch_marker",
+        )
+        if refresh_result.new_validation:
+            extra[SESSION_EXTRA_TRACKING_KEY] = dict(refresh_result.new_validation)
+    except Exception:  # noqa: BLE001
+        pass
+
     try:
         updated = _replace(session, extra=extra)
     except TypeError:

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_recovery.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_recovery.py
@@ -627,13 +627,114 @@ def _stamp_bootstrap_progress(
         pass
 
 
+# P1-Z6 B — pre-PR transient failure recovery.  edit_timeout_live_editor
+# / edit_subprocess_failed / commit_failed 같이 "한 번 더 시도하면 풀릴
+# 가능성" 이 있는 reason 들.  structural failure (strategy_unresolved /
+# write_scope_resolved_empty / forbidden_scope / bootstrap_required:
+# scaffold_apply_failed 등) 는 본 recoverable set 에 포함 안 됨.
+TRANSIENT_PRE_PR_RETRYABLE_REASONS: tuple = (
+    "edit_timeout_live_editor",
+    "edit_subprocess_failed",
+    "edit_failed",  # 옛 generic reason — backward compat
+)
+
+
+def recover_transient_pre_pr_failures(
+    queue: JobQueue,
+    *,
+    max_per_run: int = 50,
+    log_fn: Optional[Callable[[str, Optional[Any]], None]] = None,
+) -> Tuple[str, ...]:
+    """P1-Z6 B — pre-PR transient ``failed_retryable`` 행을 requeue.
+
+    ``edit_timeout_live_editor`` / ``edit_subprocess_failed`` 같이 transient
+    성격의 reason 으로 떨어진 행은 ``requeue_retryable`` 로 재시도 시도.
+    attempt 카운터는 자동 +1.  ``max_attempts`` 를 넘으면 queue 가
+    terminal 로 떨어뜨림 — 본 함수가 attempt 폭주 만들지 않음.
+
+    structural failure (``write_scope_resolved_empty`` /
+    ``tech_lead_strategy_unresolved`` 등) 는 본 recoverable set 에 안
+    들어가 절대 자동 retry 되지 않는다.
+
+    반환: requeue 된 job_id 튜플.
+    """
+
+    db_path = getattr(queue, "_db_path", None)
+    if db_path is None:
+        return ()
+
+    import json as _json
+    import sqlite3 as _sqlite3
+
+    try:
+        with _sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = _sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT job_id, result_json, attempt
+                FROM job_queue
+                WHERE job_type = 'coding_execute'
+                  AND state = 'failed_retryable'
+                ORDER BY updated_at DESC
+                LIMIT ?
+                """,
+                (int(max_per_run),),
+            ).fetchall()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "coding_execute transient retry sweep: sqlite query failed",
+            exc_info=True,
+        )
+        return ()
+
+    requeued: list[str] = []
+    for row in rows or ():
+        try:
+            payload = _json.loads(row["result_json"] or "{}")
+        except Exception:  # noqa: BLE001
+            continue
+        reason_raw = str(payload.get("reason") or payload.get("error") or "").strip().lower()
+        # reason 토큰만 비교 (suffix detail 무시).  e.g. ``edit_timeout_live_editor:_SubprocessError``
+        reason_token = reason_raw.split(":", 1)[0]
+        if reason_token not in TRANSIENT_PRE_PR_RETRYABLE_REASONS:
+            continue
+        try:
+            queue.requeue_retryable(row["job_id"])
+            requeued.append(row["job_id"])
+            logger.warning(
+                "coding_execute transient retry: requeued %s (reason=%s, attempt=%s)",
+                row["job_id"],
+                reason_token,
+                row["attempt"],
+            )
+            if log_fn is not None:
+                try:
+                    log_fn(
+                        f"coding_execute transient retry: requeued {row['job_id']} "
+                        f"(reason={reason_token})",
+                        None,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "coding_execute transient retry: requeue failed for %s",
+                row["job_id"],
+                exc_info=True,
+            )
+            continue
+    return tuple(requeued)
+
+
 __all__ = (
     "BOOTSTRAP_RECOVERABLE_SUB_TOKENS",
     "BOOTSTRAP_REQUIRED_REASON_PREFIX",
     "TARGET_REPO_MISSING_REASON_PREFIX",
+    "TRANSIENT_PRE_PR_RETRYABLE_REASONS",
     "_classify_bootstrap_reason",
     "_is_bootstrap_capability_enabled",
     "_revive_failed_terminal_row",
     "recover_bootstrap_required_rows",
     "recover_target_repo_missing_rows",
+    "recover_transient_pre_pr_failures",
 )

--- a/src/yule_orchestrator/agents/job_queue/coding_execute_terminal_skip.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_execute_terminal_skip.py
@@ -1,0 +1,167 @@
+"""P1-Z B — terminal session resurrection 차단 helpers.
+
+배경
+====
+``coding_execute_dispatcher.iter_ready_coding_jobs`` 는 옛 wiring 에서
+``session.state`` 검사가 없어서 operator 가 폐기 (REJECTED) 한 session 도
+``coding_job=ready`` 가 extra 에 남아있으면 stale marker self-heal 로
+다시 새 coding_execute row 를 만들어 살아났다.  canonical sessions
+``166c416a1ed0`` / ``c7bc03b8d41a`` 가 runtime restart 후 살아나던
+직접 원인.
+
+본 모듈
+========
+* :func:`is_terminal_session(session) -> bool` — WorkflowState 가
+  ``completed`` / ``rejected`` 이면 True.
+* :data:`SESSION_EXTRA_TERMINAL_SKIP_KEY` — operator surface 에 stamp 할
+  audit key.
+* :func:`stamp_terminal_session_skip(...)` — dispatch pre-pass 가 호출:
+  terminal session 인데 ready coding_job / dispatch marker 가 남아있으면
+  ``coding_execute_terminal_skip`` audit 만 stamp 하고 re-enqueue 차단.
+
+dispatcher 자체 LOC 가 1000 임계 안에 머물도록 별도 모듈로 분리.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+TERMINAL_SESSION_STATES: frozenset = frozenset({"completed", "rejected"})
+SESSION_EXTRA_TERMINAL_SKIP_KEY: str = "coding_execute_terminal_skip"
+
+
+def is_terminal_session(session: Any) -> bool:
+    """session.state ∈ {completed, rejected} 면 True.
+
+    WorkflowState enum / 문자열 둘 다 흡수.  state 가 None / 누락이면
+    False (보수적으로 살아있다고 본다).
+    """
+
+    raw = getattr(session, "state", None)
+    if raw is None:
+        return False
+    text = getattr(raw, "value", None)
+    if text is None:
+        text = str(raw)
+    return str(text).strip().lower() in TERMINAL_SESSION_STATES
+
+
+def stamp_terminal_session_skip(
+    *,
+    session_loader: Optional[Callable[[], Iterable[Any]]] = None,
+    update_session_fn: Optional[Callable[..., Any]] = None,
+    coding_job_reader: Optional[Callable[[Any], Optional[Mapping[str, Any]]]] = None,
+    dispatch_marker_key: str = "coding_execute_dispatch",
+    ready_statuses: Optional[frozenset] = None,
+    now: Optional[datetime] = None,
+) -> int:
+    """Terminal session 에 audit 만 stamp 하고 re-enqueue 차단.
+
+    *session_loader* / *update_session_fn* / *coding_job_reader* 는 caller
+    (dispatcher) 가 inject — 본 helper 는 storage I/O 직접 안 함.
+    *ready_statuses* 가 None 이면 ``frozenset({"ready"})`` 로 폴백.
+
+    반환: audit 가 stamp 된 session 수 (테스트가 0/1/N 검증).
+    """
+
+    if session_loader is None:
+        from .coding_execute_dispatcher import _default_session_loader
+
+        session_loader = _default_session_loader
+    if update_session_fn is None:
+        from .coding_execute_dispatcher import _default_update_session
+
+        update_session_fn = _default_update_session
+    if coding_job_reader is None:
+        from .coding_execute_dispatcher import _read_coding_job
+
+        coding_job_reader = _read_coding_job
+    ready_set = ready_statuses or frozenset({"ready"})
+
+    try:
+        sessions = list(session_loader() or ())
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "stamp_terminal_session_skip: session loader raised",
+            exc_info=True,
+        )
+        return 0
+
+    when = (now or datetime.now(tz=timezone.utc)).replace(microsecond=0).isoformat()
+    stamped = 0
+    for session in sessions:
+        if not is_terminal_session(session):
+            continue
+        coding_job = coding_job_reader(session)
+        has_ready_job = (
+            isinstance(coding_job, Mapping)
+            and str(coding_job.get("status") or "").strip().lower() in ready_set
+        )
+        extra_raw = getattr(session, "extra", None) or {}
+        has_marker = (
+            isinstance(extra_raw, Mapping)
+            and isinstance(extra_raw.get(dispatch_marker_key), Mapping)
+        )
+        if not (has_ready_job or has_marker):
+            continue
+
+        extra = dict(extra_raw)
+        raw_state = getattr(session, "state", "")
+        state_text = getattr(raw_state, "value", None) or str(raw_state or "")
+        state_text = str(state_text).lower()
+        existing_skip = extra.get(SESSION_EXTRA_TERMINAL_SKIP_KEY)
+        # idempotent — 같은 terminal state 면 audit 재기록 안 함
+        if (
+            isinstance(existing_skip, Mapping)
+            and str(existing_skip.get("session_state") or "").lower() == state_text
+        ):
+            continue
+        extra[SESSION_EXTRA_TERMINAL_SKIP_KEY] = {
+            "session_state": state_text,
+            "reason": "terminal_session_skip",
+            "had_ready_coding_job": bool(has_ready_job),
+            "had_dispatch_marker": bool(has_marker),
+            "at": when,
+        }
+
+        try:
+            from dataclasses import replace as _replace
+
+            updated = _replace(session, extra=extra)
+        except Exception:  # noqa: BLE001
+            continue
+        try:
+            update_session_fn(
+                updated,
+                now=(now or datetime.now(tz=timezone.utc)),
+            )
+            stamped += 1
+            logger.warning(
+                "coding_execute dispatcher: terminal session skip — "
+                "session=%s state=%s had_ready_job=%s had_marker=%s — "
+                "re-enqueue 차단",
+                getattr(session, "session_id", "?"),
+                state_text,
+                has_ready_job,
+                has_marker,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "coding_execute dispatcher: persisting terminal_skip audit raised",
+                exc_info=True,
+            )
+    return stamped
+
+
+__all__ = (
+    "SESSION_EXTRA_TERMINAL_SKIP_KEY",
+    "TERMINAL_SESSION_STATES",
+    "is_terminal_session",
+    "stamp_terminal_session_skip",
+)

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -328,19 +328,30 @@ class LocalGitWorktreeProvisioner:
     def provision(
         self, *, request: CodingExecuteRequest, branch: str
     ) -> WorktreeContext:
-        # P1-Q E — Issue-first hard guard.  어떤 agent 가 호출하든 branch
-        # 생성 전에 issue anchor 가 반드시 있어야 한다.  branch name 에
-        # ``issue-<n>`` 또는 request.issue_number > 0.  옛 wiring 은 issue
-        # 없이도 branch / commit / draft PR 까지 그대로 가능했고, 그게 사
-        # 용자가 명시 reject 한 회귀의 직접 원인.  cross-repo 적용 — repo
-        # 와 무관하게 동일.
+        # P1-Q E — Issue-first hard guard + P1-R Git Flow branch validator.
+        # 어떤 agent (Claude Code / Codex / engineering / 보조) 든 branch
+        # 생성 전에 두 검증 모두 통과해야 한다.  Git Flow 검증이 issue
+        # anchor 도 동시에 본다 — feature/bugfix/fix/refactor/agent prefix
+        # 면 issue-N 필수, release/hotfix 는 면제 + tag 별도.
         try:
             from ..governance.repo_write_policy import (
+                GitFlowBranchContext,
                 IssueAnchorContext,
                 PolicyViolation,
+                enforce_git_flow_branch,
                 enforce_issue_anchor,
             )
 
+            # 1. Git Flow branch prefix + slug 검증 (protected branch 차단
+            #    포함)
+            enforce_git_flow_branch(
+                GitFlowBranchContext(
+                    branch=branch,
+                    issue_number_hint=request.issue_number,
+                )
+            )
+            # 2. issue anchor 검증 — Git Flow 가 release/hotfix 면제 했지만
+            #    일반 feature 가 이미 통과한 경우에도 한 번 더 명시 검증.
             enforce_issue_anchor(
                 IssueAnchorContext(
                     branch=branch,
@@ -351,9 +362,10 @@ class LocalGitWorktreeProvisioner:
             raise WorktreeProvisionError(
                 reason=exc.reason,
                 message=(
-                    f"issue-first hard guard: {exc.detail}. "
+                    f"governance hard guard: {exc.detail}. "
                     "Create a GitHub issue first and reference it via "
-                    "`issue-<n>` in branch_hint OR pass request.issue_number."
+                    "`issue-<n>` in a Git Flow branch (feature/bugfix/fix/"
+                    "refactor/...) OR pass request.issue_number."
                 ),
             ) from exc
 

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -1200,11 +1200,15 @@ class GithubAppDraftPRCreator:
         repo = request.repo_full_name
         if not repo:
             raise ValueError("GithubAppDraftPRCreator requires repo_full_name")
-        # P1-M D — 한국어 humanizer 가 slice/세션 정보로 명확한 제목 생성.
-        # slice_spec / session_prompt 는 dispatcher 가 request.metadata 에 stamp.
-        try:
-            from ..coding.human_titles import build_pr_title
+        # P1-M D + P1-S — 한국어 humanizer 가 slice/세션 정보로 명확한
+        # 제목 생성.  옛 wiring 의 ``except`` fallback 은 ``📝 coding-executor
+        # draft`` 같은 기계형 텍스트로 떨어져 validator 가 즉시 reject 했고,
+        # 그게 canonical session 166c416a1ed0 이 무한 reject 된 직접 원인.
+        # 본 round 의 fallback 은 반드시 validator 통과를 보장하는 한국어
+        # default (``_korean_fallback_title``).
+        from ..coding.human_titles import _korean_fallback_title, build_pr_title
 
+        try:
             metadata = request.metadata or {}
             slice_spec = (
                 metadata.get("slice_spec")
@@ -1222,16 +1226,43 @@ class GithubAppDraftPRCreator:
                 branch_hint=context.branch,
                 issue_number=request.issue_number,
             )
-        except Exception:  # noqa: BLE001 — never block PR on title helper
-            title = (
-                f"📝 #{request.issue_number} coding-executor draft"
-                if request.issue_number
-                else f"📝 coding-executor draft — {context.branch}"
+        except Exception:  # noqa: BLE001 — never block PR on builder hiccup
+            logger.warning(
+                "GithubAppDraftPRCreator: build_pr_title raised — "
+                "falling back to deterministic Korean default title",
+                exc_info=True,
             )
+            title = _korean_fallback_title(
+                issue_number=request.issue_number, area=None
+            )
+
+        # P1-S — defensive post-validate.  build_pr_title 이 정상 반환했지만
+        # validator 의 한국어 4 자 / machine pattern 검사 변경 등으로 reject
+        # 되는 future regression 차단.  reject 시 한국어 fallback 으로
+        # 교체.  본 자기 교정 이후에는 enforce_pr_title 이 통과 보장.
+        try:
+            from ..governance.repo_write_policy import (
+                PolicyViolation as _PolicyViolation,
+                validate_pr_title as _validate_pr_title,
+            )
+
+            pretest = _validate_pr_title(title)
+            if not pretest.ok:
+                logger.warning(
+                    "GithubAppDraftPRCreator: build_pr_title produced "
+                    "policy-rejected title (%r) — auto-correcting to "
+                    "Korean fallback",
+                    title,
+                )
+                title = _korean_fallback_title(
+                    issue_number=request.issue_number, area=None
+                )
+        except Exception:  # noqa: BLE001 - validator 자체 import 실패는 무시
+            pass
         body = _draft_pr_body(request, context)
 
         # P1-N — cross-repo PR title + issue anchor hard guard.
-        # 옛 wiring 은 "coding-executor draft #4" 같은 기계 제목 / issue
+        # 옛 wiring 은 machine 형 fallback / issue
         # 없는 PR 가 그대로 GitHub 로 흘러갔다. 본 가드가 PR 생성 직전
         # raise 해서 다음 PR 부터는 위반 자체가 막힌다.
         try:

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -1095,6 +1095,66 @@ class CodingCommitError(RuntimeError):
 def _commit_message(
     request: CodingExecuteRequest, context: WorktreeContext
 ) -> str:
+    """commit message — record-only / live-edit 구분.
+
+    P1-W — 옛 wiring 은 항상 "RecordOnly editor 의 dry 산출" 본문을
+    찍어서, P1-V 이후 LiveCodeEditor 가 실제로 코드 수정한 commit 도
+    record-only 라고 거짓말했다. ``context.metadata["live_editor_apply"]``
+    가 있으면 진짜 LLM 편집이라는 신호 → 다른 gitmoji + 본문.
+
+    gitmoji 휴리스틱: live edit 은 ✨ (새 기능). 운영자가 더 정확한
+    gitmoji 가 필요하면 ``metadata["commit_gitmoji_override"]`` 지정.
+    """
+
+    live_audit = (context.metadata or {}).get("live_editor_apply") if isinstance(
+        context.metadata, Mapping
+    ) else None
+    is_live_edit = bool(live_audit) and bool(context.edited_files)
+    override = None
+    if isinstance(context.metadata, Mapping):
+        override = context.metadata.get("commit_gitmoji_override")
+
+    if is_live_edit:
+        gitmoji = (str(override).strip() if override else "") or "✨"
+        head = (
+            f"{gitmoji} #{request.issue_number} coding-executor 구현"
+            if request.issue_number
+            else f"{gitmoji} coding-executor 구현"
+        )
+        provider = str(live_audit.get("provider", "?")) if isinstance(live_audit, Mapping) else "?"
+        model = str(live_audit.get("model", "?")) if isinstance(live_audit, Mapping) else "?"
+        changed = list(context.edited_files or ())
+        sample_lines = [f"- {rel}" for rel in changed[:5]]
+        if len(changed) > 5:
+            sample_lines.append(f"- … ({len(changed) - 5} 개 추가 파일 생략)")
+        if not sample_lines:
+            sample_lines = ["- 없음"]
+        refused = list((live_audit or {}).get("refused_by_scope") or []) if isinstance(live_audit, Mapping) else []
+        refused_forbidden = list((live_audit or {}).get("refused_by_forbidden") or []) if isinstance(live_audit, Mapping) else []
+        note_lines = [
+            f"- live LLM editor (provider={provider}, model={model}) 가 worktree {len(changed)} 개 파일 수정",
+            f"- branch={context.branch} (from {request.base_branch})",
+        ]
+        if refused:
+            note_lines.append(
+                f"- write_scope 밖이라 거부된 파일: {', '.join(refused[:3])}"
+                + (" …" if len(refused) > 3 else "")
+            )
+        if refused_forbidden:
+            note_lines.append(
+                f"- forbidden_scope 매칭으로 거부된 파일: {', '.join(refused_forbidden[:3])}"
+                + (" …" if len(refused_forbidden) > 3 else "")
+            )
+        return (
+            f"{head}\n"
+            "\n변경 이유\n"
+            f"- coding_execute job (executor={request.executor_role}) 의 live LLM editor 산출\n"
+            "\n주요 변경 사항\n"
+            + "\n".join(sample_lines)
+            + "\n\n비고\n"
+            + "\n".join(note_lines)
+        )
+
     head = (
         f"📝 #{request.issue_number} coding-executor 계획 기록"
         if request.issue_number

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -76,6 +76,11 @@ DEFAULT_TEST_COMMAND: Tuple[str, ...] = (
 DEFAULT_PLAN_FILE_REL: str = "runs/coding-executor-plans/{branch_slug}.md"
 
 
+def _is_record_only_plan_artifact(rel_path: str) -> bool:
+    rel = str(rel_path or "").strip().replace("\\", "/")
+    return rel.startswith("runs/coding-executor-plans/") and rel.endswith(".md")
+
+
 @dataclass(frozen=True)
 class LiveExecutorAvailability:
     """What the live executor can wire in the current environment.
@@ -1109,7 +1114,11 @@ def _commit_message(
     live_audit = (context.metadata or {}).get("live_editor_apply") if isinstance(
         context.metadata, Mapping
     ) else None
-    is_live_edit = bool(live_audit) and bool(context.edited_files)
+    changed = list(context.edited_files or ())
+    material_changed = [
+        rel for rel in changed if not _is_record_only_plan_artifact(rel)
+    ]
+    is_live_edit = bool(live_audit) and bool(material_changed)
     override = None
     if isinstance(context.metadata, Mapping):
         override = context.metadata.get("commit_gitmoji_override")
@@ -1123,16 +1132,17 @@ def _commit_message(
         )
         provider = str(live_audit.get("provider", "?")) if isinstance(live_audit, Mapping) else "?"
         model = str(live_audit.get("model", "?")) if isinstance(live_audit, Mapping) else "?"
-        changed = list(context.edited_files or ())
-        sample_lines = [f"- {rel}" for rel in changed[:5]]
-        if len(changed) > 5:
-            sample_lines.append(f"- … ({len(changed) - 5} 개 추가 파일 생략)")
+        sample_lines = [f"- {rel}" for rel in material_changed[:5]]
+        if len(material_changed) > 5:
+            sample_lines.append(
+                f"- … ({len(material_changed) - 5} 개 추가 파일 생략)"
+            )
         if not sample_lines:
             sample_lines = ["- 없음"]
         refused = list((live_audit or {}).get("refused_by_scope") or []) if isinstance(live_audit, Mapping) else []
         refused_forbidden = list((live_audit or {}).get("refused_by_forbidden") or []) if isinstance(live_audit, Mapping) else []
         note_lines = [
-            f"- live LLM editor (provider={provider}, model={model}) 가 worktree {len(changed)} 개 파일 수정",
+            f"- live LLM editor (provider={provider}, model={model}) 가 worktree {len(material_changed)} 개 파일 수정",
             f"- branch={context.branch} (from {request.base_branch})",
         ]
         if refused:
@@ -1400,8 +1410,11 @@ def _draft_pr_body(
     live_audit = (context.metadata or {}).get("live_editor_apply") if isinstance(
         context.metadata, Mapping
     ) else None
-    is_live_edit = bool(live_audit) and bool(context.edited_files)
     changed = list(context.edited_files or ())
+    material_changed = [
+        rel for rel in changed if not _is_record_only_plan_artifact(rel)
+    ]
+    is_live_edit = bool(live_audit) and bool(material_changed)
 
     if is_live_edit:
         provider = str((live_audit or {}).get("provider", "?")) if isinstance(live_audit, Mapping) else "?"
@@ -1411,11 +1424,13 @@ def _draft_pr_body(
 
         purpose_lines = [
             f"- coding_execute job (executor=`{request.executor_role}`) 의 live LLM editor 산출.",
-            f"- live editor (provider=`{provider}`, model=`{model}`) 가 worktree 내 {len(changed)} 개 파일 실제 수정.",
+            f"- live editor (provider=`{provider}`, model=`{model}`) 가 worktree 내 {len(material_changed)} 개 파일 실제 수정.",
         ]
-        files_block = [f"- `{rel}`" for rel in changed[:8]]
-        if len(changed) > 8:
-            files_block.append(f"- … ({len(changed) - 8} 개 추가 파일 생략 — full list 는 commit diff)")
+        files_block = [f"- `{rel}`" for rel in material_changed[:8]]
+        if len(material_changed) > 8:
+            files_block.append(
+                f"- … ({len(material_changed) - 8} 개 추가 파일 생략 — full list 는 commit diff)"
+            )
         risk_lines = [
             "- safety_rules 준수: " + (", ".join(request.safety_rules) if request.safety_rules else "(미지정)"),
             "- live LLM 편집 PR — reviewer 가 diff 직접 검토 필요. operator 가 머지 결정.",

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -1395,21 +1395,32 @@ def detect_live_executor_availability(
     pr = "github_app" if live_client is not None else "blocked"
     pusher_blocker = "" if live_client else "LiveGithubAppClient 미주입 (.env.local 의 YULE_GITHUB_APP_* 필요)"
     pr_blocker = pusher_blocker
+
+    # P1-T — live editor 가 build_live_executor 에서 우선 선택되므로 본
+    # 진단 결과도 같은 우선순위를 반영.
+    live_editor_on = (
+        (os.environ.get(ENV_LIVE_EDITOR_ENABLED) or "").strip().lower() == "true"
+        and bool((os.environ.get(ENV_LIVE_EDITOR_PROVIDER) or "").strip())
+    )
     bootstrap_on = _greenfield_bootstrap_enabled()
-    editor_label = (
-        "greenfield_bootstrap+record_only_delegate"
-        if bootstrap_on
-        else "greenfield_bootstrap (disabled — env off)"
-    )
-    editor_blocker = (
-        ""
-        if bootstrap_on
-        else (
-            "greenfield bootstrap disabled — set "
-            f"{ENV_GREENFIELD_BOOTSTRAP_ENABLED}=1 to enable scaffold "
-            "of empty target repos"
+    if live_editor_on:
+        provider = (os.environ.get(ENV_LIVE_EDITOR_PROVIDER) or "").strip()
+        editor_label = f"live_llm({provider})"
+        editor_blocker = ""
+    elif bootstrap_on:
+        editor_label = "greenfield_bootstrap+record_only_delegate"
+        editor_blocker = (
+            "live editor disabled — set "
+            f"{ENV_LIVE_EDITOR_ENABLED}=true + {ENV_LIVE_EDITOR_PROVIDER}=claude-cli "
+            "for non-greenfield real edit path"
         )
-    )
+    else:
+        editor_label = "greenfield_bootstrap (disabled — env off)"
+        editor_blocker = (
+            "neither live editor nor greenfield bootstrap enabled — set "
+            f"{ENV_LIVE_EDITOR_ENABLED}=true (live LLM) OR "
+            f"{ENV_GREENFIELD_BOOTSTRAP_ENABLED}=1 (scaffold empty repo)"
+        )
     return LiveExecutorAvailability(
         worktree_provisioner=bool(repo_root),
         code_editor=editor_label,
@@ -1423,12 +1434,47 @@ def detect_live_executor_availability(
     )
 
 
+def _default_claude_cli_subprocess_runner(
+    cmd: Sequence[str], *, cwd: Optional[str] = None, **_kwargs
+) -> _SubprocessResult:
+    """기본 subprocess 기반 claude CLI 실행기.
+
+    P1-T B — LiveCodeEditor 가 default 로 사용하는 runner.  운영자가
+    명시적으로 더 정교한 runner (예: timeout / streaming / retry) 가
+    필요하면 ``claude_subprocess_adapter`` 모듈을 wiring.
+
+    cwd 는 worktree 경로 — claude CLI 가 그 디렉터리 안에서 파일 수정.
+    """
+
+    args = [str(c) for c in cmd if c]
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=600,  # 10 min — claude 가 큰 작업 다 끝나도록
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _SubprocessError(
+            exit_code=124,
+            stdout=(exc.stdout or "").decode() if isinstance(exc.stdout, bytes) else (exc.stdout or ""),
+            stderr=f"claude CLI timeout after 600s",
+        ) from exc
+    return _SubprocessResult(
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+        exit_code=completed.returncode,
+    )
+
+
 def build_live_executor(
     *,
     repo_root: str,
     live_client: Optional[Any] = None,
     worktree_root: Optional[str] = None,
     test_command: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
 ) -> Mapping[str, Any]:
     """Compose the 6 Protocol implementations as a kwargs dict.
 
@@ -1437,19 +1483,58 @@ def build_live_executor(
     pusher / draft-PR slots fall back to the
     :class:`_NotImplementedStep` defaults — the worker will still
     fail loudly with ``REASON_NOT_IMPLEMENTED`` on those steps.
+
+    P1-T A — code_editor 선택 우선순위:
+
+      1. ``YULE_LIVE_EDITOR_ENABLED=true`` + ``YULE_LIVE_EDITOR_PROVIDER=claude-cli``
+         + ``claude`` binary on PATH (또는 명시적 runner injection):
+         → :class:`LiveCodeEditor` (실제 LLM 편집 = product code 수정)
+      2. 위 조건 미충족: :class:`GreenfieldBootstrapEditor` (greenfield
+         시 scaffold / non-greenfield 시 record-only delegate)
+
+      옛 wiring 은 무조건 (2) 만 사용 → ``YULE_LIVE_EDITOR_ENABLED=true``
+      를 set 해도 production 이 LiveCodeEditor 를 절대 선택 안 함.
+      P1-T A 가 (1) 분기를 wiring 해서 non-greenfield repo 도 real edit
+      path 로 진입 가능.
     """
+
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    code_editor: Any = GreenfieldBootstrapEditor()
+    code_editor_audit = "GreenfieldBootstrapEditor"
+
+    # P1-T — LiveCodeEditor 가능 여부 점검.  None 이면 env off / provider
+    # 미설정 → 옛 GreenfieldBootstrapEditor fallback.
+    live_editor = build_live_editor_from_env(
+        env_map,
+        subprocess_runner=_default_claude_cli_subprocess_runner,
+    )
+    if live_editor is not None:
+        code_editor = live_editor
+        code_editor_audit = (
+            f"LiveCodeEditor(provider={getattr(live_editor, 'provider', '?')})"
+        )
+        logger.info(
+            "build_live_executor: live code editor selected — %s "
+            "(env=%s + %s)",
+            code_editor_audit,
+            ENV_LIVE_EDITOR_ENABLED,
+            ENV_LIVE_EDITOR_PROVIDER,
+        )
+    else:
+        logger.info(
+            "build_live_executor: %s selected (live editor disabled — "
+            "set %s=true + %s=claude-cli for real-edit path)",
+            code_editor_audit,
+            ENV_LIVE_EDITOR_ENABLED,
+            ENV_LIVE_EDITOR_PROVIDER,
+        )
 
     bundle: dict[str, Any] = {
         "worktree_provisioner": LocalGitWorktreeProvisioner(
             repo_root=repo_root, worktree_root=worktree_root
         ),
-        # P1-H — pick GreenfieldBootstrapEditor automatically. The new
-        # editor delegates to record-only behavior for non-greenfield
-        # cases, so this is a strict superset. Bootstrap actually
-        # writes files only when YULE_CODING_EXECUTOR_GREENFIELD_BOOTSTRAP_ENABLED=1;
-        # otherwise greenfield surfaces a clear ``live_editor_unavailable``
-        # reason instead of silently writing record-only notes only.
-        "code_editor": GreenfieldBootstrapEditor(),
+        "code_editor": code_editor,
         "test_runner": SubprocessTestRunner(
             default_command=tuple(test_command or DEFAULT_TEST_COMMAND)
         ),

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -1631,6 +1631,130 @@ def _tail(text: Optional[str], *, lines: int = 20) -> str:
     return "\n".join(parts[-lines:])
 
 
+# ---------------------------------------------------------------------------
+# P1-V — LiveCodeEditor worktree change collector
+# ---------------------------------------------------------------------------
+
+
+def _runner_stdout(result: Any) -> str:
+    """runner 반환 모양을 흡수.  ``_SubprocessResult`` (attr) / test fake
+    (Mapping) / None 모두 처리.  반환값이 명시 stdout 키/속성 없으면 빈
+    문자열.
+    """
+
+    if result is None:
+        return ""
+    stdout_attr = getattr(result, "stdout", None)
+    if stdout_attr is not None:
+        return str(stdout_attr)
+    if isinstance(result, Mapping):
+        return str(result.get("stdout") or "")
+    return ""
+
+
+def _parse_porcelain_line(line: str) -> Optional[str]:
+    """git status --porcelain v1 한 줄에서 변경된 파일 경로 추출.
+
+    포맷:
+      * ``"XY path"`` — modified / added / untracked / deleted
+      * ``"XY old -> new"`` — rename (destination 만 반환)
+      * X, Y ∈ {' ', 'M', 'A', 'D', 'R', 'C', 'U', '?', '!'}
+
+    제외:
+      * fully-deleted (``" D path"`` / ``"D  path"``) — committer 가
+        stage 못 함
+      * ignored (``"!!"``) — 처음부터 무시
+    """
+
+    if not line or len(line) < 4:
+        return None
+    status = line[:2]
+    rest = line[3:]
+    if status[0] == "!" or status[1] == "!":
+        return None
+    if status == " D" or status == "DD" or status == "D ":
+        return None
+    if " -> " in rest:
+        _, _, dest = rest.partition(" -> ")
+        rest = dest
+    return rest.strip().strip('"') or None
+
+
+def _normalize_scope_entry(entry: str) -> str:
+    """write_scope / forbidden_scope 한 항목을 prefix 매칭용으로 정규화.
+
+    ``services/auth/**`` / ``services/auth/`` / ``services/auth`` 모두
+    ``services/auth`` 로 떨어진다.
+    """
+
+    return (entry or "").strip().rstrip("/").rstrip("*").rstrip("/")
+
+
+def _path_in_scope(rel: str, scope: Sequence[str]) -> bool:
+    """rel_path 가 scope prefix 중 하나에 매칭되는지.  빈 scope → True."""
+
+    if not scope:
+        return True
+    norm = rel[2:] if rel.startswith("./") else rel.lstrip("/")
+    for entry in scope:
+        token = _normalize_scope_entry(entry)
+        if not token:
+            return True
+        if norm == token or norm.startswith(token + "/"):
+            return True
+    return False
+
+
+def _collect_changed_paths(
+    *,
+    runner: Any,
+    worktree_path: str,
+    write_scope: Sequence[str] = (),
+    forbidden_scope: Sequence[str] = (),
+) -> Tuple[Tuple[str, ...], Tuple[str, ...], Tuple[str, ...]]:
+    """worktree 의 git status --porcelain 으로 변경 수집 + scope 필터.
+
+    Returns (detected_in_scope, refused_by_scope, refused_by_forbidden).
+
+    git 가 실패하면 모두 빈 튜플 (LiveCodeEditor 가 no-op 으로 떨어지고
+    worker 의 P1-U C 가 정직한 reason 으로 surface).
+    """
+
+    if not worktree_path:
+        return (), (), ()
+    try:
+        result = runner(
+            ["git", "-C", worktree_path, "status", "--porcelain"],
+            capture_output=True,
+        )
+    except Exception:
+        return (), (), ()
+
+    stdout = _runner_stdout(result)
+    if not stdout:
+        return (), (), ()
+
+    detected: list[str] = []
+    refused_scope: list[str] = []
+    refused_forbidden: list[str] = []
+    seen: set[str] = set()
+    for raw_line in stdout.splitlines():
+        rel = _parse_porcelain_line(raw_line)
+        if not rel or rel in seen:
+            continue
+        seen.add(rel)
+        if _path_in_scope(rel, forbidden_scope) and forbidden_scope:
+            # forbidden 은 명시 매칭 시에만 reject — 빈 forbidden 은 통과
+            refused_forbidden.append(rel)
+            continue
+        if write_scope and not _path_in_scope(rel, write_scope):
+            refused_scope.append(rel)
+            continue
+        detected.append(rel)
+
+    return tuple(detected), tuple(refused_scope), tuple(refused_forbidden)
+
+
 __all__ = (
     "DEFAULT_PLAN_FILE_REL",
     "DEFAULT_TEST_COMMAND",
@@ -1886,12 +2010,39 @@ class LiveCodeEditor:
         # in the prompt cannot reach the network.
         cmd = ("claude", "-p", redacted_prompt, "--model", self.model)
         result = runner(cmd, cwd=context.worktree_path)
-        # The runner is operator-defined; we accept any truthy
-        # return shape. The MVP only verifies the call did not
-        # raise. Patch validation / file diffing lands in a
-        # follow-up PR (TODO).
         _ = result
-        return context
+
+        # P1-V — claude-cli 가 자체 Edit/Write tool 로 worktree 안의 파일을
+        # 직접 수정해도, 옛 wiring 은 context 를 그대로 돌려줘서
+        # ``edited_files=()`` 가 commit 단계까지 흘러갔다.  여기서
+        # ``git status --porcelain`` 으로 변경 수집 + write_scope /
+        # forbidden_scope 필터 → committer 가 진짜 변경된 파일만 stage.
+        detected, refused_by_scope, refused_by_forbidden = _collect_changed_paths(
+            runner=runner,
+            worktree_path=context.worktree_path,
+            write_scope=tuple(request.write_scope or ()),
+            forbidden_scope=tuple(request.forbidden_scope or ()),
+        )
+
+        if not detected and not refused_by_scope and not refused_by_forbidden:
+            # 실제 0건 — worker 의 P1-U C no-op detection 이 이후
+            # REASON_LIVE_EDITOR_NO_EDITS_PRODUCED 로 정직하게 surface.
+            return context
+
+        new_edited = tuple(list(context.edited_files) + list(detected))
+        new_metadata = dict(context.metadata or {})
+        live_audit = dict(new_metadata.get("live_editor_apply") or {})
+        live_audit["provider"] = self.provider
+        live_audit["model"] = self.model
+        live_audit["detected_changed_files"] = list(detected)
+        live_audit["refused_by_scope"] = list(refused_by_scope)
+        live_audit["refused_by_forbidden"] = list(refused_by_forbidden)
+        new_metadata["live_editor_apply"] = live_audit
+        return replace(
+            context,
+            edited_files=new_edited,
+            metadata=new_metadata,
+        )
 
 
 def build_live_editor_from_env(

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_live.py
@@ -1382,7 +1382,13 @@ def _draft_pr_body(
 ) -> str:
     """draft PR body. P0-T runtime_policy.validate_pr_body 통과하도록
     5 섹션 (purpose / scope / risks / tests / issue_linkage) + audit block
-    을 모두 갖춘다."""
+    을 모두 갖춘다.
+
+    P1-X — context.metadata["live_editor_apply"] 있고 edited_files 가
+    plan markdown 외 진짜 파일을 포함하면 live-edit 분기.  옛 wiring 은
+    항상 "RecordOnlyCodeEditor 가 만든 계획 markdown 만" 본문을 emit 해서
+    reviewer 가 실제 LLM 편집 PR 도 record-only 라고 오해 → fake success.
+    """
 
     test_summary = context.test_summary or {}
     test_status = (
@@ -1390,6 +1396,76 @@ def _draft_pr_body(
         if isinstance(test_summary, Mapping)
         else None
     ) or ("dry_run" if test_summary.get("dry_run") else "unknown")
+
+    live_audit = (context.metadata or {}).get("live_editor_apply") if isinstance(
+        context.metadata, Mapping
+    ) else None
+    is_live_edit = bool(live_audit) and bool(context.edited_files)
+    changed = list(context.edited_files or ())
+
+    if is_live_edit:
+        provider = str((live_audit or {}).get("provider", "?")) if isinstance(live_audit, Mapping) else "?"
+        model = str((live_audit or {}).get("model", "?")) if isinstance(live_audit, Mapping) else "?"
+        refused_scope = list((live_audit or {}).get("refused_by_scope") or []) if isinstance(live_audit, Mapping) else []
+        refused_forbidden = list((live_audit or {}).get("refused_by_forbidden") or []) if isinstance(live_audit, Mapping) else []
+
+        purpose_lines = [
+            f"- coding_execute job (executor=`{request.executor_role}`) 의 live LLM editor 산출.",
+            f"- live editor (provider=`{provider}`, model=`{model}`) 가 worktree 내 {len(changed)} 개 파일 실제 수정.",
+        ]
+        files_block = [f"- `{rel}`" for rel in changed[:8]]
+        if len(changed) > 8:
+            files_block.append(f"- … ({len(changed) - 8} 개 추가 파일 생략 — full list 는 commit diff)")
+        risk_lines = [
+            "- safety_rules 준수: " + (", ".join(request.safety_rules) if request.safety_rules else "(미지정)"),
+            "- live LLM 편집 PR — reviewer 가 diff 직접 검토 필요. operator 가 머지 결정.",
+        ]
+        if refused_scope:
+            risk_lines.append(
+                "- write_scope 밖이라 거부된 파일: " + ", ".join(f"`{p}`" for p in refused_scope[:5])
+            )
+        if refused_forbidden:
+            risk_lines.append(
+                "- forbidden_scope 매칭으로 거부된 파일: " + ", ".join(f"`{p}`" for p in refused_forbidden[:5])
+            )
+
+        parts = [
+            "## 📌 관련 이슈",
+            f"- close #{request.issue_number}" if request.issue_number else "- (no issue)",
+            "",
+            "## ✨ 과제 내용 (목적)",
+            *purpose_lines,
+            "",
+            "## 🎯 범위 (scope)",
+            f"- in_scope: write_scope={list(request.write_scope) or '(미지정)'}",
+            f"- out_of_scope: forbidden_scope={list(request.forbidden_scope) or '(미지정)'}",
+            "- 실제 수정 파일:",
+            *[f"  {line}" for line in files_block],
+            "",
+            "## ⚠️ 리스크 (risks)",
+            *risk_lines,
+            "",
+            "## ✅ 테스트 (tests)",
+            f"- test_status: `{test_status}`",
+            f"- test_summary: `{dict(test_summary) if isinstance(test_summary, Mapping) else test_summary}`",
+            "",
+            "## :camera_with_flash: 스크린샷(선택)",
+            "_(N/A)_",
+            "",
+            "## 📚 참고 (references)",
+            f"- session_id: `{request.session_id}`",
+            f"- branch: `{context.branch}` (from `{request.base_branch}`)",
+            f"- commit: `{context.commit_sha[:10] if context.commit_sha else '-'}`",
+            "",
+            "## 🤖 Agent WorkOS Audit",
+            f"- branch: `{context.branch}` (from `{request.base_branch}`)",
+            f"- repo: `{request.repo_full_name}`",
+            f"- role: `{request.executor_role}`",
+            f"- engineering-agent runtime_policy: branch/PR/tag hard rails 적용",
+            f"- mode: `live` (G6 LiveGithubAppClient — LiveCodeEditor provider=`{provider}`)",
+            "- merge: do-not-merge until operator review",
+        ]
+        return "\n".join(parts) + "\n"
 
     parts = [
         "## 📌 관련 이슈",

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
@@ -105,6 +105,13 @@ REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE: str = (
     "non_greenfield_real_edit_unavailable"
 )
 
+# P1-U — live editor 가 호출됐지만 실제 파일 수정 0건인 경우.  옛 wiring
+# 은 이 케이스를 generic ``commit_failed`` 로 surface 했지만, 실제로는
+# commit 명령이 실행조차 안 됨 (committer 가 edited_files 비면 early
+# return).  본 reason 으로 operator 에게 "LLM call OK 였지만 파일 수정
+# 0 — prompt 보강 / provider / write_scope 점검 필요" 라는 명확한 신호.
+REASON_LIVE_EDITOR_NO_EDITS_PRODUCED: str = "live_editor_no_edits_produced"
+
 
 _PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
     {"main", "master", "develop", "dev", "prod", "release"}
@@ -707,6 +714,46 @@ class CodingExecutorWorker:
                     )
                 raise
 
+            # P1-U C — live editor no-op detection.  옛 wiring 은
+            # LiveCodeEditor 가 호출됐지만 실제 파일 0건 수정 시 committer
+            # 가 edited_files 비어서 early-return commit_sha="" → worker 가
+            # generic REASON_COMMIT_FAILED 로 surface.  사용자는 "왜 commit
+            # 실패했는지" 가 아니라 "왜 LLM 이 파일을 안 만들었는지" 를
+            # 알아야 한다.
+            # 본 분기는 live editor 일 때만 firing — RecordOnly / Greenfield
+            # 같은 plan-only editor 의 정상 동작은 무영향.
+            editor_class_name = type(self._editor).__name__
+            is_live_editor = editor_class_name == "LiveCodeEditor"
+            if is_live_editor and not (ctx.edited_files or ()):
+                provider = getattr(self._editor, "provider", "unknown")
+                model = getattr(self._editor, "model", "unknown")
+                detail_audit = {
+                    "job_id": in_progress.job_id,
+                    "reason": REASON_LIVE_EDITOR_NO_EDITS_PRODUCED,
+                    "branch": branch,
+                    "code_editor": editor_class_name,
+                    "provider": provider,
+                    "model": model,
+                    "worktree_path": ctx.worktree_path,
+                    "changed_files_count": 0,
+                    "detail": (
+                        "live editor call completed but produced 0 modified "
+                        "files — operator may need to refine prompt, check "
+                        "write_scope, or verify provider response"
+                    ),
+                }
+                self._stamp_progress(
+                    session_id=request.session_id,
+                    marker=PROGRESS_CODING_BLOCKED,
+                    detail=detail_audit,
+                )
+                return self._fail(
+                    in_progress,
+                    terminal=False,
+                    reason=REASON_LIVE_EDITOR_NO_EDITS_PRODUCED,
+                    branch=branch,
+                )
+
             ctx = self._tests.run(request=request, context=ctx)
             # P1-G: test runner 가 bootstrap_required 로 short-circuit
             # 한 경우 — repo 에 detectable stack 이 없음. record-only
@@ -1181,6 +1228,7 @@ __all__ = (
     "REASON_PR_FAILED",
     "REASON_PROTECTED_BRANCH",
     "REASON_BOOTSTRAP_REQUIRED",
+    "REASON_LIVE_EDITOR_NO_EDITS_PRODUCED",
     "REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE",
     "REASON_PUSH_FAILED",
     "REASON_TARGET_REPO_MISSING",

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
@@ -112,6 +112,14 @@ REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE: str = (
 # 0 — prompt 보강 / provider / write_scope 점검 필요" 라는 명확한 신호.
 REASON_LIVE_EDITOR_NO_EDITS_PRODUCED: str = "live_editor_no_edits_produced"
 
+# P1-Z4 D — write_scope 가 target repo 의 실제 layout 과 0건 매칭일 때.
+# placeholder (``src/<service>/...``) 같이 caller 가 정합성 없는 scope 를
+# 넘긴 경우 / repo 가 다른 구조 (``apps/`` monorepo) 인 경우 모두.
+# LLM 호출 자체를 건너뛰지는 않지만 (claude-cli 가 새 파일을 만들 수도
+# 있음) detected=0 이면 본 reason 으로 분류 → operator 가 "write_scope
+# 가 repo layout 과 안 맞아 매칭 가능한 candidate 0개" 라는 명확한 진단.
+REASON_WRITE_SCOPE_RESOLVED_EMPTY: str = "write_scope_resolved_empty"
+
 
 _PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
     {"main", "master", "develop", "dev", "prod", "release"}
@@ -727,20 +735,60 @@ class CodingExecutorWorker:
             if is_live_editor and not (ctx.edited_files or ()):
                 provider = getattr(self._editor, "provider", "unknown")
                 model = getattr(self._editor, "model", "unknown")
+                # P1-Z4 D — write_scope 가 target repo layout 과 매칭되는지
+                # 점검.  placeholder (``<service>``) / 다른 layout 등으로
+                # 0 매칭이면 더 구체적인 reason 으로 분류.
+                scope_resolution = None
+                scope_audit: Mapping[str, Any] = {}
+                try:
+                    from .coding_write_scope_resolution import (
+                        resolve_write_scope_against_worktree,
+                    )
+
+                    scope_resolution = resolve_write_scope_against_worktree(
+                        worktree_path=ctx.worktree_path,
+                        write_scope=tuple(request.write_scope or ()),
+                    )
+                    scope_audit = scope_resolution.to_audit()
+                except Exception:  # noqa: BLE001
+                    scope_audit = {"resolution_error": True}
+
+                scope_empty = bool(
+                    scope_resolution is not None
+                    and scope_resolution.can_decide_mismatch
+                    and not scope_resolution.has_any_match
+                )
+                no_edit_reason = (
+                    REASON_WRITE_SCOPE_RESOLVED_EMPTY
+                    if scope_empty
+                    else REASON_LIVE_EDITOR_NO_EDITS_PRODUCED
+                )
+                no_edit_detail = (
+                    "write_scope 가 target repo layout 과 0건 매칭 — "
+                    f"unmatched_prefixes={list((scope_resolution.unmatched_prefixes if scope_resolution else ()))[:3]} "
+                    "(placeholder scope 인 경우 caller 가 repo-aware 로 resolve 필요)"
+                    if scope_empty
+                    else (
+                        "live editor call completed but produced 0 modified "
+                        "files — operator may need to refine prompt, check "
+                        "write_scope, or verify provider response"
+                    )
+                )
                 detail_audit = {
                     "job_id": in_progress.job_id,
-                    "reason": REASON_LIVE_EDITOR_NO_EDITS_PRODUCED,
+                    "reason": no_edit_reason,
                     "branch": branch,
                     "code_editor": editor_class_name,
                     "provider": provider,
                     "model": model,
                     "worktree_path": ctx.worktree_path,
                     "changed_files_count": 0,
-                    "detail": (
-                        "live editor call completed but produced 0 modified "
-                        "files — operator may need to refine prompt, check "
-                        "write_scope, or verify provider response"
+                    "write_scope_resolution": dict(scope_audit),
+                    "resolved_write_scope_count": len(
+                        scope_resolution.matched_prefixes if scope_resolution else ()
                     ),
+                    "prompt_summary": (request.generated_prompt or "")[:200],
+                    "detail": no_edit_detail,
                 }
                 self._stamp_progress(
                     session_id=request.session_id,
@@ -750,7 +798,7 @@ class CodingExecutorWorker:
                 return self._fail(
                     in_progress,
                     terminal=False,
-                    reason=REASON_LIVE_EDITOR_NO_EDITS_PRODUCED,
+                    reason=no_edit_reason,
                     branch=branch,
                 )
 

--- a/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_executor_worker.py
@@ -120,6 +120,16 @@ REASON_LIVE_EDITOR_NO_EDITS_PRODUCED: str = "live_editor_no_edits_produced"
 # 가 repo layout 과 안 맞아 매칭 가능한 candidate 0개" 라는 명확한 진단.
 REASON_WRITE_SCOPE_RESOLVED_EMPTY: str = "write_scope_resolved_empty"
 
+# P1-Z6 A — editor.apply 단계의 subprocess timeout (exit_code=124).  옛
+# wiring 은 generic ``edit_failed: _SubprocessError: subprocess failed:
+# exit=124`` 로 surface 해서 operator 가 "어디서 timeout 났는지" 진단
+# 불가.  본 reason 은 failing_stage / subprocess_kind / timeout_seconds
+# / stderr_tail / command_summary 까지 audit 에 채워 즉시 진단 가능.
+REASON_EDIT_TIMEOUT_LIVE_EDITOR: str = "edit_timeout_live_editor"
+# P1-Z6 A — editor.apply 의 non-timeout subprocess failure (exit_code !=
+# 124).  옛 generic edit_failed 보다 구체적인 surface.
+REASON_EDIT_SUBPROCESS_FAILED: str = "edit_subprocess_failed"
+
 
 _PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
     {"main", "master", "develop", "dev", "prod", "release"}
@@ -443,10 +453,18 @@ class CodingExecutorWorker:
         request: CodingExecuteRequest,
         *,
         priority: int = 0,
-        max_attempts: int = 1,
+        max_attempts: int = 3,
         now: Optional[float] = None,
     ) -> Tuple[Job, bool]:
-        """Idempotent insert — returns ``(job, created)``."""
+        """Idempotent insert — returns ``(job, created)``.
+
+        P1-Z6 B — default ``max_attempts`` 를 1 → 3 으로.  옛 default 는
+        ``failed_retryable`` reason 으로 종료해도 ``attempt+1 >= 1`` 이라
+        ``requeue_retryable`` 이 곧장 terminal 로 끝냈다.  pre-PR transient
+        failure (예: live editor subprocess timeout) 는 실제로 한 번 더
+        시도할 가치가 있음.  structural failure 는 worker 가 ``terminal=True``
+        로 명시 종료 — max_attempts 가 자동 retry 보호망 역할만 한다.
+        """
 
         if not request.session_id or not request.executor_role:
             raise ValueError("session_id + executor_role required")
@@ -691,6 +709,71 @@ class CodingExecutorWorker:
                         in_progress,
                         terminal=True,
                         reason=REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE,
+                        branch=branch,
+                    )
+                # P1-Z6 A — _SubprocessError 의 exit_code=124 는 claude-cli
+                # 같은 live editor subprocess 의 timeout.  옛 wiring 은
+                # generic ``edit_failed: exit=124`` 로 surface 해서 operator
+                # 가 어디서 timeout 났는지 모름.  본 분기는 failing_stage /
+                # subprocess_kind / timeout_seconds / stderr_tail /
+                # command_summary 까지 audit 에 채워 즉시 진단 가능.
+                if exc_name == "_SubprocessError":
+                    exit_code = getattr(exc, "exit_code", None)
+                    stderr_tail = (getattr(exc, "stderr", "") or "")[-400:]
+                    is_timeout = int(exit_code or 0) == 124
+                    reason_token = (
+                        REASON_EDIT_TIMEOUT_LIVE_EDITOR
+                        if is_timeout
+                        else REASON_EDIT_SUBPROCESS_FAILED
+                    )
+                    code_editor = type(self._editor).__name__
+                    provider = getattr(self._editor, "provider", "unknown")
+                    model = getattr(self._editor, "model", "unknown")
+                    # strategy / write_scope audit — operator 가 prompt /
+                    # scope / repo layout 어디가 문제인지 즉시 파악.
+                    metadata = request.metadata or {}
+                    strategy_audit = None
+                    if isinstance(metadata, Mapping):
+                        strategy_audit = metadata.get("implementation_strategy")
+                    detail_audit = {
+                        "job_id": in_progress.job_id,
+                        "reason": reason_token,
+                        "failing_stage": "live_editor_apply",
+                        "subprocess_kind": (
+                            "claude_cli" if code_editor == "LiveCodeEditor" else code_editor
+                        ),
+                        "exit_code": exit_code,
+                        "timeout_seconds": 600 if is_timeout else None,
+                        "stderr_tail": stderr_tail,
+                        "branch": branch,
+                        "code_editor": code_editor,
+                        "provider": provider,
+                        "model": model,
+                        "worktree_path": getattr(ctx, "worktree_path", "") if ctx else "",
+                        "repo_full_name": request.repo_full_name,
+                        "write_scope": list(request.write_scope or ()),
+                        "forbidden_scope": list(request.forbidden_scope or ()),
+                        "implementation_strategy_id": (
+                            strategy_audit.get("strategy_id")
+                            if isinstance(strategy_audit, Mapping)
+                            else None
+                        ),
+                        "prompt_summary": (request.generated_prompt or "")[:200],
+                        "detail": _short(exc),
+                    }
+                    self._stamp_progress(
+                        session_id=request.session_id,
+                        marker=PROGRESS_CODING_BLOCKED,
+                        detail=detail_audit,
+                    )
+                    # P1-Z6 B — transient timeout 은 retryable, 다른 exit_code
+                    # 도 일단 retryable (max_attempts 가 bound 함).  structural
+                    # failure (strategy unresolved / scope mismatch) 는 별도
+                    # 분기에서 이미 terminal 로 처리.
+                    return self._fail(
+                        in_progress,
+                        terminal=False,
+                        reason=reason_token,
                         branch=branch,
                     )
                 if exc_name == "BootstrapApplyFailed":

--- a/src/yule_orchestrator/agents/job_queue/coding_write_scope_resolution.py
+++ b/src/yule_orchestrator/agents/job_queue/coding_write_scope_resolution.py
@@ -1,0 +1,201 @@
+"""P1-Z4 D — write_scope vs worktree layout 정합성 점검.
+
+배경
+----
+canonical session ``000f13fb121b`` 의 coding_proposal write_scope:
+
+  ``("src/<service>/api/**", "src/<service>/domain/**",
+     "src/<service>/repository/**", "src/<service>/security/**",
+     "migrations/**", "tests/<service>/api/**")``
+
+target repo ``naver-search-clone`` 은 ``apps/`` 중심 monorepo 구조라
+위 prefix 들이 실제 디렉터리와 0건 매칭.  결과: LiveCodeEditor 가 LLM
+호출까지 했지만 worktree 안에 편집 가능한 candidate 가 0개라 modified
+file 0건 → generic ``live_editor_no_edits_produced`` 로 종료.
+
+본 모듈
+========
+* :func:`resolve_write_scope_against_worktree(worktree_path, write_scope)
+  -> WriteScopeResolution` — 각 scope prefix 마다 worktree 안에 실제
+  매칭되는 경로 (dir 또는 file) 가 있는지 평가.  결과 dataclass:
+
+    * ``matched_prefixes`` — 매칭된 prefix 들
+    * ``unmatched_prefixes`` — 매칭 0건인 prefix 들
+    * ``sample_paths`` — 매칭된 실제 경로 샘플 (operator surface 용)
+    * ``has_any_match`` — True 면 LiveCodeEditor 진행 가능, False 면
+      worker 가 ``write_scope_resolved_empty`` 로 정직 차단
+
+storage I/O 없음 — 파일시스템 read 만.  caller (worker) 가 결과를 보고
+다음 단계 결정.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WriteScopeResolution:
+    matched_prefixes: Tuple[str, ...] = ()
+    unmatched_prefixes: Tuple[str, ...] = ()
+    sample_paths: Tuple[str, ...] = field(default_factory=tuple)
+    worktree_path: str = ""
+    write_scope: Tuple[str, ...] = field(default_factory=tuple)
+    worktree_exists: bool = False
+
+    @property
+    def has_any_match(self) -> bool:
+        return bool(self.matched_prefixes)
+
+    @property
+    def can_decide_mismatch(self) -> bool:
+        """worktree 가 실제로 존재하고 scope 가 비어있지 않을 때만
+        mismatch 판단 가능.  worktree 가 없으면 caller 는 generic
+        no-edit 로 떨어뜨려야 함."""
+
+        return self.worktree_exists and bool(self.write_scope)
+
+    @property
+    def is_placeholder_scope(self) -> bool:
+        """``src/<service>/...`` 같은 angle-bracket placeholder 가 있는지."""
+
+        for entry in self.write_scope:
+            if "<" in entry and ">" in entry:
+                return True
+        return False
+
+    def to_audit(self) -> dict:
+        return {
+            "worktree_path": self.worktree_path,
+            "worktree_exists": self.worktree_exists,
+            "write_scope": list(self.write_scope),
+            "matched_prefixes": list(self.matched_prefixes),
+            "unmatched_prefixes": list(self.unmatched_prefixes),
+            "sample_paths": list(self.sample_paths),
+            "has_any_match": self.has_any_match,
+            "can_decide_mismatch": self.can_decide_mismatch,
+            "is_placeholder_scope": self.is_placeholder_scope,
+        }
+
+
+def _normalize_prefix(entry: str) -> str:
+    """write_scope entry 를 디렉터리 prefix 로 정규화.
+
+    ``src/<service>/api/**`` → ``src/<service>/api``
+    ``services/auth/**`` → ``services/auth``
+    """
+
+    text = (entry or "").strip()
+    text = text.rstrip("/").rstrip("*").rstrip("/")
+    return text
+
+
+def resolve_write_scope_against_worktree(
+    *,
+    worktree_path: str,
+    write_scope: Sequence[str],
+    sample_limit: int = 5,
+) -> WriteScopeResolution:
+    """worktree 안에 write_scope 가 실제로 매칭되는 path 가 있는지 점검.
+
+    각 prefix 는 (1) 그 자체가 디렉터리/파일로 존재하거나 (2) glob 와
+    매칭하는 자식이 존재하면 matched.  placeholder (``<service>`` 같은
+    각괄호 literal) 가 들어있으면 보통 매칭 0건 → unmatched.
+    """
+
+    write_scope_tuple = tuple(str(x) for x in (write_scope or ()) if str(x).strip())
+    if not worktree_path or not write_scope_tuple:
+        return WriteScopeResolution(
+            worktree_path=worktree_path,
+            write_scope=write_scope_tuple,
+            worktree_exists=False,
+        )
+
+    root = Path(worktree_path)
+    if not root.is_dir():
+        return WriteScopeResolution(
+            worktree_path=worktree_path,
+            write_scope=write_scope_tuple,
+            worktree_exists=False,
+        )
+
+    matched: list[str] = []
+    unmatched: list[str] = []
+    samples: list[str] = []
+
+    for entry in write_scope_tuple:
+        prefix = _normalize_prefix(entry)
+        if not prefix:
+            # ``**`` 같은 universal scope — 어떤 worktree 라도 매칭.
+            matched.append(entry)
+            continue
+        candidate = root / prefix
+        try:
+            if candidate.exists():
+                matched.append(entry)
+                if candidate.is_dir():
+                    for child in candidate.iterdir():
+                        rel = str(child.relative_to(root))
+                        if rel not in samples:
+                            samples.append(rel)
+                        if len(samples) >= sample_limit:
+                            break
+                else:
+                    rel = str(candidate.relative_to(root))
+                    if rel not in samples:
+                        samples.append(rel)
+                continue
+        except OSError:
+            pass
+
+        # glob fallback — prefix 가 dir 로는 안 보이지만 그 안의 file 이
+        # 있을 수 있다 (예: ``src/auth.py``).  segment 단위로 검사.
+        segments = [s for s in prefix.split("/") if s]
+        if segments:
+            parent = root
+            try:
+                # parent 디렉터리부터 단계별로 존재성 검사
+                for idx, seg in enumerate(segments[:-1]):
+                    parent = parent / seg
+                    if not parent.is_dir():
+                        parent = None
+                        break
+                if parent is not None:
+                    leaf = segments[-1]
+                    # leaf 와 정확히 일치하는 file / dir 가 있는지
+                    matching = list(parent.glob(leaf))
+                    if matching:
+                        matched.append(entry)
+                        for m in matching[: sample_limit - len(samples)]:
+                            try:
+                                rel = str(m.relative_to(root))
+                            except ValueError:
+                                rel = str(m)
+                            if rel not in samples:
+                                samples.append(rel)
+                        continue
+            except (OSError, ValueError):
+                pass
+
+        unmatched.append(entry)
+
+    return WriteScopeResolution(
+        matched_prefixes=tuple(matched),
+        unmatched_prefixes=tuple(unmatched),
+        sample_paths=tuple(samples[:sample_limit]),
+        worktree_path=worktree_path,
+        write_scope=write_scope_tuple,
+        worktree_exists=True,
+    )
+
+
+__all__ = (
+    "WriteScopeResolution",
+    "resolve_write_scope_against_worktree",
+)

--- a/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
+++ b/src/yule_orchestrator/agents/job_queue/github_work_order_executor.py
@@ -27,7 +27,7 @@ session 갱신 키
 {
   "issue_number": 77,                          # 생성/재사용된 번호
   "html_url": "https://github.com/.../issues/77",
-  "title": "[기능] 회원가입 ...",
+  "title": "[Feature] 회원가입 ...",
   "labels": ["✨ Feature", "📃 Docs"],
   "approval_id": "approval-1",
   "approved_by": "masterway",

--- a/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
+++ b/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
@@ -1,0 +1,371 @@
+"""P1-Z A — Approved 세션이 ``needs_issue`` dead-end 로 떨어지지 않게.
+
+배경
+====
+이전 wiring:
+
+  * Discord ``코딩 권한 제안`` phrase → coding_proposal stamp +
+    ``enqueue_github_work_approval`` (approval card 게시 + approval row
+    에 ``github_work_order_proposal`` payload stamp).
+  * Discord ``승인`` reply → ``handle_github_work_approval_reply`` →
+    ``dispatch_github_work_order`` (queue row 생성).
+  * 그 사이 어딘가가 깨지거나 (proposal payload 누락 / approval_worker
+    미주입), 또는 CLI ``yule engineer approve`` 처럼 approval row 자체가
+    없는 경로면 session state 는 ``approved`` 인데도 work_order 가
+    영원히 enqueue 되지 않음 → ``tracking_validation=needs_issue`` 의
+    dead-end.
+
+라이브 사례: session ``f2f36607d175`` 는 state=approved 이지만
+``github_work_order_issue=None``, queue row 0, tracking=needs_issue.
+
+본 모듈
+========
+* :func:`decide_post_approval_action` — pure 결정 함수 (no I/O). session
+  하나를 받아 work_order 가 필요한지 판단.  결과:
+
+    - ``noop`` + reason (이미 anchor 있음 / proposal 없음 / target 부족 ...)
+    - ``needs_work_order`` + ``repo`` + ``existing_issue_number`` 등 payload
+
+* :func:`dispatch_post_approval_work_order` — pure 결정 + queue dispatch.
+  CLI / Discord 양쪽이 같은 contract 로 호출.  approval_id 가 명시되지
+  않은 경로 (CLI) 면 deterministic synthetic id (``cli-approve-<sid>``)
+  를 부여해 ``dispatch_github_work_order`` 의 approval-required guard 를
+  통과.
+
+idempotency
+-----------
+- 이미 anchor 가 있으면 noop.
+- 이미 in-flight work_order (``find_active_work_order`` 매칭) 가 있으면
+  ``dispatch_github_work_order`` 가 dedup → ``skipped_reason`` 으로 반환.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+ACTION_NOOP: str = "noop"
+ACTION_NEEDS_WORK_ORDER: str = "needs_work_order"
+ACTION_DISPATCHED: str = "dispatched"
+ACTION_FAILED: str = "failed"
+
+
+# Noop reasons — operator surface 에서 "왜 dispatch 안 됐는지" 한 줄로 확인.
+NOOP_REASON_NOT_APPROVED: str = "session_not_approved"
+NOOP_REASON_NO_EXTRA: str = "session_extra_missing"
+NOOP_REASON_NO_CODING_PROPOSAL: str = "no_coding_proposal"
+NOOP_REASON_ANCHOR_ALREADY_STAMPED: str = "anchor_already_stamped"
+NOOP_REASON_NO_GITHUB_TARGET: str = "no_github_target"
+NOOP_REASON_UNSUPPORTED_TARGET_KIND: str = "unsupported_target_kind"
+NOOP_REASON_NO_REPO: str = "no_repo_full_name"
+NOOP_REASON_TERMINAL_SESSION: str = "terminal_session"
+
+FAIL_REASON_PROPOSAL_NOT_ELIGIBLE: str = "proposal_not_eligible"
+FAIL_REASON_BUILD_RAISED: str = "proposal_build_raised"
+FAIL_REASON_DISPATCH_RAISED: str = "dispatch_raised"
+
+
+SESSION_EXTRA_POST_APPROVAL_DISPATCH_KEY: str = "post_approval_dispatch"
+
+
+@dataclass(frozen=True)
+class PostApprovalDecision:
+    """Pure 결정 결과.  ``action`` 이 ``needs_work_order`` 일 때만 dispatch
+    경로로 진입.  caller 가 ``noop`` 인 경우 reason 만 audit 에 남기면 됨.
+    """
+
+    action: str
+    reason: Optional[str] = None
+    repo: Optional[str] = None
+    existing_issue_number: Optional[int] = None
+    source_channel_id: Optional[int] = None
+    source_thread_id: Optional[int] = None
+    source_message_id: Optional[int] = None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        result = int(value)
+        return result if result > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalized_state(session: Any) -> str:
+    raw = getattr(session, "state", None)
+    if raw is None:
+        return ""
+    text = getattr(raw, "value", None)
+    if text is None:
+        text = str(raw)
+    return str(text).strip().lower()
+
+
+def _resolve_repo(session: Any, extra: Mapping[str, Any]) -> Optional[str]:
+    """coding_proposal / github_target / extra hint 에서 repo full name 추출."""
+
+    # coding_proposal 의 명시 repo
+    proposal = extra.get("coding_proposal")
+    if isinstance(proposal, Mapping):
+        repo = str(proposal.get("repo_full_name") or "").strip()
+        if repo and "/" in repo:
+            return repo
+    # extra.repo_full_name
+    repo = str(extra.get("repo_full_name") or "").strip()
+    if repo and "/" in repo:
+        return repo
+    # github_target.owner + repo
+    target = extra.get("github_target")
+    if isinstance(target, Mapping):
+        owner = str(target.get("owner") or "").strip()
+        name = str(target.get("repo") or "").strip()
+        if owner and name:
+            return f"{owner}/{name}"
+    return None
+
+
+def decide_post_approval_action(session: Any) -> PostApprovalDecision:
+    """Pure decision: should the caller dispatch a github_work_order?
+
+    Caller (CLI / Discord) 가 본 함수 결과만으로 다음 액션을 정할 수 있어야
+    한다 — 본 함수는 storage I/O / network 호출 절대 없음.
+    """
+
+    extra_raw = getattr(session, "extra", None)
+    if not isinstance(extra_raw, Mapping):
+        return PostApprovalDecision(action=ACTION_NOOP, reason=NOOP_REASON_NO_EXTRA)
+    extra = extra_raw
+
+    state = _normalized_state(session)
+    if state in {"completed", "rejected"}:
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_TERMINAL_SESSION
+        )
+    if state != "approved":
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_NOT_APPROVED
+        )
+
+    coding_proposal = extra.get("coding_proposal")
+    if not isinstance(coding_proposal, Mapping) or not coding_proposal:
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_NO_CODING_PROPOSAL
+        )
+
+    # Already has anchor — work_order already produced an issue earlier
+    anchor = extra.get("github_work_order_issue")
+    if isinstance(anchor, Mapping) and _coerce_int(anchor.get("issue_number")):
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_ANCHOR_ALREADY_STAMPED
+        )
+
+    target = extra.get("github_target")
+    if not isinstance(target, Mapping) or not target:
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_NO_GITHUB_TARGET
+        )
+
+    kind = str(target.get("kind") or "").strip().lower()
+    if kind not in {"repo", "issue", "pull_request"}:
+        return PostApprovalDecision(
+            action=ACTION_NOOP,
+            reason=f"{NOOP_REASON_UNSUPPORTED_TARGET_KIND}:{kind or 'unknown'}",
+        )
+
+    repo = _resolve_repo(session, extra)
+    if not repo:
+        return PostApprovalDecision(action=ACTION_NOOP, reason=NOOP_REASON_NO_REPO)
+
+    existing_issue = _coerce_int(extra.get("existing_issue_number"))
+    if existing_issue is None and kind == "issue":
+        existing_issue = _coerce_int(target.get("number"))
+
+    return PostApprovalDecision(
+        action=ACTION_NEEDS_WORK_ORDER,
+        repo=repo,
+        existing_issue_number=existing_issue,
+        source_channel_id=getattr(session, "channel_id", None),
+        source_thread_id=getattr(session, "thread_id", None),
+        source_message_id=_coerce_int(
+            extra.get("intake_message_id")
+            or (coding_proposal.get("source_message_id") if isinstance(coding_proposal, Mapping) else None)
+        ),
+    )
+
+
+def _synthetic_approval_id(session_id: str) -> str:
+    """approval row 없는 path (CLI) 용 deterministic id.
+
+    ``dispatch_github_work_order`` 는 ``approval_id`` 가 빈 문자열이면
+    refuse → CLI 가 같은 contract 로 진입할 수 있게 deterministic
+    prefix 부여.  같은 session 으로 두 번 호출되면 같은 id → idempotent.
+    """
+
+    return f"cli-approve-{session_id or 'unknown'}"
+
+
+def _now_iso(now: Optional[datetime] = None) -> str:
+    base = now or datetime.now(tz=timezone.utc)
+    return base.replace(microsecond=0).isoformat()
+
+
+def dispatch_post_approval_work_order(
+    *,
+    session: Any,
+    queue: Any,
+    requested_by: str = "",
+    approval_id: Optional[str] = None,
+    approved_by: Optional[str] = None,
+    dry_run: Optional[bool] = None,
+    now: Optional[datetime] = None,
+    proposal_builder: Optional[Any] = None,
+) -> Mapping[str, Any]:
+    """Approved 세션에 work_order 가 필요하면 build + dispatch.
+
+    *proposal_builder* 는 ``build_github_work_order_proposal`` callable
+    (테스트가 inject).  미주입 시 lazy import.  결과는 dict — caller
+    가 그대로 audit / operator surface 에 stamp.
+    """
+
+    decision = decide_post_approval_action(session)
+    if decision.action != ACTION_NEEDS_WORK_ORDER:
+        return {
+            "action": ACTION_NOOP,
+            "reason": decision.reason,
+            "session_id": getattr(session, "session_id", None),
+        }
+
+    builder = proposal_builder
+    if builder is None:
+        try:
+            from ...discord.integrations.github_workos_adapter import (
+                build_github_work_order_proposal,
+            )
+
+            builder = build_github_work_order_proposal
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "dispatch_post_approval_work_order: proposal builder import failed",
+                exc_info=True,
+            )
+            return {
+                "action": ACTION_FAILED,
+                "reason": f"{FAIL_REASON_BUILD_RAISED}:{type(exc).__name__}",
+                "session_id": getattr(session, "session_id", None),
+            }
+
+    request_text = getattr(session, "prompt", "") or ""
+    try:
+        proposal = builder(
+            session=session,
+            request_text=request_text,
+            source_channel_id=decision.source_channel_id,
+            source_thread_id=decision.source_thread_id,
+            source_message_id=decision.source_message_id,
+            requested_by=requested_by,
+            repo=decision.repo,
+            existing_issue_number=decision.existing_issue_number,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "dispatch_post_approval_work_order: proposal builder raised "
+            "for session=%s",
+            getattr(session, "session_id", "?"),
+            exc_info=True,
+        )
+        return {
+            "action": ACTION_FAILED,
+            "reason": f"{FAIL_REASON_BUILD_RAISED}:{type(exc).__name__}",
+            "session_id": getattr(session, "session_id", None),
+        }
+
+    if proposal is None:
+        return {
+            "action": ACTION_FAILED,
+            "reason": FAIL_REASON_PROPOSAL_NOT_ELIGIBLE,
+            "session_id": getattr(session, "session_id", None),
+        }
+
+    from .github_work_order import (
+        GitHubWorkOrder,
+        dispatch_github_work_order,
+    )
+
+    effective_approval = (approval_id or "").strip() or _synthetic_approval_id(
+        str(getattr(session, "session_id", "") or "")
+    )
+    effective_approver = (approved_by or "").strip() or requested_by or "engineer-cli"
+    work_order = GitHubWorkOrder.from_proposal(
+        proposal,
+        approval_id=effective_approval,
+        approved_by=effective_approver,
+        approved_at=_now_iso(now),
+        dry_run=dry_run,
+    )
+
+    try:
+        outcome = dispatch_github_work_order(
+            queue,
+            work_order,
+            now=(now.timestamp() if now is not None else None),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "dispatch_post_approval_work_order: dispatch_github_work_order "
+            "raised for session=%s",
+            getattr(session, "session_id", "?"),
+            exc_info=True,
+        )
+        return {
+            "action": ACTION_FAILED,
+            "reason": f"{FAIL_REASON_DISPATCH_RAISED}:{type(exc).__name__}",
+            "session_id": getattr(session, "session_id", None),
+        }
+
+    if outcome.skipped_reason:
+        return {
+            "action": ACTION_NOOP,
+            "reason": outcome.skipped_reason,
+            "session_id": getattr(session, "session_id", None),
+        }
+
+    job_id = outcome.job.job_id if outcome.job is not None else None
+    return {
+        "action": ACTION_DISPATCHED,
+        "reason": None,
+        "session_id": getattr(session, "session_id", None),
+        "job_id": job_id,
+        "approval_id": effective_approval,
+        "approved_by": effective_approver,
+        "repo": decision.repo,
+        "existing_issue_number": decision.existing_issue_number,
+    }
+
+
+__all__ = (
+    "ACTION_DISPATCHED",
+    "ACTION_FAILED",
+    "ACTION_NEEDS_WORK_ORDER",
+    "ACTION_NOOP",
+    "FAIL_REASON_BUILD_RAISED",
+    "FAIL_REASON_DISPATCH_RAISED",
+    "FAIL_REASON_PROPOSAL_NOT_ELIGIBLE",
+    "NOOP_REASON_ANCHOR_ALREADY_STAMPED",
+    "NOOP_REASON_NO_CODING_PROPOSAL",
+    "NOOP_REASON_NO_EXTRA",
+    "NOOP_REASON_NO_GITHUB_TARGET",
+    "NOOP_REASON_NO_REPO",
+    "NOOP_REASON_NOT_APPROVED",
+    "NOOP_REASON_TERMINAL_SESSION",
+    "NOOP_REASON_UNSUPPORTED_TARGET_KIND",
+    "PostApprovalDecision",
+    "SESSION_EXTRA_POST_APPROVAL_DISPATCH_KEY",
+    "decide_post_approval_action",
+    "dispatch_post_approval_work_order",
+)

--- a/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
+++ b/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
@@ -310,6 +310,10 @@ def dispatch_post_approval_work_order(
 
     request_text = getattr(session, "prompt", "") or ""
     try:
+        # P1-Z3 — approved_continuation=True 로 builder 의 prompt-phrase 기반
+        # coding-intent 게이트 우회.  decide_post_approval_action 이 이미
+        # lifecycle / target / packet / proposal / anchor / repo / terminal
+        # 모든 가드 통과 검증한 상태 → structured signals 가 source of truth.
         proposal = builder(
             session=session,
             request_text=request_text,
@@ -319,6 +323,7 @@ def dispatch_post_approval_work_order(
             requested_by=requested_by,
             repo=decision.repo,
             existing_issue_number=decision.existing_issue_number,
+            approved_continuation=True,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning(

--- a/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
+++ b/src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py
@@ -65,6 +65,11 @@ NOOP_REASON_NO_GITHUB_TARGET: str = "no_github_target"
 NOOP_REASON_UNSUPPORTED_TARGET_KIND: str = "unsupported_target_kind"
 NOOP_REASON_NO_REPO: str = "no_repo_full_name"
 NOOP_REASON_TERMINAL_SESSION: str = "terminal_session"
+# P1-Z2 — coding_proposal absent + handoff packet path 가 lifecycle_mode 가
+# research_only / 누락이면 work_order 안 만든다.  intake 가 explicit
+# implementation 신호 또는 coding_proposal 둘 중 하나로 의도를 표명해야 함.
+NOOP_REASON_NO_CODING_INTENT_SIGNAL: str = "no_coding_intent_signal"
+NOOP_REASON_RESEARCH_ONLY_LIFECYCLE: str = "research_only_lifecycle"
 
 FAIL_REASON_PROPOSAL_NOT_ELIGIBLE: str = "proposal_not_eligible"
 FAIL_REASON_BUILD_RAISED: str = "proposal_build_raised"
@@ -108,25 +113,38 @@ def _normalized_state(session: Any) -> str:
 
 
 def _resolve_repo(session: Any, extra: Mapping[str, Any]) -> Optional[str]:
-    """coding_proposal / github_target / extra hint 에서 repo full name 추출."""
+    """coding_proposal / handoff_packet / github_target / extra hint 에서 repo 추출.
 
-    # coding_proposal 의 명시 repo
+    P1-Z2 — coding_proposal absent + handoff packet only 경로도 지원.
+    handoff packet 의 ``github_target`` 은 동일 owner/repo 모양이라 그대로 흡수.
+    """
+
+    # 1. coding_proposal 의 명시 repo (옛 경로)
     proposal = extra.get("coding_proposal")
     if isinstance(proposal, Mapping):
         repo = str(proposal.get("repo_full_name") or "").strip()
         if repo and "/" in repo:
             return repo
-    # extra.repo_full_name
+    # 2. session.extra.repo_full_name
     repo = str(extra.get("repo_full_name") or "").strip()
     if repo and "/" in repo:
         return repo
-    # github_target.owner + repo
+    # 3. session.extra.github_target.owner + repo
     target = extra.get("github_target")
     if isinstance(target, Mapping):
         owner = str(target.get("owner") or "").strip()
         name = str(target.get("repo") or "").strip()
         if owner and name:
             return f"{owner}/{name}"
+    # 4. P1-Z2 — coding_handoff_packet.github_target.owner + repo
+    packet = extra.get("coding_handoff_packet")
+    if isinstance(packet, Mapping):
+        packet_target = packet.get("github_target")
+        if isinstance(packet_target, Mapping):
+            owner = str(packet_target.get("owner") or "").strip()
+            name = str(packet_target.get("repo") or "").strip()
+            if owner and name:
+                return f"{owner}/{name}"
     return None
 
 
@@ -152,12 +170,6 @@ def decide_post_approval_action(session: Any) -> PostApprovalDecision:
             action=ACTION_NOOP, reason=NOOP_REASON_NOT_APPROVED
         )
 
-    coding_proposal = extra.get("coding_proposal")
-    if not isinstance(coding_proposal, Mapping) or not coding_proposal:
-        return PostApprovalDecision(
-            action=ACTION_NOOP, reason=NOOP_REASON_NO_CODING_PROPOSAL
-        )
-
     # Already has anchor — work_order already produced an issue earlier
     anchor = extra.get("github_work_order_issue")
     if isinstance(anchor, Mapping) and _coerce_int(anchor.get("issue_number")):
@@ -165,7 +177,41 @@ def decide_post_approval_action(session: Any) -> PostApprovalDecision:
             action=ACTION_NOOP, reason=NOOP_REASON_ANCHOR_ALREADY_STAMPED
         )
 
+    # P1-Z2 — coding intent eligibility:
+    #   * coding_proposal 존재 (옛 경로) OR
+    #   * coding_handoff_packet + lifecycle_mode != research_only (실제 intake)
+    # research_only 신호가 명시되면 어떤 경우든 work_order 안 만든다.
+    coding_proposal = extra.get("coding_proposal")
+    has_coding_proposal = isinstance(coding_proposal, Mapping) and bool(coding_proposal)
+    handoff_packet = extra.get("coding_handoff_packet")
+    has_handoff_packet = isinstance(handoff_packet, Mapping) and bool(handoff_packet)
+    lifecycle_mode = str(extra.get("lifecycle_mode") or "").strip().lower()
+
+    if lifecycle_mode == "research_only":
+        return PostApprovalDecision(
+            action=ACTION_NOOP, reason=NOOP_REASON_RESEARCH_ONLY_LIFECYCLE
+        )
+
+    if not has_coding_proposal:
+        # handoff packet 만 있는 실제 intake 경로 — implementation 신호 필요.
+        # lifecycle_mode 명시 missing 이라도 packet 만으로는 의도 확신 못함 →
+        # 안전한 default 는 "implementation 명시 또는 coding_proposal" 둘 중 하나.
+        if not has_handoff_packet:
+            return PostApprovalDecision(
+                action=ACTION_NOOP, reason=NOOP_REASON_NO_CODING_PROPOSAL
+            )
+        if lifecycle_mode != "implementation":
+            return PostApprovalDecision(
+                action=ACTION_NOOP, reason=NOOP_REASON_NO_CODING_INTENT_SIGNAL
+            )
+
     target = extra.get("github_target")
+    if not isinstance(target, Mapping) or not target:
+        # P1-Z2 — handoff packet 안의 github_target 도 본다 (캐싱된 사본).
+        if has_handoff_packet:
+            packet_target = handoff_packet.get("github_target")
+            if isinstance(packet_target, Mapping) and packet_target:
+                target = packet_target
     if not isinstance(target, Mapping) or not target:
         return PostApprovalDecision(
             action=ACTION_NOOP, reason=NOOP_REASON_NO_GITHUB_TARGET
@@ -186,16 +232,18 @@ def decide_post_approval_action(session: Any) -> PostApprovalDecision:
     if existing_issue is None and kind == "issue":
         existing_issue = _coerce_int(target.get("number"))
 
+    # source ids — coding_proposal 의 message id 우선, 없으면 intake 캐시 / None.
+    proposal_message_id = None
+    if has_coding_proposal:
+        proposal_message_id = _coerce_int(coding_proposal.get("source_message_id"))
     return PostApprovalDecision(
         action=ACTION_NEEDS_WORK_ORDER,
         repo=repo,
         existing_issue_number=existing_issue,
         source_channel_id=getattr(session, "channel_id", None),
         source_thread_id=getattr(session, "thread_id", None),
-        source_message_id=_coerce_int(
-            extra.get("intake_message_id")
-            or (coding_proposal.get("source_message_id") if isinstance(coding_proposal, Mapping) else None)
-        ),
+        source_message_id=_coerce_int(extra.get("intake_message_id"))
+        or proposal_message_id,
     )
 
 

--- a/src/yule_orchestrator/agents/job_queue/pr_approval.py
+++ b/src/yule_orchestrator/agents/job_queue/pr_approval.py
@@ -266,15 +266,32 @@ def render_pr_merge_summary(proposal: PRMergeProposal) -> str:
     lines.append(header)
     lines.append("")
 
+    # P1-R — 한국어 4 섹션 (작업 내용 / 목적 / 영향 범위 / 다음 단계) 강제.
+    # repo_write_policy.validate_approval_card_quality 가 본 텍스트를 검증
+    # 하므로 4 섹션 헤더는 항상 명시.
+    lines.append("작업 내용")
     if proposal.body_excerpt:
-        lines.append("📋 무엇이 바뀌나")
-        lines.append(proposal.body_excerpt)
-        lines.append("")
+        lines.append(f"- {proposal.body_excerpt}")
+    else:
+        lines.append(f"- PR #{proposal.pr_number} 머지")
+    lines.append("")
 
+    lines.append("목적")
+    is_draft_escalation = bool(
+        (proposal.extra or {}).get("draft_escalation")
+    )
+    if is_draft_escalation:
+        lines.append("- draft PR 을 ready for review 로 전환한 뒤 머지")
+    else:
+        lines.append("- 검토 완료된 PR 을 머지하여 다음 작업 단계 진행")
+    lines.append("")
+
+    lines.append("영향 범위")
     if proposal.scope_labels:
         scope = " / ".join(proposal.scope_labels)
-        lines.append(f"🎯 영향 범위: {scope}")
-
+        lines.append(f"- {scope}")
+    else:
+        lines.append(f"- {proposal.repo} (base: {proposal.base_branch})")
     risk_label = {
         "LOW": "LOW",
         "MEDIUM": "MEDIUM",
@@ -283,15 +300,23 @@ def render_pr_merge_summary(proposal: PRMergeProposal) -> str:
     risk_emoji = {"LOW": "🟢", "MEDIUM": "🟡", "HIGH": "🔴"}.get(
         risk_label, "⚠️"
     )
-    lines.append(f"{risk_emoji} 위험도: {risk_label}")
-
+    lines.append(f"- 위험도: {risk_emoji} {risk_label}")
     if proposal.check_runs_summary:
-        lines.append(proposal.check_runs_summary)
+        lines.append(f"- {proposal.check_runs_summary}")
     if proposal.branch_protection_summary:
-        lines.append(proposal.branch_protection_summary)
+        lines.append(f"- {proposal.branch_protection_summary}")
+    lines.append("")
+
+    lines.append("다음 단계")
+    if is_draft_escalation:
+        lines.append(
+            "- 승인 시 ready_for_review 전환 → 5-step gate 재실행 → merge"
+        )
+    else:
+        lines.append("- 승인 시 5-step gate 통과 후 머지 + 다음 slice 진행")
+    lines.append("")
 
     if proposal.pr_url:
-        lines.append("")
         lines.append(f"🔗 {proposal.pr_url}")
         lines.append("")
 

--- a/src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py
+++ b/src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py
@@ -290,6 +290,28 @@ def promote_session_to_coding_ready(
         },
     )
 
+    # P1-Z4 C — anchor stamp + coding_job=ready 직후 tracking_validation
+    # 재평가.  옛 wiring 은 intake 시점 needs_issue 가 그대로 남아 operator
+    # surface 가 "아직 issue 없어 멈춤" 처럼 보이던 회귀 차단.
+    try:
+        from ..coding.tracking_refresh import (
+            SESSION_EXTRA_TRACKING_KEY,
+            refresh_tracking_validation,
+        )
+
+        class _ProxySession:
+            extra = None
+
+        proxy = _ProxySession()
+        proxy.extra = extra
+        refresh_result = refresh_tracking_validation(
+            session=proxy, triggered_by="coding_job_ready"
+        )
+        if refresh_result.new_validation:
+            extra[SESSION_EXTRA_TRACKING_KEY] = dict(refresh_result.new_validation)
+    except Exception:  # noqa: BLE001
+        pass
+
     return ContinuationOutcome(
         promoted=True,
         coding_job=job_payload,

--- a/src/yule_orchestrator/agents/lifecycle/session_mode.py
+++ b/src/yule_orchestrator/agents/lifecycle/session_mode.py
@@ -61,6 +61,25 @@ EXTRA_SCOPE = "scope"
 EXTRA_DECIDED_AT = "mode_decided_at"
 EXTRA_DECIDED_BY = "mode_decided_by"
 
+# P1-R — intake governance contract 확장.  사용자 명시 5 새 키.  운영자가
+# 한눈에 "이 세션은 어떤 거버넌스 모드인지" 보고 라우터 / executor /
+# merge continuation 도 분기 시 동일 contract 를 본다.
+BRANCH_STRATEGY_GIT_FLOW = "git_flow"
+BRANCH_STRATEGY_VALUES = (BRANCH_STRATEGY_GIT_FLOW,)
+BRANCH_STRATEGY_DEFAULT = BRANCH_STRATEGY_GIT_FLOW
+
+RELEASE_STRATEGY_TAGGED = "tagged_release"
+RELEASE_STRATEGY_VALUES = (RELEASE_STRATEGY_TAGGED,)
+RELEASE_STRATEGY_DEFAULT = RELEASE_STRATEGY_TAGGED
+
+ISSUE_POLICY_REQUIRED = "issue_required"
+ISSUE_POLICY_VALUES = (ISSUE_POLICY_REQUIRED,)
+ISSUE_POLICY_DEFAULT = ISSUE_POLICY_REQUIRED
+
+EXTRA_BRANCH_STRATEGY = "branch_strategy"
+EXTRA_RELEASE_STRATEGY = "release_strategy"
+EXTRA_ISSUE_POLICY = "issue_policy"
+
 
 @dataclass(frozen=True)
 class SessionMode:
@@ -326,10 +345,34 @@ def parse_mode_hints(text: str) -> Mapping[str, Optional[str]]:
     value ``None`` when not detected. Never raises.
     """
 
-    out: dict = {"work_mode": None, "topology": None, "scope": None}
+    out: dict = {
+        "work_mode": None,
+        "topology": None,
+        "scope": None,
+        # P1-R — intake governance contract 확장.  prompt 토큰으로 명시
+        # 가능; 명시 없으면 default (git_flow / tagged_release / issue_required).
+        "branch_strategy": None,
+        "release_strategy": None,
+        "issue_policy": None,
+    }
     if not text:
         return out
     lowered = text.lower()
+
+    # branch_strategy / release_strategy / issue_policy
+    if any(
+        token in lowered for token in ("git_flow", "git-flow", "git flow")
+    ):
+        out["branch_strategy"] = BRANCH_STRATEGY_GIT_FLOW
+    if any(
+        token in lowered
+        for token in ("tagged_release", "tagged release", "tag release")
+    ):
+        out["release_strategy"] = RELEASE_STRATEGY_TAGGED
+    if any(
+        token in lowered for token in ("issue_required", "issue required")
+    ):
+        out["issue_policy"] = ISSUE_POLICY_REQUIRED
 
     # work_mode
     if any(
@@ -395,6 +438,39 @@ def _persist(
     extra[EXTRA_SCOPE] = scope
     extra[EXTRA_DECIDED_BY] = decided_by
     extra[EXTRA_DECIDED_AT] = _now_iso(now)
+    # P1-R — intake governance contract 확장.  branch_strategy /
+    # release_strategy / issue_policy 도 같이 영속 — 모두 default 값.
+    # 명시적 override 는 ensure_session_mode_governance 헬퍼 또는 직접
+    # caller 가 prompt 파싱 후 setdefault 로 가능.
+    extra.setdefault(EXTRA_BRANCH_STRATEGY, BRANCH_STRATEGY_DEFAULT)
+    extra.setdefault(EXTRA_RELEASE_STRATEGY, RELEASE_STRATEGY_DEFAULT)
+    extra.setdefault(EXTRA_ISSUE_POLICY, ISSUE_POLICY_DEFAULT)
+
+
+def apply_governance_hints(
+    extra: dict,
+    *,
+    branch_strategy: Optional[str] = None,
+    release_strategy: Optional[str] = None,
+    issue_policy: Optional[str] = None,
+) -> None:
+    """P1-R — prompt 파싱 결과 (또는 explicit override) 를 extra 에 머지.
+
+    값이 None 또는 알 수 없는 값이면 default 보존.  명시 hint 만 영속.
+    """
+
+    if branch_strategy and branch_strategy in BRANCH_STRATEGY_VALUES:
+        extra[EXTRA_BRANCH_STRATEGY] = branch_strategy
+    elif EXTRA_BRANCH_STRATEGY not in extra:
+        extra[EXTRA_BRANCH_STRATEGY] = BRANCH_STRATEGY_DEFAULT
+    if release_strategy and release_strategy in RELEASE_STRATEGY_VALUES:
+        extra[EXTRA_RELEASE_STRATEGY] = release_strategy
+    elif EXTRA_RELEASE_STRATEGY not in extra:
+        extra[EXTRA_RELEASE_STRATEGY] = RELEASE_STRATEGY_DEFAULT
+    if issue_policy and issue_policy in ISSUE_POLICY_VALUES:
+        extra[EXTRA_ISSUE_POLICY] = issue_policy
+    elif EXTRA_ISSUE_POLICY not in extra:
+        extra[EXTRA_ISSUE_POLICY] = ISSUE_POLICY_DEFAULT
 
 
 def _now_iso(now: Optional[datetime]) -> str:
@@ -410,10 +486,23 @@ def _str_or_none(value: Any) -> Optional[str]:
 
 
 __all__ = (
+    "BRANCH_STRATEGY_DEFAULT",
+    "BRANCH_STRATEGY_GIT_FLOW",
+    "BRANCH_STRATEGY_VALUES",
     "DECIDED_BY_INFERRED",
     "DECIDED_BY_USER",
+    "EXTRA_BRANCH_STRATEGY",
     "EXTRA_DECIDED_AT",
     "EXTRA_DECIDED_BY",
+    "EXTRA_ISSUE_POLICY",
+    "EXTRA_RELEASE_STRATEGY",
+    "ISSUE_POLICY_DEFAULT",
+    "ISSUE_POLICY_REQUIRED",
+    "ISSUE_POLICY_VALUES",
+    "RELEASE_STRATEGY_DEFAULT",
+    "RELEASE_STRATEGY_TAGGED",
+    "RELEASE_STRATEGY_VALUES",
+    "apply_governance_hints",
     "EXTRA_SCOPE",
     "EXTRA_TOPOLOGY",
     "EXTRA_WORK_MODE",

--- a/src/yule_orchestrator/cli/engineer.py
+++ b/src/yule_orchestrator/cli/engineer.py
@@ -54,6 +54,59 @@ def run_engineer_approve_command(repo_root: Path, agent_id: str, session_id: str
     orchestrator = _build_orchestrator(repo_root, agent_id)
     session = orchestrator.approve(session_id)
     print(f"approved session={session.session_id} state={session.state.value}", file=sys.stderr)
+
+    # P1-Z A — approved + issue_required + no anchor → work_order dispatch.
+    # Discord approval reply 와 같은 continuation contract.  옛 wiring 은
+    # CLI 가 state 만 approved 로 flipped 하고 work_order 는 영원히 안
+    # 만들어져 ``tracking_validation=needs_issue`` 의 dead-end 였다.
+    try:
+        from ..agents.job_queue.post_approval_dispatch import (
+            ACTION_DISPATCHED,
+            ACTION_FAILED,
+            dispatch_post_approval_work_order,
+        )
+        from ..agents.job_queue.store import JobQueue
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"post-approval dispatch: import failed ({type(exc).__name__}) — "
+            "skipping work_order continuation",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        queue = JobQueue()
+        outcome = dispatch_post_approval_work_order(
+            session=session,
+            queue=queue,
+            requested_by=agent_id or "engineer-cli",
+            approved_by=agent_id or "engineer-cli",
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"post-approval dispatch: raised ({type(exc).__name__}: {exc}) — "
+            "session approved but no work_order enqueued",
+            file=sys.stderr,
+        )
+        return 0
+
+    action = outcome.get("action")
+    if action == ACTION_DISPATCHED:
+        print(
+            f"post-approval work_order dispatched: job={outcome.get('job_id')} "
+            f"repo={outcome.get('repo')} approval={outcome.get('approval_id')}",
+            file=sys.stderr,
+        )
+    elif action == ACTION_FAILED:
+        print(
+            f"post-approval dispatch failed: reason={outcome.get('reason')}",
+            file=sys.stderr,
+        )
+    else:  # noop
+        print(
+            f"post-approval dispatch noop: reason={outcome.get('reason')}",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -296,6 +296,52 @@ def _register_engineering_commands_impl(
                 discord_module=discord,
             )
 
+    # P1-R-2 — governance contract 명시 옵션 choices.
+    # 옛 wiring 은 운영자가 prompt 첫 줄에 ``autonomous_merge, git_flow,
+    # tagged_release, issue_required`` 문자열로 적어야 했다.  명시 필드로
+    # 받으면 (1) 누락 / 오타 0, (2) UI 에서 governance 확정, (3) prompt
+    # 본문은 업무 내용에만 집중.  prompt token 은 fallback 으로 유지.
+    #
+    # 옛 test stub 의 app_commands 모듈에는 Choice / choices 데코레이터가
+    # 없을 수 있어서 graceful fallback — Choice 미지원 환경에서는 옵션
+    # 없이 command 만 등록 (CI 환경에서도 호환).
+    _Choice_cls = getattr(app_commands, "Choice", None)
+    _choices_decorator = getattr(app_commands, "choices", None)
+
+    def _build_choices(*pairs: tuple) -> Optional[list]:
+        if _Choice_cls is None:
+            return None
+        return [_Choice_cls(name=n, value=v) for (n, v) in pairs]
+
+    _WORK_MODE_CHOICES = _build_choices(
+        ("approval_required (사람 승인 필수)", "approval_required"),
+        ("autonomous_merge (자율 머지)", "autonomous_merge"),
+    )
+    _BRANCH_STRATEGY_CHOICES = _build_choices(
+        ("git_flow (feature/release/hotfix prefix)", "git_flow"),
+    )
+    _RELEASE_STRATEGY_CHOICES = _build_choices(
+        ("tagged_release (semver vX.Y.Z tag)", "tagged_release"),
+    )
+    _ISSUE_POLICY_CHOICES = _build_choices(
+        ("issue_required (issue-N anchor 필수)", "issue_required"),
+    )
+    _TOPOLOGY_CHOICES = _build_choices(
+        ("single_repo (단일 repo)", "single_repo"),
+        ("multi_repo (여러 repo)", "multi_repo"),
+    )
+    _SCOPE_CHOICES = _build_choices(
+        ("single_scope (단일 범위)", "single_scope"),
+        ("full_stack_single_repo (단일 repo 풀스택)", "full_stack_single_repo"),
+        ("layer_scoped (레이어 한정)", "layer_scoped"),
+        ("cross_repo_program (여러 repo 프로그램)", "cross_repo_program"),
+    )
+
+    def _maybe_choices_decorator(**kwargs):
+        if _choices_decorator is None or any(v is None for v in kwargs.values()):
+            return lambda fn: fn
+        return _choices_decorator(**kwargs)
+
     @bot.tree.command(
         name="engineer_intake",
         description="engineering-agent에게 작업을 위임합니다 (접수 메시지를 채널에 게시).",
@@ -305,13 +351,41 @@ def _register_engineering_commands_impl(
         prompt="자연어 작업 요청.",
         task_type="명시 task type (생략 시 키워드 분류).",
         write_requested="이 작업이 코드/문서 쓰기를 요구하는지 여부.",
+        work_mode="자율 머지 / 사람 승인 모드 (생략 시 prompt 파싱 → default).",
+        branch_strategy="브랜치 전략 (생략 시 git_flow 기본).",
+        release_strategy="릴리즈 전략 (생략 시 tagged_release 기본).",
+        issue_policy="이슈 정책 (생략 시 issue_required 기본).",
+        topology="작업 대상 repo 갯수 (생략 시 single_repo).",
+        scope="작업 깊이 (생략 시 single_scope).",
+    )
+    @_maybe_choices_decorator(
+        work_mode=_WORK_MODE_CHOICES,
+        branch_strategy=_BRANCH_STRATEGY_CHOICES,
+        release_strategy=_RELEASE_STRATEGY_CHOICES,
+        issue_policy=_ISSUE_POLICY_CHOICES,
+        topology=_TOPOLOGY_CHOICES,
+        scope=_SCOPE_CHOICES,
     )
     async def engineer_intake(
         interaction: "discord.Interaction",
         prompt: str,
         task_type: Optional[str] = None,
         write_requested: bool = False,
+        work_mode: Optional["app_commands.Choice[str]"] = None,
+        branch_strategy: Optional["app_commands.Choice[str]"] = None,
+        release_strategy: Optional["app_commands.Choice[str]"] = None,
+        issue_policy: Optional["app_commands.Choice[str]"] = None,
+        topology: Optional["app_commands.Choice[str]"] = None,
+        scope: Optional["app_commands.Choice[str]"] = None,
     ) -> None:
+        # Choice → 원시 문자열 (또는 None) 추출
+        def _v(opt: Any) -> Optional[str]:
+            if opt is None:
+                return None
+            return getattr(opt, "value", None) or (
+                opt if isinstance(opt, str) else None
+            )
+
         try:
             if not await _safe_defer(interaction, discord_module=discord):
                 return
@@ -323,6 +397,12 @@ def _register_engineering_commands_impl(
                     write_requested=write_requested,
                     channel_id=interaction.channel_id,
                     user_id=interaction.user.id,
+                    explicit_work_mode=_v(work_mode),
+                    explicit_branch_strategy=_v(branch_strategy),
+                    explicit_release_strategy=_v(release_strategy),
+                    explicit_issue_policy=_v(issue_policy),
+                    explicit_topology=_v(topology),
+                    explicit_scope=_v(scope),
                 )
             except (WorkflowError, ValueError) as exc:
                 await _send_message_chunks(
@@ -707,6 +787,12 @@ def _run_engineer_intake(
     write_requested: bool,
     channel_id: Optional[int],
     user_id: Optional[int],
+    explicit_work_mode: Optional[str] = None,
+    explicit_branch_strategy: Optional[str] = None,
+    explicit_release_strategy: Optional[str] = None,
+    explicit_issue_policy: Optional[str] = None,
+    explicit_topology: Optional[str] = None,
+    explicit_scope: Optional[str] = None,
 ):
     parsed: Optional[TaskType] = None
     if task_type:
@@ -725,15 +811,22 @@ def _run_engineer_intake(
         user_id=user_id,
     )
 
-    # P1-M A — slash command path 도 session.extra 에 work_mode /
-    # topology / scope / mode_decided_* 를 영속해야 한다. 옛 wiring 은
-    # 채널 router path 만 ``prepare_coding_session_context`` 를 거쳤기
-    # 때문에 `/engineer_intake` 슬래시 세션은 work_mode=None 으로 떨어졌고,
-    # background pr_merge_continuation_loop 가 approval_required 로 fallback
-    # 됐다 (회귀: session fe5eedc65196).
+    # P1-M A + P1-R-2 — slash command path 가 session.extra 에 거버넌스
+    # contract (work_mode / topology / scope / branch_strategy /
+    # release_strategy / issue_policy + mode_decided_*) 영속.  옛 wiring
+    # 은 prompt 토큰만 파싱했지만 P1-R-2 부터 명시 옵션이 prompt 보다
+    # 강한 우선순위.
+    governance_summary: Optional[Mapping[str, Any]] = None
     try:
-        _persist_intake_mode_and_backlog(
-            session=result.session, prompt_text=prompt
+        governance_summary = _persist_intake_mode_and_backlog(
+            session=result.session,
+            prompt_text=prompt,
+            explicit_work_mode=explicit_work_mode,
+            explicit_branch_strategy=explicit_branch_strategy,
+            explicit_release_strategy=explicit_release_strategy,
+            explicit_issue_policy=explicit_issue_policy,
+            explicit_topology=explicit_topology,
+            explicit_scope=explicit_scope,
         )
     except Exception:  # noqa: BLE001 - never block intake response
         import logging
@@ -742,6 +835,16 @@ def _run_engineer_intake(
             "engineer_intake: mode/backlog 영속화 실패 — 본문 응답은 그대로 진행",
             exc_info=True,
         )
+
+    # P1-R-2 C — operator 가 접수 직후 governance contract 를 한눈에 본다.
+    # result.message 끝에 한국어 1 줄 + 6 키 + source 토큰 append.
+    if governance_summary is not None:
+        try:
+            result = _append_governance_block_to_result(
+                result, governance_summary
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     # P0-T smoke fix (session c5278a9043f2 repro):
     # /engineer_intake 슬래시 명령이 issue-less full-stack coding 요청을
@@ -768,39 +871,151 @@ def _run_engineer_intake(
 
 
 def _persist_intake_mode_and_backlog(
-    *, session: Any, prompt_text: str
-) -> None:
-    """P1-M — slash command intake 직후 mode/backlog 영속화.
+    *,
+    session: Any,
+    prompt_text: str,
+    explicit_work_mode: Optional[str] = None,
+    explicit_branch_strategy: Optional[str] = None,
+    explicit_release_strategy: Optional[str] = None,
+    explicit_issue_policy: Optional[str] = None,
+    explicit_topology: Optional[str] = None,
+    explicit_scope: Optional[str] = None,
+) -> Optional[Mapping[str, Any]]:
+    """P1-M + P1-R-2 — slash command intake 직후 governance + backlog 영속.
 
-    1. ``prepare_coding_session_context`` 로 work_mode/topology/scope
-       /mode_decided_* 계산 후 session.extra 머지.
-    2. full_stack_single_repo 의도면 ``seed_coding_backlog`` 호출해
-       backlog 8 개 slice 를 stamp (이미 있으면 보존).
+    우선순위: **slash option > prompt token > default**.
+
+    1. ``prepare_coding_session_context`` 가 prompt 파싱 결과를 영속.
+    2. explicit slash option 이 있으면 그 값으로 덮어쓰기 + ``mode_decided_by``
+       를 ``slash_option_explicit`` 으로 갱신.
+    3. ``seed_coding_backlog`` — full-stack 의도면 backlog 8-slice stamp.
+
+    Returns:
+        영속된 governance contract dict (operator surface 용).  세션 없거나
+        실패하면 None.
     """
 
     if session is None:
-        return
+        return None
     try:
         from ..engineering_channel_router.session_persistence import (
             _persist_coding_session_context,
         )
     except Exception:  # noqa: BLE001 - partial install
-        return
+        return None
 
     refs = list(getattr(session, "references_user", None) or ())
     user_links = tuple(str(r) for r in refs)
-    _persist_coding_session_context(
+    persisted_session = _persist_coding_session_context(
         session,
         message_text=prompt_text or "",
         user_links=user_links,
     )
+    target_session = persisted_session or session
+
+    # P1-R-2 B — explicit slash option 이 prompt parse 결과보다 우선.
+    # session.extra 를 직접 갱신.
+    explicit_overrides: dict = {}
+    if explicit_work_mode:
+        explicit_overrides["work_mode"] = explicit_work_mode
+    if explicit_branch_strategy:
+        explicit_overrides["branch_strategy"] = explicit_branch_strategy
+    if explicit_release_strategy:
+        explicit_overrides["release_strategy"] = explicit_release_strategy
+    if explicit_issue_policy:
+        explicit_overrides["issue_policy"] = explicit_issue_policy
+    if explicit_topology:
+        explicit_overrides["topology"] = explicit_topology
+    if explicit_scope:
+        explicit_overrides["scope"] = explicit_scope
+
+    if explicit_overrides:
+        try:
+            from dataclasses import replace as _replace
+            from datetime import datetime, timezone as _tz
+            from ...agents.workflow_state import (
+                load_session as _load,
+                update_session as _update,
+            )
+
+            sid = getattr(target_session, "session_id", None)
+            fresh = _load(sid) if sid else None
+            if fresh is not None:
+                new_extra = dict(getattr(fresh, "extra", None) or {})
+                for k, v in explicit_overrides.items():
+                    new_extra[k] = v
+                # source 토큰 — slash option 이 적어도 하나 있으면 explicit.
+                new_extra["mode_decided_by"] = "slash_option_explicit"
+                new_extra["mode_decided_at"] = (
+                    datetime.now(tz=_tz.utc)
+                    .replace(microsecond=0)
+                    .isoformat()
+                )
+                _update(
+                    _replace(fresh, extra=new_extra),
+                    now=datetime.now(tz=_tz.utc),
+                )
+                target_session = _replace(fresh, extra=new_extra)
+        except Exception:  # noqa: BLE001 - never block intake
+            pass
 
     try:
         from ...agents.coding.coding_backlog_seed import seed_coding_backlog
 
-        seed_coding_backlog(session_id=getattr(session, "session_id", None))
+        seed_coding_backlog(session_id=getattr(target_session, "session_id", None))
     except Exception:  # noqa: BLE001
-        return
+        pass
+
+    # operator surface 용 governance summary 반환
+    extra = getattr(target_session, "extra", None) or {}
+    if not isinstance(extra, Mapping):
+        return None
+    return {
+        "work_mode": extra.get("work_mode"),
+        "topology": extra.get("topology"),
+        "scope": extra.get("scope"),
+        "branch_strategy": extra.get("branch_strategy"),
+        "release_strategy": extra.get("release_strategy"),
+        "issue_policy": extra.get("issue_policy"),
+        "mode_decided_by": extra.get("mode_decided_by"),
+        "mode_decided_at": extra.get("mode_decided_at"),
+    }
+
+
+def _append_governance_block_to_result(result: Any, summary: Mapping[str, Any]) -> Any:
+    """P1-R-2 C — intake result.message 끝에 한국어 governance block append.
+
+    result 는 ``IntakeResult`` 류 — ``message`` 속성을 가진 dataclass.  immutable
+    이면 ``dataclasses.replace`` 로 새 instance 반환.  속성이 없으면 원본 그대로.
+    """
+
+    lines = [
+        "",
+        "🛡 거버넌스 contract (intake 시점에 확정):",
+        f"- 작업 모드: `{summary.get('work_mode') or '(미정)'}`",
+        f"- 토폴로지: `{summary.get('topology') or '(미정)'}`",
+        f"- 범위: `{summary.get('scope') or '(미정)'}`",
+        f"- 브랜치 전략: `{summary.get('branch_strategy') or '(미정)'}`",
+        f"- 릴리즈 전략: `{summary.get('release_strategy') or '(미정)'}`",
+        f"- 이슈 정책: `{summary.get('issue_policy') or '(미정)'}`",
+        f"- 결정 출처: `{summary.get('mode_decided_by') or '(미정)'}`",
+    ]
+    block = "\n".join(lines)
+    existing = getattr(result, "message", None)
+    if not isinstance(existing, str):
+        return result
+    new_message = existing.rstrip() + "\n" + block
+    try:
+        from dataclasses import replace as _replace
+
+        return _replace(result, message=new_message)
+    except TypeError:
+        # not a dataclass — try direct attribute set
+        try:
+            object.__setattr__(result, "message", new_message)
+        except Exception:  # noqa: BLE001
+            pass
+        return result
 
 
 def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -1061,12 +1061,20 @@ def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:
         if isinstance(extra_for_strategy, Mapping)
         else "implementation"
     )
+    # P1-Z6 C — toplevel_paths 가 비어있을 때 local target repo checkout
+    # 을 직접 scan.  ``_default_repo_root_resolver`` 가 env / sibling 디렉터리
+    # / orchestrator self-repo 까지 검사 → canonical case
+    # (``naver-search-clone``) 에서 apps/api + apps/web 인지 가능.
+    workspace_root: Optional[str] = None
+    if not toplevel_paths:
+        workspace_root = _resolve_local_target_repo_root(session, prompt_text)
     try:
         strategy = synthesize_implementation_strategy(
             user_request=prompt_text or "",
             toplevel_paths=toplevel_paths,
             lifecycle_mode=lifecycle_mode,
             topology="single_repo",
+            workspace_root=workspace_root,
         )
     except Exception:  # noqa: BLE001
         strategy = None
@@ -1085,6 +1093,45 @@ def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:
         _persist_coding_proposal(session, proposal)
     except Exception:  # noqa: BLE001
         return
+
+
+def _resolve_local_target_repo_root(
+    session: Any, prompt_text: str
+) -> Optional[str]:
+    """P1-Z6 C — repo_full_name → local checkout 디렉터리 resolution.
+
+    intake 시점에는 worktree provisioning 전.  하지만 operator 가 이미
+    local 에 target repo 를 clone 해뒀으면 그 경로의 toplevel 디렉터리만
+    있어도 strategy 가 정확한 결정 가능.
+
+    ``_default_repo_root_resolver`` 가 env (``YULE_CODING_EXECUTOR_REPO_ROOTS_JSON``
+    / ``..._SEARCH_ROOTS``) + sibling 디렉터리까지 검색.  resolver 가
+    None 반환하면 (없으면) caller 는 None workspace_root 로 strategy
+    호출 → greenfield fallback.
+    """
+
+    try:
+        from ...agents.job_queue.coding_executor_live import (
+            _default_repo_root_resolver,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+    repo_full_name = _extract_repo_from_session(session, prompt_text)
+    if not repo_full_name:
+        return None
+
+    try:
+        from pathlib import Path
+
+        orchestrator_root = str(Path.cwd())
+        resolved, _searched = _default_repo_root_resolver(
+            repo_full_name,
+            orchestrator_repo_root=orchestrator_root,
+        )
+        return resolved
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _gather_repo_toplevel_paths_from_session(session: Any) -> tuple:

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -1137,7 +1137,9 @@ def _maybe_post_intake_approval_card(
     )
     from ..integrations.github_workos_adapter import (
         enqueue_github_work_approval,
-        should_route_to_github_workos,
+    )
+    from ..integrations.intake_approval_eligibility import (
+        decide_intake_approval_card_eligibility,
     )
 
     # intake 직후 session.extra 는 비어있을 수 있으므로 adapter 가 인식할
@@ -1163,10 +1165,14 @@ def _maybe_post_intake_approval_card(
             except Exception:  # noqa: BLE001
                 pass
 
-    eligible, reason, _ = should_route_to_github_workos(
-        session=session, request_text=prompt_text
+    # P1-Z4 A — should_route_to_github_workos 의 prompt phrase 게이트 대신
+    # 구조 신호 (write_requested + lifecycle + github_target + handoff_packet)
+    # 만으로 판단.  canonical session ``000f13fb121b`` 가 자연어 prompt
+    # 때문에 카드 누락된 회귀 직접 차단.
+    decision = decide_intake_approval_card_eligibility(
+        session=session, prompt_text=prompt_text
     )
-    if not eligible:
+    if not decision.eligible:
         return
 
     # P0-W — slash intake 가 coding intent 로 인정된 시점에 즉시
@@ -1198,6 +1204,10 @@ def _maybe_post_intake_approval_card(
             approval_worker=worker,
             requested_by=requested_by,
             repo=resolved_repo,
+            # P1-Z4 A — intake-time gate 가 이미 구조 신호로 통과시킴.
+            # builder 의 prompt phrase 게이트 우회 → 자연어 prompt 도
+            # 카드 게시 가능.
+            trust_session_signals=True,
         )
 
     try:

--- a/src/yule_orchestrator/discord/commands/__init__.py
+++ b/src/yule_orchestrator/discord/commands/__init__.py
@@ -1040,16 +1040,42 @@ def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:
 
     try:
         from ...agents.coding.authorization import recommend_authorization
+        from ...agents.coding.implementation_strategy import (
+            synthesize_implementation_strategy,
+        )
         from ..engineering_channel_router.session_persistence import (
             _persist_coding_proposal,
         )
     except Exception:  # noqa: BLE001 - partial install fallback
         return
 
+    # P1-Z5 — tech-lead/orchestrator 가 먼저 implementation strategy 를
+    # synthesise.  full-stack-app + single_repo intake 에서 repo layout +
+    # user request 신호로 first_slice_owner / write_scope 결정.  옛 wiring
+    # 은 manifest 의 placeholder ``src/<service>/...`` 가 그대로 내려와
+    # ``write_scope_resolved_empty`` 회귀 발생.
+    toplevel_paths = _gather_repo_toplevel_paths_from_session(session)
+    extra_for_strategy = getattr(session, "extra", None) or {}
+    lifecycle_mode = (
+        str(extra_for_strategy.get("lifecycle_mode") or "implementation")
+        if isinstance(extra_for_strategy, Mapping)
+        else "implementation"
+    )
+    try:
+        strategy = synthesize_implementation_strategy(
+            user_request=prompt_text or "",
+            toplevel_paths=toplevel_paths,
+            lifecycle_mode=lifecycle_mode,
+            topology="single_repo",
+        )
+    except Exception:  # noqa: BLE001
+        strategy = None
+
     try:
         proposal = recommend_authorization(
             user_request=prompt_text or "",
             session_id=getattr(session, "session_id", None),
+            implementation_strategy=strategy,
         )
     except Exception:  # noqa: BLE001 - never block intake on proposal failure
         return
@@ -1059,6 +1085,37 @@ def _ensure_coding_proposal_on_session(session: Any, prompt_text: str) -> None:
         _persist_coding_proposal(session, proposal)
     except Exception:  # noqa: BLE001
         return
+
+
+def _gather_repo_toplevel_paths_from_session(session: Any) -> tuple:
+    """session.extra 안에서 repo top-level 디렉터리 신호 수집.
+
+    P1-Z5 — order: repo_contract.toplevel_paths (있으면) > coding_handoff_packet
+    .repo_contract.toplevel_paths > 빈 튜플 (greenfield 로 처리됨).  worktree
+    scan 까지는 intake 단계에서 안 함 (provisioning 전).  caller 가 명시
+    hint 를 ``extra["repo_toplevel_paths"]`` 로 줄 수 있다.
+    """
+
+    extra = getattr(session, "extra", None) or {}
+    if not isinstance(extra, Mapping):
+        return ()
+    candidates: list[str] = []
+    explicit = extra.get("repo_toplevel_paths")
+    if isinstance(explicit, (list, tuple)):
+        candidates.extend(str(p) for p in explicit if str(p).strip())
+    contract = extra.get("repo_contract")
+    if isinstance(contract, Mapping):
+        tops = contract.get("toplevel_paths")
+        if isinstance(tops, (list, tuple)):
+            candidates.extend(str(p) for p in tops if str(p).strip())
+    handoff = extra.get("coding_handoff_packet")
+    if isinstance(handoff, Mapping):
+        packet_contract = handoff.get("repo_contract")
+        if isinstance(packet_contract, Mapping):
+            tops = packet_contract.get("toplevel_paths")
+            if isinstance(tops, (list, tuple)):
+                candidates.extend(str(p) for p in tops if str(p).strip())
+    return tuple(dict.fromkeys(candidates))
 
 
 def _extract_repo_from_session(session: Any, prompt_text: str) -> Optional[str]:

--- a/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
+++ b/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
@@ -574,6 +574,7 @@ async def enqueue_github_work_approval(
     repo_contract: Optional[RepoContract] = None,
     issue_template_loader: Optional[Callable[[str], Optional[str]]] = None,
     existing_issue_number: Optional[int] = None,
+    trust_session_signals: bool = False,
 ) -> GitHubWorkApprovalOutcome:
     """Build a proposal + enqueue (and optionally post) the approval card.
 
@@ -604,11 +605,16 @@ async def enqueue_github_work_approval(
         repo_contract=repo_contract,
         issue_template_loader=issue_template_loader,
         existing_issue_number=existing_issue_number,
+        # P1-Z4 A — intake-time approval card 또는 trusted continuation
+        # 경로면 builder 의 prompt phrase 게이트를 우회.  caller (slash
+        # intake helper) 가 이미 구조 신호로 eligibility 통과시켰음.
+        approved_continuation=trust_session_signals,
     )
     if proposal is None:
         eligible, skipped_reason, _ = should_route_to_github_workos(
             session=session,
             request_text=request_text,
+            approved_continuation=trust_session_signals,
         )
         return GitHubWorkApprovalOutcome(
             proposal=None,

--- a/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
+++ b/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
@@ -361,13 +361,20 @@ def _minimal_repo_contract_from_repo(repo: Optional[str]) -> Optional[RepoContra
 def _coerce_existing_issue(
     explicit: Optional[int], session: Any
 ) -> Optional[int]:
-    """Caller-provided existing issue > session anchor > None.
+    """Caller-provided existing issue > prompt anchor > session anchor > None.
 
-    The anchor key (``github_work_order_issue.issue_number``) is set by
-    a previous run of :class:`GitHubWorkOrderWorker` after a successful
-    auto-create. If the operator restarts the flow for the same session
-    (e.g. re-runs intake), we treat the existing anchor as the issue
-    number so a second issue isn't created.
+    Priority (P1-U):
+
+      1. ``explicit`` (slash option / caller-injected) — strongest signal.
+      2. ``session.extra["existing_issue_number"]`` — prompt URL / `#N`
+         / `issue N` anchor extracted by ``prepare_coding_session_context``.
+      3. ``session.extra["github_work_order_issue"].issue_number`` — anchor
+         stamped by a previous run of :class:`GitHubWorkOrderWorker` after
+         a successful auto-create.
+
+    옛 wiring 은 (2) 가 없어서 사용자가 prompt 에 issue URL / `#5` 를
+    명시해도 work_order 가 auto-create 로 새 issue 를 생성했다.  본
+    helper 가 (2) 우선순위로 잡아 reuse 강제.
     """
 
     if explicit is not None:
@@ -380,6 +387,18 @@ def _coerce_existing_issue(
     extra = getattr(session, "extra", None)
     if not isinstance(extra, Mapping):
         return None
+
+    # P1-U — prompt URL / 텍스트 anchor 우선
+    prompt_anchor = extra.get("existing_issue_number")
+    if prompt_anchor is not None:
+        try:
+            value = int(prompt_anchor)
+        except (TypeError, ValueError):
+            value = 0
+        if value > 0:
+            return value
+
+    # 옛 anchor (이미 auto-create 거친 세션의 anchor)
     anchor = extra.get("github_work_order_issue")
     if not isinstance(anchor, Mapping):
         return None

--- a/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
+++ b/src/yule_orchestrator/discord/integrations/github_workos_adapter.py
@@ -165,6 +165,7 @@ def should_route_to_github_workos(
     *,
     session: Any,
     request_text: str,
+    approved_continuation: bool = False,
 ) -> Tuple[bool, str, Optional[str]]:
     """Return ``(eligible, skipped_reason, kind_hint)``.
 
@@ -172,6 +173,16 @@ def should_route_to_github_workos(
     proposal. ``skipped_reason`` is one of the ``SKIPPED_*`` constants
     or ``""`` when eligible. ``kind_hint`` is the lifecycle_mode for
     debugging.
+
+    P1-Z3 — *approved_continuation* True 면 fresh intake 가 아니라
+    이미 approved 된 세션의 work_order continuation 경로.  intake 단계
+    에서 ``lifecycle_mode`` / ``github_target`` / ``coding_handoff_packet``
+    이 이미 stamp 됐고, decide_post_approval_action 이 false-positive
+    가드까지 통과시킨 상태.  따라서 prompt phrase 기반 coding-intent
+    재판정은 **건너뛴다** — structured signals 가 더 강한 source of truth.
+
+    그러나 ``lifecycle_mode == "research_only"`` 와 obsidian intent 는
+    어떤 경우든 reject — operator 명시 의도 / domain mismatch 보호.
     """
 
     if detect_obsidian_intent(request_text):
@@ -184,6 +195,12 @@ def should_route_to_github_workos(
     lifecycle = str(extra.get("lifecycle_mode") or "").strip().lower()
     if lifecycle == "research_only":
         return False, SKIPPED_RESEARCH_ONLY, lifecycle
+
+    if approved_continuation:
+        # P1-Z3 — structured signals 신뢰.  prompt phrase 가 약해도
+        # decide_post_approval_action 이 이미 lifecycle + target + packet
+        # / proposal / anchor / terminal / repo 모든 가드 통과 검증함.
+        return True, "", lifecycle or None
 
     intent = detect_coding_intent(request_text)
     if intent.research_only:
@@ -222,6 +239,7 @@ def build_github_work_order_proposal(
     repo_contract: Optional[RepoContract] = None,
     issue_template_loader: Optional[Callable[[str], Optional[str]]] = None,
     existing_issue_number: Optional[int] = None,
+    approved_continuation: bool = False,
 ) -> Optional[GitHubWorkOrderProposal]:
     """Compose a :class:`GitHubWorkOrderProposal` for *session* / *request_text*,
     or ``None`` when the request should not flow through the GitHub
@@ -245,11 +263,25 @@ def build_github_work_order_proposal(
     eligible, skipped_reason, _hint = should_route_to_github_workos(
         session=session,
         request_text=request_text,
+        approved_continuation=approved_continuation,
     )
     if not eligible:
         return None
 
     intent = detect_coding_intent(request_text)
+    # P1-Z3 — approved continuation 경로에서 prompt 가 약해 intent.coding_required
+    # 가 False 라도 (decide_post_approval_action 이 이미 lifecycle/target/packet
+    # 가드 통과시킨 상태) proposal 의 ``intent_actions`` 가 빈 튜플로 떨어져
+    # operator surface 가 "어떤 작업인지 모름" 으로 보일 수 있다.  최소 한 줄의
+    # generic action label 을 부여해 audit 줄이 비어있지 않도록 한다.
+    if approved_continuation and not intent.actions:
+        from yule_orchestrator.agents.job_queue.github_work_order import CodingIntent
+
+        intent = CodingIntent(
+            coding_required=True,
+            matched=intent.matched or ("approved_continuation",),
+            actions=("코드 변경 (approved continuation)",),
+        )
     extras_payload: dict[str, Any] = dict(extra or {})
 
     selected, excluded = _resolve_roles_from_session(session)

--- a/src/yule_orchestrator/discord/integrations/intake_approval_eligibility.py
+++ b/src/yule_orchestrator/discord/integrations/intake_approval_eligibility.py
@@ -1,0 +1,152 @@
+"""P1-Z4 A — slash intake approval card eligibility (structured signals).
+
+배경
+----
+``_maybe_post_intake_approval_card`` 는 옛 wiring 에서
+:func:`should_route_to_github_workos` 를 그대로 재사용했다.  그 helper
+는 fresh intake routing 용이라 ``detect_coding_intent(request_text)``
+까지 강제 — prompt 가 자연어 ("실제 구현 가능한 상태까지 구현" / repo
+URL only / "issue 만들어서 시작") 면 ``no_coding_intent`` 로 skip 됐다.
+
+결과: receipt 는 "승인 필요" 라고 안내했는데 ``#승인-대기`` 카드는
+안 떠서 operator 가 무한 대기.  canonical session ``000f13fb121b`` 가
+직접 사례.
+
+본 모듈
+========
+intake 시점의 approval card posting 은 **구조 신호** 만으로 판단 —
+prompt phrase 게이트 재사용 금지.  체크 신호:
+
+  * ``write_requested == True``  — operator 가 명시 코딩 의도
+  * ``write_blocked_reason`` 존재 또는 lifecycle 가 implementation
+    (approval-needed 동등 신호)
+  * ``extra.lifecycle_mode == "implementation"`` (research_only 아님)
+  * ``extra.github_target`` 있음
+  * ``extra.coding_handoff_packet`` 있음
+  * obsidian intent 아님 (prompt 가 vault 저장 요청이면 카드 안 띄움)
+
+본 helper 는 pure decision (no I/O).  caller 가 결과만 보고 카드
+게시 여부 결정.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+ELIGIBILITY_ELIGIBLE: str = "eligible"
+ELIGIBILITY_SKIPPED: str = "skipped"
+
+SKIP_REASON_NOT_WRITE_REQUESTED: str = "not_write_requested"
+SKIP_REASON_RESEARCH_ONLY_LIFECYCLE: str = "research_only_lifecycle"
+SKIP_REASON_OBSIDIAN_INTENT: str = "obsidian_intent"
+SKIP_REASON_NO_GITHUB_TARGET: str = "no_github_target"
+SKIP_REASON_NO_HANDOFF_PACKET: str = "no_coding_handoff_packet"
+SKIP_REASON_NO_IMPLEMENTATION_SIGNAL: str = "no_implementation_signal"
+SKIP_REASON_NO_EXTRA: str = "session_extra_missing"
+
+
+@dataclass(frozen=True)
+class IntakeApprovalCardDecision:
+    """Pure decision result.  ``eligible == True`` 이면 caller 가
+    카드 게시 진행, False 면 ``skip_reason`` 만 audit.
+    """
+
+    eligible: bool
+    skip_reason: Optional[str] = None
+    lifecycle_mode: Optional[str] = None
+
+
+def decide_intake_approval_card_eligibility(
+    *,
+    session: Any,
+    prompt_text: str,
+) -> IntakeApprovalCardDecision:
+    """intake 시점에 ``#승인-대기`` 카드 게시 여부를 판단.
+
+    P1-Z4 — should_route_to_github_workos 를 호출하지 않는다.  prompt
+    phrase 게이트는 fresh intake routing 의 다른 경로 (channel router
+    coding_gate) 가 담당.  본 helper 는 오직 구조 신호만 본다.
+    """
+
+    # obsidian intent 는 명확히 다른 domain — 어떤 경우든 차단.
+    if _detect_obsidian_intent_safe(prompt_text):
+        return IntakeApprovalCardDecision(
+            eligible=False, skip_reason=SKIP_REASON_OBSIDIAN_INTENT
+        )
+
+    # write_requested 가 False 면 operator 가 코딩 의도 명시 안 함.
+    if not getattr(session, "write_requested", False):
+        return IntakeApprovalCardDecision(
+            eligible=False, skip_reason=SKIP_REASON_NOT_WRITE_REQUESTED
+        )
+
+    extra_raw = getattr(session, "extra", None)
+    if not isinstance(extra_raw, Mapping):
+        return IntakeApprovalCardDecision(
+            eligible=False, skip_reason=SKIP_REASON_NO_EXTRA
+        )
+    extra: Mapping[str, Any] = extra_raw
+
+    lifecycle_mode = str(extra.get("lifecycle_mode") or "").strip().lower() or None
+    if lifecycle_mode == "research_only":
+        return IntakeApprovalCardDecision(
+            eligible=False,
+            skip_reason=SKIP_REASON_RESEARCH_ONLY_LIFECYCLE,
+            lifecycle_mode=lifecycle_mode,
+        )
+    if lifecycle_mode != "implementation":
+        # 명시 implementation 신호 없으면 silently skip — operator 가
+        # 잘못 fresh intake 만 한 케이스 보호 (false-positive 차단).
+        return IntakeApprovalCardDecision(
+            eligible=False,
+            skip_reason=SKIP_REASON_NO_IMPLEMENTATION_SIGNAL,
+            lifecycle_mode=lifecycle_mode,
+        )
+
+    target = extra.get("github_target")
+    if not isinstance(target, Mapping) or not target:
+        return IntakeApprovalCardDecision(
+            eligible=False,
+            skip_reason=SKIP_REASON_NO_GITHUB_TARGET,
+            lifecycle_mode=lifecycle_mode,
+        )
+
+    handoff = extra.get("coding_handoff_packet")
+    if not isinstance(handoff, Mapping) or not handoff:
+        return IntakeApprovalCardDecision(
+            eligible=False,
+            skip_reason=SKIP_REASON_NO_HANDOFF_PACKET,
+            lifecycle_mode=lifecycle_mode,
+        )
+
+    return IntakeApprovalCardDecision(
+        eligible=True, skip_reason=None, lifecycle_mode=lifecycle_mode
+    )
+
+
+def _detect_obsidian_intent_safe(text: str) -> bool:
+    """``detect_obsidian_intent`` lazy import — circular import 방지."""
+
+    try:
+        from .github_workos_adapter import detect_obsidian_intent
+
+        return detect_obsidian_intent(text or "")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = (
+    "ELIGIBILITY_ELIGIBLE",
+    "ELIGIBILITY_SKIPPED",
+    "IntakeApprovalCardDecision",
+    "SKIP_REASON_NOT_WRITE_REQUESTED",
+    "SKIP_REASON_NO_EXTRA",
+    "SKIP_REASON_NO_GITHUB_TARGET",
+    "SKIP_REASON_NO_HANDOFF_PACKET",
+    "SKIP_REASON_NO_IMPLEMENTATION_SIGNAL",
+    "SKIP_REASON_OBSIDIAN_INTENT",
+    "SKIP_REASON_RESEARCH_ONLY_LIFECYCLE",
+    "decide_intake_approval_card_eligibility",
+)

--- a/src/yule_orchestrator/discord/integrations/pr_merge_adapter.py
+++ b/src/yule_orchestrator/discord/integrations/pr_merge_adapter.py
@@ -85,11 +85,36 @@ def _approval_request_from_proposal(
     # proposal.extra 로 복원하므로 round-trip 안전.
     extras: dict = dict(proposal.to_extra())
     extras["session_id"] = str(session_id)
+
+    summary_body = render_pr_merge_summary(proposal)
+
+    # P1-R — approval_required 모드 카드는 한국어 4 섹션 (작업 내용 /
+    # 목적 / 영향 범위 / 다음 단계) 필수.  render_pr_merge_summary 가
+    # 4 섹션을 명시 작성하지만, future regression 차단을 위해 enqueue
+    # 직전에도 한 번 더 enforce.  autonomous_merge 모드는 본 검증 스킵
+    # (validate_approval_card_quality 가 work_mode 분기).
+    try:
+        from ...agents.governance.repo_write_policy import (
+            ApprovalCardQualityContext,
+            enforce_approval_card_quality,
+        )
+
+        work_mode = str((proposal.extra or {}).get("work_mode") or "")
+        enforce_approval_card_quality(
+            ApprovalCardQualityContext(
+                body=summary_body,
+                approval_kind=APPROVAL_KIND_PR_MERGE,
+                work_mode=work_mode or None,
+            )
+        )
+    except Exception:
+        raise  # PolicyViolation 그대로 호출자 (worker) 까지 surface
+
     return ApprovalRequest(
         session_id=session_id,
         approval_kind=APPROVAL_KIND_PR_MERGE,
         title=title,
-        summary=render_pr_merge_summary(proposal),
+        summary=summary_body,
         requested_action=requested_action,
         created_by=proposal.requested_by or "",
         source_channel_id=source_channel_id,

--- a/src/yule_orchestrator/runtime/coding_executor_runner.py
+++ b/src/yule_orchestrator/runtime/coding_executor_runner.py
@@ -387,6 +387,33 @@ async def run_coding_executor(
             exc_info=True,
         )
 
+    # P1-Z6 B startup recovery — pre-PR transient failure (edit_timeout /
+    # edit_subprocess_failed / 옛 edit_failed) 자동 retry.  옛 wiring 은
+    # max_attempts=1 이라 ``failed_retryable`` reason 으로 떨어져도
+    # 곧장 terminal 로 종료됐다.  이제 max_attempts=3 + 본 sweep 이
+    # ``requeue_retryable`` 로 한 번 더 시도시키는 자동 self-healing 루프.
+    # structural failure (write_scope_resolved_empty / strategy_unresolved /
+    # forbidden) 는 recoverable set 에 안 들어가 절대 자동 retry 안 됨.
+    try:
+        from ..agents.job_queue.coding_execute_recovery import (
+            recover_transient_pre_pr_failures,
+        )
+
+        retried_transient = recover_transient_pre_pr_failures(
+            queue=queue, log_fn=lambda msg, _exc: logger.info(msg)
+        )
+        if retried_transient:
+            logger.info(
+                "coding_execute transient retry: requeued %d row(s) — "
+                "edit_timeout / edit_subprocess_failed 가 자동 재시도",
+                len(retried_transient),
+            )
+    except Exception:  # noqa: BLE001 - never crash startup
+        logger.warning(
+            "coding_execute transient retry: startup sweep raised",
+            exc_info=True,
+        )
+
     async def _process(job):
         # Spawn a per-job keepalive task. picked_by 는 pick(...) 시점에
         # service_id 로 설정되므로 worker_id 도 동일.

--- a/src/yule_orchestrator/runtime/dev_watch.py
+++ b/src/yule_orchestrator/runtime/dev_watch.py
@@ -1,0 +1,377 @@
+"""P1-Z6 D — dev-only file watch + selective service restart.
+
+배경
+----
+사용자 요구: ``yule runtime up`` 후 코드 수정할 때마다 전체 supervisor
+재기동은 디버깅 루프를 길게 만든다.  hot-reload / selective restart 가
+없어서 매번 down/up 반복.
+
+본 모듈
+========
+* opt-in 만 — production / systemd path 는 절대 건드리지 않음.
+* polling 기반 (외부 dependency 없음).  ``watchfiles`` / ``watchdog``
+  같은 패키지 도입 X.
+* 파일 → 영향 서비스 매핑 (``FILE_SERVICE_AFFECTED_MAP``).  매핑이
+  없으면 conservative fallback (관련 engineering services 집합 restart).
+* dev runtime 의 supervisor 가 본 helper 를 import 해 사용.
+
+API
+====
+* :func:`compute_affected_services(changed_files)` — pure (no I/O) 파일 →
+  영향 서비스 집합 결정.
+* :class:`FileWatcher` — polling-based mtime watcher.  외부 dep 없음.
+* :func:`run_dev_watch_loop(...)` — supervisor 가 호출하는 메인 루프.
+  파일 변경 감지 → 영향 서비스 restart fn 호출.
+
+production safety
+=================
+* :class:`FileWatcher` 는 dev 전용 — env (``YULE_RUNTIME_DEV_WATCH=1``)
+  또는 explicit CLI ``--watch`` 가 켜져야만 활성.
+* systemd unit / production launcher 는 본 모듈 import 안 함.
+* watcher 실패는 supervisor 본체 안 깸 (best-effort).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, FrozenSet, Iterable, Mapping, Optional, Set, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+SERVICE_CODING_EXECUTOR: str = "eng-coding-executor"
+SERVICE_GITHUB_WORK_ORDER_EXECUTOR: str = "eng-github-work-order-executor"
+SERVICE_DISCORD_GATEWAY: str = "eng-discord-gateway"
+SERVICE_APPROVAL_WORKER: str = "eng-approval-worker"
+SERVICE_OBSIDIAN_WRITER: str = "eng-obsidian-writer"
+
+
+# Conservative engineering set — shared module 변경 시 restart 대상.
+ENGINEERING_SERVICES_SET: FrozenSet[str] = frozenset(
+    {
+        SERVICE_CODING_EXECUTOR,
+        SERVICE_GITHUB_WORK_ORDER_EXECUTOR,
+        SERVICE_DISCORD_GATEWAY,
+        SERVICE_APPROVAL_WORKER,
+        SERVICE_OBSIDIAN_WRITER,
+    }
+)
+
+
+# P1-Z6 D — 파일 path prefix → 영향 받는 service 집합 매핑.
+# 가장 좁은 prefix 매칭 우선 — caller (FileWatcher) 가 정렬 후 first-match.
+FILE_SERVICE_AFFECTED_MAP: Mapping[str, FrozenSet[str]] = {
+    # coding executor pipeline
+    "src/yule_orchestrator/runtime/coding_executor_runner.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_executor_worker.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_executor_live.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_execute_dispatcher.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_execute_recovery.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_execute_terminal_skip.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/coding_write_scope_resolution.py": frozenset(
+        {SERVICE_CODING_EXECUTOR}
+    ),
+    # github work order executor
+    "src/yule_orchestrator/agents/job_queue/github_work_order_executor.py": frozenset(
+        {SERVICE_GITHUB_WORK_ORDER_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/github_work_order.py": frozenset(
+        {SERVICE_GITHUB_WORK_ORDER_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/github_work_order_recovery.py": frozenset(
+        {SERVICE_GITHUB_WORK_ORDER_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/work_order_coding_continuation.py": frozenset(
+        {SERVICE_GITHUB_WORK_ORDER_EXECUTOR, SERVICE_CODING_EXECUTOR}
+    ),
+    "src/yule_orchestrator/agents/job_queue/post_approval_dispatch.py": frozenset(
+        {SERVICE_GITHUB_WORK_ORDER_EXECUTOR}
+    ),
+    # Discord gateway
+    "src/yule_orchestrator/discord/commands/__init__.py": frozenset(
+        {SERVICE_DISCORD_GATEWAY}
+    ),
+    "src/yule_orchestrator/discord/integrations/github_workos_adapter.py": frozenset(
+        {SERVICE_DISCORD_GATEWAY}
+    ),
+    "src/yule_orchestrator/discord/integrations/intake_approval_eligibility.py": frozenset(
+        {SERVICE_DISCORD_GATEWAY}
+    ),
+    "src/yule_orchestrator/discord/engineering_channel_router/": frozenset(
+        {SERVICE_DISCORD_GATEWAY}
+    ),
+    "src/yule_orchestrator/discord/bot/": frozenset({SERVICE_DISCORD_GATEWAY}),
+    "src/yule_orchestrator/discord/forum/": frozenset({SERVICE_DISCORD_GATEWAY}),
+    # Approval worker
+    "src/yule_orchestrator/agents/job_queue/approval_reply.py": frozenset(
+        {SERVICE_APPROVAL_WORKER}
+    ),
+    "src/yule_orchestrator/agents/job_queue/approval_discord_poster.py": frozenset(
+        {SERVICE_APPROVAL_WORKER}
+    ),
+    # Obsidian writer
+    "src/yule_orchestrator/agents/job_queue/obsidian_writer_worker.py": frozenset(
+        {SERVICE_OBSIDIAN_WRITER}
+    ),
+}
+
+
+# Strategy / coding planning shared — affects coding_executor + work_order
+SHARED_CODING_PATHS: Tuple[str, ...] = (
+    "src/yule_orchestrator/agents/coding/",
+)
+
+
+@dataclass(frozen=True)
+class AffectedDecision:
+    """파일 변경 → 영향 서비스 결정 결과."""
+
+    services: FrozenSet[str]
+    reason: str
+    matched_prefix: Optional[str] = None
+    conservative_fallback: bool = False
+
+
+def compute_affected_services(
+    changed_files: Iterable[str],
+) -> AffectedDecision:
+    """변경된 파일 경로 집합 → restart 대상 service 집합 결정.
+
+    Pure — no I/O.  same input → same output.  caller (FileWatcher) 가
+    호출하고, 결과의 ``services`` 만 restart fn 으로 전달.
+    """
+
+    affected: Set[str] = set()
+    matched_prefixes: list[str] = []
+    fallback_triggered = False
+
+    # 정렬: 긴 prefix 가 먼저 매칭 (좁은 매칭 우선)
+    sorted_mapping = sorted(
+        FILE_SERVICE_AFFECTED_MAP.items(),
+        key=lambda kv: -len(kv[0]),
+    )
+
+    files = sorted(set(str(f).replace("\\", "/") for f in changed_files if f))
+    for rel_path in files:
+        path_matched = False
+        for prefix, services in sorted_mapping:
+            if rel_path.startswith(prefix):
+                affected.update(services)
+                matched_prefixes.append(prefix)
+                path_matched = True
+                break
+        if path_matched:
+            continue
+        # shared coding planning paths
+        for shared in SHARED_CODING_PATHS:
+            if rel_path.startswith(shared):
+                affected.update(
+                    {SERVICE_CODING_EXECUTOR, SERVICE_GITHUB_WORK_ORDER_EXECUTOR}
+                )
+                matched_prefixes.append(shared)
+                path_matched = True
+                break
+        if path_matched:
+            continue
+        # conservative fallback — 매핑 없는 src/yule_orchestrator 변경은
+        # 전체 engineering set 재시작.  매핑 외 변경 (tests/ / docs/) 은
+        # 무시.
+        if rel_path.startswith("src/yule_orchestrator/"):
+            affected.update(ENGINEERING_SERVICES_SET)
+            fallback_triggered = True
+            matched_prefixes.append("<conservative-fallback>")
+
+    return AffectedDecision(
+        services=frozenset(affected),
+        reason=(
+            "conservative_fallback"
+            if fallback_triggered
+            else (
+                "explicit_mapping"
+                if matched_prefixes
+                else "no_match"
+            )
+        ),
+        matched_prefix=", ".join(sorted(set(matched_prefixes))) if matched_prefixes else None,
+        conservative_fallback=fallback_triggered,
+    )
+
+
+class FileWatcher:
+    """Polling-based mtime watcher.  외부 dep 없음.
+
+    *roots* 는 watch 할 디렉터리 집합 (예: ``src/yule_orchestrator``).
+    *extensions* 는 추적할 확장자 (기본 ``.py``).  *interval* 은 폴링
+    주기 (초).
+    """
+
+    def __init__(
+        self,
+        *,
+        roots: Iterable[str],
+        extensions: Tuple[str, ...] = (".py",),
+        interval_seconds: float = 1.5,
+    ) -> None:
+        self._roots: Tuple[Path, ...] = tuple(Path(r) for r in roots)
+        self._extensions: Tuple[str, ...] = tuple(extensions)
+        self._interval = max(0.5, float(interval_seconds))
+        self._mtimes: dict[str, float] = {}
+
+    def snapshot(self) -> Mapping[str, float]:
+        """현재 mtime snapshot 수집.  내부 상태 안 갱신."""
+
+        result: dict[str, float] = {}
+        for root in self._roots:
+            if not root.is_dir():
+                continue
+            for path in root.rglob("*"):
+                if not path.is_file():
+                    continue
+                if self._extensions and not str(path).endswith(self._extensions):
+                    continue
+                try:
+                    result[str(path)] = path.stat().st_mtime
+                except OSError:
+                    continue
+        return result
+
+    def detect_changes(self) -> Tuple[str, ...]:
+        """이전 snapshot 과 비교해 변경된 파일 경로 (repo-relative).
+
+        첫 호출 시 baseline 만 수집 → 빈 튜플.  이후 호출부터 변경 감지.
+        """
+
+        current = self.snapshot()
+        if not self._mtimes:
+            self._mtimes = dict(current)
+            return ()
+        changed: list[str] = []
+        for path, mtime in current.items():
+            previous = self._mtimes.get(path)
+            if previous is None or mtime > previous:
+                changed.append(path)
+        # mtime baseline 갱신
+        self._mtimes = dict(current)
+        return tuple(_to_repo_relative(p) for p in changed)
+
+    @property
+    def interval(self) -> float:
+        return self._interval
+
+
+def _to_repo_relative(absolute_path: str) -> str:
+    """``/abs/path/src/yule_orchestrator/...`` → ``src/yule_orchestrator/...``."""
+
+    p = Path(absolute_path)
+    parts = p.parts
+    try:
+        idx = parts.index("src")
+        return "/".join(parts[idx:])
+    except ValueError:
+        return absolute_path
+
+
+def dev_watch_enabled() -> bool:
+    """env / CLI 명시 opt-in 만 활성화."""
+
+    value = os.environ.get("YULE_RUNTIME_DEV_WATCH", "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def run_dev_watch_iteration(
+    *,
+    watcher: FileWatcher,
+    restart_service_fn: Callable[[str], None],
+    log_fn: Optional[Callable[[str], None]] = None,
+) -> AffectedDecision:
+    """한 사이클 — 변경 감지 + 영향 서비스 restart 호출.
+
+    storage / network I/O 직접 안 함.  caller 가 ``restart_service_fn``
+    inject (실제 supervisor 의 restart 핸들러).  변경 0건이면
+    no-restart, AffectedDecision.services 비어있음.
+
+    반환: AffectedDecision — 호출자 audit 용.
+    """
+
+    changed = watcher.detect_changes()
+    decision = compute_affected_services(changed)
+    if not changed:
+        return decision
+    if log_fn:
+        try:
+            log_fn(
+                f"dev watch: {len(changed)} file(s) changed → "
+                f"restart {sorted(decision.services) or '(no-op)'} "
+                f"(reason={decision.reason}, matched={decision.matched_prefix})"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    for service in sorted(decision.services):
+        try:
+            restart_service_fn(service)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "dev_watch: restart_service_fn raised for %s",
+                service,
+                exc_info=True,
+            )
+    return decision
+
+
+def run_dev_watch_loop(
+    *,
+    watcher: FileWatcher,
+    restart_service_fn: Callable[[str], None],
+    stop_predicate: Callable[[], bool] = lambda: False,
+    log_fn: Optional[Callable[[str], None]] = None,
+) -> None:
+    """``stop_predicate`` 가 True 반환할 때까지 watch 루프 실행.
+
+    blocking — supervisor 가 별도 thread / asyncio task 에서 호출.
+    """
+
+    while not stop_predicate():
+        try:
+            run_dev_watch_iteration(
+                watcher=watcher,
+                restart_service_fn=restart_service_fn,
+                log_fn=log_fn,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("dev_watch loop iteration raised", exc_info=True)
+        time.sleep(watcher.interval)
+
+
+__all__ = (
+    "AffectedDecision",
+    "ENGINEERING_SERVICES_SET",
+    "FILE_SERVICE_AFFECTED_MAP",
+    "FileWatcher",
+    "SERVICE_APPROVAL_WORKER",
+    "SERVICE_CODING_EXECUTOR",
+    "SERVICE_DISCORD_GATEWAY",
+    "SERVICE_GITHUB_WORK_ORDER_EXECUTOR",
+    "SERVICE_OBSIDIAN_WRITER",
+    "SHARED_CODING_PATHS",
+    "compute_affected_services",
+    "dev_watch_enabled",
+    "run_dev_watch_iteration",
+    "run_dev_watch_loop",
+)

--- a/tests/agents/lifecycle/test_session_mode.py
+++ b/tests/agents/lifecycle/test_session_mode.py
@@ -199,9 +199,20 @@ class HintParserTests(unittest.TestCase):
         self.assertEqual(hints["scope"], SCOPE_LAYER)
 
     def test_no_hint(self) -> None:
+        # P1-R — parse_mode_hints 가 governance contract 확장으로 추가 키
+        # (branch_strategy / release_strategy / issue_policy) 도 None 으로
+        # 반환.  토큰 명시 없으면 None.
         hints = parse_mode_hints("그냥 작업해 줘")
         self.assertEqual(
-            hints, {"work_mode": None, "topology": None, "scope": None}
+            hints,
+            {
+                "work_mode": None,
+                "topology": None,
+                "scope": None,
+                "branch_strategy": None,
+                "release_strategy": None,
+                "issue_policy": None,
+            },
         )
 
 

--- a/tests/agents/test_live_code_editor.py
+++ b/tests/agents/test_live_code_editor.py
@@ -208,8 +208,12 @@ class ProviderDispatchTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = _worktree_ctx(Path(tmp))
             new_ctx = editor.apply(request=_request(), context=ctx)
+        # P1-V — fake runner 가 "ok" 만 돌려주면 worktree 스캔이 변경
+        # 0건으로 떨어져 context 가 그대로 반환된다.  진짜 0-edit no-op
+        # 경로는 worker 의 P1-U C 가 surface.
         self.assertIs(new_ctx, ctx)
-        self.assertEqual(len(fake.calls), 1)
+        # P1-V — 이제 claude call + git status --porcelain 2 호출.
+        self.assertEqual(len(fake.calls), 2)
         cmd, kwargs = fake.calls[0]
         self.assertEqual(cmd[0], "claude")
         self.assertEqual(cmd[1], "-p")
@@ -217,6 +221,12 @@ class ProviderDispatchTests(unittest.TestCase):
         self.assertIn("--model", cmd)
         self.assertIn("claude-sonnet-4-6", cmd)
         self.assertEqual(kwargs.get("cwd"), str(Path(tmp)))
+        # P1-V — 두 번째 call 은 worktree 변경 수집.
+        status_cmd, status_kwargs = fake.calls[1]
+        self.assertEqual(tuple(status_cmd[:2]), ("git", "-C"))
+        self.assertIn("status", status_cmd)
+        self.assertIn("--porcelain", status_cmd)
+        self.assertTrue(status_kwargs.get("capture_output"))
 
     def test_claude_cli_no_runner_blocks(self) -> None:
         editor = LiveCodeEditor(

--- a/tests/agents/test_p1m_session_recovery_and_intake.py
+++ b/tests/agents/test_p1m_session_recovery_and_intake.py
@@ -411,7 +411,7 @@ class HumanTitleTests(unittest.TestCase):
         title = build_issue_title(
             session_prompt=_PROMPT_AUTONOMOUS, slice_spec=slice_spec
         )
-        self.assertIn("[기능]", title)
+        self.assertIn("[Feature]", title)
         self.assertIn("검색", title)
         self.assertNotIn("autonomous_merge", title.lower())
 

--- a/tests/agents/test_p1s_pr_title_production_path.py
+++ b/tests/agents/test_p1s_pr_title_production_path.py
@@ -1,0 +1,269 @@
+"""P1-S — PR title production path 가 절대 machine-like 출력 X.
+
+1. coding executor PR creation path uses Korean human title builder
+2. no production path emits machine-like `coding-executor draft` title
+3. no production path emits branch-name-derived PR title fallback
+4. 166c416a1ed0-like context (repo + issue #5 + backend slice) yields
+   valid Korean human-readable PR title
+5. missing optional slice metadata still yields human-readable Korean
+   fallback title
+6. title policy validator and title builder are aligned
+7. retry path no longer fails with invalid_pr_title_not_human_readable_korean
+8. English-only / mode-token-only prompt 도 한국어 fallback 으로 self-correct
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.coding.human_titles import (
+    _korean_fallback_title,
+    build_pr_title,
+)
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    PolicyViolation,
+    enforce_pr_title,
+    validate_pr_title,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1, 6 — builder 와 validator 의 정합성
+# ---------------------------------------------------------------------------
+
+
+class BuilderValidatorAlignmentTests(unittest.TestCase):
+    """모든 build_pr_title 출력이 enforce_pr_title 통과해야 한다."""
+
+    def test_korean_prompt_passes(self) -> None:
+        title = build_pr_title(
+            session_prompt="네이버 검색 풀스택 MVP 구축",
+            issue_number=5,
+        )
+        enforce_pr_title(title)  # raises if invalid
+        self.assertIn("네이버", title)
+        self.assertIn("(#5)", title)
+
+    def test_empty_prompt_self_corrects_to_korean_fallback(self) -> None:
+        title = build_pr_title(
+            session_prompt="",
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        self.assertIn("[구현]", title)
+        self.assertIn("(#5)", title)
+        # 옛 회귀 — branch_hint 의 segment 가 절대 title 에 안 들어감
+        self.assertNotIn("agent/", title)
+        self.assertNotIn("backend-engineer", title)
+        self.assertNotIn("coding-execute", title)
+
+    def test_english_only_prompt_self_corrects(self) -> None:
+        # 영어 prompt 면 한국어 4자 미만 → fallback 으로 self-correct
+        title = build_pr_title(
+            session_prompt="add login api for naver clone",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        self.assertIn("[구현]", title)
+        # 영어 본문은 절대 통과해서는 안 됨
+        self.assertNotIn("add login api", title)
+
+    def test_mode_tokens_only_prompt_self_corrects(self) -> None:
+        title = build_pr_title(
+            session_prompt="autonomous_merge, git_flow, tagged_release, issue_required",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        # 모드 토큰은 모두 strip → 한국어 fallback
+        self.assertNotIn("autonomous_merge", title)
+        self.assertNotIn("git_flow", title)
+        self.assertIn("[구현]", title)
+
+
+# ---------------------------------------------------------------------------
+# 2, 3 — 옛 회귀 (machine-like / branch-name) 차단
+# ---------------------------------------------------------------------------
+
+
+class NoMachineLikeOutputTests(unittest.TestCase):
+    def test_coding_executor_draft_literal_is_rejected_by_validator(self) -> None:
+        """validator 가 옛 fallback 텍스트를 reject 하는지 가드 — 본 PR 이
+        validator 와 builder 둘 다 강화한 것을 보장."""
+
+        legacy = "📝 #5 coding-executor draft"
+        r = validate_pr_title(legacy)
+        self.assertFalse(r.ok)
+
+    def test_builder_never_emits_branch_name_token(self) -> None:
+        """canonical session 166c416a1ed0 의 branch
+        ``agent/backend-engineer/issue-5-coding-execute`` 의 마지막 segment
+        가 절대 title 에 들어가지 않음.  옛 wiring 의 회귀 직접 가드."""
+
+        # 한국어 prompt 정상 + branch_hint 전달 → branch slug 영원히 미사용
+        title = build_pr_title(
+            session_prompt="네이버 검색 풀스택 MVP 구축",
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        self.assertNotIn("issue-5-coding-execute", title)
+        # 한국어 prompt 빈 case 도
+        title2 = build_pr_title(
+            session_prompt="",
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        self.assertNotIn("issue-5-coding-execute", title2)
+
+
+# ---------------------------------------------------------------------------
+# 4, 5 — canonical 166c416a1ed0 context
+# ---------------------------------------------------------------------------
+
+
+class CanonicalSessionContextTests(unittest.TestCase):
+    def test_canonical_166c_with_slice_yields_human_title(self) -> None:
+        slice_spec = {
+            "title": "회원가입 / 로그인 API 1차",
+            "area": "auth",
+            "executor_role": "backend-engineer",
+        }
+        title = build_pr_title(
+            session_prompt="네이버 검색형 풀스택 MVP 구축",
+            slice_spec=slice_spec,
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        self.assertIn("[구현][인증]", title)
+        self.assertIn("회원가입", title)
+        self.assertIn("(#5)", title)
+
+    def test_canonical_166c_without_slice_uses_prompt_summary(self) -> None:
+        """slice_spec 없음 — single_scope intake 의 경우. prompt 의
+        Korean summary 가 title 로 들어감."""
+
+        title = build_pr_title(
+            session_prompt=(
+                "네이버 검색형 풀스택 MVP 구축 (인증/검색/UI) "
+                "https://github.com/yule-studio/naver-search-clone"
+            ),
+            slice_spec=None,
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        self.assertIn("[구현]", title)
+        self.assertIn("네이버", title)
+        self.assertIn("(#5)", title)
+
+    def test_canonical_166c_no_slice_no_prompt_uses_korean_default(self) -> None:
+        """최악 case — slice / prompt 둘 다 빈약 → Korean default fallback."""
+
+        title = build_pr_title(
+            session_prompt="",
+            slice_spec=None,
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        enforce_pr_title(title)
+        # default fallback
+        self.assertIn("[구현]", title)
+        self.assertIn("코딩 작업", title)
+        self.assertIn("(#5)", title)
+
+
+# ---------------------------------------------------------------------------
+# 7 — retry path: 다시 호출해도 같은 결과 + 항상 통과
+# ---------------------------------------------------------------------------
+
+
+class RetryPathTests(unittest.TestCase):
+    def test_repeated_build_with_same_input_is_deterministic_and_valid(
+        self,
+    ) -> None:
+        inputs = dict(
+            session_prompt="네이버 검색 풀스택 MVP",
+            slice_spec=None,
+            branch_hint="agent/backend-engineer/issue-5-coding-execute",
+            issue_number=5,
+        )
+        first = build_pr_title(**inputs)
+        second = build_pr_title(**inputs)
+        third = build_pr_title(**inputs)
+        self.assertEqual(first, second)
+        self.assertEqual(second, third)
+        for t in (first, second, third):
+            enforce_pr_title(t)
+
+
+# ---------------------------------------------------------------------------
+# 8 — live PR creator 의 dangerous fallback 회귀 가드
+# ---------------------------------------------------------------------------
+
+
+class LivePRCreatorFallbackGuardTests(unittest.TestCase):
+    """coding_executor_live.GithubAppDraftPRCreator.open 의 except fallback
+    이 더 이상 ``coding-executor draft`` 리터럴을 emit 하지 않음을 source-
+    grep + import 호출로 가드."""
+
+    def test_live_pr_creator_uses_korean_fallback(self) -> None:
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/agents/job_queue/coding_executor_live.py"
+        ).read_text(encoding="utf-8")
+        # 옛 회귀 fallback 텍스트가 더 이상 코드에 없음
+        self.assertNotIn("coding-executor draft", src)
+        # 새 fallback 호출 site 존재
+        self.assertIn("_korean_fallback_title", src)
+        # post-validate 분기 존재
+        self.assertIn("validate_pr_title", src)
+
+    def test_live_creator_imports_human_titles_unconditionally(self) -> None:
+        """build_pr_title / _korean_fallback_title 가 import 가능한 상태로
+        wiring 됨."""
+
+        from yule_orchestrator.agents.coding.human_titles import (
+            _korean_fallback_title,
+            build_pr_title,
+        )
+
+        self.assertTrue(callable(build_pr_title))
+        self.assertTrue(callable(_korean_fallback_title))
+
+
+# ---------------------------------------------------------------------------
+# 보조 — _korean_fallback_title 직접 검증
+# ---------------------------------------------------------------------------
+
+
+class KoreanFallbackTitleTests(unittest.TestCase):
+    def test_with_issue_and_area(self) -> None:
+        title = _korean_fallback_title(issue_number=5, area="인증")
+        enforce_pr_title(title)
+        self.assertIn("[구현][인증]", title)
+        self.assertIn("(#5)", title)
+
+    def test_with_issue_no_area(self) -> None:
+        title = _korean_fallback_title(issue_number=5)
+        enforce_pr_title(title)
+        self.assertIn("[구현]", title)
+        self.assertIn("(#5)", title)
+
+    def test_no_issue_no_area(self) -> None:
+        title = _korean_fallback_title(issue_number=None)
+        enforce_pr_title(title)
+        self.assertIn("[구현]", title)
+        # (#N) suffix 없음
+        self.assertNotIn("(#", title)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_p1t_live_editor_production_wiring.py
+++ b/tests/agents/test_p1t_live_editor_production_wiring.py
@@ -1,0 +1,296 @@
+"""P1-T — build_live_executor 가 LiveCodeEditor 우선 선택.
+
+옛 회귀: build_live_executor 가 무조건 GreenfieldBootstrapEditor() 만
+사용 → 운영자가 YULE_LIVE_EDITOR_ENABLED=true 를 set 해도 production
+runtime 이 LiveCodeEditor 를 절대 선택 안 함 → non-greenfield repo 가
+record-only delegate 로 떨어짐 → planning markdown 만 commit.
+
+사용자 명시 7 acceptance:
+
+1. non-greenfield repo no longer silently falls back to record-only
+2. issue #5-like context resolves into real edit capable path when env on
+3. missing required env yields explicit blocker (not silent plan-only)
+4. build_live_executor / build_live_editor_from_env wiring actually selects
+   live editor
+5. planning markdown-only output not the primary success path for
+   non-greenfield implementation requests
+6. issue #5 continuity preserved (env / wiring changes only — no issue
+   side effects)
+7. existing greenfield bootstrap behavior does not regress
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    ENV_GREENFIELD_BOOTSTRAP_ENABLED,
+    ENV_LIVE_EDITOR_ENABLED,
+    ENV_LIVE_EDITOR_PROVIDER,
+    GreenfieldBootstrapEditor,
+    LiveCodeEditor,
+    PROVIDER_CLAUDE_CLI,
+    build_live_executor,
+    build_live_editor_from_env,
+    detect_live_executor_availability,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1, 4 — env on → LiveCodeEditor 가 실제 선택
+# ---------------------------------------------------------------------------
+
+
+class BuildLiveExecutorPicksLiveEditorTests(unittest.TestCase):
+    def test_env_on_with_claude_cli_picks_live_code_editor(self) -> None:
+        bundle = build_live_executor(
+            repo_root="/tmp/repo",
+            env={
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+            },
+        )
+        self.assertIsInstance(bundle["code_editor"], LiveCodeEditor)
+        self.assertEqual(bundle["code_editor"].provider, PROVIDER_CLAUDE_CLI)
+
+    def test_env_off_falls_back_to_greenfield_bootstrap(self) -> None:
+        bundle = build_live_executor(repo_root="/tmp/repo", env={})
+        self.assertIsInstance(
+            bundle["code_editor"], GreenfieldBootstrapEditor
+        )
+
+    def test_env_on_but_no_provider_falls_back(self) -> None:
+        # ENABLED=true 인데 PROVIDER 가 비어 있으면 build_live_editor_from_env
+        # 가 None 반환 → GreenfieldBootstrapEditor 로 fallback
+        bundle = build_live_executor(
+            repo_root="/tmp/repo",
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        self.assertIsInstance(
+            bundle["code_editor"], GreenfieldBootstrapEditor
+        )
+
+    def test_env_on_with_unrelated_provider_still_returns_live_editor(self) -> None:
+        # provider=anthropic 도 build_live_editor_from_env 는 LiveCodeEditor
+        # 반환 (apply 시점에 BlockedLiveEditorError raise) — 옛 wiring 회귀
+        # 가드: 어떤 provider 든 build_live_executor 가 LiveCodeEditor 를
+        # 받으면 그것을 사용.
+        bundle = build_live_executor(
+            repo_root="/tmp/repo",
+            env={
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: "anthropic",
+            },
+        )
+        self.assertIsInstance(bundle["code_editor"], LiveCodeEditor)
+
+
+# ---------------------------------------------------------------------------
+# 2 — issue #5 context (non-greenfield repo + live editor on) wires real edit
+# ---------------------------------------------------------------------------
+
+
+class Issue5ContextRealEditWiringTests(unittest.TestCase):
+    def test_non_greenfield_repo_with_live_editor_on_uses_live_code_editor(
+        self,
+    ) -> None:
+        """naver-search-clone (non-greenfield) + YULE_LIVE_EDITOR_ENABLED=true
+        → bundle.code_editor 는 LiveCodeEditor.  옛 GreenfieldBootstrap 의
+        record-only delegate 분기로 떨어지지 않음."""
+
+        bundle = build_live_executor(
+            repo_root="/tmp/naver-search-clone",
+            env={
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+            },
+        )
+        editor = bundle["code_editor"]
+        self.assertIsInstance(editor, LiveCodeEditor)
+        # provider snapshot — operator audit
+        self.assertEqual(editor.provider, PROVIDER_CLAUDE_CLI)
+
+
+# ---------------------------------------------------------------------------
+# 3 — missing env → operator-visible blocker reason
+# ---------------------------------------------------------------------------
+
+
+class AvailabilitySurfaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {
+            k: os.environ.get(k)
+            for k in (
+                ENV_LIVE_EDITOR_ENABLED,
+                ENV_LIVE_EDITOR_PROVIDER,
+                ENV_GREENFIELD_BOOTSTRAP_ENABLED,
+            )
+        }
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_env_off_surface_says_set_live_editor_or_greenfield(self) -> None:
+        for k in (
+            ENV_LIVE_EDITOR_ENABLED,
+            ENV_LIVE_EDITOR_PROVIDER,
+            ENV_GREENFIELD_BOOTSTRAP_ENABLED,
+        ):
+            os.environ.pop(k, None)
+        av = detect_live_executor_availability(repo_root="/tmp/r")
+        self.assertIn("disabled", av.code_editor)
+        self.assertIn(ENV_LIVE_EDITOR_ENABLED, av.code_editor_blocker)
+
+    def test_env_on_surface_says_live_llm_provider(self) -> None:
+        os.environ[ENV_LIVE_EDITOR_ENABLED] = "true"
+        os.environ[ENV_LIVE_EDITOR_PROVIDER] = PROVIDER_CLAUDE_CLI
+        av = detect_live_executor_availability(repo_root="/tmp/r")
+        self.assertEqual(av.code_editor, f"live_llm({PROVIDER_CLAUDE_CLI})")
+        self.assertEqual(av.code_editor_blocker, "")
+
+    def test_only_greenfield_on_surface_says_record_only_with_hint(self) -> None:
+        os.environ.pop(ENV_LIVE_EDITOR_ENABLED, None)
+        os.environ.pop(ENV_LIVE_EDITOR_PROVIDER, None)
+        os.environ[ENV_GREENFIELD_BOOTSTRAP_ENABLED] = "1"
+        av = detect_live_executor_availability(repo_root="/tmp/r")
+        self.assertIn("record_only_delegate", av.code_editor)
+        self.assertIn(ENV_LIVE_EDITOR_ENABLED, av.code_editor_blocker)
+
+
+# ---------------------------------------------------------------------------
+# 5 — planning-only PR 회귀 가드 (governance.PolicyViolation 흐름 활용)
+# ---------------------------------------------------------------------------
+
+
+class PlanningOnlyPRForbidsRegressionTests(unittest.TestCase):
+    """YULE_CODING_EXECUTOR_PLANNING_ONLY_PR_FORBIDDEN=1 + live editor off
+    + non-greenfield → editor.apply 가 NonGreenfieldRealEditUnavailable
+    raise.  operator 가 명시 opt-out 했을 때 silent plan-only commit
+    회귀 차단 (P1-M F 이미 한 동작 + 본 round 의 새 LiveCodeEditor 분기
+    가 그 위에서 우선)."""
+
+    def test_planning_forbidden_env_blocks_non_greenfield_delegate(self) -> None:
+        from yule_orchestrator.agents.job_queue.coding_executor_live import (
+            ENV_PLANNING_ONLY_PR_FORBIDDEN,
+            NonGreenfieldRealEditUnavailable,
+        )
+        from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+            CodingExecuteRequest,
+            WorktreeContext,
+        )
+
+        editor = GreenfieldBootstrapEditor(
+            env={ENV_PLANNING_ONLY_PR_FORBIDDEN: "1"}
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "package.json").write_text("{}")
+            (root / ".git").mkdir()
+            ctx = WorktreeContext(branch="b", worktree_path=str(root))
+            req = CodingExecuteRequest(
+                session_id="s",
+                executor_role="backend-engineer",
+                user_request="r",
+                generated_prompt="p",
+                write_scope=("src/**",),
+                forbidden_scope=(),
+                safety_rules=(),
+                base_branch="main",
+                branch_hint="agent/x",
+                repo_full_name="yule-studio/naver-search-clone",
+                issue_number=5,
+                dry_run=False,
+                metadata={},
+            )
+            with self.assertRaises(NonGreenfieldRealEditUnavailable):
+                editor.apply(request=req, context=ctx)
+
+
+# ---------------------------------------------------------------------------
+# 7 — existing greenfield bootstrap behavior 회귀 없음
+# ---------------------------------------------------------------------------
+
+
+class GreenfieldBootstrapRegressionTests(unittest.TestCase):
+    def test_env_off_default_bundle_still_uses_greenfield_editor(self) -> None:
+        """본 round 수정으로 옛 default 동작이 깨지면 안 됨 — live editor
+        env 미설정 + greenfield env 미설정 → 옛 GreenfieldBootstrapEditor."""
+
+        bundle = build_live_executor(repo_root="/tmp/r", env={})
+        self.assertIsInstance(
+            bundle["code_editor"], GreenfieldBootstrapEditor
+        )
+
+    def test_greenfield_env_on_alone_picks_greenfield_editor(self) -> None:
+        bundle = build_live_executor(
+            repo_root="/tmp/r",
+            env={ENV_GREENFIELD_BOOTSTRAP_ENABLED: "1"},
+        )
+        # live editor env 없으면 옛대로 GreenfieldBootstrapEditor 선택
+        # (그 안에서 bootstrap_capable=True 인 상태)
+        self.assertIsInstance(
+            bundle["code_editor"], GreenfieldBootstrapEditor
+        )
+
+    def test_live_editor_overrides_greenfield_when_both_on(self) -> None:
+        """둘 다 켜져 있으면 LiveCodeEditor 우선 — 사용자 의도 (LLM 편집
+        가능 환경) 에 맞음."""
+
+        bundle = build_live_executor(
+            repo_root="/tmp/r",
+            env={
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+                ENV_GREENFIELD_BOOTSTRAP_ENABLED: "1",
+            },
+        )
+        self.assertIsInstance(bundle["code_editor"], LiveCodeEditor)
+
+
+# ---------------------------------------------------------------------------
+# Bonus — _default_claude_cli_subprocess_runner 가 LiveCodeEditor 에 주입됨
+# ---------------------------------------------------------------------------
+
+
+class DefaultSubprocessRunnerWiredTests(unittest.TestCase):
+    def test_live_editor_has_runner_injected(self) -> None:
+        editor = build_live_editor_from_env(
+            {
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+            },
+            subprocess_runner=lambda cmd, **kw: None,
+        )
+        self.assertIsNotNone(editor)
+        self.assertIsNotNone(editor._subprocess_runner)
+
+    def test_build_live_executor_injects_default_runner(self) -> None:
+        bundle = build_live_executor(
+            repo_root="/tmp/r",
+            env={
+                ENV_LIVE_EDITOR_ENABLED: "true",
+                ENV_LIVE_EDITOR_PROVIDER: PROVIDER_CLAUDE_CLI,
+            },
+        )
+        editor = bundle["code_editor"]
+        self.assertIsInstance(editor, LiveCodeEditor)
+        # runner 가 None 이면 안 됨 — 옛 회귀 (LiveCodeEditor 가 매번
+        # "runner not injected" 로 BlockedLiveEditorError raise)
+        self.assertIsNotNone(editor._subprocess_runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_p1u_issue_reuse_and_noop_detection.py
+++ b/tests/agents/test_p1u_issue_reuse_and_noop_detection.py
@@ -1,0 +1,362 @@
+"""P1-U — issue #5 재사용 + live editor no-op 진단.
+
+8 사용자 acceptance:
+
+1. prompt with explicit GitHub issue URL reuses existing issue
+2. prompt with `#5` / `issue 5` / `이슈 5` reuses existing issue
+3. existing issue explicit > auto-create priority
+4. reused issue session.extra 에 existing_issue_number + source 영속
+5. live editor 0 edits → explicit no-op reason, not commit_failed
+6. commit_failed reserved for real git commit failure after actual edits
+7. operator surface shows issue reuse + no-op diagnostics
+8. stale tracking "needs issue" cleared when reuse succeeds
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import replace as _replace
+from types import SimpleNamespace
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.coding.coding_session_context import (
+    _extract_explicit_issue_number,
+    prepare_coding_session_context,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    REASON_COMMIT_FAILED,
+    REASON_LIVE_EDITOR_NO_EDITS_PRODUCED,
+    CodingExecuteRequest,
+    CodingExecutorWorker,
+    WorktreeContext,
+)
+from yule_orchestrator.agents.job_queue.heartbeat import HeartbeatStore
+from yule_orchestrator.agents.job_queue.state_machine import JobState
+from yule_orchestrator.agents.job_queue.store import JobQueue
+from yule_orchestrator.discord.integrations.github_workos_adapter import (
+    _coerce_existing_issue,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2 — explicit issue anchor extraction (URL + text)
+# ---------------------------------------------------------------------------
+
+
+class ExplicitIssueAnchorExtractionTests(unittest.TestCase):
+    def test_url_issue_anchor_persists_to_extras(self) -> None:
+        ctx = prepare_coding_session_context(
+            message_text=(
+                "네이버 검색 풀스택 MVP — 기존 issue #5 사용 "
+                "https://github.com/yule-studio/naver-search-clone/issues/5"
+            ),
+            user_links=(
+                "https://github.com/yule-studio/naver-search-clone/issues/5",
+            ),
+            existing_extra={},
+            discover_contract=False,
+        )
+        self.assertEqual(ctx.extras_update.get("existing_issue_number"), 5)
+        self.assertEqual(
+            ctx.extras_update.get("existing_issue_source"), "prompt_url"
+        )
+
+    def test_text_pattern_hash_anchor(self) -> None:
+        self.assertEqual(_extract_explicit_issue_number("기존 issue #5 사용"), 5)
+        self.assertEqual(_extract_explicit_issue_number("그래도 #42 로 진행"), 42)
+
+    def test_text_pattern_issue_word(self) -> None:
+        self.assertEqual(_extract_explicit_issue_number("reuse issue 5"), 5)
+        self.assertEqual(_extract_explicit_issue_number("issue#5"), 5)
+
+    def test_text_pattern_korean_issue_word(self) -> None:
+        self.assertEqual(_extract_explicit_issue_number("이슈 5 그대로 진행"), 5)
+        self.assertEqual(
+            _extract_explicit_issue_number("이슈 #12 anchor"), 12
+        )
+
+    def test_no_anchor_returns_none(self) -> None:
+        self.assertIsNone(_extract_explicit_issue_number("새로 시작"))
+        # 단순 숫자는 무시 (false positive 차단)
+        self.assertIsNone(_extract_explicit_issue_number("page 5 of doc"))
+
+    def test_text_pattern_only_in_extras_when_no_url(self) -> None:
+        # URL 없음 + prompt 에 #5 → existing_issue_source=prompt_text
+        ctx = prepare_coding_session_context(
+            message_text="기존 issue #5 그대로 사용해줘. 새로 만들지 마",
+            user_links=(),
+            existing_extra={},
+            discover_contract=False,
+        )
+        self.assertEqual(ctx.extras_update.get("existing_issue_number"), 5)
+        self.assertEqual(
+            ctx.extras_update.get("existing_issue_source"), "prompt_text"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3, 4 — _coerce_existing_issue priority
+# ---------------------------------------------------------------------------
+
+
+class CoerceExistingIssuePriorityTests(unittest.TestCase):
+    def test_explicit_caller_wins(self) -> None:
+        sess = SimpleNamespace(extra={"existing_issue_number": 99})
+        self.assertEqual(_coerce_existing_issue(5, sess), 5)
+
+    def test_session_existing_issue_number_used_over_anchor(self) -> None:
+        sess = SimpleNamespace(
+            extra={
+                "existing_issue_number": 5,
+                "github_work_order_issue": {"issue_number": 99},
+            }
+        )
+        # 새 P1-U 키 (5) 가 옛 anchor (99) 보다 우선
+        self.assertEqual(_coerce_existing_issue(None, sess), 5)
+
+    def test_old_anchor_used_when_no_prompt_anchor(self) -> None:
+        sess = SimpleNamespace(
+            extra={"github_work_order_issue": {"issue_number": 7}}
+        )
+        self.assertEqual(_coerce_existing_issue(None, sess), 7)
+
+    def test_no_session_no_explicit_returns_none(self) -> None:
+        sess = SimpleNamespace(extra={})
+        self.assertIsNone(_coerce_existing_issue(None, sess))
+
+
+# ---------------------------------------------------------------------------
+# 5, 6 — live editor no-op detection
+# ---------------------------------------------------------------------------
+
+
+class _FakeLiveCodeEditor:
+    """LiveCodeEditor 처럼 보이는 fake — type().__name__ 만 매칭하면 됨."""
+
+    provider = "claude-cli"
+    model = "claude-sonnet-4-6"
+
+    def apply(self, *, request, context):
+        # 실제 LiveCodeEditor 처럼 edited_files 안 건드림 → no-op
+        return context
+
+
+# LiveCodeEditor 와 동일한 class name 으로 worker가 감지
+_FakeLiveCodeEditor.__name__ = "LiveCodeEditor"
+
+
+class _FakeProvisioner:
+    def provision(self, *, request, branch):
+        return WorktreeContext(
+            branch=branch,
+            worktree_path="/tmp/" + branch.replace("/", "_"),
+            base_commit_sha="basesha",
+        )
+
+
+class _FakeRecordOnlyEditor:
+    """plan-only editor — edited_files 에 plan 파일 추가."""
+
+    def apply(self, *, request, context):
+        return _replace(
+            context,
+            edited_files=tuple(
+                list(context.edited_files) + ["runs/coding-executor-plans/x.md"]
+            ),
+        )
+
+
+_FakeRecordOnlyEditor.__name__ = "RecordOnlyCodeEditor"
+
+
+class _FakeTests:
+    def run(self, *, request, context):
+        return _replace(
+            context, test_summary={"status": "ok", "passed": 1}
+        )
+
+
+class _FakeCommitter:
+    def commit(self, *, request, context):
+        return _replace(context, commit_sha="commitsha-after-real-edit")
+
+
+class _FakePusher:
+    def push(self, *, request, context):
+        return _replace(context, pushed=True)
+
+
+class _FakePR:
+    def open(self, *, request, context):
+        return _replace(context, pr_number=99, pr_url="https://x/y/pull/99")
+
+
+def _make_request(*, issue_number: int = 5) -> CodingExecuteRequest:
+    return CodingExecuteRequest(
+        session_id="s-noop-1",
+        executor_role="backend-engineer",
+        user_request="네이버 검색 MVP",
+        generated_prompt="(p)",
+        write_scope=("src/**",),
+        forbidden_scope=(),
+        safety_rules=(),
+        base_branch="main",
+        branch_hint=f"feature/auth-issue-{issue_number}",
+        repo_full_name="yule-studio/naver-search-clone",
+        issue_number=issue_number,
+        dry_run=False,
+        metadata={},
+    )
+
+
+class _WorkerFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._db = self._tmp.name + "/queue.sqlite3"
+        self.queue = JobQueue(db_path=self._db)
+        self.heartbeats = HeartbeatStore(db_path=self._db)
+
+
+class LiveEditorNoOpDetectionTests(_WorkerFixture):
+    def test_no_edits_produced_yields_explicit_reason(self) -> None:
+        worker = CodingExecutorWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            worktree_provisioner=_FakeProvisioner(),
+            code_editor=_FakeLiveCodeEditor(),
+            test_runner=_FakeTests(),
+            committer=_FakeCommitter(),
+            pusher=_FakePusher(),
+            draft_pr_creator=_FakePR(),
+        )
+        worker.enqueue(_make_request())
+        outcome = worker.run_one(worker_id="t")
+        # 옛 wiring: REASON_COMMIT_FAILED.  새 wiring:
+        # REASON_LIVE_EDITOR_NO_EDITS_PRODUCED.
+        self.assertNotEqual(outcome.failure_reason, REASON_COMMIT_FAILED)
+        self.assertEqual(
+            outcome.failure_reason, REASON_LIVE_EDITOR_NO_EDITS_PRODUCED
+        )
+        # state 는 failed_retryable (terminal 아님 — operator 가 prompt
+        # 보강 후 retry 가능)
+        self.assertEqual(
+            outcome.terminal_state, JobState.FAILED_RETRYABLE.value
+        )
+
+    def test_record_only_editor_with_plan_file_is_not_no_op(self) -> None:
+        """RecordOnly / Greenfield 같은 plan editor 는 edited_files 에 plan
+        파일 추가 → no-op 분기 firing 안 됨 (옛 정상 동작 보존)."""
+
+        worker = CodingExecutorWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            worktree_provisioner=_FakeProvisioner(),
+            code_editor=_FakeRecordOnlyEditor(),
+            test_runner=_FakeTests(),
+            committer=_FakeCommitter(),
+            pusher=_FakePusher(),
+            draft_pr_creator=_FakePR(),
+        )
+        worker.enqueue(_make_request())
+        outcome = worker.run_one(worker_id="t")
+        # plan 파일이 commit 됐다고 가정 — SAVED 분기
+        self.assertEqual(
+            outcome.terminal_state, JobState.SAVED.value
+        )
+
+    def test_live_editor_with_actual_edits_proceeds_to_commit(self) -> None:
+        """LiveCodeEditor 인 척하지만 edited_files 채워서 반환 → no-op
+        아님 → 다음 단계 진행."""
+
+        class _LiveWithEdits:
+            provider = "claude-cli"
+            model = "claude-sonnet-4-6"
+
+            def apply(self, *, request, context):
+                return _replace(
+                    context,
+                    edited_files=tuple(
+                        list(context.edited_files) + ["src/api/auth.ts"]
+                    ),
+                )
+
+        _LiveWithEdits.__name__ = "LiveCodeEditor"
+
+        worker = CodingExecutorWorker(
+            queue=self.queue,
+            heartbeats=self.heartbeats,
+            worktree_provisioner=_FakeProvisioner(),
+            code_editor=_LiveWithEdits(),
+            test_runner=_FakeTests(),
+            committer=_FakeCommitter(),
+            pusher=_FakePusher(),
+            draft_pr_creator=_FakePR(),
+        )
+        worker.enqueue(_make_request())
+        outcome = worker.run_one(worker_id="t")
+        # edited_files 있음 → no-op 분기 안 타고 SAVED
+        self.assertEqual(outcome.terminal_state, JobState.SAVED.value)
+
+
+# ---------------------------------------------------------------------------
+# 7 — source-grep wiring guard (no-op detection 코드 실제 존재)
+# ---------------------------------------------------------------------------
+
+
+class WorkerWiringGuardTests(unittest.TestCase):
+    def test_worker_source_contains_no_op_detection(self) -> None:
+        from pathlib import Path
+
+        src = Path(
+            "src/yule_orchestrator/agents/job_queue/coding_executor_worker.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("REASON_LIVE_EDITOR_NO_EDITS_PRODUCED", src)
+        self.assertIn("live_editor_no_edits_produced", src)
+        # 옛 회귀 — generic commit_failed 가 LiveCodeEditor no-op 케이스에
+        # 잘못 firing 하면 안 됨.  본 source-grep 가드는 새 분기 코드가
+        # LiveCodeEditor 식별을 한다는 점을 강제.
+        self.assertIn("is_live_editor", src)
+
+
+# ---------------------------------------------------------------------------
+# 8 — issue reuse + tracking surface 정합성
+# ---------------------------------------------------------------------------
+
+
+class IssueReuseSurfaceTests(unittest.TestCase):
+    def test_extras_includes_issue_reuse_metadata(self) -> None:
+        """existing_issue_number + existing_issue_source 영속 → operator
+        surface 가 stale 'needs issue' 가 아니라 'reusing issue #5' 로 보임."""
+
+        ctx = prepare_coding_session_context(
+            message_text=(
+                "기존 이슈 #5 그대로 진행 "
+                "https://github.com/yule-studio/naver-search-clone/issues/5"
+            ),
+            user_links=(
+                "https://github.com/yule-studio/naver-search-clone/issues/5",
+            ),
+            existing_extra={
+                "tracking_blocked_reason": "needs_issue",  # stale state
+            },
+            discover_contract=False,
+        )
+        # P1-U 가 anchor 를 영속 → 다음 work_order builder 가 auto-create
+        # 안 함.  운영자가 다음 인스턴스에서 stale tracking 을 직접
+        # 갱신할 수 있도록 anchor metadata 가 명시.
+        self.assertEqual(ctx.extras_update.get("existing_issue_number"), 5)
+        self.assertEqual(
+            ctx.extras_update.get("existing_issue_source"), "prompt_url"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_p1v_live_editor_worktree_scan.py
+++ b/tests/agents/test_p1v_live_editor_worktree_scan.py
@@ -1,0 +1,341 @@
+"""P1-V — LiveCodeEditor worktree 변경 수집 + scope 필터 회귀.
+
+P1-U C 가 ``REASON_LIVE_EDITOR_NO_EDITS_PRODUCED`` 로 0-edit 케이스를
+정직하게 surface 하긴 하지만, LiveCodeEditor 자체가 claude-cli 가
+실제로 worktree 안의 파일을 수정해도 ``edited_files=()`` 로 돌려보내는
+한 진짜 코드 commit 은 영영 안 흐른다.  본 모듈은 worktree 스캔 후
+파일이 잡혔는지 / write_scope 가 정상 거부했는지 / 0-edit 케이스가
+fallback 으로 떨어지는지 확정한다.
+
+stdlib unittest 만 사용 (pytest fixture / pip 의존 X).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    ENV_LIVE_EDITOR_ENABLED,
+    ENV_LIVE_EDITOR_PROVIDER,
+    LiveCodeEditor,
+    PROVIDER_CLAUDE_CLI,
+    _collect_changed_paths,
+    _parse_porcelain_line,
+    _path_in_scope,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    WorktreeContext,
+)
+
+
+def _request(**overrides: Any) -> CodingExecuteRequest:
+    base = {
+        "session_id": "sess-p1v-scan",
+        "executor_role": "backend-engineer",
+        "user_request": "implement search clone",
+        "generated_prompt": "implement /search route under app/api/search/route.ts",
+        "write_scope": ("app/", "components/"),
+        "forbidden_scope": (".github/workflows/",),
+        "safety_rules": (),
+        "base_branch": "main",
+        "branch_hint": "feat/search-issue-5",
+        "repo_full_name": "yule-studio/naver-search-clone",
+        "issue_number": 5,
+        "dry_run": False,
+        "metadata": {},
+    }
+    base.update(overrides)
+    return CodingExecuteRequest(**base)
+
+
+def _worktree_ctx(path: Path) -> WorktreeContext:
+    return WorktreeContext(
+        branch="feat/search-issue-5",
+        worktree_path=str(path),
+        base_commit_sha="cafe1234",
+    )
+
+
+class _ProgrammableRunner:
+    """fake subprocess runner — 인자 (cmd) 첫 토큰별로 다른 stdout 반환."""
+
+    def __init__(self, *, status_stdout: str = "", raise_on_status: bool = False) -> None:
+        self.calls: list[tuple[Sequence[str], Mapping[str, Any]]] = []
+        self._status_stdout = status_stdout
+        self._raise_on_status = raise_on_status
+
+    def __call__(self, cmd: Sequence[str], **kwargs: Any) -> Mapping[str, Any]:
+        cmd_tuple = tuple(cmd)
+        self.calls.append((cmd_tuple, dict(kwargs)))
+        if "status" in cmd_tuple and "--porcelain" in cmd_tuple:
+            if self._raise_on_status:
+                raise RuntimeError("git status simulated failure")
+            return {"stdout": self._status_stdout, "exit_code": 0}
+        return {"stdout": "ok", "exit_code": 0}
+
+
+# ---------------------------------------------------------------------------
+# Porcelain parser
+# ---------------------------------------------------------------------------
+
+
+class PorcelainParserTests(unittest.TestCase):
+    def test_modified_line(self) -> None:
+        self.assertEqual(_parse_porcelain_line(" M app/api/search/route.ts"), "app/api/search/route.ts")
+
+    def test_added_staged_line(self) -> None:
+        self.assertEqual(_parse_porcelain_line("A  components/SearchBox.tsx"), "components/SearchBox.tsx")
+
+    def test_untracked_line(self) -> None:
+        self.assertEqual(_parse_porcelain_line("?? app/page.tsx"), "app/page.tsx")
+
+    def test_rename_takes_destination(self) -> None:
+        rel = _parse_porcelain_line("R  old/path.ts -> new/path.ts")
+        self.assertEqual(rel, "new/path.ts")
+
+    def test_fully_deleted_is_dropped(self) -> None:
+        # committer 가 stage 못 함.  drop 하면 안전.
+        self.assertIsNone(_parse_porcelain_line(" D removed.ts"))
+
+    def test_ignored_class_dropped(self) -> None:
+        self.assertIsNone(_parse_porcelain_line("!! .DS_Store"))
+
+    def test_too_short_returns_none(self) -> None:
+        self.assertIsNone(_parse_porcelain_line(""))
+        self.assertIsNone(_parse_porcelain_line("ok"))
+
+    def test_quoted_path_unwrapped(self) -> None:
+        rel = _parse_porcelain_line('?? "components/Search Box.tsx"')
+        self.assertEqual(rel, "components/Search Box.tsx")
+
+
+# ---------------------------------------------------------------------------
+# Path-in-scope matcher
+# ---------------------------------------------------------------------------
+
+
+class PathInScopeTests(unittest.TestCase):
+    def test_empty_scope_means_no_restriction(self) -> None:
+        self.assertTrue(_path_in_scope("any/file.ts", ()))
+
+    def test_direct_prefix_match(self) -> None:
+        self.assertTrue(_path_in_scope("app/page.tsx", ("app/",)))
+
+    def test_glob_suffix_normalized(self) -> None:
+        # ``services/auth/**`` / ``services/auth/`` 같은 모양도 같은 prefix.
+        self.assertTrue(_path_in_scope("services/auth/login.py", ("services/auth/**",)))
+        self.assertTrue(_path_in_scope("services/auth/login.py", ("services/auth",)))
+
+    def test_no_match_returns_false(self) -> None:
+        self.assertFalse(_path_in_scope("infrastructure/k8s.yaml", ("app/",)))
+
+
+# ---------------------------------------------------------------------------
+# _collect_changed_paths — scope 필터링 회귀
+# ---------------------------------------------------------------------------
+
+
+class CollectChangedPathsTests(unittest.TestCase):
+    def test_in_scope_files_collected(self) -> None:
+        runner = _ProgrammableRunner(
+            status_stdout=" M app/api/search/route.ts\n?? components/SearchBox.tsx\n",
+        )
+        detected, refused_scope, refused_forbidden = _collect_changed_paths(
+            runner=runner,
+            worktree_path="/tmp/fake",
+            write_scope=("app/", "components/"),
+            forbidden_scope=(),
+        )
+        self.assertEqual(detected, ("app/api/search/route.ts", "components/SearchBox.tsx"))
+        self.assertEqual(refused_scope, ())
+        self.assertEqual(refused_forbidden, ())
+
+    def test_out_of_scope_files_refused(self) -> None:
+        runner = _ProgrammableRunner(
+            status_stdout=" M app/page.tsx\n M infrastructure/k8s.yaml\n",
+        )
+        detected, refused_scope, _ = _collect_changed_paths(
+            runner=runner,
+            worktree_path="/tmp/fake",
+            write_scope=("app/",),
+            forbidden_scope=(),
+        )
+        self.assertEqual(detected, ("app/page.tsx",))
+        self.assertEqual(refused_scope, ("infrastructure/k8s.yaml",))
+
+    def test_forbidden_scope_rejects_even_in_write_scope(self) -> None:
+        # ``.github/workflows/`` 는 write_scope 가 broad 해도 forbidden 으로 reject.
+        runner = _ProgrammableRunner(
+            status_stdout=" M .github/workflows/ci.yaml\n M app/page.tsx\n",
+        )
+        detected, refused_scope, refused_forbidden = _collect_changed_paths(
+            runner=runner,
+            worktree_path="/tmp/fake",
+            write_scope=(".github/", "app/"),
+            forbidden_scope=(".github/workflows/",),
+        )
+        self.assertEqual(detected, ("app/page.tsx",))
+        self.assertEqual(refused_scope, ())
+        self.assertEqual(refused_forbidden, (".github/workflows/ci.yaml",))
+
+    def test_runner_raises_returns_empty(self) -> None:
+        runner = _ProgrammableRunner(raise_on_status=True)
+        detected, refused_scope, refused_forbidden = _collect_changed_paths(
+            runner=runner,
+            worktree_path="/tmp/fake",
+            write_scope=("app/",),
+            forbidden_scope=(),
+        )
+        self.assertEqual((detected, refused_scope, refused_forbidden), ((), (), ()))
+
+    def test_empty_worktree_path_returns_empty(self) -> None:
+        runner = _ProgrammableRunner(status_stdout=" M app/page.tsx\n")
+        detected, refused_scope, refused_forbidden = _collect_changed_paths(
+            runner=runner,
+            worktree_path="",
+            write_scope=("app/",),
+            forbidden_scope=(),
+        )
+        self.assertEqual((detected, refused_scope, refused_forbidden), ((), (), ()))
+        # runner 도 호출 안 함
+        self.assertEqual(runner.calls, [])
+
+    def test_dedupes_repeated_paths(self) -> None:
+        # rare but possible if git status emits both staged and unstaged
+        # entries for the same path.
+        runner = _ProgrammableRunner(
+            status_stdout="MM app/page.tsx\n M app/page.tsx\n",
+        )
+        detected, _, _ = _collect_changed_paths(
+            runner=runner,
+            worktree_path="/tmp/fake",
+            write_scope=("app/",),
+            forbidden_scope=(),
+        )
+        self.assertEqual(detected, ("app/page.tsx",))
+
+
+# ---------------------------------------------------------------------------
+# LiveCodeEditor.apply — 진짜 변경 surface
+# ---------------------------------------------------------------------------
+
+
+class LiveCodeEditorAppliesChangesTests(unittest.TestCase):
+    def test_changed_files_populated_after_runner(self) -> None:
+        runner = _ProgrammableRunner(
+            status_stdout=" M app/api/search/route.ts\n?? components/SearchBox.tsx\n",
+        )
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=runner,
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _worktree_ctx(Path(tmp))
+            new_ctx = editor.apply(request=_request(), context=ctx)
+        self.assertEqual(
+            new_ctx.edited_files,
+            ("app/api/search/route.ts", "components/SearchBox.tsx"),
+        )
+        # metadata 에 live audit 영속.
+        audit = dict(new_ctx.metadata or {}).get("live_editor_apply")
+        self.assertIsNotNone(audit)
+        self.assertEqual(audit["provider"], PROVIDER_CLAUDE_CLI)
+        self.assertEqual(
+            audit["detected_changed_files"],
+            ["app/api/search/route.ts", "components/SearchBox.tsx"],
+        )
+        self.assertEqual(audit["refused_by_scope"], [])
+        self.assertEqual(audit["refused_by_forbidden"], [])
+
+    def test_zero_edits_returns_context_identity(self) -> None:
+        # 진짜 0건 → context 그대로 → worker 의 P1-U C 가 surface
+        runner = _ProgrammableRunner(status_stdout="")
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=runner,
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _worktree_ctx(Path(tmp))
+            new_ctx = editor.apply(request=_request(), context=ctx)
+        self.assertIs(new_ctx, ctx)
+        self.assertEqual(new_ctx.edited_files, ())
+
+    def test_refused_files_surface_in_metadata_but_not_committed(self) -> None:
+        runner = _ProgrammableRunner(
+            status_stdout=" M app/page.tsx\n M infrastructure/k8s.yaml\n",
+        )
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=runner,
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _worktree_ctx(Path(tmp))
+            new_ctx = editor.apply(
+                request=_request(write_scope=("app/",)),
+                context=ctx,
+            )
+        # commit 단계에 흘러가는 건 in-scope 파일만.
+        self.assertEqual(new_ctx.edited_files, ("app/page.tsx",))
+        audit = dict(new_ctx.metadata or {})["live_editor_apply"]
+        self.assertEqual(audit["refused_by_scope"], ["infrastructure/k8s.yaml"])
+
+    def test_git_status_runner_call_uses_capture_output(self) -> None:
+        # 운영진단용 — runner 가 stdout 을 받아야 worktree 변경 수집이 됨.
+        runner = _ProgrammableRunner(status_stdout="?? app/x.ts\n")
+        editor = LiveCodeEditor(
+            provider=PROVIDER_CLAUDE_CLI,
+            subprocess_runner=runner,
+            env={ENV_LIVE_EDITOR_ENABLED: "true"},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = _worktree_ctx(Path(tmp))
+            editor.apply(request=_request(), context=ctx)
+        status_calls = [
+            (cmd, kwargs)
+            for cmd, kwargs in runner.calls
+            if "status" in cmd and "--porcelain" in cmd
+        ]
+        self.assertEqual(len(status_calls), 1)
+        status_cmd, status_kwargs = status_calls[0]
+        self.assertEqual(status_cmd[:2], ("git", "-C"))
+        self.assertTrue(status_kwargs.get("capture_output"))
+
+
+# ---------------------------------------------------------------------------
+# Source-grep guard — wiring 회귀
+# ---------------------------------------------------------------------------
+
+
+class WorktreeScanWiringGuardTests(unittest.TestCase):
+    def test_live_editor_calls_collect_changed_paths(self) -> None:
+        # 누군가 refactor 로 _collect_changed_paths 호출을 빼버리면 회귀.
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import coding_executor_live as mod
+
+        source = inspect.getsource(mod.LiveCodeEditor._apply_via_claude_cli)
+        self.assertIn("_collect_changed_paths", source)
+        self.assertIn("write_scope", source)
+        self.assertIn("forbidden_scope", source)
+
+    def test_module_exports_collect_helper(self) -> None:
+        from yule_orchestrator.agents.job_queue import coding_executor_live as mod
+
+        self.assertTrue(callable(getattr(mod, "_collect_changed_paths", None)))
+        self.assertTrue(callable(getattr(mod, "_parse_porcelain_line", None)))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1w_commit_message_honest_surface.py
+++ b/tests/agents/test_p1w_commit_message_honest_surface.py
@@ -1,0 +1,237 @@
+"""P1-W — _commit_message 가 live-edit / record-only 정직 구분.
+
+옛 wiring 은 항상 "RecordOnly editor 의 dry 산출" 본문을 만들어서 P1-V
+LiveCodeEditor 가 실제 코드 수정한 commit 도 "이건 dry plan" 이라고
+거짓말했다.  본 모듈은 context.metadata["live_editor_apply"] +
+edited_files 신호 시 새 본문 + ✨ gitmoji 가 떨어지고, 옛 record-only
+경로는 그대로 보존되며, 양쪽 다 enforce_commit_message 통과하는지
+회귀한다.
+
+stdlib unittest 만 사용.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    enforce_commit_message,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    _commit_message,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    WorktreeContext,
+)
+
+
+def _request(**overrides: Any) -> CodingExecuteRequest:
+    base = {
+        "session_id": "sess-p1w",
+        "executor_role": "fullstack-engineer",
+        "user_request": "implement /search route",
+        "generated_prompt": "implement /search route under app/api/search/",
+        "write_scope": ("app/",),
+        "forbidden_scope": (),
+        "safety_rules": (),
+        "base_branch": "main",
+        "branch_hint": "feat/search-issue-5",
+        "repo_full_name": "yule-studio/naver-search-clone",
+        "issue_number": 5,
+        "dry_run": False,
+        "metadata": {},
+    }
+    base.update(overrides)
+    return CodingExecuteRequest(**base)
+
+
+def _live_edit_ctx(*, files=("app/api/search/route.ts", "components/SearchBox.tsx")) -> WorktreeContext:
+    return WorktreeContext(
+        branch="feat/search-issue-5",
+        worktree_path="/tmp/wt-fake",
+        base_commit_sha="cafe1234",
+        edited_files=tuple(files),
+        metadata={
+            "live_editor_apply": {
+                "provider": "claude-cli",
+                "model": "claude-sonnet-4-6",
+                "detected_changed_files": list(files),
+                "refused_by_scope": [],
+                "refused_by_forbidden": [],
+            }
+        },
+    )
+
+
+def _record_only_ctx() -> WorktreeContext:
+    return WorktreeContext(
+        branch="feat/search-issue-5",
+        worktree_path="/tmp/wt-fake",
+        base_commit_sha="cafe1234",
+        edited_files=("runs/coding-executor-plans/feat-search-issue-5.md",),
+        # metadata 비어있음 → record-only 분기.
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live-edit branch
+# ---------------------------------------------------------------------------
+
+
+class LiveEditCommitMessageTests(unittest.TestCase):
+    def test_uses_sparkle_gitmoji_for_live_edit(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        first_line = msg.splitlines()[0]
+        self.assertTrue(first_line.startswith("✨"), first_line)
+        self.assertNotIn("📝", first_line)
+
+    def test_includes_issue_number(self) -> None:
+        msg = _commit_message(_request(issue_number=5), _live_edit_ctx())
+        self.assertIn("#5", msg.splitlines()[0])
+
+    def test_title_says_구현_not_계획(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        first_line = msg.splitlines()[0]
+        self.assertIn("구현", first_line)
+        self.assertNotIn("계획 기록", first_line)
+
+    def test_body_lists_changed_files(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        self.assertIn("app/api/search/route.ts", msg)
+        self.assertIn("components/SearchBox.tsx", msg)
+
+    def test_body_surfaces_provider_and_model(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        self.assertIn("provider=claude-cli", msg)
+        self.assertIn("model=claude-sonnet-4-6", msg)
+
+    def test_body_says_live_llm_editor_not_recordonly(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        self.assertIn("live LLM editor", msg)
+        self.assertNotIn("RecordOnly editor 의 dry 산출", msg)
+
+    def test_many_files_truncated_with_summary(self) -> None:
+        ten_files = tuple(f"app/page-{i}.tsx" for i in range(10))
+        ctx = _live_edit_ctx(files=ten_files)
+        msg = _commit_message(_request(), ctx)
+        # 처음 5 개만 list 되고 그 다음 한 줄로 "… (N 개 추가)" 가 와야.
+        self.assertIn("app/page-0.tsx", msg)
+        self.assertIn("app/page-4.tsx", msg)
+        self.assertIn("5 개 추가 파일 생략", msg)
+        # 6+ 인덱스는 본문에서 빠져야 함 (truncated).
+        self.assertNotIn("app/page-7.tsx", msg)
+
+    def test_refused_by_scope_surfaced_when_present(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/x",
+            worktree_path="/tmp/wt",
+            base_commit_sha="abc",
+            edited_files=("app/page.tsx",),
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": ["app/page.tsx"],
+                    "refused_by_scope": ["infrastructure/k8s.yaml"],
+                    "refused_by_forbidden": [],
+                }
+            },
+        )
+        msg = _commit_message(_request(), ctx)
+        self.assertIn("write_scope 밖", msg)
+        self.assertIn("infrastructure/k8s.yaml", msg)
+
+    def test_refused_by_forbidden_surfaced_when_present(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/x",
+            worktree_path="/tmp/wt",
+            base_commit_sha="abc",
+            edited_files=("app/page.tsx",),
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": ["app/page.tsx"],
+                    "refused_by_scope": [],
+                    "refused_by_forbidden": [".github/workflows/ci.yaml"],
+                }
+            },
+        )
+        msg = _commit_message(_request(), ctx)
+        self.assertIn("forbidden_scope", msg)
+        self.assertIn(".github/workflows/ci.yaml", msg)
+
+    def test_passes_enforce_commit_message(self) -> None:
+        msg = _commit_message(_request(), _live_edit_ctx())
+        # raise PolicyViolation if not policy-compliant
+        enforce_commit_message(msg, is_initial=False)
+
+    def test_override_gitmoji_respected(self) -> None:
+        # 운영자가 metadata 로 명시한 gitmoji 가 ✨ 보다 우선.
+        ctx = _live_edit_ctx()
+        new_metadata = dict(ctx.metadata or {})
+        new_metadata["commit_gitmoji_override"] = "🐛"
+        ctx = WorktreeContext(
+            branch=ctx.branch,
+            worktree_path=ctx.worktree_path,
+            base_commit_sha=ctx.base_commit_sha,
+            edited_files=ctx.edited_files,
+            metadata=new_metadata,
+        )
+        msg = _commit_message(_request(), ctx)
+        self.assertTrue(msg.splitlines()[0].startswith("🐛"))
+
+
+# ---------------------------------------------------------------------------
+# Record-only branch (옛 동작 회귀 가드)
+# ---------------------------------------------------------------------------
+
+
+class RecordOnlyCommitMessageTests(unittest.TestCase):
+    def test_uses_memo_gitmoji_for_record_only(self) -> None:
+        msg = _commit_message(_request(), _record_only_ctx())
+        self.assertTrue(msg.splitlines()[0].startswith("📝"))
+
+    def test_says_recordonly_dry(self) -> None:
+        msg = _commit_message(_request(), _record_only_ctx())
+        self.assertIn("RecordOnly editor 의 dry 산출", msg)
+        self.assertNotIn("live LLM editor", msg)
+
+    def test_passes_enforce_commit_message(self) -> None:
+        msg = _commit_message(_request(), _record_only_ctx())
+        enforce_commit_message(msg, is_initial=False)
+
+    def test_no_live_audit_no_edited_files_still_record_only(self) -> None:
+        # edge — 정말 0건 이지만 metadata 가 빈 경우.  record-only 분기로
+        # 떨어진다 (옛 behavior 유지).
+        ctx = WorktreeContext(branch="x", worktree_path="/tmp", edited_files=())
+        msg = _commit_message(_request(), ctx)
+        self.assertTrue(msg.splitlines()[0].startswith("📝"))
+
+
+# ---------------------------------------------------------------------------
+# Source-grep guard
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_commit_message_source_branches_on_live_editor_apply(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import coding_executor_live as mod
+
+        source = inspect.getsource(mod._commit_message)
+        self.assertIn("live_editor_apply", source)
+        self.assertIn("live LLM editor", source)
+        self.assertIn("RecordOnly", source)  # 옛 경로 보존 회귀
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1w_commit_message_honest_surface.py
+++ b/tests/agents/test_p1w_commit_message_honest_surface.py
@@ -215,6 +215,27 @@ class RecordOnlyCommitMessageTests(unittest.TestCase):
         msg = _commit_message(_request(), ctx)
         self.assertTrue(msg.splitlines()[0].startswith("📝"))
 
+    def test_live_audit_with_plan_markdown_only_stays_record_only(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/search-issue-5",
+            worktree_path="/tmp/wt-fake",
+            base_commit_sha="cafe1234",
+            edited_files=("runs/coding-executor-plans/feat-search-issue-5.md",),
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": [
+                        "runs/coding-executor-plans/feat-search-issue-5.md"
+                    ],
+                }
+            },
+        )
+        msg = _commit_message(_request(), ctx)
+        self.assertTrue(msg.splitlines()[0].startswith("📝"), msg)
+        self.assertIn("RecordOnly editor 의 dry 산출", msg)
+        self.assertNotIn("live LLM editor", msg)
+
 
 # ---------------------------------------------------------------------------
 # Source-grep guard

--- a/tests/agents/test_p1x_draft_pr_body_honest_surface.py
+++ b/tests/agents/test_p1x_draft_pr_body_honest_surface.py
@@ -197,6 +197,28 @@ class RecordOnlyPRBodyTests(unittest.TestCase):
         self.assertTrue(result.ok, result)
         self.assertEqual(result.missing_sections, ())
 
+    def test_live_audit_with_plan_markdown_only_stays_record_only(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/search-issue-5",
+            worktree_path="/tmp/wt-fake",
+            base_commit_sha="cafe1234",
+            edited_files=("runs/coding-executor-plans/feat-search-issue-5.md",),
+            commit_sha="deadbeefcafef00d",
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": [
+                        "runs/coding-executor-plans/feat-search-issue-5.md"
+                    ],
+                }
+            },
+        )
+        body = _draft_pr_body(_request(), ctx)
+        self.assertIn("`RecordOnlyCodeEditor` 가 만든 계획 markdown 만 포함", body)
+        self.assertIn("RecordOnly editor", body)
+        self.assertNotIn("live LLM editor", body)
+
 
 # ---------------------------------------------------------------------------
 # Source-grep guard

--- a/tests/agents/test_p1x_draft_pr_body_honest_surface.py
+++ b/tests/agents/test_p1x_draft_pr_body_honest_surface.py
@@ -1,0 +1,221 @@
+"""P1-X — _draft_pr_body 가 live edit / record-only 정직 구분.
+
+옛 _draft_pr_body 는 항상 "RecordOnlyCodeEditor 가 만든 계획 markdown
+만 포함" + "live editor 미연결" + "mode: live (RecordOnly editor)" 라고
+박아서, P1-V LiveCodeEditor 가 실제로 코드 수정한 PR 도 reviewer 가
+record-only 라고 오해 → fake success.  본 모듈은 metadata 기반 분기 +
+양쪽 validate_pr_body 통과 + 5 섹션 보존을 회귀한다.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.governance.runtime_policy import validate_pr_body
+from yule_orchestrator.agents.job_queue.coding_executor_live import (
+    _draft_pr_body,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    CodingExecuteRequest,
+    WorktreeContext,
+)
+
+
+def _request(**overrides: Any) -> CodingExecuteRequest:
+    base = {
+        "session_id": "sess-p1x",
+        "executor_role": "fullstack-engineer",
+        "user_request": "implement /search route",
+        "generated_prompt": "implement /search route",
+        "write_scope": ("app/", "components/"),
+        "forbidden_scope": (".github/workflows/",),
+        "safety_rules": ("no force push", "no merge to main"),
+        "base_branch": "main",
+        "branch_hint": "feat/search-issue-5",
+        "repo_full_name": "yule-studio/naver-search-clone",
+        "issue_number": 5,
+        "dry_run": False,
+        "metadata": {},
+    }
+    base.update(overrides)
+    return CodingExecuteRequest(**base)
+
+
+def _live_edit_ctx(*, files=("app/api/search/route.ts", "components/SearchBox.tsx")) -> WorktreeContext:
+    return WorktreeContext(
+        branch="feat/search-issue-5",
+        worktree_path="/tmp/wt-fake",
+        base_commit_sha="cafe1234",
+        edited_files=tuple(files),
+        commit_sha="deadbeefcafef00d",
+        metadata={
+            "live_editor_apply": {
+                "provider": "claude-cli",
+                "model": "claude-sonnet-4-6",
+                "detected_changed_files": list(files),
+                "refused_by_scope": [],
+                "refused_by_forbidden": [],
+            }
+        },
+    )
+
+
+def _record_only_ctx() -> WorktreeContext:
+    return WorktreeContext(
+        branch="feat/search-issue-5",
+        worktree_path="/tmp/wt-fake",
+        base_commit_sha="cafe1234",
+        edited_files=("runs/coding-executor-plans/feat-search-issue-5.md",),
+        commit_sha="deadbeefcafef00d",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live-edit PR body
+# ---------------------------------------------------------------------------
+
+
+class LiveEditPRBodyTests(unittest.TestCase):
+    def test_says_live_llm_editor(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        self.assertIn("live LLM editor", body)
+
+    def test_does_not_claim_record_only_plan_markdown(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        self.assertNotIn("`RecordOnlyCodeEditor` 가 만든 계획 markdown 만 포함", body)
+        self.assertNotIn("live editor 미연결", body)
+
+    def test_audit_mode_says_live_code_editor_not_record_only(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        audit_lines = [
+            ln for ln in body.splitlines() if "mode:" in ln and "live" in ln
+        ]
+        self.assertTrue(audit_lines, body)
+        joined = "\n".join(audit_lines)
+        self.assertIn("LiveCodeEditor", joined)
+        self.assertNotIn("RecordOnly editor", joined)
+
+    def test_lists_changed_files(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        self.assertIn("app/api/search/route.ts", body)
+        self.assertIn("components/SearchBox.tsx", body)
+
+    def test_provider_and_model_visible(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        self.assertIn("claude-cli", body)
+        self.assertIn("claude-sonnet-4-6", body)
+
+    def test_many_files_truncated(self) -> None:
+        ten = tuple(f"app/page-{i}.tsx" for i in range(10))
+        ctx = _live_edit_ctx(files=ten)
+        body = _draft_pr_body(_request(), ctx)
+        self.assertIn("app/page-0.tsx", body)
+        self.assertIn("app/page-7.tsx", body)
+        # 8 + 1 truncation line → page-8 / page-9 빠짐.
+        self.assertIn("2 개 추가 파일 생략", body)
+        self.assertNotIn("app/page-9.tsx", body)
+
+    def test_refused_by_scope_surfaced(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/x",
+            worktree_path="/tmp/wt",
+            edited_files=("app/page.tsx",),
+            commit_sha="abc",
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": ["app/page.tsx"],
+                    "refused_by_scope": ["infrastructure/k8s.yaml"],
+                    "refused_by_forbidden": [],
+                }
+            },
+        )
+        body = _draft_pr_body(_request(), ctx)
+        self.assertIn("write_scope 밖", body)
+        self.assertIn("infrastructure/k8s.yaml", body)
+
+    def test_refused_by_forbidden_surfaced(self) -> None:
+        ctx = WorktreeContext(
+            branch="feat/x",
+            worktree_path="/tmp/wt",
+            edited_files=("app/page.tsx",),
+            commit_sha="abc",
+            metadata={
+                "live_editor_apply": {
+                    "provider": "claude-cli",
+                    "model": "claude-sonnet-4-6",
+                    "detected_changed_files": ["app/page.tsx"],
+                    "refused_by_scope": [],
+                    "refused_by_forbidden": [".github/workflows/ci.yaml"],
+                }
+            },
+        )
+        body = _draft_pr_body(_request(), ctx)
+        self.assertIn("forbidden_scope", body)
+        self.assertIn(".github/workflows/ci.yaml", body)
+
+    def test_passes_validate_pr_body(self) -> None:
+        body = _draft_pr_body(_request(), _live_edit_ctx())
+        result = validate_pr_body(body)
+        self.assertTrue(result.ok, result)
+        self.assertEqual(result.missing_sections, ())
+        self.assertTrue(result.audit_block_present)
+
+    def test_includes_issue_link(self) -> None:
+        body = _draft_pr_body(_request(issue_number=5), _live_edit_ctx())
+        self.assertIn("close #5", body)
+
+
+# ---------------------------------------------------------------------------
+# Record-only PR body (옛 동작 회귀 가드)
+# ---------------------------------------------------------------------------
+
+
+class RecordOnlyPRBodyTests(unittest.TestCase):
+    def test_says_record_only_plan_markdown(self) -> None:
+        body = _draft_pr_body(_request(), _record_only_ctx())
+        self.assertIn("`RecordOnlyCodeEditor` 가 만든 계획 markdown 만 포함", body)
+
+    def test_audit_mode_still_record_only(self) -> None:
+        body = _draft_pr_body(_request(), _record_only_ctx())
+        self.assertIn("RecordOnly editor", body)
+
+    def test_does_not_claim_live_llm_edit(self) -> None:
+        body = _draft_pr_body(_request(), _record_only_ctx())
+        self.assertNotIn("live LLM editor", body)
+
+    def test_passes_validate_pr_body(self) -> None:
+        body = _draft_pr_body(_request(), _record_only_ctx())
+        result = validate_pr_body(body)
+        self.assertTrue(result.ok, result)
+        self.assertEqual(result.missing_sections, ())
+
+
+# ---------------------------------------------------------------------------
+# Source-grep guard
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_draft_pr_body_branches_on_live_editor_apply(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import coding_executor_live as mod
+
+        source = inspect.getsource(mod._draft_pr_body)
+        self.assertIn("live_editor_apply", source)
+        self.assertIn("live LLM editor", source)
+        self.assertIn("LiveCodeEditor", source)
+        # 옛 record-only 경로 보존 회귀
+        self.assertIn("RecordOnly editor", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1y_title_taxonomy_split.py
+++ b/tests/agents/test_p1y_title_taxonomy_split.py
@@ -1,0 +1,237 @@
+"""P1-Y — issue/PR prefix taxonomy 분리 + builder/template 정렬 회귀.
+
+배경
+----
+이전 (P1-N) 에서 모든 title prefix 가 한국어로 통일됐다가, GitHub 목록
+가독성 / 외부 dashboards 와의 정합성을 위해 issue prefix 만 영문
+taxonomy 로 다시 정렬했다 — PR prefix 는 한국어 정책 유지.
+
+핵심 contract:
+  * issue prefix → ``[Feature] / [Bug] / [Docs] / [Refactor] / [Chore]
+    / [Test]`` 만 허용
+  * PR prefix → ``[구현] / [수정] / [문서] / [설정] / [테스트] /
+    [리팩토링]`` 만 허용
+  * 두 정책은 ``validate_issue_title`` / ``validate_pr_title`` 분리
+  * ``[기능]`` (옛 한국어 issue prefix) / ``[Feat]`` (옛 축약) 둘 다 거부
+
+본 모듈은 위 contract 가 다음 refactor 때 다시 한 allowlist 로 합쳐지지
+않도록 명시 회귀 라인을 박는다.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.human_titles import build_issue_title
+from yule_orchestrator.agents.github_workos.issue_quality import (
+    INTENT_BUGFIX,
+    INTENT_CHORE,
+    INTENT_DOCS,
+    INTENT_FEATURE,
+    INTENT_FULL_STACK_MVP,
+    INTENT_REFACTOR,
+    INTENT_TEST,
+    synthesize_korean_title,
+)
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    REASON_INVALID_ISSUE_TITLE,
+    REASON_INVALID_PR_TITLE,
+    validate_issue_title,
+    validate_pr_title,
+)
+
+
+# ---------------------------------------------------------------------------
+# Issue allowlist — English only
+# ---------------------------------------------------------------------------
+
+
+class IssueTitleAllowlistTests(unittest.TestCase):
+    def test_accepts_all_six_english_prefixes(self) -> None:
+        cases = [
+            "[Feature] 네이버 검색 MVP — 인증 흐름 1차",
+            "[Bug] 검색 페이지가 빈 결과 처리 실패",
+            "[Docs] 운영 매뉴얼 5섹션 구조 정리",
+            "[Refactor] 검색 라우터 책임 분리",
+            "[Chore] 의존성 업데이트 및 lock 정리",
+            "[Test] 검색 API 응답 회귀 추가",
+        ]
+        for title in cases:
+            with self.subTest(title=title):
+                result = validate_issue_title(title)
+                self.assertTrue(result.ok, msg=f"{title} → {result.reason}/{result.detail}")
+
+    def test_rejects_legacy_korean_prefix(self) -> None:
+        # 옛 [기능] prefix — PR 쪽으로 잘못 쓸 일 없게 issue 도 reject.
+        result = validate_issue_title("[기능] 네이버 검색 MVP 인증 흐름")
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, REASON_INVALID_ISSUE_TITLE)
+
+    def test_rejects_legacy_short_feat_prefix(self) -> None:
+        # ``[Feat]`` 축약은 명시 거부 — taxonomy 일관성.
+        result = validate_issue_title("[Feat] 네이버 검색 MVP 인증")
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, REASON_INVALID_ISSUE_TITLE)
+
+    def test_rejects_pr_korean_prefix_in_issue(self) -> None:
+        # PR 전용 prefix 를 issue 에 잘못 쓰면 reject.
+        result = validate_issue_title("[구현] 인증 시스템 보강 1차")
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, REASON_INVALID_ISSUE_TITLE)
+
+    def test_issue_title_still_requires_korean_body(self) -> None:
+        # English prefix 만 있고 본문이 영문이면 4 한국어 chars 미만 → reject.
+        result = validate_issue_title("[Feature] add login API endpoint")
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, REASON_INVALID_ISSUE_TITLE)
+
+
+# ---------------------------------------------------------------------------
+# PR allowlist — Korean only
+# ---------------------------------------------------------------------------
+
+
+class PRTitleAllowlistTests(unittest.TestCase):
+    def test_accepts_all_six_korean_prefixes(self) -> None:
+        cases = [
+            "[구현][인증] 회원가입 API 1차 (#7)",
+            "[수정] 검색 결과 페이지 빈 응답 회귀 (#9)",
+            "[문서] 운영 매뉴얼 5섹션 보강 (#11)",
+            "[설정] CI 환경 변수 정리 (#13)",
+            "[테스트] 회원가입 회귀 케이스 추가 (#15)",
+            "[리팩토링] 검색 라우터 책임 분리 (#17)",
+        ]
+        for title in cases:
+            with self.subTest(title=title):
+                result = validate_pr_title(title)
+                self.assertTrue(result.ok, msg=f"{title} → {result.reason}/{result.detail}")
+
+    def test_rejects_english_issue_prefix_in_pr(self) -> None:
+        # 사용자가 강조: PR 은 issue 의 영문 prefix 절대 받지 않음.
+        for prefix in ("[Feature]", "[Bug]", "[Docs]", "[Refactor]", "[Chore]", "[Test]"):
+            with self.subTest(prefix=prefix):
+                result = validate_pr_title(f"{prefix} 인증 API 추가 (#7)")
+                self.assertFalse(result.ok)
+                self.assertEqual(result.reason, REASON_INVALID_PR_TITLE)
+
+
+# ---------------------------------------------------------------------------
+# Builder + intent mapping alignment
+# ---------------------------------------------------------------------------
+
+
+class IssueTitleBuilderTests(unittest.TestCase):
+    def test_build_issue_title_emits_feature_prefix(self) -> None:
+        title = build_issue_title(
+            session_prompt="네이버 검색형 풀스택 MVP 구축",
+        )
+        self.assertTrue(title.startswith("[Feature]"), title)
+
+    def test_build_issue_title_with_slice_emits_feature_area(self) -> None:
+        title = build_issue_title(
+            session_prompt="구현 작업",
+            slice_spec={"title": "회원가입 API 1차", "area": "auth"},
+        )
+        self.assertTrue(title.startswith("[Feature]"), title)
+        # 영역 라벨 (한국어) 도 포함되어야 함.
+        self.assertIn("인증", title)
+
+
+class SynthesizeKoreanTitleTests(unittest.TestCase):
+    def test_full_stack_emits_feature(self) -> None:
+        title, _strategy = synthesize_korean_title(
+            request_text="네이버 검색형 풀스택 MVP",
+            intent=INTENT_FULL_STACK_MVP,
+        )
+        self.assertTrue(title.startswith("[Feature]"), title)
+
+    def test_bugfix_emits_bug(self) -> None:
+        title, _strategy = synthesize_korean_title(
+            request_text="검색 결과 빈 응답 회귀 수정",
+            intent=INTENT_BUGFIX,
+        )
+        self.assertTrue(title.startswith("[Bug]"), title)
+
+    def test_docs_emits_docs(self) -> None:
+        title, _ = synthesize_korean_title(request_text="운영 매뉴얼 보강", intent=INTENT_DOCS)
+        self.assertTrue(title.startswith("[Docs]"), title)
+
+    def test_refactor_emits_refactor(self) -> None:
+        title, _ = synthesize_korean_title(
+            request_text="검색 라우터 책임 분리", intent=INTENT_REFACTOR
+        )
+        self.assertTrue(title.startswith("[Refactor]"), title)
+
+    def test_chore_emits_chore(self) -> None:
+        title, _ = synthesize_korean_title(
+            request_text="config 정리 작업", intent=INTENT_CHORE
+        )
+        self.assertTrue(title.startswith("[Chore]"), title)
+
+    def test_test_emits_test(self) -> None:
+        title, _ = synthesize_korean_title(
+            request_text="회귀 테스트 추가", intent=INTENT_TEST
+        )
+        self.assertTrue(title.startswith("[Test]"), title)
+
+    def test_feature_emits_feature(self) -> None:
+        title, _ = synthesize_korean_title(
+            request_text="신규 기능 추가", intent=INTENT_FEATURE
+        )
+        self.assertTrue(title.startswith("[Feature]"), title)
+
+
+# ---------------------------------------------------------------------------
+# Template alignment
+# ---------------------------------------------------------------------------
+
+
+class FeatureIssueTemplateTests(unittest.TestCase):
+    def test_feature_template_title_prefix_is_feature(self) -> None:
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[2] / ".github" / "ISSUE_TEMPLATE" / "-feature--issue-template.md"
+        text = path.read_text(encoding="utf-8")
+        # ``title:`` 줄이 [Feature] 로 정렬.
+        self.assertIn('title: "[Feature]"', text)
+        # 옛 표기 흔적이 없어야.
+        self.assertNotIn('title: "[Feat]"', text)
+        self.assertNotIn('title: "[기능]"', text)
+
+
+# ---------------------------------------------------------------------------
+# Cross-allowlist isolation guard
+# ---------------------------------------------------------------------------
+
+
+class AllowlistIsolationGuardTests(unittest.TestCase):
+    def test_issue_and_pr_allowlists_are_disjoint(self) -> None:
+        from yule_orchestrator.agents.governance.repo_write_policy import (
+            _ALLOWED_ISSUE_TITLE_PREFIXES,
+            _ALLOWED_PR_TITLE_PREFIXES,
+        )
+
+        issue_set = set(_ALLOWED_ISSUE_TITLE_PREFIXES)
+        pr_set = set(_ALLOWED_PR_TITLE_PREFIXES)
+        intersection = issue_set & pr_set
+        self.assertEqual(intersection, set(), f"shared prefixes: {intersection}")
+        # 그리고 각자 6개 이상 (정책 contract).
+        self.assertGreaterEqual(len(issue_set), 6)
+        self.assertGreaterEqual(len(pr_set), 6)
+
+    def test_validator_module_exports_split_allowlists(self) -> None:
+        from yule_orchestrator.agents.governance import repo_write_policy as mod
+
+        self.assertTrue(hasattr(mod, "_ALLOWED_ISSUE_TITLE_PREFIXES"))
+        self.assertTrue(hasattr(mod, "_ALLOWED_PR_TITLE_PREFIXES"))
+        # 옛 통합 이름 흔적이 정의돼있지 않아야 — refactor 때 collision 방지.
+        self.assertFalse(hasattr(mod, "_ALLOWED_TITLE_PREFIXES"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z2_handoff_packet_continuation.py
+++ b/tests/agents/test_p1z2_handoff_packet_continuation.py
@@ -1,0 +1,418 @@
+"""P1-Z2 — actual ``/engineer_intake`` session shape continuation 회귀.
+
+배경
+----
+P1-Z 의 ``decide_post_approval_action`` 은 ``extra["coding_proposal"]`` 가
+없으면 즉시 ``NOOP_REASON_NO_CODING_PROPOSAL`` 로 종료했다.  하지만
+실제 dead-end session 인 ``f2f36607d175`` 의 shape:
+
+  * ``extra.github_target`` 있음
+  * ``extra.coding_handoff_packet`` 있음
+  * ``extra.lifecycle_mode == "implementation"`` 있음
+  * ``extra.coding_proposal`` **없음**
+
+이 회귀 라인은 위 shape (handoff packet + lifecycle_mode + github_target)
+가 ``needs_work_order`` 로 인정되고, 동시에 false-positive (research_only /
+no target / no repo / terminal / anchor 있음) 케이스는 여전히 noop 으로
+머무는지 확정한다.
+
+stdlib unittest 만 사용.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.post_approval_dispatch import (
+    ACTION_DISPATCHED,
+    ACTION_FAILED,
+    ACTION_NEEDS_WORK_ORDER,
+    ACTION_NOOP,
+    NOOP_REASON_ANCHOR_ALREADY_STAMPED,
+    NOOP_REASON_NO_CODING_INTENT_SIGNAL,
+    NOOP_REASON_NO_CODING_PROPOSAL,
+    NOOP_REASON_NO_GITHUB_TARGET,
+    NOOP_REASON_NO_REPO,
+    NOOP_REASON_RESEARCH_ONLY_LIFECYCLE,
+    NOOP_REASON_TERMINAL_SESSION,
+    decide_post_approval_action,
+    dispatch_post_approval_work_order,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mimic real intake-time session.extra shape
+# ---------------------------------------------------------------------------
+
+
+class _State:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:  # noqa: D401
+        return self.value
+
+
+@dataclass
+class _FakeSession:
+    session_id: str = "f2f36607d175"
+    state: Any = field(default_factory=lambda: _State("approved"))
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    prompt: str = (
+        "yule-studio/naver-search-clone 에 검색 풀스택 MVP "
+        "(인증 + 검색 + 블로그 + 메일) 구현해줘"
+    )
+    channel_id: Optional[int] = 9100
+    thread_id: Optional[int] = 9200
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        session_id: str = "f2f36607d175",
+        state: str = "approved",
+        extra: Optional[Mapping[str, Any]] = None,
+        prompt: Optional[str] = None,
+        channel_id: Optional[int] = 9100,
+        thread_id: Optional[int] = 9200,
+    ) -> "_FakeSession":
+        return cls(
+            session_id=session_id,
+            state=_State(state),
+            extra=dict(extra or {}),
+            prompt=prompt or (
+                "yule-studio/naver-search-clone 에 검색 풀스택 MVP "
+                "(인증 + 검색 + 블로그 + 메일) 구현해줘"
+            ),
+            channel_id=channel_id,
+            thread_id=thread_id,
+        )
+
+
+_TARGET_REPO = {
+    "kind": "repo",
+    "owner": "yule-studio",
+    "repo": "naver-search-clone",
+    "number": None,
+}
+
+
+def _handoff_extra(
+    *,
+    lifecycle_mode: Optional[str] = "implementation",
+    include_target: bool = True,
+    include_packet: bool = True,
+    coding_proposal: Optional[Mapping[str, Any]] = None,
+    anchor: Optional[Mapping[str, Any]] = None,
+) -> dict:
+    extra: dict[str, Any] = {}
+    if include_target:
+        extra["github_target"] = dict(_TARGET_REPO)
+    if include_packet:
+        extra["coding_handoff_packet"] = {
+            "canonical_request": "검색 풀스택 MVP 구현",
+            "github_target": dict(_TARGET_REPO),
+            "repo_contract_summary": "yule-studio/naver-search-clone (default branch=main)",
+            "mode": "approval_required",
+            "topology": "single_repo",
+            "scope_mode": "full_stack_single_repo",
+            "tracking_mode": "repo_root",
+            "next_action": "open_issue",
+            "notes": {},
+        }
+    if lifecycle_mode is not None:
+        extra["lifecycle_mode"] = lifecycle_mode
+    if coding_proposal is not None:
+        extra["coding_proposal"] = dict(coding_proposal)
+    if anchor is not None:
+        extra["github_work_order_issue"] = dict(anchor)
+    return extra
+
+
+def _in_memory_queue():
+    tmpdir = tempfile.mkdtemp(prefix="yule-p1z2-")
+    from yule_orchestrator.agents.job_queue.store import JobQueue
+
+    return JobQueue(db_path=Path(tmpdir) / "queue.sqlite")
+
+
+# ---------------------------------------------------------------------------
+# Actual dead-end shape — handoff packet path
+# ---------------------------------------------------------------------------
+
+
+class HandoffPacketContinuationTests(unittest.TestCase):
+    """실제 ``f2f36607d175`` 류 shape 의 continuation 회귀."""
+
+    def test_actual_dead_end_shape_needs_work_order(self) -> None:
+        """state=approved + packet + target + lifecycle=implementation +
+        no coding_proposal → needs_work_order (옛 NO_CODING_PROPOSAL noop 차단)."""
+
+        session = _FakeSession.make(state="approved", extra=_handoff_extra())
+        decision = decide_post_approval_action(session)
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER, decision)
+        self.assertEqual(decision.repo, "yule-studio/naver-search-clone")
+        self.assertIsNone(decision.existing_issue_number)
+
+    def test_handoff_packet_path_dispatches_through_builder(self) -> None:
+        """end-to-end: handoff-only session 이 실제 queue insert 까지 진행."""
+
+        captured: dict[str, Any] = {}
+
+        def fake_builder(**kwargs):
+            captured.update(kwargs)
+
+            class _Proposal:
+                proposal_id = "p-handoff-1"
+                session_id = kwargs["session"].session_id
+                source_channel_id = kwargs["source_channel_id"]
+                source_thread_id = kwargs["source_thread_id"]
+                source_message_id = kwargs["source_message_id"]
+                request_summary = kwargs["request_text"][:120]
+                selected_roles = ("tech-lead", "fullstack-engineer")
+                intent_actions = ("코드 변경",)
+                repo = kwargs["repo"]
+                base_branch = "main"
+                dry_run_default = False
+                extra: Mapping[str, Any] = {}
+                issue_auto_create_plan = None
+                existing_issue_number = kwargs.get("existing_issue_number")
+
+            return _Proposal()
+
+        session = _FakeSession.make(state="approved", extra=_handoff_extra())
+        queue = _in_memory_queue()
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=queue,
+            requested_by="cli-user",
+            proposal_builder=fake_builder,
+        )
+        # builder 가 실제 호출됐는지 — coding_proposal 없어도 진입.
+        self.assertIn("repo", captured)
+        self.assertEqual(captured["repo"], "yule-studio/naver-search-clone")
+        # decide 가 needs_work_order → dispatch 가 dispatched 또는 noop(dedup)
+        # 둘 다 NOT failed/no_coding_proposal.
+        self.assertIn(result["action"], (ACTION_DISPATCHED, ACTION_NOOP))
+        self.assertNotEqual(result.get("reason"), NOOP_REASON_NO_CODING_PROPOSAL)
+
+    def test_handoff_packet_with_existing_issue_anchor_in_extra(self) -> None:
+        extra = _handoff_extra()
+        extra["existing_issue_number"] = 5
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(decision.existing_issue_number, 5)
+
+    def test_handoff_packet_with_issue_kind_target(self) -> None:
+        extra = _handoff_extra()
+        extra["github_target"] = {
+            "kind": "issue",
+            "owner": "yule-studio",
+            "repo": "naver-search-clone",
+            "number": 12,
+        }
+        # handoff packet 안의 target 도 issue 로 매칭.
+        extra["coding_handoff_packet"]["github_target"] = dict(extra["github_target"])
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(decision.existing_issue_number, 12)
+
+    def test_handoff_packet_target_in_packet_only_still_works(self) -> None:
+        """session.extra.github_target 누락이지만 packet 내부에는 있음 →
+        decision 이 packet target 으로 fallback 해서 needs_work_order."""
+
+        extra = _handoff_extra(include_target=False)
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER, decision)
+        self.assertEqual(decision.repo, "yule-studio/naver-search-clone")
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards — handoff packet 만으로 다 통과시키면 안 됨
+# ---------------------------------------------------------------------------
+
+
+class HandoffPacketFalsePositiveGuardTests(unittest.TestCase):
+    def test_handoff_packet_with_research_only_lifecycle_is_noop(self) -> None:
+        decision = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra=_handoff_extra(lifecycle_mode="research_only"),
+            )
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_RESEARCH_ONLY_LIFECYCLE)
+
+    def test_handoff_packet_without_lifecycle_signal_is_noop(self) -> None:
+        decision = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra=_handoff_extra(lifecycle_mode=None),
+            )
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_NO_CODING_INTENT_SIGNAL)
+
+    def test_handoff_packet_with_unknown_lifecycle_is_noop(self) -> None:
+        # "ideation" / 기타 임의 token → implementation 명시가 아니므로 noop.
+        decision = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra=_handoff_extra(lifecycle_mode="ideation"),
+            )
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_NO_CODING_INTENT_SIGNAL)
+
+    def test_no_handoff_packet_no_proposal_is_noop(self) -> None:
+        # 옛 NO_CODING_PROPOSAL 경로 그대로.
+        decision = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra=_handoff_extra(include_packet=False, lifecycle_mode="implementation"),
+            )
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_NO_CODING_PROPOSAL)
+
+    def test_handoff_packet_no_target_anywhere_is_noop(self) -> None:
+        # packet 도 target 없음 + extra 도 target 없음 → no_github_target.
+        extra = _handoff_extra(include_target=False)
+        extra["coding_handoff_packet"]["github_target"] = None
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_NO_GITHUB_TARGET)
+
+    def test_handoff_packet_target_without_owner_repo_is_no_repo(self) -> None:
+        extra = _handoff_extra()
+        extra["github_target"] = {"kind": "repo", "owner": "", "repo": ""}
+        extra["coding_handoff_packet"]["github_target"] = {"kind": "repo", "owner": "", "repo": ""}
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_NO_REPO)
+
+    def test_handoff_packet_with_existing_anchor_is_noop(self) -> None:
+        decision = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra=_handoff_extra(
+                    anchor={"issue_number": 5, "repo": "yule-studio/naver-search-clone"}
+                ),
+            )
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_ANCHOR_ALREADY_STAMPED)
+
+    def test_handoff_packet_terminal_session_is_noop(self) -> None:
+        for state in ("rejected", "completed"):
+            with self.subTest(state=state):
+                decision = decide_post_approval_action(
+                    _FakeSession.make(state=state, extra=_handoff_extra())
+                )
+                self.assertEqual(decision.action, ACTION_NOOP)
+                self.assertEqual(decision.reason, NOOP_REASON_TERMINAL_SESSION)
+
+
+# ---------------------------------------------------------------------------
+# Existing coding_proposal path — 회귀 없음
+# ---------------------------------------------------------------------------
+
+
+class CodingProposalPathRegressionTests(unittest.TestCase):
+    def test_coding_proposal_path_still_needs_work_order(self) -> None:
+        # P1-Z 의 옛 경로 — coding_proposal + github_target → needs_work_order.
+        extra = {
+            "coding_proposal": {
+                "executor_role": "fullstack-engineer",
+                "review_roles": ["tech-lead"],
+            },
+            "github_target": dict(_TARGET_REPO),
+        }
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(decision.repo, "yule-studio/naver-search-clone")
+
+    def test_coding_proposal_overrides_missing_lifecycle(self) -> None:
+        """coding_proposal 가 있으면 lifecycle_mode 누락이라도 needs_work_order."""
+
+        extra = {
+            "coding_proposal": {"executor_role": "fullstack-engineer"},
+            "github_target": dict(_TARGET_REPO),
+        }
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NEEDS_WORK_ORDER)
+
+    def test_coding_proposal_with_research_only_lifecycle_is_noop(self) -> None:
+        """coding_proposal 가 있어도 lifecycle 가 research_only 면 noop —
+        안전 우선."""
+
+        extra = {
+            "coding_proposal": {"executor_role": "fullstack-engineer"},
+            "github_target": dict(_TARGET_REPO),
+            "lifecycle_mode": "research_only",
+        }
+        decision = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra=extra)
+        )
+        self.assertEqual(decision.action, ACTION_NOOP)
+        self.assertEqual(decision.reason, NOOP_REASON_RESEARCH_ONLY_LIFECYCLE)
+
+
+# ---------------------------------------------------------------------------
+# Source-grep wiring guard
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_decide_source_branches_on_handoff_packet(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            post_approval_dispatch as mod,
+        )
+
+        source = inspect.getsource(mod.decide_post_approval_action)
+        self.assertIn("coding_handoff_packet", source)
+        self.assertIn("lifecycle_mode", source)
+        self.assertIn("research_only", source)
+        # 옛 NO_CODING_PROPOSAL early-return 이 사라졌는지 (handoff 분기 이후로 이동).
+        # 단순히 string 이 존재할 수는 있으므로 placement 회귀는 위 _no_handoff_packet
+        # test 가 보장.
+
+    def test_resolve_repo_source_reads_packet(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            post_approval_dispatch as mod,
+        )
+
+        source = inspect.getsource(mod._resolve_repo)
+        self.assertIn("coding_handoff_packet", source)
+        self.assertIn("github_target", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z3_live_builder_continuation.py
+++ b/tests/agents/test_p1z3_live_builder_continuation.py
@@ -1,0 +1,449 @@
+"""P1-Z3 — actual ``build_github_work_order_proposal`` 가 approved
+continuation 경로에서 prompt phrase 게이트를 우회하는지 회귀.
+
+배경
+----
+P1-Z2 는 ``decide_post_approval_action`` 가 handoff_packet 경로를
+허용하도록 확장했지만, ``dispatch_post_approval_work_order`` 가 실제
+``build_github_work_order_proposal`` 을 호출할 때 그 builder 가 다시
+``should_route_to_github_workos(...)`` → ``detect_coding_intent(request_text)``
+를 강제했다.
+
+실측: lifecycle_mode=implementation + handoff packet + github_target 이
+이미 있는 approved session 이라도, ``session.prompt`` 가 GitHub URL +
+"실제 구현 가능한 상태까지 구현" 같은 일반 자연어면
+``detect_coding_intent`` 가 ``coding_required=False`` → builder 가
+``None`` 반환 → dead-end.
+
+P1-Z3 fix
+---------
+``should_route_to_github_workos`` 와 ``build_github_work_order_proposal``
+에 ``approved_continuation`` 플래그 추가.  True 면 prompt phrase 기반
+coding-intent 재판정을 우회 — structured signals (lifecycle / packet /
+target) 이 source of truth.  단 ``lifecycle == research_only`` 와
+obsidian intent 는 여전히 reject (안전 우선).
+
+본 회귀는 **fake_builder 없이** 실제 builder 를 사용해 게이트가 진짜로
+닫혔는지 확정한다.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.post_approval_dispatch import (
+    ACTION_DISPATCHED,
+    ACTION_FAILED,
+    ACTION_NOOP,
+    NOOP_REASON_RESEARCH_ONLY_LIFECYCLE,
+    dispatch_post_approval_work_order,
+)
+from yule_orchestrator.discord.integrations.github_workos_adapter import (
+    SKIPPED_NO_CODING_INTENT,
+    SKIPPED_OBSIDIAN_INTENT,
+    SKIPPED_RESEARCH_ONLY,
+    build_github_work_order_proposal,
+    should_route_to_github_workos,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _State:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:  # noqa: D401
+        return self.value
+
+
+@dataclass
+class _FakeSession:
+    session_id: str = "f2f36607d175"
+    state: Any = field(default_factory=lambda: _State("approved"))
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    prompt: str = ""
+    channel_id: Optional[int] = 9100
+    thread_id: Optional[int] = 9200
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        session_id: str = "f2f36607d175",
+        state: str = "approved",
+        extra: Optional[Mapping[str, Any]] = None,
+        prompt: str = "",
+        channel_id: Optional[int] = 9100,
+        thread_id: Optional[int] = 9200,
+    ) -> "_FakeSession":
+        return cls(
+            session_id=session_id,
+            state=_State(state),
+            extra=dict(extra or {}),
+            prompt=prompt,
+            channel_id=channel_id,
+            thread_id=thread_id,
+        )
+
+
+_TARGET_REPO = {
+    "kind": "repo",
+    "owner": "yule-studio",
+    "repo": "naver-search-clone",
+    "number": None,
+}
+
+
+def _handoff_extra(
+    *,
+    lifecycle_mode: Optional[str] = "implementation",
+) -> dict:
+    extra: dict[str, Any] = {
+        "github_target": dict(_TARGET_REPO),
+        "coding_handoff_packet": {
+            "canonical_request": "검색 풀스택 MVP 구현",
+            "github_target": dict(_TARGET_REPO),
+            "mode": "approval_required",
+            "topology": "single_repo",
+            "scope_mode": "full_stack_single_repo",
+            "tracking_mode": "repo_root",
+            "next_action": "open_issue",
+            "notes": {},
+        },
+    }
+    if lifecycle_mode is not None:
+        extra["lifecycle_mode"] = lifecycle_mode
+    return extra
+
+
+def _in_memory_queue():
+    tmpdir = tempfile.mkdtemp(prefix="yule-p1z3-")
+    from yule_orchestrator.agents.job_queue.store import JobQueue
+
+    return JobQueue(db_path=Path(tmpdir) / "queue.sqlite")
+
+
+# Real intake prompt styles from observed dead-end sessions.
+_PROMPT_REPO_ONLY = "https://github.com/yule-studio/naver-search-clone"
+_PROMPT_IMPLEMENTATION = (
+    "https://github.com/yule-studio/naver-search-clone "
+    "실제 구현 가능한 상태까지 구현"
+)
+_PROMPT_AUTO_ISSUE = (
+    "https://github.com/yule-studio/naver-search-clone "
+    "새 GitHub issue를 생성해서 그 issue anchor 기준으로 시작"
+)
+
+
+# ---------------------------------------------------------------------------
+# Route gate: approved_continuation flag
+# ---------------------------------------------------------------------------
+
+
+class ShouldRouteApprovedContinuationTests(unittest.TestCase):
+    """``should_route_to_github_workos(..., approved_continuation=True)``
+    가 prompt phrase 기반 reject 를 건너뛰지만 lifecycle / obsidian
+    가드는 유지."""
+
+    def test_approved_continuation_passes_repo_only_prompt(self) -> None:
+        session = _FakeSession.make(extra=_handoff_extra(), prompt=_PROMPT_REPO_ONLY)
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            approved_continuation=True,
+        )
+        self.assertTrue(eligible, reason)
+        self.assertEqual(reason, "")
+
+    def test_approved_continuation_passes_implementation_natural_language(self) -> None:
+        session = _FakeSession.make(extra=_handoff_extra(), prompt=_PROMPT_IMPLEMENTATION)
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            approved_continuation=True,
+        )
+        self.assertTrue(eligible, reason)
+
+    def test_approved_continuation_passes_auto_issue_prompt(self) -> None:
+        session = _FakeSession.make(extra=_handoff_extra(), prompt=_PROMPT_AUTO_ISSUE)
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            approved_continuation=True,
+        )
+        self.assertTrue(eligible, reason)
+
+    def test_approved_continuation_research_only_lifecycle_still_blocks(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(lifecycle_mode="research_only"),
+            prompt="이거 구현해줘 — 모든 기능 풀스택",
+        )
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            approved_continuation=True,
+        )
+        self.assertFalse(eligible)
+        self.assertEqual(reason, SKIPPED_RESEARCH_ONLY)
+
+    def test_approved_continuation_obsidian_intent_still_blocks(self) -> None:
+        # obsidian save intent — different domain, 반드시 reject.
+        session = _FakeSession.make(extra=_handoff_extra(), prompt="vault 에 저장해줘")
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            approved_continuation=True,
+        )
+        self.assertFalse(eligible)
+        self.assertEqual(reason, SKIPPED_OBSIDIAN_INTENT)
+
+
+# ---------------------------------------------------------------------------
+# Fresh intake routing 회귀 — approved_continuation=False 면 옛 동작
+# ---------------------------------------------------------------------------
+
+
+class FreshIntakeRoutingRegressionTests(unittest.TestCase):
+    def test_fresh_intake_repo_only_prompt_still_rejected(self) -> None:
+        """fresh intake 에서 prompt 가 약하면 옛 동작 그대로 reject — 무지성
+        통과 금지."""
+
+        session = _FakeSession.make(extra=_handoff_extra(), prompt=_PROMPT_REPO_ONLY)
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+            # default approved_continuation=False
+        )
+        self.assertFalse(eligible)
+        self.assertEqual(reason, SKIPPED_NO_CODING_INTENT)
+
+    def test_fresh_intake_with_strong_coding_phrase_passes(self) -> None:
+        session = _FakeSession.make(extra=_handoff_extra(), prompt="이거 구현해줘")
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+        )
+        self.assertTrue(eligible, reason)
+
+    def test_fresh_intake_research_only_lifecycle_blocks(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(lifecycle_mode="research_only"),
+            prompt="이거 구현해줘",
+        )
+        eligible, reason, _ = should_route_to_github_workos(
+            session=session,
+            request_text=session.prompt,
+        )
+        self.assertFalse(eligible)
+        self.assertEqual(reason, SKIPPED_RESEARCH_ONLY)
+
+
+# ---------------------------------------------------------------------------
+# Live builder: actual build_github_work_order_proposal
+# ---------------------------------------------------------------------------
+
+
+class LiveBuilderApprovedContinuationTests(unittest.TestCase):
+    """**Real builder** — fake_builder 안 씀.  approved continuation 경로의
+    proposal 이 정말 None 이 아니라 채워지는지."""
+
+    def test_real_builder_with_repo_only_prompt_returns_proposal(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(),
+            prompt=_PROMPT_REPO_ONLY,
+        )
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text=session.prompt,
+            repo="yule-studio/naver-search-clone",
+            approved_continuation=True,
+        )
+        self.assertIsNotNone(proposal, "approved continuation 에서 proposal=None 회귀")
+        self.assertEqual(proposal.session_id, "f2f36607d175")
+        self.assertEqual(proposal.repo, "yule-studio/naver-search-clone")
+        self.assertTrue(proposal.coding_required)
+        # P1-Z3 — prompt phrase 가 약해도 intent_actions 가 비지 않도록 fallback
+        self.assertTrue(proposal.intent_actions)
+
+    def test_real_builder_with_implementation_prompt_returns_proposal(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text=session.prompt,
+            repo="yule-studio/naver-search-clone",
+            approved_continuation=True,
+        )
+        self.assertIsNotNone(proposal)
+
+    def test_real_builder_with_auto_issue_prompt_returns_proposal(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(),
+            prompt=_PROMPT_AUTO_ISSUE,
+        )
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text=session.prompt,
+            repo="yule-studio/naver-search-clone",
+            approved_continuation=True,
+        )
+        self.assertIsNotNone(proposal)
+
+    def test_real_builder_default_path_still_rejects_weak_prompt(self) -> None:
+        """approved_continuation 명시 안 하면 옛 builder 동작 그대로."""
+
+        session = _FakeSession.make(extra=_handoff_extra(), prompt=_PROMPT_REPO_ONLY)
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text=session.prompt,
+            repo="yule-studio/naver-search-clone",
+            # default approved_continuation=False
+        )
+        self.assertIsNone(proposal, "fresh intake 에서 약한 prompt 통과 회귀")
+
+    def test_real_builder_research_only_lifecycle_returns_none(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(lifecycle_mode="research_only"),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        proposal = build_github_work_order_proposal(
+            session=session,
+            request_text=session.prompt,
+            repo="yule-studio/naver-search-clone",
+            approved_continuation=True,
+        )
+        self.assertIsNone(proposal)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: dispatch_post_approval_work_order with real builder
+# ---------------------------------------------------------------------------
+
+
+class DispatchPostApprovalWithRealBuilderTests(unittest.TestCase):
+    def test_actual_dead_end_shape_dispatches_through_real_builder(self) -> None:
+        """f2f36607d175 류 shape — real builder path 가 실제 queue insert."""
+
+        session = _FakeSession.make(
+            extra=_handoff_extra(),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+            # default proposal_builder = real build_github_work_order_proposal
+        )
+        self.assertEqual(result.get("action"), ACTION_DISPATCHED, result)
+        self.assertIsNotNone(result.get("job_id"))
+        self.assertEqual(result.get("repo"), "yule-studio/naver-search-clone")
+
+    def test_research_only_still_noop(self) -> None:
+        session = _FakeSession.make(
+            extra=_handoff_extra(lifecycle_mode="research_only"),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+        )
+        self.assertEqual(result.get("action"), ACTION_NOOP)
+        self.assertEqual(result.get("reason"), NOOP_REASON_RESEARCH_ONLY_LIFECYCLE)
+
+    def test_terminal_session_still_noop_even_with_real_builder(self) -> None:
+        from yule_orchestrator.agents.job_queue.post_approval_dispatch import (
+            NOOP_REASON_TERMINAL_SESSION,
+        )
+
+        session = _FakeSession.make(
+            state="rejected",
+            extra=_handoff_extra(),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+        )
+        self.assertEqual(result.get("action"), ACTION_NOOP)
+        self.assertEqual(result.get("reason"), NOOP_REASON_TERMINAL_SESSION)
+
+    def test_idempotent_second_dispatch_dedups(self) -> None:
+        """같은 session 으로 두 번 dispatch → 두 번째는 duplicate dedup."""
+
+        session = _FakeSession.make(
+            extra=_handoff_extra(),
+            prompt=_PROMPT_IMPLEMENTATION,
+        )
+        queue = _in_memory_queue()
+        first = dispatch_post_approval_work_order(
+            session=session,
+            queue=queue,
+            requested_by="cli-user",
+        )
+        self.assertEqual(first.get("action"), ACTION_DISPATCHED, first)
+        second = dispatch_post_approval_work_order(
+            session=session,
+            queue=queue,
+            requested_by="cli-user",
+        )
+        # find_active_work_order 가 같은 session_id 매칭 → skipped_reason 으로 noop.
+        self.assertEqual(second.get("action"), ACTION_NOOP, second)
+
+
+# ---------------------------------------------------------------------------
+# Source-grep wiring guards
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_should_route_signature_has_approved_continuation(self) -> None:
+        import inspect
+
+        from yule_orchestrator.discord.integrations import (
+            github_workos_adapter as adapter_mod,
+        )
+
+        sig = inspect.signature(adapter_mod.should_route_to_github_workos)
+        self.assertIn("approved_continuation", sig.parameters)
+        self.assertFalse(sig.parameters["approved_continuation"].default)
+
+    def test_build_proposal_signature_has_approved_continuation(self) -> None:
+        import inspect
+
+        from yule_orchestrator.discord.integrations import (
+            github_workos_adapter as adapter_mod,
+        )
+
+        sig = inspect.signature(adapter_mod.build_github_work_order_proposal)
+        self.assertIn("approved_continuation", sig.parameters)
+
+    def test_dispatch_post_approval_passes_approved_continuation(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            post_approval_dispatch as mod,
+        )
+
+        source = inspect.getsource(mod.dispatch_post_approval_work_order)
+        self.assertIn("approved_continuation=True", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z4_canonical_path_consistency.py
+++ b/tests/agents/test_p1z4_canonical_path_consistency.py
@@ -1,0 +1,442 @@
+"""P1-Z4 — canonical coding path end-to-end consistency 회귀.
+
+배경
+----
+canonical session ``000f13fb121b`` 가 노출한 5 가지 회귀:
+
+1. slash intake approval card 가 prompt phrase 게이트에 막혀 누락
+2. ``PR #183 브랜치`` 문구가 target repo 의 existing issue anchor 로 오인
+3. anchor stamp 이후에도 ``tracking_validation.status = needs_issue`` stale
+4. ``live_editor_no_edits_produced`` 가 write_scope mismatch 인지 모호
+5. 위 4 가지가 누적되어 operator surface 가 일관성 잃음
+
+본 회귀는 위 5 가지가 영구히 회귀하지 않도록 lock.
+
+stdlib unittest 만.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.coding_session_context import (
+    _disqualified_numbers_in_text,
+    _extract_explicit_issue_number,
+)
+from yule_orchestrator.agents.coding.tracking_refresh import (
+    SESSION_EXTRA_TRACKING_KEY,
+    refresh_tracking_validation,
+)
+from yule_orchestrator.agents.job_queue.coding_write_scope_resolution import (
+    WriteScopeResolution,
+    resolve_write_scope_against_worktree,
+)
+from yule_orchestrator.discord.integrations.intake_approval_eligibility import (
+    SKIP_REASON_NOT_WRITE_REQUESTED,
+    SKIP_REASON_NO_GITHUB_TARGET,
+    SKIP_REASON_NO_HANDOFF_PACKET,
+    SKIP_REASON_NO_IMPLEMENTATION_SIGNAL,
+    SKIP_REASON_OBSIDIAN_INTENT,
+    SKIP_REASON_RESEARCH_ONLY_LIFECYCLE,
+    decide_intake_approval_card_eligibility,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _State:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+@dataclass
+class _FakeSession:
+    session_id: str = "000f13fb121b"
+    state: Any = field(default_factory=lambda: _State("intake"))
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    prompt: str = ""
+    channel_id: Optional[int] = 100
+    thread_id: Optional[int] = 200
+    write_requested: bool = True
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        state: str = "intake",
+        extra: Optional[Mapping[str, Any]] = None,
+        prompt: str = "",
+        write_requested: bool = True,
+    ) -> "_FakeSession":
+        return cls(
+            state=_State(state),
+            extra=dict(extra or {}),
+            prompt=prompt,
+            write_requested=write_requested,
+        )
+
+
+_TARGET = {
+    "kind": "repo",
+    "owner": "yule-studio",
+    "repo": "naver-search-clone",
+    "number": None,
+}
+
+
+def _intake_extra(
+    *,
+    lifecycle_mode: Optional[str] = "implementation",
+    include_target: bool = True,
+    include_packet: bool = True,
+) -> dict:
+    extra: dict[str, Any] = {}
+    if lifecycle_mode is not None:
+        extra["lifecycle_mode"] = lifecycle_mode
+    if include_target:
+        extra["github_target"] = dict(_TARGET)
+    if include_packet:
+        extra["coding_handoff_packet"] = {
+            "canonical_request": "검색 풀스택 MVP 구현",
+            "github_target": dict(_TARGET),
+            "tracking_mode": "repo_root",
+            "next_action": "open_issue",
+            "notes": {},
+        }
+    return extra
+
+
+# ---------------------------------------------------------------------------
+# A — intake approval card eligibility (structured signals)
+# ---------------------------------------------------------------------------
+
+
+class IntakeApprovalCardEligibilityTests(unittest.TestCase):
+    """canonical ``000f13fb121b`` shape: write_requested + lifecycle +
+    target + handoff 모두 있어야 카드 게시.  prompt phrase 의존 없음."""
+
+    def test_full_canonical_shape_is_eligible(self) -> None:
+        session = _FakeSession.make(
+            extra=_intake_extra(),
+            prompt="https://github.com/yule-studio/naver-search-clone "
+            "실제 구현 가능한 상태까지 구현",
+        )
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text=session.prompt
+        )
+        self.assertTrue(decision.eligible, decision)
+        self.assertIsNone(decision.skip_reason)
+
+    def test_weak_natural_language_prompt_still_eligible(self) -> None:
+        """canonical 000f13fb121b 가 카드 누락된 원인 — repo URL only 도
+        구조 신호만 갖춰져 있으면 통과."""
+
+        session = _FakeSession.make(
+            extra=_intake_extra(),
+            prompt="https://github.com/yule-studio/naver-search-clone",
+        )
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text=session.prompt
+        )
+        self.assertTrue(decision.eligible)
+
+    def test_issue_anchor_natural_language_eligible(self) -> None:
+        session = _FakeSession.make(
+            extra=_intake_extra(),
+            prompt="새 GitHub issue를 생성해서 그 issue anchor 기준으로 시작",
+        )
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text=session.prompt
+        )
+        self.assertTrue(decision.eligible)
+
+    def test_not_write_requested_skips(self) -> None:
+        session = _FakeSession.make(extra=_intake_extra(), write_requested=False)
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="anything"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.skip_reason, SKIP_REASON_NOT_WRITE_REQUESTED)
+
+    def test_research_only_lifecycle_skips(self) -> None:
+        session = _FakeSession.make(
+            extra=_intake_extra(lifecycle_mode="research_only")
+        )
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="구현해줘"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.skip_reason, SKIP_REASON_RESEARCH_ONLY_LIFECYCLE)
+
+    def test_missing_lifecycle_signal_skips(self) -> None:
+        session = _FakeSession.make(extra=_intake_extra(lifecycle_mode=None))
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="구현해줘"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(
+            decision.skip_reason, SKIP_REASON_NO_IMPLEMENTATION_SIGNAL
+        )
+
+    def test_no_github_target_skips(self) -> None:
+        session = _FakeSession.make(extra=_intake_extra(include_target=False))
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="구현해줘"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.skip_reason, SKIP_REASON_NO_GITHUB_TARGET)
+
+    def test_no_handoff_packet_skips(self) -> None:
+        session = _FakeSession.make(extra=_intake_extra(include_packet=False))
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="구현해줘"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.skip_reason, SKIP_REASON_NO_HANDOFF_PACKET)
+
+    def test_obsidian_intent_skips(self) -> None:
+        session = _FakeSession.make(extra=_intake_extra())
+        decision = decide_intake_approval_card_eligibility(
+            session=session, prompt_text="vault 에 저장해줘"
+        )
+        self.assertFalse(decision.eligible)
+        self.assertEqual(decision.skip_reason, SKIP_REASON_OBSIDIAN_INTENT)
+
+
+# ---------------------------------------------------------------------------
+# B — existing issue anchor parser: PR / cross-repo disqualifiers
+# ---------------------------------------------------------------------------
+
+
+class ExistingIssueAnchorParserTests(unittest.TestCase):
+    """canonical 000f13fb121b 의 ``PR #183 브랜치`` 가 target repo 의
+    issue anchor 로 오인되지 않게."""
+
+    def test_pr_hash_number_is_disqualified(self) -> None:
+        # 옛 회귀: `PR #183 브랜치` 의 183 이 issue anchor 로 잡힘.
+        result = _extract_explicit_issue_number("이 작업은 PR #183 브랜치에서 시작")
+        self.assertIsNone(result)
+
+    def test_pull_request_number_is_disqualified(self) -> None:
+        result = _extract_explicit_issue_number("Pull Request #42 를 참고")
+        self.assertIsNone(result)
+
+    def test_cross_repo_reference_is_disqualified(self) -> None:
+        # ``yule-studio-agent#123`` 같은 cross-repo refs.
+        result = _extract_explicit_issue_number(
+            "yule-studio/yule-studio-agent#123 참고"
+        )
+        self.assertIsNone(result)
+
+    def test_legitimate_issue_hash_passes(self) -> None:
+        result = _extract_explicit_issue_number("이슈 #5 작업")
+        self.assertEqual(result, 5)
+
+    def test_issue_keyword_passes(self) -> None:
+        result = _extract_explicit_issue_number("issue 42 를 reuse")
+        self.assertEqual(result, 42)
+
+    def test_pr_disqualifier_does_not_block_separate_issue_ref(self) -> None:
+        # PR #183 은 disqualified, 하지만 "이슈 #5" 는 살아남아야.
+        result = _extract_explicit_issue_number("PR #183 닫힌 뒤 이슈 #5 작업")
+        self.assertEqual(result, 5)
+
+    def test_disqualified_set_contains_pr_numbers(self) -> None:
+        disqualified = _disqualified_numbers_in_text(
+            "PR #100 / pull request #200 / yule/repo#300"
+        )
+        self.assertEqual(disqualified, {100, 200, 300})
+
+    def test_first_segment_falsehood_does_not_skip_following_valid(self) -> None:
+        # 첫 매칭 (PR #183) 이 disqualified 더라도 후속 (#5) 가 valid 면
+        # 그것을 사용.
+        result = _extract_explicit_issue_number(
+            "이전 PR #183 후속 이슈 #5 처리"
+        )
+        self.assertEqual(result, 5)
+
+
+# ---------------------------------------------------------------------------
+# C — tracking_validation refresh after anchor stamp
+# ---------------------------------------------------------------------------
+
+
+class TrackingValidationRefreshTests(unittest.TestCase):
+    def test_refresh_after_issue_anchor_no_longer_needs_issue(self) -> None:
+        """canonical 000f13fb121b: anchor stamp 됐는데 needs_issue 가 남던
+        회귀.  refresh 호출 후 status 가 'ok' 또는 needs_branch 등 다른
+        단계로 갱신돼야 함."""
+
+        # 1) 시작 — anchor 없음 → needs_issue
+        session = _FakeSession.make(
+            state="approved",
+            extra={
+                "github_target": dict(_TARGET),
+                "work_mode": "approval_required",
+                "coding_handoff_packet": _intake_extra()["coding_handoff_packet"],
+                # 옛 stale tracking_validation
+                SESSION_EXTRA_TRACKING_KEY: {
+                    "status": "needs_issue",
+                    "blocked": True,
+                },
+            },
+        )
+        result_before = refresh_tracking_validation(
+            session=session, triggered_by="probe_before"
+        )
+        self.assertEqual(result_before.previous_status, "needs_issue")
+
+        # 2) anchor stamp → target.kind == "issue" + number
+        session.extra = dict(session.extra)
+        session.extra["github_target"] = {
+            "kind": "issue",
+            "owner": "yule-studio",
+            "repo": "naver-search-clone",
+            "number": 5,
+        }
+        session.extra["branch_name"] = "feature/auth-issue-5"
+        result_after = refresh_tracking_validation(
+            session=session, triggered_by="anchor_stamp"
+        )
+        self.assertNotEqual(result_after.new_status, "needs_issue")
+
+    def test_refresh_idempotent_when_no_change(self) -> None:
+        session = _FakeSession.make(
+            state="intake",
+            extra={
+                "github_target": dict(_TARGET),
+                "work_mode": "approval_required",
+                "coding_handoff_packet": _intake_extra()["coding_handoff_packet"],
+            },
+        )
+        first = refresh_tracking_validation(session=session, triggered_by="x")
+        # 같은 input 재평가 → 같은 status
+        second = refresh_tracking_validation(session=session, triggered_by="y")
+        self.assertEqual(first.new_status, second.new_status)
+
+
+# ---------------------------------------------------------------------------
+# D — write_scope vs repo layout resolution
+# ---------------------------------------------------------------------------
+
+
+class WriteScopeResolutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def test_placeholder_scope_does_not_match_apps_layout(self) -> None:
+        """canonical 000f13fb121b 의 write_scope (``src/<service>/api/**``)
+        가 ``apps/`` monorepo 와 0 매칭인지."""
+
+        (self.root / "apps" / "web").mkdir(parents=True)
+        (self.root / "apps" / "api").mkdir(parents=True)
+
+        result = resolve_write_scope_against_worktree(
+            worktree_path=str(self.root),
+            write_scope=(
+                "src/<service>/api/**",
+                "src/<service>/domain/**",
+                "tests/<service>/api/**",
+            ),
+        )
+        self.assertTrue(result.worktree_exists)
+        self.assertFalse(result.has_any_match)
+        self.assertTrue(result.is_placeholder_scope)
+        self.assertTrue(result.can_decide_mismatch)
+        self.assertEqual(len(result.unmatched_prefixes), 3)
+
+    def test_matching_scope_finds_sample_paths(self) -> None:
+        (self.root / "apps" / "web" / "src").mkdir(parents=True)
+        (self.root / "apps" / "web" / "src" / "page.tsx").touch()
+
+        result = resolve_write_scope_against_worktree(
+            worktree_path=str(self.root),
+            write_scope=("apps/**",),
+        )
+        self.assertTrue(result.has_any_match)
+        self.assertIn("apps/web", result.sample_paths)
+
+    def test_worktree_missing_marks_unknown(self) -> None:
+        result = resolve_write_scope_against_worktree(
+            worktree_path="/tmp/definitely-not-exist-p1z4",
+            write_scope=("src/**",),
+        )
+        self.assertFalse(result.worktree_exists)
+        self.assertFalse(result.can_decide_mismatch)
+        # caller 가 generic no-edit 으로 떨어뜨려야 — write_scope_resolved_empty
+        # 안 띄움
+
+    def test_empty_scope_returns_unable_to_decide(self) -> None:
+        result = resolve_write_scope_against_worktree(
+            worktree_path=str(self.root),
+            write_scope=(),
+        )
+        self.assertFalse(result.can_decide_mismatch)
+
+
+# ---------------------------------------------------------------------------
+# Wiring guards
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_slash_intake_uses_new_eligibility_helper(self) -> None:
+        import inspect
+
+        from yule_orchestrator.discord import commands as cmd_mod
+
+        source = inspect.getsource(cmd_mod._maybe_post_intake_approval_card)
+        self.assertIn("decide_intake_approval_card_eligibility", source)
+        self.assertIn("trust_session_signals=True", source)
+
+    def test_anchor_parser_source_has_pr_disqualifier(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.coding import (
+            coding_session_context as ctx_mod,
+        )
+
+        # module-level patterns 까지 봐야 PR disqualifier 패턴이 보인다.
+        source = inspect.getsource(ctx_mod)
+        self.assertIn("_PR_DISQUALIFIER_PATTERNS", source)
+        self.assertIn(r"\bPR\s", source)
+        self.assertIn("pull", source.lower())
+
+    def test_worker_branches_on_write_scope_resolved_empty(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            coding_executor_worker as worker_mod,
+        )
+
+        source = inspect.getsource(worker_mod.CodingExecutorWorker)
+        self.assertIn("resolve_write_scope_against_worktree", source)
+        self.assertIn("REASON_WRITE_SCOPE_RESOLVED_EMPTY", source)
+
+    def test_dispatcher_refreshes_tracking_validation(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            coding_execute_dispatcher as disp_mod,
+        )
+
+        source = inspect.getsource(disp_mod._persist_dispatch_marker)
+        self.assertIn("refresh_tracking_validation", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z5_implementation_strategy.py
+++ b/tests/agents/test_p1z5_implementation_strategy.py
@@ -1,0 +1,333 @@
+"""P1-Z5 — tech-lead implementation strategy 가 manifest scope 를 대체.
+
+배경
+----
+canonical session ``000f13fb121b`` 의 backend manifest 고정 write_scope
+(``src/<service>/api/**``) 가 target repo (``apps/`` monorepo) 와 0
+매칭으로 ``write_scope_resolved_empty`` 회귀.
+
+본 회귀 라인은 다음을 lock:
+
+1. apps/ + packages/ monorepo fixture → STRATEGY_MONOREPO_APPS,
+   first_slice_owner = backend-engineer, scope = ['apps/api/**',
+   'packages/**'].  ``<service>`` 등 placeholder literal 없음.
+2. frontend/+backend/ split → STRATEGY_FRONTEND_BACKEND_SPLIT,
+   backend-engineer first slice, scope = ['backend/**', ...].
+3. classic ``src/`` only monolith → STRATEGY_CLASSIC_SRC_LAYOUT.
+4. empty repo → STRATEGY_GREENFIELD_EMPTY, scope 포함.
+5. unknown layout → STRATEGY_UNRESOLVED, resolved=False.
+6. user 가 "UI 부터" 요청 → frontend-engineer first slice.
+7. ``recommend_authorization`` 가 strategy.resolved=True 일 때 manifest
+   write_scope 무시 + scope_source='strategy'.
+8. strategy 없을 때 옛 keyword-based behavior 보존 (no regression).
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Mapping
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.authorization import recommend_authorization
+from yule_orchestrator.agents.coding.implementation_strategy import (
+    ImplementationStrategy,
+    ROLE_BACKEND,
+    ROLE_FRONTEND,
+    STRATEGY_CLASSIC_SRC_LAYOUT,
+    STRATEGY_FRONTEND_BACKEND_SPLIT,
+    STRATEGY_GREENFIELD_EMPTY,
+    STRATEGY_MONOREPO_APPS,
+    STRATEGY_UNRESOLVED,
+    detect_repo_layout_signals,
+    detect_request_signals,
+    synthesize_implementation_strategy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Request / layout signal extraction
+# ---------------------------------------------------------------------------
+
+
+class RequestSignalDetectionTests(unittest.TestCase):
+    def test_fullstack_request_detected(self) -> None:
+        signals = detect_request_signals(
+            "네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)"
+        )
+        self.assertTrue(signals["full_stack"])
+        self.assertIn("auth", signals["scope_hints"])
+        self.assertIn("search", signals["scope_hints"])
+        self.assertIn("blog", signals["scope_hints"])
+        self.assertIn("mail", signals["scope_hints"])
+
+    def test_backend_first_hint(self) -> None:
+        signals = detect_request_signals("백엔드 먼저 인증 API 구현")
+        self.assertTrue(signals["backend_first_hints"])
+
+    def test_frontend_first_hint(self) -> None:
+        signals = detect_request_signals("UI 부터 만들어줘 — 디자인 시스템 먼저")
+        self.assertTrue(signals["frontend_first_hints"])
+
+
+class RepoLayoutSignalTests(unittest.TestCase):
+    def test_apps_packages_monorepo(self) -> None:
+        signals = detect_repo_layout_signals(
+            ("apps/web", "apps/api", "packages/ui", "README.md")
+        )
+        self.assertTrue(signals["has_apps_dir"])
+        self.assertTrue(signals["has_packages_dir"])
+
+    def test_frontend_backend_split(self) -> None:
+        signals = detect_repo_layout_signals(
+            ("frontend/src", "backend/api", "README.md")
+        )
+        self.assertTrue(signals["has_frontend_dir"])
+        self.assertTrue(signals["has_backend_dir"])
+
+    def test_client_server_split(self) -> None:
+        signals = detect_repo_layout_signals(("client/src", "server/main"))
+        self.assertTrue(signals["has_client_dir"])
+        self.assertTrue(signals["has_server_dir"])
+
+    def test_classic_src_monolith(self) -> None:
+        signals = detect_repo_layout_signals(("src/", "tests/", "pyproject.toml"))
+        self.assertTrue(signals["has_src_dir"])
+        self.assertFalse(signals["has_apps_dir"])
+
+    def test_empty(self) -> None:
+        signals = detect_repo_layout_signals(())
+        self.assertTrue(signals["is_empty_or_unknown"])
+
+
+# ---------------------------------------------------------------------------
+# Strategy synthesis — canonical shapes
+# ---------------------------------------------------------------------------
+
+
+class SynthesizeStrategyTests(unittest.TestCase):
+    def test_naver_search_clone_like_monorepo_apps(self) -> None:
+        """실제 ``naver-search-clone`` 류: apps/web + apps/api → monorepo,
+        backend first slice."""
+
+        strategy = synthesize_implementation_strategy(
+            user_request="네이버 검색형 풀스택 MVP 구축 (인증/검색/블로그/메일)",
+            toplevel_paths=("apps", "packages", "README.md"),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_MONOREPO_APPS)
+        self.assertTrue(strategy.resolved)
+        self.assertEqual(strategy.first_slice_owner, ROLE_BACKEND)
+        self.assertIn("apps/api/**", strategy.first_slice_scope)
+        self.assertIn("packages/**", strategy.first_slice_scope)
+        # placeholder literal 절대 없음
+        for path in strategy.first_slice_scope:
+            self.assertNotIn("<", path)
+            self.assertNotIn(">", path)
+        # frontend 영역 작업 금지 (slice 분리)
+        self.assertIn("apps/web/**", strategy.first_slice_forbidden)
+
+    def test_frontend_first_user_intent_overrides_default(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="UI 부터 만들어줘 — 디자인 시스템 먼저",
+            toplevel_paths=("apps", "packages"),
+        )
+        self.assertEqual(strategy.first_slice_owner, ROLE_FRONTEND)
+        self.assertIn("apps/web/**", strategy.first_slice_scope)
+        self.assertIn("apps/api/**", strategy.first_slice_forbidden)
+
+    def test_frontend_backend_split_layout(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="인증 API 부터 만들어줘 — 풀스택",
+            toplevel_paths=("frontend/", "backend/", "tests/"),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_FRONTEND_BACKEND_SPLIT)
+        self.assertEqual(strategy.first_slice_owner, ROLE_BACKEND)
+        self.assertIn("backend/**", strategy.first_slice_scope)
+
+    def test_classic_src_monolith(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="검색 API 구현 풀스택",
+            toplevel_paths=("src/", "tests/", "pyproject.toml"),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_CLASSIC_SRC_LAYOUT)
+        self.assertTrue(strategy.resolved)
+        self.assertIn("src/**", strategy.first_slice_scope)
+        for path in strategy.first_slice_scope:
+            self.assertNotIn("<service>", path)
+
+    def test_empty_repo_is_greenfield(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="풀스택 구현",
+            toplevel_paths=(),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_GREENFIELD_EMPTY)
+        self.assertTrue(strategy.resolved)
+
+    def test_unknown_layout_is_unresolved(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="풀스택 구현",
+            toplevel_paths=("docs", "README.md", "LICENSE"),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_UNRESOLVED)
+        self.assertFalse(strategy.resolved)
+        self.assertEqual(strategy.fallback_reason, "repo_layout_unclassified")
+        # placeholder scope 안 내려보냄
+        self.assertEqual(strategy.first_slice_scope, ())
+
+    def test_research_only_lifecycle_is_unresolved(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="apps/api 어떻게 동작하는지 조사",
+            toplevel_paths=("apps",),
+            lifecycle_mode="research_only",
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_UNRESOLVED)
+        self.assertFalse(strategy.resolved)
+
+    def test_participants_include_opposite_role(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="검색 API 구현",
+            toplevel_paths=("apps",),
+        )
+        self.assertIn(ROLE_FRONTEND, strategy.participant_roles)
+
+
+# ---------------------------------------------------------------------------
+# recommend_authorization 가 strategy 우선
+# ---------------------------------------------------------------------------
+
+
+class RecommendAuthorizationStrategyIntegrationTests(unittest.TestCase):
+    def test_strategy_resolved_overrides_manifest_write_scope(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="네이버 검색형 풀스택 MVP",
+            toplevel_paths=("apps", "packages"),
+        )
+        prop = recommend_authorization(
+            user_request="네이버 검색형 풀스택 MVP",
+            implementation_strategy=strategy,
+        )
+        # executor = strategy.first_slice_owner
+        self.assertEqual(prop.executor_role, ROLE_BACKEND)
+        # write_scope = strategy.first_slice_scope (manifest 무시)
+        self.assertIn("apps/api/**", prop.write_scope)
+        # placeholder literal 절대 없음
+        for path in prop.write_scope:
+            self.assertNotIn("<", path)
+        # audit
+        self.assertEqual(prop.metadata.get("scope_source"), "strategy")
+        self.assertEqual(
+            prop.metadata.get("implementation_strategy", {}).get("strategy_id"),
+            STRATEGY_MONOREPO_APPS,
+        )
+
+    def test_strategy_resolved_overrides_keyword_score_zero(self) -> None:
+        """prompt 가 keyword scorer 에 매칭 0건이라도 strategy 가 살리면
+        backend-engineer 가 executor."""
+
+        strategy = synthesize_implementation_strategy(
+            user_request="(prompt-without-any-keyword)",
+            toplevel_paths=("apps", "packages"),
+            explicit_first_slice_owner=ROLE_BACKEND,
+        )
+        prop = recommend_authorization(
+            user_request="(prompt-without-any-keyword)",
+            implementation_strategy=strategy,
+        )
+        self.assertEqual(prop.executor_role, ROLE_BACKEND)
+        self.assertEqual(prop.metadata.get("scope_source"), "strategy")
+
+    def test_strategy_unresolved_falls_back_to_manifest_with_audit(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="auth 구현",
+            toplevel_paths=("docs",),
+        )
+        # docs only → unresolved
+        self.assertFalse(strategy.resolved)
+        prop = recommend_authorization(
+            user_request="auth 구현 백엔드 API DB 인증 회원가입",
+            implementation_strategy=strategy,
+        )
+        # manifest fallback 사용 + scope_source 가 unresolved 명시
+        self.assertEqual(
+            prop.metadata.get("scope_source"), "tech_lead_strategy_unresolved"
+        )
+
+    def test_no_strategy_preserves_legacy_keyword_path(self) -> None:
+        """strategy=None 일 때 옛 keyword 기반 동작 그대로."""
+
+        prop = recommend_authorization(
+            user_request="회원가입 API 구현 — 백엔드 Spring 인증 OAuth2 보안",
+        )
+        # manifest scope 가 그대로 (placeholder 가 있을 수 있음 — 옛 동작
+        # 보존)
+        self.assertEqual(prop.metadata.get("scope_source"), "manifest_default")
+
+    def test_strategy_resolved_review_and_participants_strategy_driven(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="네이버 검색형 풀스택 MVP",
+            toplevel_paths=("apps", "packages"),
+        )
+        prop = recommend_authorization(
+            user_request="네이버 검색형 풀스택 MVP",
+            implementation_strategy=strategy,
+        )
+        # backend first slice → participants 에 frontend + devops
+        self.assertIn(ROLE_FRONTEND, prop.participant_roles)
+
+
+# ---------------------------------------------------------------------------
+# downstream write_scope_resolved_empty 회귀 가드
+# ---------------------------------------------------------------------------
+
+
+class StrategyDoesNotProducePlaceholderScopeTests(unittest.TestCase):
+    """strategy 가 만든 scope 는 worker 의 write_scope mismatch 검사 (P1-Z4 D)
+    를 통과 (실제 apps/api 같은 path 가 worktree 와 매칭) — 가짜 fixture
+    수준에서라도 placeholder 가 끼면 안 됨."""
+
+    def test_apps_layout_strategy_scope_has_no_placeholder(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="네이버 검색형 풀스택 MVP",
+            toplevel_paths=("apps", "packages"),
+        )
+        for path in strategy.first_slice_scope:
+            self.assertNotIn("<", path, f"placeholder literal 남음: {path}")
+            self.assertNotIn("<service>", path)
+
+    def test_unresolved_strategy_yields_empty_scope_not_placeholder(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="구현",
+            toplevel_paths=("docs",),
+        )
+        self.assertEqual(strategy.first_slice_scope, ())
+
+
+# ---------------------------------------------------------------------------
+# Wiring guards
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_authorization_module_imports_strategy(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.coding import authorization as auth_mod
+
+        source = inspect.getsource(auth_mod.recommend_authorization)
+        self.assertIn("implementation_strategy", source)
+        self.assertIn("scope_source", source)
+
+    def test_slash_intake_synthesizes_strategy(self) -> None:
+        import inspect
+
+        from yule_orchestrator.discord import commands as cmd_mod
+
+        source = inspect.getsource(cmd_mod._ensure_coding_proposal_on_session)
+        self.assertIn("synthesize_implementation_strategy", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z6_coding_retry_strategy_devwatch.py
+++ b/tests/agents/test_p1z6_coding_retry_strategy_devwatch.py
@@ -1,0 +1,408 @@
+"""P1-Z6 — canonical coding path retry + strategy repo-aware + dev watch.
+
+배경
+----
+canonical session ``6911f9d65e5d`` (job ``1779178961452-f2705c655a9b``)
+가 노출한 4 가지 회귀:
+
+1. ``coding_execute`` 가 ``edit_failed: _SubprocessError: subprocess
+   failed: exit=124`` 로 죽음 — operator surface 가 generic 해서
+   어디서 timeout 났는지 진단 불가.
+2. ``failed_retryable`` 인데 실제 자동 재시도 안 됨 — max_attempts=1
+   default + recovery sweep 없음.
+3. ``strategy_id=single_repo_greenfield_empty`` — 실제 target repo
+   (``naver-search-clone``) 는 ``apps/`` 구조였는데 toplevel=[] 로
+   잘못 분류.
+4. 사용자가 매번 ``runtime up`` 전체 재기동 — dev hot-reload 없음.
+
+본 회귀는 위 4 가지를 영구히 lock.
+
+stdlib unittest 만.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.coding.implementation_strategy import (
+    STRATEGY_GREENFIELD_EMPTY,
+    STRATEGY_MONOREPO_APPS,
+    ROLE_BACKEND,
+    scan_toplevel_paths_from_workspace,
+    synthesize_implementation_strategy,
+)
+from yule_orchestrator.agents.job_queue.coding_execute_recovery import (
+    TRANSIENT_PRE_PR_RETRYABLE_REASONS,
+    recover_transient_pre_pr_failures,
+)
+from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+    REASON_EDIT_SUBPROCESS_FAILED,
+    REASON_EDIT_TIMEOUT_LIVE_EDITOR,
+    REASON_WRITE_SCOPE_RESOLVED_EMPTY,
+)
+from yule_orchestrator.runtime.dev_watch import (
+    AffectedDecision,
+    ENGINEERING_SERVICES_SET,
+    FileWatcher,
+    SERVICE_CODING_EXECUTOR,
+    SERVICE_DISCORD_GATEWAY,
+    SERVICE_GITHUB_WORK_ORDER_EXECUTOR,
+    compute_affected_services,
+    dev_watch_enabled,
+    run_dev_watch_iteration,
+)
+
+
+# ---------------------------------------------------------------------------
+# A — edit timeout structured diagnostics
+# ---------------------------------------------------------------------------
+
+
+class EditTimeoutReasonTests(unittest.TestCase):
+    def test_reason_constants_exist_and_distinct(self) -> None:
+        self.assertEqual(
+            REASON_EDIT_TIMEOUT_LIVE_EDITOR, "edit_timeout_live_editor"
+        )
+        self.assertEqual(REASON_EDIT_SUBPROCESS_FAILED, "edit_subprocess_failed")
+        self.assertNotEqual(
+            REASON_EDIT_TIMEOUT_LIVE_EDITOR, REASON_EDIT_SUBPROCESS_FAILED
+        )
+
+    def test_worker_source_branches_on_subprocess_error_exit_code(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            coding_executor_worker as worker_mod,
+        )
+
+        source = inspect.getsource(worker_mod.CodingExecutorWorker.process_job)
+        # exit_code=124 분기 + structured audit
+        self.assertIn("_SubprocessError", source)
+        self.assertIn("REASON_EDIT_TIMEOUT_LIVE_EDITOR", source)
+        self.assertIn("failing_stage", source)
+        self.assertIn("subprocess_kind", source)
+        self.assertIn("timeout_seconds", source)
+        self.assertIn("stderr_tail", source)
+
+
+# ---------------------------------------------------------------------------
+# B — pre-PR retry policy: max_attempts default + recovery sweep
+# ---------------------------------------------------------------------------
+
+
+class PrePRRetryDefaultsTests(unittest.TestCase):
+    def test_enqueue_default_max_attempts_is_three(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue.coding_executor_worker import (
+            CodingExecutorWorker,
+        )
+
+        sig = inspect.signature(CodingExecutorWorker.enqueue)
+        self.assertEqual(sig.parameters["max_attempts"].default, 3)
+
+    def test_transient_reasons_set_includes_edit_timeout(self) -> None:
+        self.assertIn(
+            "edit_timeout_live_editor", TRANSIENT_PRE_PR_RETRYABLE_REASONS
+        )
+        self.assertIn(
+            "edit_subprocess_failed", TRANSIENT_PRE_PR_RETRYABLE_REASONS
+        )
+
+    def test_structural_reasons_not_in_transient_set(self) -> None:
+        # write_scope_resolved_empty / strategy unresolved 는 retry 대상 아님.
+        self.assertNotIn(
+            REASON_WRITE_SCOPE_RESOLVED_EMPTY, TRANSIENT_PRE_PR_RETRYABLE_REASONS
+        )
+        self.assertNotIn(
+            "tech_lead_strategy_unresolved", TRANSIENT_PRE_PR_RETRYABLE_REASONS
+        )
+
+    def test_recovery_sweep_with_in_memory_queue(self) -> None:
+        from yule_orchestrator.agents.job_queue.state_machine import JobState
+        from yule_orchestrator.agents.job_queue.store import JobQueue
+
+        tmpdir = tempfile.mkdtemp(prefix="yule-p1z6-retry-")
+        queue = JobQueue(db_path=Path(tmpdir) / "queue.sqlite")
+
+        # 1) edit_timeout_live_editor 로 떨어진 row 추가
+        job = queue.enqueue(
+            session_id="sess-z6-1",
+            job_type="coding_execute",
+            payload={"session_id": "sess-z6-1", "executor_role": "backend-engineer"},
+            max_attempts=3,
+        )
+        queue.pick(worker_id="w1", job_types=["coding_execute"])
+        queue.transition(
+            job.job_id,
+            JobState.FAILED_RETRYABLE,
+            result={"reason": "edit_timeout_live_editor", "branch": "f/x"},
+        )
+
+        requeued = recover_transient_pre_pr_failures(queue)
+        self.assertIn(job.job_id, requeued)
+
+        # 2) structural reason 은 retry 안 됨
+        job2 = queue.enqueue(
+            session_id="sess-z6-2",
+            job_type="coding_execute",
+            payload={"session_id": "sess-z6-2", "executor_role": "backend-engineer"},
+            max_attempts=3,
+        )
+        queue.pick(worker_id="w1", job_types=["coding_execute"])
+        queue.transition(
+            job2.job_id,
+            JobState.FAILED_RETRYABLE,
+            result={"reason": REASON_WRITE_SCOPE_RESOLVED_EMPTY, "branch": "f/y"},
+        )
+        requeued2 = recover_transient_pre_pr_failures(queue)
+        self.assertNotIn(job2.job_id, requeued2)
+
+
+# ---------------------------------------------------------------------------
+# C — strategy reads workspace_root local checkout
+# ---------------------------------------------------------------------------
+
+
+class StrategyWorkspaceRootScanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        (self.root / "apps" / "web").mkdir(parents=True)
+        (self.root / "apps" / "api").mkdir(parents=True)
+        (self.root / "packages" / "shared").mkdir(parents=True)
+        (self.root / "README.md").touch()
+
+    def test_scan_returns_apps_packages(self) -> None:
+        result = scan_toplevel_paths_from_workspace(str(self.root))
+        self.assertIn("apps", result)
+        self.assertIn("packages", result)
+
+    def test_scan_returns_empty_for_missing_dir(self) -> None:
+        result = scan_toplevel_paths_from_workspace("/tmp/definitely-not-p1z6")
+        self.assertEqual(result, ())
+
+    def test_scan_returns_empty_for_none(self) -> None:
+        self.assertEqual(scan_toplevel_paths_from_workspace(None), ())
+
+    def test_strategy_uses_workspace_root_when_toplevel_empty(self) -> None:
+        """canonical session 6911f9d65e5d 의 회귀: toplevel=[] + workspace_root
+        주어졌을 때 local scan 으로 apps/ 감지."""
+
+        strategy = synthesize_implementation_strategy(
+            user_request="네이버 검색형 풀스택 MVP 구축",
+            toplevel_paths=(),
+            workspace_root=str(self.root),
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_MONOREPO_APPS)
+        self.assertTrue(strategy.resolved)
+        self.assertEqual(strategy.first_slice_owner, ROLE_BACKEND)
+        self.assertIn("apps/api/**", strategy.first_slice_scope)
+
+    def test_explicit_toplevel_paths_wins_over_workspace(self) -> None:
+        """caller 가 명시 toplevel 줬으면 그것이 우선 — workspace scan
+        skip."""
+
+        strategy = synthesize_implementation_strategy(
+            user_request="검색 구현",
+            toplevel_paths=("src", "tests"),
+            workspace_root=str(self.root),  # apps/ 있지만
+        )
+        # toplevel=src/tests 만 → classic_src_layout
+        from yule_orchestrator.agents.coding.implementation_strategy import (
+            STRATEGY_CLASSIC_SRC_LAYOUT,
+        )
+
+        self.assertEqual(strategy.strategy_id, STRATEGY_CLASSIC_SRC_LAYOUT)
+
+    def test_workspace_root_missing_falls_back_to_greenfield(self) -> None:
+        strategy = synthesize_implementation_strategy(
+            user_request="구현",
+            toplevel_paths=(),
+            workspace_root=None,
+        )
+        self.assertEqual(strategy.strategy_id, STRATEGY_GREENFIELD_EMPTY)
+
+
+# ---------------------------------------------------------------------------
+# D — dev watch / selective restart
+# ---------------------------------------------------------------------------
+
+
+class ComputeAffectedServicesTests(unittest.TestCase):
+    def test_coding_executor_file_targets_only_coding_executor(self) -> None:
+        decision = compute_affected_services(
+            ["src/yule_orchestrator/runtime/coding_executor_runner.py"]
+        )
+        self.assertEqual(decision.services, frozenset({SERVICE_CODING_EXECUTOR}))
+        self.assertEqual(decision.reason, "explicit_mapping")
+
+    def test_discord_commands_file_targets_only_discord_gateway(self) -> None:
+        decision = compute_affected_services(
+            ["src/yule_orchestrator/discord/commands/__init__.py"]
+        )
+        self.assertEqual(decision.services, frozenset({SERVICE_DISCORD_GATEWAY}))
+
+    def test_github_work_order_file_targets_only_work_order_executor(self) -> None:
+        decision = compute_affected_services(
+            ["src/yule_orchestrator/agents/job_queue/github_work_order_executor.py"]
+        )
+        self.assertEqual(
+            decision.services, frozenset({SERVICE_GITHUB_WORK_ORDER_EXECUTOR})
+        )
+
+    def test_shared_coding_module_targets_both_executor_and_work_order(self) -> None:
+        decision = compute_affected_services(
+            ["src/yule_orchestrator/agents/coding/implementation_strategy.py"]
+        )
+        self.assertIn(SERVICE_CODING_EXECUTOR, decision.services)
+        self.assertIn(SERVICE_GITHUB_WORK_ORDER_EXECUTOR, decision.services)
+
+    def test_unmapped_orchestrator_file_triggers_conservative_fallback(self) -> None:
+        decision = compute_affected_services(
+            ["src/yule_orchestrator/agents/something_new/helper.py"]
+        )
+        self.assertTrue(decision.conservative_fallback)
+        self.assertEqual(decision.services, ENGINEERING_SERVICES_SET)
+        self.assertEqual(decision.reason, "conservative_fallback")
+
+    def test_unrelated_file_no_restart(self) -> None:
+        decision = compute_affected_services(
+            ["docs/operations.md", "tests/agents/test_foo.py"]
+        )
+        self.assertEqual(decision.services, frozenset())
+        self.assertEqual(decision.reason, "no_match")
+
+    def test_empty_changes_no_restart(self) -> None:
+        decision = compute_affected_services([])
+        self.assertEqual(decision.services, frozenset())
+
+
+class DevWatchOptInTests(unittest.TestCase):
+    def test_dev_watch_disabled_by_default(self) -> None:
+        import os as _os
+
+        previous = _os.environ.pop("YULE_RUNTIME_DEV_WATCH", None)
+        try:
+            self.assertFalse(dev_watch_enabled())
+        finally:
+            if previous is not None:
+                _os.environ["YULE_RUNTIME_DEV_WATCH"] = previous
+
+    def test_dev_watch_enabled_by_env(self) -> None:
+        import os as _os
+
+        previous = _os.environ.get("YULE_RUNTIME_DEV_WATCH")
+        _os.environ["YULE_RUNTIME_DEV_WATCH"] = "1"
+        try:
+            self.assertTrue(dev_watch_enabled())
+        finally:
+            if previous is None:
+                _os.environ.pop("YULE_RUNTIME_DEV_WATCH", None)
+            else:
+                _os.environ["YULE_RUNTIME_DEV_WATCH"] = previous
+
+
+class FileWatcherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name) / "src"
+        self.root.mkdir(parents=True)
+
+    def test_first_call_returns_empty_baseline(self) -> None:
+        (self.root / "yule_orchestrator").mkdir()
+        (self.root / "yule_orchestrator" / "x.py").write_text("a", encoding="utf-8")
+        watcher = FileWatcher(roots=[str(self.root)])
+        self.assertEqual(watcher.detect_changes(), ())
+
+    def test_modified_file_detected_as_change(self) -> None:
+        f = self.root / "y.py"
+        f.write_text("v1", encoding="utf-8")
+        watcher = FileWatcher(roots=[str(self.root)])
+        watcher.detect_changes()  # baseline
+        import time as _time
+
+        _time.sleep(0.01)
+        f.write_text("v2", encoding="utf-8")
+        # touch mtime forward explicitly
+        import os as _os
+
+        _os.utime(f, (f.stat().st_atime, f.stat().st_mtime + 5))
+        changes = watcher.detect_changes()
+        self.assertTrue(any(p.endswith("y.py") for p in changes))
+
+
+class RunDevWatchIterationTests(unittest.TestCase):
+    def test_iteration_no_changes_no_restart(self) -> None:
+        class _StaticWatcher:
+            interval = 1.0
+
+            def detect_changes(self):
+                return ()
+
+        called: list[str] = []
+        decision = run_dev_watch_iteration(
+            watcher=_StaticWatcher(),  # type: ignore[arg-type]
+            restart_service_fn=lambda svc: called.append(svc),
+        )
+        self.assertEqual(decision.services, frozenset())
+        self.assertEqual(called, [])
+
+    def test_iteration_with_change_triggers_restart(self) -> None:
+        class _StaticWatcher:
+            interval = 1.0
+            _calls = 0
+
+            def detect_changes(self):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "src/yule_orchestrator/runtime/coding_executor_runner.py",
+                    )
+                return ()
+
+        called: list[str] = []
+        decision = run_dev_watch_iteration(
+            watcher=_StaticWatcher(),  # type: ignore[arg-type]
+            restart_service_fn=lambda svc: called.append(svc),
+        )
+        self.assertEqual(decision.services, frozenset({SERVICE_CODING_EXECUTOR}))
+        self.assertEqual(called, [SERVICE_CODING_EXECUTOR])
+
+
+# ---------------------------------------------------------------------------
+# Wiring guards
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_runner_imports_transient_recovery(self) -> None:
+        import inspect
+
+        from yule_orchestrator.runtime import coding_executor_runner
+
+        source = inspect.getsource(coding_executor_runner)
+        self.assertIn("recover_transient_pre_pr_failures", source)
+
+    def test_slash_intake_passes_workspace_root_to_strategy(self) -> None:
+        import inspect
+
+        from yule_orchestrator.discord import commands as cmd_mod
+
+        source = inspect.getsource(cmd_mod._ensure_coding_proposal_on_session)
+        self.assertIn("workspace_root", source)
+        self.assertIn("_resolve_local_target_repo_root", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agents/test_p1z_approval_continuation_and_terminal_skip.py
+++ b/tests/agents/test_p1z_approval_continuation_and_terminal_skip.py
@@ -1,0 +1,494 @@
+"""P1-Z — Approved → work_order 복구 + terminal session resurrection 차단.
+
+배경
+----
+사용자가 폐기한 canonical sessions (``166c416a1ed0``, ``c7bc03b8d41a``)
+가 runtime restart 후 stale dispatch marker self-heal 로 다시
+``coding_execute`` 큐에 enqueue 됐다.  동시에 새 승인 세션 ``f2f36607d175``
+는 state=approved 인데도 ``github_work_order_issue`` 없고 queue row 0
+인 dead-end.
+
+본 회귀 라인은 다음 5 가지 contract 를 명시 lock:
+
+1. ``decide_post_approval_action`` 이 approved + coding_proposal +
+   github_target + no anchor → ``needs_work_order``.
+2. 이미 anchor / coding_proposal 없음 / target 없음 / terminal session
+   → ``noop`` (reason 별).
+3. ``dispatch_post_approval_work_order`` 가 inject 된 builder + queue
+   로 실제 work_order row 생성.
+4. ``coding_execute_dispatcher.iter_ready_coding_jobs`` 가 rejected /
+   completed session 은 yield 안 함.
+5. ``_stamp_terminal_session_skip`` 이 terminal + ready coding_job 인
+   session 에 audit marker 만 stamp 하고 새 row 안 만듦.
+
+stdlib unittest 만 사용.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Optional
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_orchestrator.agents.job_queue.coding_execute_dispatcher import (
+    SESSION_EXTRA_DISPATCH_KEY,
+    SESSION_EXTRA_TERMINAL_SKIP_KEY,
+    _stamp_terminal_session_skip,
+    iter_ready_coding_jobs,
+)
+from yule_orchestrator.agents.job_queue.coding_execute_terminal_skip import (
+    TERMINAL_SESSION_STATES,
+    is_terminal_session,
+)
+from yule_orchestrator.agents.job_queue.post_approval_dispatch import (
+    ACTION_DISPATCHED,
+    ACTION_FAILED,
+    ACTION_NEEDS_WORK_ORDER,
+    ACTION_NOOP,
+    FAIL_REASON_PROPOSAL_NOT_ELIGIBLE,
+    NOOP_REASON_ANCHOR_ALREADY_STAMPED,
+    NOOP_REASON_NO_CODING_PROPOSAL,
+    NOOP_REASON_NO_GITHUB_TARGET,
+    NOOP_REASON_NO_REPO,
+    NOOP_REASON_NOT_APPROVED,
+    NOOP_REASON_TERMINAL_SESSION,
+    SESSION_EXTRA_POST_APPROVAL_DISPATCH_KEY,
+    decide_post_approval_action,
+    dispatch_post_approval_work_order,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _State:
+    """Mimics WorkflowState enum — ``.value`` 가 'approved' / 'rejected' / ..."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:  # noqa: D401
+        return self.value
+
+
+@dataclass
+class _FakeSession:
+    session_id: str = "sess-p1z-1"
+    state: Any = field(default_factory=lambda: _State("approved"))
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    prompt: str = "implement search clone"
+    channel_id: Optional[int] = 100
+    thread_id: Optional[int] = 200
+
+    @classmethod
+    def make(
+        cls,
+        *,
+        session_id: str = "sess-p1z-1",
+        state: str = "approved",
+        extra: Optional[Mapping[str, Any]] = None,
+        prompt: str = "implement search clone",
+        channel_id: Optional[int] = 100,
+        thread_id: Optional[int] = 200,
+    ) -> "_FakeSession":
+        return cls(
+            session_id=session_id,
+            state=_State(state),
+            extra=dict(extra or {}),
+            prompt=prompt,
+            channel_id=channel_id,
+            thread_id=thread_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# decide_post_approval_action
+# ---------------------------------------------------------------------------
+
+
+_PROPOSAL = {"executor_role": "fullstack-engineer", "review_roles": ["tech-lead"]}
+_TARGET = {
+    "kind": "repo",
+    "owner": "yule-studio",
+    "repo": "naver-search-clone",
+    "number": None,
+}
+
+
+class DecidePostApprovalActionTests(unittest.TestCase):
+    def test_intake_state_is_noop(self) -> None:
+        d = decide_post_approval_action(_FakeSession.make(state="intake"))
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_NOT_APPROVED)
+
+    def test_rejected_state_is_terminal_noop(self) -> None:
+        d = decide_post_approval_action(_FakeSession.make(state="rejected"))
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_TERMINAL_SESSION)
+
+    def test_completed_state_is_terminal_noop(self) -> None:
+        d = decide_post_approval_action(_FakeSession.make(state="completed"))
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_TERMINAL_SESSION)
+
+    def test_approved_without_proposal_is_noop(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra={"github_target": _TARGET})
+        )
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_NO_CODING_PROPOSAL)
+
+    def test_approved_with_existing_anchor_is_noop(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra={
+                    "coding_proposal": _PROPOSAL,
+                    "github_target": _TARGET,
+                    "github_work_order_issue": {"issue_number": 5, "repo": "yule-studio/naver-search-clone"},
+                },
+            )
+        )
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_ANCHOR_ALREADY_STAMPED)
+
+    def test_approved_without_target_is_noop(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(state="approved", extra={"coding_proposal": _PROPOSAL})
+        )
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_NO_GITHUB_TARGET)
+
+    def test_approved_target_without_repo_owner_is_noop(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra={
+                    "coding_proposal": _PROPOSAL,
+                    "github_target": {"kind": "repo", "owner": "", "repo": ""},
+                },
+            )
+        )
+        self.assertEqual(d.action, ACTION_NOOP)
+        self.assertEqual(d.reason, NOOP_REASON_NO_REPO)
+
+    def test_approved_with_proposal_and_target_needs_work_order(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra={"coding_proposal": _PROPOSAL, "github_target": _TARGET},
+            )
+        )
+        self.assertEqual(d.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(d.repo, "yule-studio/naver-search-clone")
+        self.assertIsNone(d.existing_issue_number)
+
+    def test_explicit_existing_issue_number_carried_through(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra={
+                    "coding_proposal": _PROPOSAL,
+                    "github_target": _TARGET,
+                    "existing_issue_number": 5,
+                },
+            )
+        )
+        self.assertEqual(d.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(d.existing_issue_number, 5)
+
+    def test_issue_kind_target_with_number_uses_target_number(self) -> None:
+        d = decide_post_approval_action(
+            _FakeSession.make(
+                state="approved",
+                extra={
+                    "coding_proposal": _PROPOSAL,
+                    "github_target": {
+                        "kind": "issue",
+                        "owner": "yule-studio",
+                        "repo": "naver-search-clone",
+                        "number": 12,
+                    },
+                },
+            )
+        )
+        self.assertEqual(d.action, ACTION_NEEDS_WORK_ORDER)
+        self.assertEqual(d.existing_issue_number, 12)
+
+
+# ---------------------------------------------------------------------------
+# dispatch_post_approval_work_order — builder/queue injection
+# ---------------------------------------------------------------------------
+
+
+class _FakeProposal:
+    """Minimal duck-typed proposal — ``GitHubWorkOrder.from_proposal`` 가
+    필요한 속성만 노출."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str = "sess-p1z-1",
+        repo: str = "yule-studio/naver-search-clone",
+        existing_issue_number: Optional[int] = None,
+    ) -> None:
+        self.proposal_id = "p-1"
+        self.session_id = session_id
+        self.source_channel_id = None
+        self.source_thread_id = None
+        self.source_message_id = None
+        self.request_summary = "implement search clone"
+        self.selected_roles = ("tech-lead", "fullstack-engineer")
+        self.intent_actions = ("코드 변경",)
+        self.repo = repo
+        self.base_branch = "main"
+        self.dry_run_default = False
+        self.extra: Mapping[str, Any] = {}
+        self.issue_auto_create_plan: Optional[Mapping[str, Any]] = None
+        self.existing_issue_number = existing_issue_number
+
+
+def _in_memory_queue():
+    """JobQueue backed by a tempfile — real enqueue / dedup wiring."""
+
+    import tempfile
+    from pathlib import Path
+
+    from yule_orchestrator.agents.job_queue.store import JobQueue
+
+    tmpdir = tempfile.mkdtemp(prefix="yule-p1z-")
+    return JobQueue(db_path=Path(tmpdir) / "queue.sqlite")
+
+
+class DispatchPostApprovalWorkOrderTests(unittest.TestCase):
+    def test_needs_work_order_path_calls_proposal_builder(self) -> None:
+        captured = {}
+
+        def fake_builder(**kwargs):
+            captured.update(kwargs)
+            return _FakeProposal(session_id=kwargs["session"].session_id)
+
+        session = _FakeSession.make(
+            state="approved",
+            extra={"coding_proposal": _PROPOSAL, "github_target": _TARGET},
+        )
+        queue = _in_memory_queue()
+
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=queue,
+            requested_by="cli-user",
+            proposal_builder=fake_builder,
+        )
+        self.assertIn(result["action"], (ACTION_DISPATCHED, ACTION_NOOP))
+        self.assertEqual(captured["repo"], "yule-studio/naver-search-clone")
+        self.assertEqual(captured["requested_by"], "cli-user")
+
+    def test_noop_when_already_anchor(self) -> None:
+        session = _FakeSession.make(
+            state="approved",
+            extra={
+                "coding_proposal": _PROPOSAL,
+                "github_target": _TARGET,
+                "github_work_order_issue": {"issue_number": 5},
+            },
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+            proposal_builder=lambda **kwargs: self.fail("builder must not be called"),
+        )
+        self.assertEqual(result["action"], ACTION_NOOP)
+        self.assertEqual(result["reason"], NOOP_REASON_ANCHOR_ALREADY_STAMPED)
+
+    def test_builder_returns_none_is_failed(self) -> None:
+        session = _FakeSession.make(
+            state="approved",
+            extra={"coding_proposal": _PROPOSAL, "github_target": _TARGET},
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+            proposal_builder=lambda **kwargs: None,
+        )
+        self.assertEqual(result["action"], ACTION_FAILED)
+        self.assertEqual(result["reason"], FAIL_REASON_PROPOSAL_NOT_ELIGIBLE)
+
+    def test_terminal_session_is_noop_not_dispatched(self) -> None:
+        session = _FakeSession.make(
+            state="rejected",
+            extra={"coding_proposal": _PROPOSAL, "github_target": _TARGET},
+        )
+        result = dispatch_post_approval_work_order(
+            session=session,
+            queue=_in_memory_queue(),
+            requested_by="cli-user",
+            proposal_builder=lambda **kwargs: self.fail("must not call builder"),
+        )
+        self.assertEqual(result["action"], ACTION_NOOP)
+        self.assertEqual(result["reason"], NOOP_REASON_TERMINAL_SESSION)
+
+
+# ---------------------------------------------------------------------------
+# Terminal session resurrection block
+# ---------------------------------------------------------------------------
+
+
+class TerminalSessionIterTests(unittest.TestCase):
+    def _make_session(self, *, state: str, sid: str, has_marker: bool = False) -> _FakeSession:
+        extra: dict[str, Any] = {
+            "coding_job": {
+                "session_id": sid,
+                "status": "ready",
+                "executor_role": "fullstack-engineer",
+            }
+        }
+        if has_marker:
+            extra[SESSION_EXTRA_DISPATCH_KEY] = {"job_id": "old-job-1"}
+        return _FakeSession.make(session_id=sid, state=state, extra=extra)
+
+    def test_rejected_session_is_skipped(self) -> None:
+        live = self._make_session(state="approved", sid="live-1")
+        rejected = self._make_session(state="rejected", sid="rej-1", has_marker=True)
+        yielded = list(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [rejected, live],
+                queue=None,
+            )
+        )
+        ids = {r.session_id for r in yielded}
+        self.assertIn("live-1", ids)
+        self.assertNotIn("rej-1", ids)
+
+    def test_completed_session_is_skipped(self) -> None:
+        completed = self._make_session(state="completed", sid="done-1")
+        yielded = list(
+            iter_ready_coding_jobs(
+                session_loader=lambda: [completed], queue=None
+            )
+        )
+        self.assertEqual(yielded, [])
+
+    def test_is_terminal_session_helper(self) -> None:
+        self.assertTrue(is_terminal_session(_FakeSession.make(state="rejected")))
+        self.assertTrue(is_terminal_session(_FakeSession.make(state="completed")))
+        self.assertFalse(is_terminal_session(_FakeSession.make(state="approved")))
+        self.assertFalse(is_terminal_session(_FakeSession.make(state="intake")))
+
+    def test_terminal_session_states_constant(self) -> None:
+        self.assertEqual(TERMINAL_SESSION_STATES, frozenset({"completed", "rejected"}))
+
+
+class TerminalSkipAuditTests(unittest.TestCase):
+    def test_stamps_skip_audit_on_rejected_session_with_marker(self) -> None:
+        persisted: list[Any] = []
+
+        def fake_update(session, *, now=None):
+            persisted.append(session)
+            return session
+
+        rejected = _FakeSession.make(
+            session_id="rej-stamp-1",
+            state="rejected",
+            extra={
+                SESSION_EXTRA_DISPATCH_KEY: {"job_id": "old-1"},
+                "coding_job": {"status": "ready", "session_id": "rej-stamp-1", "executor_role": "x"},
+            },
+        )
+        live = _FakeSession.make(
+            session_id="live-stamp-1",
+            state="approved",
+            extra={"coding_job": {"status": "ready", "session_id": "live-stamp-1", "executor_role": "x"}},
+        )
+
+        stamped = _stamp_terminal_session_skip(
+            session_loader=lambda: [rejected, live],
+            update_session_fn=fake_update,
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc),
+        )
+        self.assertEqual(stamped, 1)
+        self.assertEqual(len(persisted), 1)
+        marker = persisted[0].extra[SESSION_EXTRA_TERMINAL_SKIP_KEY]
+        self.assertEqual(marker["reason"], "terminal_session_skip")
+        self.assertEqual(marker["session_state"], "rejected")
+        self.assertTrue(marker["had_ready_coding_job"])
+        self.assertTrue(marker["had_dispatch_marker"])
+
+    def test_completed_with_no_ready_no_marker_is_skipped(self) -> None:
+        persisted: list[Any] = []
+        done = _FakeSession.make(
+            session_id="done-1",
+            state="completed",
+            extra={"coding_job": {"status": "saved", "session_id": "done-1", "executor_role": "x"}},
+        )
+        stamped = _stamp_terminal_session_skip(
+            session_loader=lambda: [done],
+            update_session_fn=lambda s, *, now=None: persisted.append(s),
+        )
+        self.assertEqual(stamped, 0)
+        self.assertEqual(persisted, [])
+
+    def test_idempotent_does_not_restamp_same_state(self) -> None:
+        already = _FakeSession.make(
+            session_id="rej-idemp-1",
+            state="rejected",
+            extra={
+                SESSION_EXTRA_DISPATCH_KEY: {"job_id": "old-1"},
+                "coding_job": {"status": "ready", "session_id": "rej-idemp-1", "executor_role": "x"},
+                SESSION_EXTRA_TERMINAL_SKIP_KEY: {
+                    "session_state": "rejected",
+                    "reason": "terminal_session_skip",
+                    "had_ready_coding_job": True,
+                    "had_dispatch_marker": True,
+                    "at": "2026-05-19T00:00:00+00:00",
+                },
+            },
+        )
+        persisted: list[Any] = []
+        stamped = _stamp_terminal_session_skip(
+            session_loader=lambda: [already],
+            update_session_fn=lambda s, *, now=None: persisted.append(s),
+        )
+        self.assertEqual(stamped, 0)
+        self.assertEqual(persisted, [])
+
+
+# ---------------------------------------------------------------------------
+# Source-grep wiring guard
+# ---------------------------------------------------------------------------
+
+
+class WiringGuardTests(unittest.TestCase):
+    def test_cli_engineer_approve_imports_dispatch(self) -> None:
+        import inspect
+
+        from yule_orchestrator.cli import engineer as cli_mod
+
+        source = inspect.getsource(cli_mod.run_engineer_approve_command)
+        self.assertIn("dispatch_post_approval_work_order", source)
+        self.assertIn("JobQueue", source)
+        self.assertIn("post_approval", source)
+
+    def test_dispatcher_invokes_terminal_skip(self) -> None:
+        import inspect
+
+        from yule_orchestrator.agents.job_queue import (
+            coding_execute_dispatcher as disp_mod,
+        )
+
+        source = inspect.getsource(disp_mod.dispatch_ready_coding_jobs)
+        self.assertIn("_stamp_terminal_session_skip", source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/discord/test_engineer_intake_governance_options.py
+++ b/tests/discord/test_engineer_intake_governance_options.py
@@ -1,0 +1,315 @@
+"""P1-R-2 — `/engineer_intake` 명시 governance 옵션 우선순위.
+
+1.  explicit work_mode=autonomous_merge 가 prompt approval_required 보다 우선
+2.  explicit work_mode=approval_required 가 prompt autonomous_merge 보다 우선
+3.  explicit branch_strategy=git_flow 영속
+4.  explicit release_strategy=tagged_release 영속
+5.  explicit issue_policy=issue_required 영속
+6.  explicit 옵션 생략 시 prompt token fallback 동작
+7.  explicit 옵션 + prompt 둘 다 없으면 default governance 값 영속
+8.  intake receipt 끝에 governance contract block 추가됨
+9.  mode_decided_by 가 slash_option_explicit / user_explicit / gateway_inferred 구분
+10. legacy intake (explicit 옵션 전부 없음) regression 없음
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from unittest.mock import MagicMock
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.lifecycle.session_mode import (
+    EXTRA_BRANCH_STRATEGY,
+    EXTRA_DECIDED_AT,
+    EXTRA_DECIDED_BY,
+    EXTRA_ISSUE_POLICY,
+    EXTRA_RELEASE_STRATEGY,
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+)
+from yule_orchestrator.agents.workflow_state import (
+    WorkflowSession,
+    WorkflowState,
+    load_session,
+    save_session,
+)
+from yule_orchestrator.discord.commands import (
+    _append_governance_block_to_result,
+    _persist_intake_mode_and_backlog,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _seed(session_id: str, *, prompt: str = "p") -> WorkflowSession:
+    s = WorkflowSession(
+        session_id=session_id,
+        prompt=prompt,
+        task_type="coding_execute",
+        state=WorkflowState.IN_PROGRESS,
+        created_at=_now(),
+        updated_at=_now(),
+        executor_role="backend-engineer",
+        extra={},
+    )
+    save_session(s)
+    return s
+
+
+class _CacheTmpFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["YULE_AGENT_CACHE_DIR"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        os.environ.pop("YULE_AGENT_CACHE_DIR", None)
+
+
+_FULLSTACK_PROMPT_AUTO = (
+    "autonomous_merge, single_repo, full_stack_single_repo "
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+_FULLSTACK_PROMPT_APPROVAL = (
+    "approval_required, single_repo, full_stack_single_repo "
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+_FULLSTACK_PROMPT_NO_TOKEN = (
+    "네이버 검색 풀스택 MVP 구현해줘 "
+    "https://github.com/yule-studio/naver-search-clone"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2 — slash option 이 prompt 토큰보다 우선
+# ---------------------------------------------------------------------------
+
+
+class SlashOptionPriorityTests(_CacheTmpFixture):
+    def test_slash_autonomous_overrides_prompt_approval(self) -> None:
+        s = _seed("s-1", prompt=_FULLSTACK_PROMPT_APPROVAL)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_APPROVAL,
+            explicit_work_mode=WORK_MODE_AUTONOMOUS,
+        )
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary["work_mode"], WORK_MODE_AUTONOMOUS)
+        self.assertEqual(summary["mode_decided_by"], "slash_option_explicit")
+        fresh = load_session("s-1")
+        self.assertEqual(fresh.extra[EXTRA_WORK_MODE], WORK_MODE_AUTONOMOUS)
+        self.assertEqual(
+            fresh.extra[EXTRA_DECIDED_BY], "slash_option_explicit"
+        )
+
+    def test_slash_approval_overrides_prompt_autonomous(self) -> None:
+        s = _seed("s-2", prompt=_FULLSTACK_PROMPT_AUTO)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_AUTO,
+            explicit_work_mode=WORK_MODE_APPROVAL,
+        )
+        self.assertEqual(summary["work_mode"], WORK_MODE_APPROVAL)
+        self.assertEqual(summary["mode_decided_by"], "slash_option_explicit")
+
+
+# ---------------------------------------------------------------------------
+# 3, 4, 5 — explicit branch_strategy / release_strategy / issue_policy 영속
+# ---------------------------------------------------------------------------
+
+
+class ExplicitGovernanceKeysPersistTests(_CacheTmpFixture):
+    def test_explicit_branch_strategy_persists(self) -> None:
+        s = _seed("s-3", prompt=_FULLSTACK_PROMPT_NO_TOKEN)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_NO_TOKEN,
+            explicit_branch_strategy="git_flow",
+        )
+        self.assertEqual(summary["branch_strategy"], "git_flow")
+        fresh = load_session("s-3")
+        self.assertEqual(fresh.extra[EXTRA_BRANCH_STRATEGY], "git_flow")
+
+    def test_explicit_release_strategy_persists(self) -> None:
+        s = _seed("s-4", prompt=_FULLSTACK_PROMPT_NO_TOKEN)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_NO_TOKEN,
+            explicit_release_strategy="tagged_release",
+        )
+        self.assertEqual(summary["release_strategy"], "tagged_release")
+        fresh = load_session("s-4")
+        self.assertEqual(
+            fresh.extra[EXTRA_RELEASE_STRATEGY], "tagged_release"
+        )
+
+    def test_explicit_issue_policy_persists(self) -> None:
+        s = _seed("s-5", prompt=_FULLSTACK_PROMPT_NO_TOKEN)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_NO_TOKEN,
+            explicit_issue_policy="issue_required",
+        )
+        self.assertEqual(summary["issue_policy"], "issue_required")
+        fresh = load_session("s-5")
+        self.assertEqual(
+            fresh.extra[EXTRA_ISSUE_POLICY], "issue_required"
+        )
+
+    def test_explicit_topology_and_scope_persist(self) -> None:
+        s = _seed("s-5b", prompt=_FULLSTACK_PROMPT_NO_TOKEN)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_NO_TOKEN,
+            explicit_topology="single_repo",
+            explicit_scope="full_stack_single_repo",
+        )
+        self.assertEqual(summary["topology"], "single_repo")
+        self.assertEqual(summary["scope"], "full_stack_single_repo")
+
+
+# ---------------------------------------------------------------------------
+# 6 — prompt token fallback
+# ---------------------------------------------------------------------------
+
+
+class PromptTokenFallbackTests(_CacheTmpFixture):
+    def test_no_slash_options_uses_prompt_tokens(self) -> None:
+        s = _seed("s-6", prompt=_FULLSTACK_PROMPT_AUTO)
+        summary = _persist_intake_mode_and_backlog(
+            session=s, prompt_text=_FULLSTACK_PROMPT_AUTO
+        )
+        # prompt 의 autonomous_merge 가 영속됨
+        self.assertEqual(summary["work_mode"], WORK_MODE_AUTONOMOUS)
+        # source 는 slash_option_explicit 가 아님 (user_explicit 또는 inferred)
+        self.assertNotEqual(
+            summary["mode_decided_by"], "slash_option_explicit"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7 — explicit 옵션 + prompt 둘 다 없으면 default
+# ---------------------------------------------------------------------------
+
+
+class DefaultGovernanceTests(_CacheTmpFixture):
+    def test_no_signal_uses_default_governance(self) -> None:
+        s = _seed("s-7", prompt="그냥 작업해 줘")
+        summary = _persist_intake_mode_and_backlog(
+            session=s, prompt_text="그냥 작업해 줘"
+        )
+        # default 값들
+        self.assertEqual(summary["branch_strategy"], "git_flow")
+        self.assertEqual(summary["release_strategy"], "tagged_release")
+        self.assertEqual(summary["issue_policy"], "issue_required")
+        # work_mode 는 default approval_required
+        self.assertEqual(summary["work_mode"], WORK_MODE_APPROVAL)
+
+
+# ---------------------------------------------------------------------------
+# 8 — intake receipt 끝에 governance block append
+# ---------------------------------------------------------------------------
+
+
+class GovernanceBlockSurfaceTests(unittest.TestCase):
+    def test_append_governance_block_adds_korean_lines(self) -> None:
+        class _FakeResult:
+            message = "원본 접수 메시지"
+
+        summary = {
+            "work_mode": "autonomous_merge",
+            "topology": "single_repo",
+            "scope": "full_stack_single_repo",
+            "branch_strategy": "git_flow",
+            "release_strategy": "tagged_release",
+            "issue_policy": "issue_required",
+            "mode_decided_by": "slash_option_explicit",
+            "mode_decided_at": "2026-05-18T00:00:00+00:00",
+        }
+        result = _append_governance_block_to_result(_FakeResult(), summary)
+        self.assertIn("🛡 거버넌스 contract", result.message)
+        self.assertIn("autonomous_merge", result.message)
+        self.assertIn("git_flow", result.message)
+        self.assertIn("tagged_release", result.message)
+        self.assertIn("issue_required", result.message)
+        self.assertIn("slash_option_explicit", result.message)
+
+
+# ---------------------------------------------------------------------------
+# 9 — mode_decided_by 가 3 분기를 구분
+# ---------------------------------------------------------------------------
+
+
+class ModeDecidedBySourceTests(_CacheTmpFixture):
+    def test_slash_option_yields_slash_option_explicit(self) -> None:
+        s = _seed("s-9a", prompt=_FULLSTACK_PROMPT_NO_TOKEN)
+        summary = _persist_intake_mode_and_backlog(
+            session=s,
+            prompt_text=_FULLSTACK_PROMPT_NO_TOKEN,
+            explicit_work_mode=WORK_MODE_AUTONOMOUS,
+        )
+        self.assertEqual(summary["mode_decided_by"], "slash_option_explicit")
+
+    def test_prompt_only_yields_user_explicit_or_inferred(self) -> None:
+        s = _seed("s-9b", prompt=_FULLSTACK_PROMPT_AUTO)
+        summary = _persist_intake_mode_and_backlog(
+            session=s, prompt_text=_FULLSTACK_PROMPT_AUTO
+        )
+        self.assertIn(
+            summary["mode_decided_by"],
+            ("user_explicit", "gateway_inferred"),
+        )
+        # 그러나 slash_option_explicit 는 절대 아님
+        self.assertNotEqual(
+            summary["mode_decided_by"], "slash_option_explicit"
+        )
+
+    def test_no_signal_yields_gateway_inferred(self) -> None:
+        s = _seed("s-9c", prompt="그냥 작업")
+        summary = _persist_intake_mode_and_backlog(
+            session=s, prompt_text="그냥 작업"
+        )
+        self.assertEqual(summary["mode_decided_by"], "gateway_inferred")
+
+
+# ---------------------------------------------------------------------------
+# 10 — legacy intake (옵션 없음) regression 없음
+# ---------------------------------------------------------------------------
+
+
+class LegacyIntakeRegressionTests(_CacheTmpFixture):
+    def test_legacy_intake_signature_still_works(self) -> None:
+        """옛 caller 가 explicit_* 인자 없이 호출해도 동작."""
+
+        s = _seed("s-10", prompt=_FULLSTACK_PROMPT_APPROVAL)
+        # 옛 호출 형식 — 키워드 explicit_* 없이
+        summary = _persist_intake_mode_and_backlog(
+            session=s, prompt_text=_FULLSTACK_PROMPT_APPROVAL
+        )
+        self.assertIsNotNone(summary)
+        # prompt 의 approval_required 가 영속됨
+        self.assertEqual(summary["work_mode"], WORK_MODE_APPROVAL)
+        # default governance 키도 영속
+        self.assertEqual(summary["branch_strategy"], "git_flow")
+        self.assertEqual(summary["release_strategy"], "tagged_release")
+        self.assertEqual(summary["issue_policy"], "issue_required")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_engineer_intake_slash_command.py
+++ b/tests/discord/test_engineer_intake_slash_command.py
@@ -199,6 +199,24 @@ class IntakeApprovalCardEnqueueTests(_SmokeFixture):
                 extra={
                     "lifecycle_mode": "implementation",
                     "active_research_roles": ["tech-lead", "backend-engineer"],
+                    # P1-Z4 A — intake eligibility 가 structured signal 기반
+                    # (github_target + coding_handoff_packet) 으로 바뀐 이후
+                    # 필수.
+                    "github_target": {
+                        "kind": "repo",
+                        "owner": "yule-studio",
+                        "repo": "naver-search-clone",
+                    },
+                    "coding_handoff_packet": {
+                        "canonical_request": _C5278A9043F2_PROMPT[:60],
+                        "github_target": {
+                            "kind": "repo",
+                            "owner": "yule-studio",
+                            "repo": "naver-search-clone",
+                        },
+                        "next_action": "open_issue",
+                        "notes": {},
+                    },
                 },
                 write_requested=True,
             )

--- a/tests/discord/test_github_workos_adapter_issue_bootstrap.py
+++ b/tests/discord/test_github_workos_adapter_issue_bootstrap.py
@@ -39,7 +39,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[기능]"\n'
+    'title: "[Feature]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -80,7 +80,7 @@ class BuildProposalIssuePlanTests(unittest.TestCase):
         assert proposal.issue_auto_create_plan is not None
         plan = proposal.issue_auto_create_plan
         self.assertEqual(plan["audit_reason"], "template_used")
-        self.assertTrue(plan["title"].startswith("[기능]"))
+        self.assertTrue(plan["title"].startswith("[Feature]"))
         self.assertIn("✨ Feature", plan["labels"])
         # extras 에 audit_reason 흔적
         self.assertEqual(

--- a/tests/discord/test_pr_merge_adapter.py
+++ b/tests/discord/test_pr_merge_adapter.py
@@ -102,7 +102,10 @@ class EnqueueHappyPathTests(_AdapterFixture):
         self.assertEqual(request.approval_kind, APPROVAL_KIND_PR_MERGE)
         self.assertIn("PR 머지 승인 — #127", request.title)
         self.assertIn("F15 corporate structure", request.title)
-        self.assertIn("위험도: LOW", rendered)
+        # P1-R — render layout 변경: "위험도" 가 "영향 범위" 섹션 안의
+        # bullet 으로 들어감.  label + 값 둘 다 별도 검사.
+        self.assertIn("위험도", rendered)
+        self.assertIn("LOW", rendered)
         self.assertIn(
             "https://github.com/yule-studio/yule-studio-agent/pull/127",
             rendered,

--- a/tests/engineering/test_issue_autocreate_end_to_end.py
+++ b/tests/engineering/test_issue_autocreate_end_to_end.py
@@ -53,7 +53,7 @@ from yule_orchestrator.agents.job_queue.github_work_order import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[기능]"\n'
+    'title: "[Feature]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -207,7 +207,7 @@ class EndToEndIssueAutoCreateTests(unittest.TestCase):
         kind, kwargs = client.calls[0]
         self.assertEqual(kind, "create_issue")
         self.assertEqual(kwargs["repo"], "yule-studio/naver-search-clone")
-        self.assertTrue(kwargs["title"].startswith("[기능]"))
+        self.assertTrue(kwargs["title"].startswith("[Feature]"))
         self.assertIn("Next.js + NestJS", kwargs["title"])
         self.assertIn("✨ Feature", kwargs["labels"])
 

--- a/tests/engineering/test_issue_quality_and_repair.py
+++ b/tests/engineering/test_issue_quality_and_repair.py
@@ -92,8 +92,8 @@ class FallbackTitleQualityTests(unittest.TestCase):
             request_summary=_NAVER_PROMPT,
             session_id="sess-x",
         )
-        # 사용자가 명시한 기대 형태와 같은 골격: `[기능] ... 풀스택 MVP 구축 (...)`
-        self.assertTrue(plan.title.startswith("[기능]"))
+        # 사용자가 명시한 기대 형태와 같은 골격: `[Feature] ... 풀스택 MVP 구축 (...)`
+        self.assertTrue(plan.title.startswith("[Feature]"))
         self.assertIn("풀스택 MVP", plan.title)
         self.assertIn("(인증/검색/블로그/메일)", plan.title)
         # 도메인 토큰 (네이버 검색형) 도 들어감
@@ -211,7 +211,7 @@ class ObsidianFallbackTests(unittest.TestCase):
             "template_source: `obsidian_fallback`", plan.body
         )
         # title 은 여전히 Korean synthesizer 적용
-        self.assertTrue(plan.title.startswith("[기능]"))
+        self.assertTrue(plan.title.startswith("[Feature]"))
 
     def test_obsidian_loader_none_falls_through(self) -> None:
         """loader 가 빈 텍스트 / None 반환 → Yule default 로 fall through."""
@@ -255,7 +255,7 @@ class IssueRepairTests(unittest.TestCase):
         self.assertTrue(outcome.dry_run)
         self.assertEqual(outcome.skipped_reason, "no_client_wired")
         # plan 은 quality fallback 으로 생성
-        self.assertTrue(outcome.plan.title.startswith("[기능]"))
+        self.assertTrue(outcome.plan.title.startswith("[Feature]"))
         self.assertIn(LABEL_FULL_STACK, outcome.plan.labels)
 
     def test_live_update_calls_client(self) -> None:
@@ -291,7 +291,7 @@ class IssueRepairTests(unittest.TestCase):
         self.assertEqual(sent["repo"], "yule-studio/naver-search-clone")
         self.assertEqual(sent["issue_number"], 1)
         # 새 title 이 한국어 명확
-        self.assertTrue(sent["title"].startswith("[기능]"))
+        self.assertTrue(sent["title"].startswith("[Feature]"))
         self.assertIn("풀스택 MVP", sent["title"])
         # labels 가 비어있지 않음
         self.assertGreater(len(sent["labels"]), 0)
@@ -360,7 +360,7 @@ class IssueLessAutoCreateRegression(unittest.TestCase):
         # plan 생성 성공 + 새 quality 적용됨
         self.assertIsNotNone(outcome.plan)
         plan = outcome.plan
-        self.assertTrue(plan.title.startswith("[기능]"))
+        self.assertTrue(plan.title.startswith("[Feature]"))
         self.assertGreater(len(plan.labels), 0)
         self.assertEqual(outcome.audit_reason, AUDIT_TEMPLATE_FALLBACK)
 

--- a/tests/engineering/test_issueless_bootstrap_end_to_end.py
+++ b/tests/engineering/test_issueless_bootstrap_end_to_end.py
@@ -62,7 +62,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[기능]"\n'
+    'title: "[Feature]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "---\n"
     "\n"
@@ -214,7 +214,7 @@ class IssuelessBootstrapEndToEndTests(unittest.TestCase):
         plan = proposal_payload.get("issue_auto_create_plan")
         self.assertIsNotNone(plan)
         assert plan is not None
-        self.assertTrue(plan["title"].startswith("[기능]"))
+        self.assertTrue(plan["title"].startswith("[Feature]"))
 
         # 2. operator 승인 → work order dispatch
         dispatch_outcome = handle_github_work_approval_reply(

--- a/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
+++ b/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
@@ -64,7 +64,7 @@ from yule_orchestrator.discord.integrations.github_workos_adapter import (
 _FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
-    'title: "[기능]"\n'
+    'title: "[Feature]"\n'
     'labels: "✨ Feature"\n'
     "---\n"
     "\n"

--- a/tests/github_workos/test_issue_auto_create.py
+++ b/tests/github_workos/test_issue_auto_create.py
@@ -51,7 +51,7 @@ _REAL_FEATURE_TEMPLATE = (
     "---\n"
     'name: "[Feature] Issue Template"\n'
     'about: 모든 라벨 관리 이슈 템플릿\n'
-    'title: "[기능]"\n'
+    'title: "[Feature]"\n'
     'labels: "✨ Feature, 📃 Docs"\n'
     "assignees: ''\n"
     "---\n"
@@ -91,7 +91,7 @@ class TemplateParsingTests(unittest.TestCase):
             text=_REAL_FEATURE_TEMPLATE,
         )
         self.assertEqual(tpl.name, "[Feature] Issue Template")
-        self.assertEqual(tpl.title_prefix, "[기능]")
+        self.assertEqual(tpl.title_prefix, "[Feature]")
         self.assertEqual(tpl.labels, ("✨ Feature", "📃 Docs"))
         self.assertEqual(tpl.assignees, ())
         self.assertIn("어떤 기능인가요?", tpl.body)
@@ -167,7 +167,7 @@ class FillTemplateTests(unittest.TestCase):
             request_summary="회원가입/로그인 구현",
             session_id="sess-1",
         )
-        self.assertTrue(plan.title.startswith("[기능]"))
+        self.assertTrue(plan.title.startswith("[Feature]"))
         self.assertIn("회원가입/로그인 구현", plan.title)
         # quote 삽입 위치 검증
         self.assertIn("> 회원가입/로그인 구현", plan.body)

--- a/tests/github_workos/test_writer_create_issue.py
+++ b/tests/github_workos/test_writer_create_issue.py
@@ -83,7 +83,7 @@ class WriterCreateIssueDryRunTests(unittest.TestCase):
         writer = GithubWriter(client=client)
         result = writer.create_issue(
             repo="owner/repo",
-            title="[기능] 회원가입",
+            title="[Feature] 회원가입",
             body="요약",
             labels=("✨ Feature",),
             assignees=("codwithyc",),
@@ -104,7 +104,7 @@ class WriterCreateIssuePolicyTests(unittest.TestCase):
         )
         result = writer.create_issue(
             repo="owner/repo",
-            title="[기능] 정책 거부 회귀 테스트",
+            title="[Feature] 정책 거부 회귀 테스트",
             body="정책 거부 테스트 본문",
         )
         self.assertEqual(result.outcome, OUTCOME_DENIED_BY_POLICY)
@@ -123,7 +123,7 @@ class WriterCreateIssueLiveTests(unittest.TestCase):
         )
         result = writer.create_issue(
             repo="owner/repo",
-            title="[기능] 회원가입",
+            title="[Feature] 회원가입",
             body="설명",
             labels=(" ✨ Feature ", "", "📃 Docs"),
             assignees=("codwithyc",),
@@ -227,7 +227,7 @@ class LiveGithubAppClientIssueTests(unittest.TestCase):
         client = _build_live_client(http)
         response = client.create_issue(
             repo="owner/repo",
-            title="[기능] X",
+            title="[Feature] X",
             body="body",
             labels=("✨ Feature", "📃 Docs"),
             assignees=("codwithyc",),
@@ -237,7 +237,7 @@ class LiveGithubAppClientIssueTests(unittest.TestCase):
         issue_reqs = [r for r in http.posted if r["url"].endswith("/repos/owner/repo/issues")]
         self.assertEqual(len(issue_reqs), 1)
         body = issue_reqs[0]["body"]
-        self.assertEqual(body["title"], "[기능] X")
+        self.assertEqual(body["title"], "[Feature] X")
         self.assertEqual(body["body"], "body")
         self.assertEqual(body["labels"], ["✨ Feature", "📃 Docs"])
         self.assertEqual(body["assignees"], ["codwithyc"])

--- a/tests/governance/test_p1r_governance_enforcement.py
+++ b/tests/governance/test_p1r_governance_enforcement.py
@@ -1,0 +1,379 @@
+"""P1-R — 11 사용자 acceptance + 보조.
+
+1.  approval_required, git_flow, tagged_release, issue_required intake
+    persists all governance keys
+2.  autonomous_merge, git_flow, tagged_release, issue_required intake
+    persists all governance keys
+3.  issue 없는 작업은 branch 생성 전에 block
+4.  invalid git-flow branch name 은 block
+5.  valid feature branch with issue anchor passes
+6.  release/hotfix completion without tag is blocked
+7.  valid tag naming passes
+8.  approval_required card without clear summary is blocked
+9.  approval_required card with required summary passes
+10. autonomous_merge mode suppresses unnecessary approval cards
+11. cross-repo target repo write path enforces same rules
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+
+from yule_orchestrator.agents.governance.repo_write_policy import (
+    ApprovalCardQualityContext,
+    GitFlowBranchContext,
+    IssueAnchorContext,
+    PolicyViolation,
+    REASON_APPROVAL_CARD_MISSING_SECTIONS,
+    REASON_INVALID_GIT_FLOW_BRANCH,
+    REASON_INVALID_RELEASE_TAG,
+    REASON_ISSUE_REQUIRED_FOR_REPO_WORK,
+    REASON_MISSING_RELEASE_TAG,
+    REASON_PROTECTED_BRANCH_DIRECT_WORK,
+    ReleaseTagContext,
+    enforce_approval_card_quality,
+    enforce_git_flow_branch,
+    enforce_release_tag,
+    validate_approval_card_quality,
+    validate_git_flow_branch,
+    validate_issue_anchor,
+    validate_release_tag,
+)
+from yule_orchestrator.agents.coding.coding_session_context import (
+    prepare_coding_session_context,
+)
+from yule_orchestrator.agents.lifecycle.session_mode import (
+    BRANCH_STRATEGY_GIT_FLOW,
+    EXTRA_BRANCH_STRATEGY,
+    EXTRA_ISSUE_POLICY,
+    EXTRA_RELEASE_STRATEGY,
+    EXTRA_SCOPE,
+    EXTRA_TOPOLOGY,
+    EXTRA_WORK_MODE,
+    ISSUE_POLICY_REQUIRED,
+    RELEASE_STRATEGY_TAGGED,
+    SCOPE_FULL_STACK,
+    TOPOLOGY_SINGLE,
+    WORK_MODE_APPROVAL,
+    WORK_MODE_AUTONOMOUS,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1, 2 — intake mode persistence (extended contract)
+# ---------------------------------------------------------------------------
+
+
+class IntakeGovernanceContractTests(unittest.TestCase):
+    def test_approval_required_intake_persists_all_seven_keys(self) -> None:
+        ctx = prepare_coding_session_context(
+            message_text=(
+                "approval_required, git_flow, tagged_release, issue_required, "
+                "single_repo, full_stack_single_repo "
+                "네이버 검색 풀스택 MVP 구현해줘 "
+                "https://github.com/yule-studio/naver-search-clone"
+            ),
+            user_links=("https://github.com/yule-studio/naver-search-clone",),
+            existing_extra={},
+            discover_contract=False,
+        )
+        ex = ctx.extras_update
+        self.assertEqual(ex.get(EXTRA_WORK_MODE), WORK_MODE_APPROVAL)
+        self.assertEqual(ex.get(EXTRA_TOPOLOGY), TOPOLOGY_SINGLE)
+        self.assertEqual(ex.get(EXTRA_SCOPE), SCOPE_FULL_STACK)
+        self.assertEqual(ex.get(EXTRA_BRANCH_STRATEGY), BRANCH_STRATEGY_GIT_FLOW)
+        self.assertEqual(ex.get(EXTRA_RELEASE_STRATEGY), RELEASE_STRATEGY_TAGGED)
+        self.assertEqual(ex.get(EXTRA_ISSUE_POLICY), ISSUE_POLICY_REQUIRED)
+        self.assertIn("mode_decided_by", ex)
+        self.assertIn("mode_decided_at", ex)
+
+    def test_autonomous_merge_intake_persists_all_seven_keys(self) -> None:
+        ctx = prepare_coding_session_context(
+            message_text=(
+                "autonomous_merge, git_flow, tagged_release, issue_required, "
+                "single_repo, full_stack_single_repo "
+                "네이버 검색 풀스택 MVP 끝까지 자율로 진행해줘"
+            ),
+            user_links=("https://github.com/yule-studio/naver-search-clone",),
+            existing_extra={},
+            discover_contract=False,
+        )
+        ex = ctx.extras_update
+        self.assertEqual(ex.get(EXTRA_WORK_MODE), WORK_MODE_AUTONOMOUS)
+        self.assertEqual(ex.get(EXTRA_BRANCH_STRATEGY), BRANCH_STRATEGY_GIT_FLOW)
+        self.assertEqual(ex.get(EXTRA_RELEASE_STRATEGY), RELEASE_STRATEGY_TAGGED)
+        self.assertEqual(ex.get(EXTRA_ISSUE_POLICY), ISSUE_POLICY_REQUIRED)
+
+    def test_default_intake_still_persists_governance_keys(self) -> None:
+        """prompt 에 토큰 명시 없어도 default 값 (git_flow / tagged_release /
+        issue_required) 이 자동 영속."""
+
+        ctx = prepare_coding_session_context(
+            message_text="일반 작업 — 추가 token 없음",
+            user_links=("https://github.com/yule-studio/naver-search-clone",),
+            existing_extra={},
+            discover_contract=False,
+        )
+        ex = ctx.extras_update
+        # default 값으로 영속
+        self.assertEqual(ex.get(EXTRA_BRANCH_STRATEGY), BRANCH_STRATEGY_GIT_FLOW)
+        self.assertEqual(ex.get(EXTRA_RELEASE_STRATEGY), RELEASE_STRATEGY_TAGGED)
+        self.assertEqual(ex.get(EXTRA_ISSUE_POLICY), ISSUE_POLICY_REQUIRED)
+
+
+# ---------------------------------------------------------------------------
+# 3, 4, 5 — Git Flow branch + issue-first
+# ---------------------------------------------------------------------------
+
+
+class GitFlowBranchValidatorTests(unittest.TestCase):
+    def test_valid_feature_with_issue_anchor_passes(self) -> None:
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="feature/auth-issue-12")
+        )
+        self.assertTrue(r.ok)
+        self.assertEqual(r.fields["kind"], "feature")
+
+    def test_invalid_prefix_blocks(self) -> None:
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="random-branch-name")
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_INVALID_GIT_FLOW_BRANCH)
+
+    def test_protected_branch_direct_work_blocks(self) -> None:
+        for b in ("main", "master", "develop", "dev", "prod", "production"):
+            with self.subTest(b=b):
+                r = validate_git_flow_branch(GitFlowBranchContext(branch=b))
+                self.assertFalse(r.ok)
+                self.assertEqual(r.reason, REASON_PROTECTED_BRANCH_DIRECT_WORK)
+
+    def test_feature_without_issue_anchor_blocks_as_issue_required(self) -> None:
+        # feature/ prefix 인데 slug 에 issue-N 없고 issue_number_hint 도 없음
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="feature/auth-no-anchor")
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_ISSUE_REQUIRED_FOR_REPO_WORK)
+
+    def test_release_branch_is_anchor_exempt(self) -> None:
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="release/v1.4.0")
+        )
+        self.assertTrue(r.ok)
+        self.assertEqual(r.fields["kind"], "release")
+
+    def test_hotfix_branch_is_anchor_exempt(self) -> None:
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="hotfix/token-refresh")
+        )
+        self.assertTrue(r.ok)
+
+    def test_issue_number_hint_satisfies_for_feature(self) -> None:
+        r = validate_git_flow_branch(
+            GitFlowBranchContext(branch="feature/auth", issue_number_hint=42)
+        )
+        self.assertTrue(r.ok)
+
+
+# ---------------------------------------------------------------------------
+# 6, 7 — tag policy
+# ---------------------------------------------------------------------------
+
+
+class TagPolicyTests(unittest.TestCase):
+    def test_release_without_tag_blocks(self) -> None:
+        r = validate_release_tag(
+            ReleaseTagContext(branch="release/v1.4.0", tag=None)
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_MISSING_RELEASE_TAG)
+
+    def test_hotfix_without_tag_blocks(self) -> None:
+        r = validate_release_tag(
+            ReleaseTagContext(branch="hotfix/token", tag=None)
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_MISSING_RELEASE_TAG)
+
+    def test_valid_semver_tag_passes(self) -> None:
+        for tag in ("v1.4.0", "v0.0.1", "v10.20.30", "v1.0.0-rc.1", "v2.0.0-beta+build.7"):
+            with self.subTest(tag=tag):
+                r = validate_release_tag(
+                    ReleaseTagContext(branch="release/x", tag=tag)
+                )
+                self.assertTrue(r.ok, tag)
+
+    def test_invalid_tag_format_blocks(self) -> None:
+        for tag in ("1.4.0", "v1.4", "release-1.4.0", "vlatest"):
+            with self.subTest(tag=tag):
+                r = validate_release_tag(
+                    ReleaseTagContext(branch="release/x", tag=tag)
+                )
+                self.assertFalse(r.ok)
+                self.assertEqual(r.reason, REASON_INVALID_RELEASE_TAG)
+
+    def test_non_release_branch_skips_tag_requirement(self) -> None:
+        # feature 같은 일반 branch 는 tag 요구 안 함
+        r = validate_release_tag(
+            ReleaseTagContext(branch="feature/auth", tag=None)
+        )
+        self.assertTrue(r.ok)
+
+
+# ---------------------------------------------------------------------------
+# 8, 9, 10 — approval card quality
+# ---------------------------------------------------------------------------
+
+
+_GOOD_BODY = (
+    "🔀 PR 머지 승인 — #4\n\n"
+    "작업 내용\n- 회원가입 API 추가\n\n"
+    "목적\n- 인증 기능이 아직 없어서 사용자가 가입 불가\n\n"
+    "영향 범위\n- services/auth, 위험도 LOW\n\n"
+    "다음 단계\n- 승인 시 ready_for_review → gate → merge\n"
+)
+
+
+class ApprovalCardQualityTests(unittest.TestCase):
+    def test_full_body_with_4_korean_sections_passes(self) -> None:
+        r = validate_approval_card_quality(
+            ApprovalCardQualityContext(body=_GOOD_BODY)
+        )
+        self.assertTrue(r.ok, r.detail)
+
+    def test_missing_one_section_blocks(self) -> None:
+        # "다음 단계" 누락
+        bad_body = (
+            "작업 내용\n- 추가\n\n"
+            "목적\n- 필요\n\n"
+            "영향 범위\n- repo\n"
+        )
+        r = validate_approval_card_quality(
+            ApprovalCardQualityContext(body=bad_body)
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_APPROVAL_CARD_MISSING_SECTIONS)
+        self.assertIn("다음 단계", r.detail)
+
+    def test_english_only_body_blocks(self) -> None:
+        # 섹션 한글 헤더 없음
+        bad = (
+            "Description: add login API\n"
+            "Why: missing auth\n"
+            "Scope: services/auth\n"
+            "Next: merge after approval\n"
+        )
+        r = validate_approval_card_quality(
+            ApprovalCardQualityContext(body=bad)
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.reason, REASON_APPROVAL_CARD_MISSING_SECTIONS)
+
+    def test_autonomous_merge_mode_skips_enforcement(self) -> None:
+        """autonomous_merge 는 사람 승인 카드 최소 사용 — 본 검증 적용 X.
+        4 섹션 누락된 short body 도 통과 (autonomous 가 operator_action
+        카드 외에는 카드를 거의 안 만든다는 의미)."""
+
+        r = validate_approval_card_quality(
+            ApprovalCardQualityContext(
+                body="short autonomous summary",
+                work_mode="autonomous_merge",
+            )
+        )
+        self.assertTrue(r.ok)
+
+    def test_render_pr_merge_summary_passes_enforcement(self) -> None:
+        """pr_approval.render_pr_merge_summary 의 출력이 항상 4 섹션
+        포함 → enforcement 통과."""
+
+        from yule_orchestrator.agents.job_queue.pr_approval import (
+            PRMergeProposal,
+            render_pr_merge_summary,
+        )
+
+        proposal = PRMergeProposal(
+            repo="yule-studio/naver-search-clone",
+            pr_number=4,
+            pr_title="[구현][인증] 회원가입",
+            pr_url="https://x/y/pull/4",
+            head_sha="s",
+            base_branch="main",
+            draft=False,
+            mergeable_state="clean",
+            summary_md="",
+            body_excerpt="회원가입 API",
+        )
+        body = render_pr_merge_summary(proposal)
+        r = validate_approval_card_quality(
+            ApprovalCardQualityContext(body=body)
+        )
+        self.assertTrue(r.ok, r.detail)
+
+
+# ---------------------------------------------------------------------------
+# 11 — cross-repo (validator repo-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class CrossRepoEnforcementTests(unittest.TestCase):
+    def test_validator_is_repo_agnostic(self) -> None:
+        """같은 branch / tag / card 입력은 repo 와 무관하게 동일 결과."""
+
+        # 어떤 repo 가정 — validator 자체는 repo 인자를 받지 않으므로
+        # context 만 동일하면 결과 동일.
+        for case_branch in (
+            "feature/auth-issue-12",  # ok
+            "random-name",  # block
+            "main",  # protected
+            "release/v1.0.0",  # ok
+        ):
+            with self.subTest(branch=case_branch):
+                r1 = validate_git_flow_branch(
+                    GitFlowBranchContext(branch=case_branch)
+                )
+                r2 = validate_git_flow_branch(
+                    GitFlowBranchContext(branch=case_branch)
+                )
+                self.assertEqual(r1.ok, r2.ok)
+                self.assertEqual(r1.reason, r2.reason)
+
+
+# ---------------------------------------------------------------------------
+# Bonus — enforce 함수의 PolicyViolation raise
+# ---------------------------------------------------------------------------
+
+
+class EnforceRaisesTests(unittest.TestCase):
+    def test_enforce_git_flow_raises_on_invalid(self) -> None:
+        with self.assertRaises(PolicyViolation) as cm:
+            enforce_git_flow_branch(
+                GitFlowBranchContext(branch="random")
+            )
+        self.assertEqual(cm.exception.reason, REASON_INVALID_GIT_FLOW_BRANCH)
+
+    def test_enforce_release_tag_raises_on_missing(self) -> None:
+        with self.assertRaises(PolicyViolation) as cm:
+            enforce_release_tag(
+                ReleaseTagContext(branch="release/v1.0.0", tag=None)
+            )
+        self.assertEqual(cm.exception.reason, REASON_MISSING_RELEASE_TAG)
+
+    def test_enforce_approval_card_raises_on_missing_sections(self) -> None:
+        with self.assertRaises(PolicyViolation) as cm:
+            enforce_approval_card_quality(
+                ApprovalCardQualityContext(body="vague PR")
+            )
+        self.assertEqual(
+            cm.exception.reason, REASON_APPROVAL_CARD_MISSING_SECTIONS
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/governance/test_repo_write_policy.py
+++ b/tests/governance/test_repo_write_policy.py
@@ -175,7 +175,7 @@ class IssueAnchorRequiredTests(unittest.TestCase):
 
 class HumanReadableTitleTests(unittest.TestCase):
     def test_issue_title_valid_korean(self) -> None:
-        r = validate_issue_title("[기능] 네이버 검색 MVP - 인증/검색 홈 1차")
+        r = validate_issue_title("[Feature] 네이버 검색 MVP - 인증/검색 홈 1차")
         self.assertTrue(r.ok)
 
     def test_pr_title_valid_korean(self) -> None:
@@ -227,7 +227,7 @@ class HappyPathTests(unittest.TestCase):
         )
         # All four validators pass
         self.assertTrue(validate_commit_message(commit).ok)
-        self.assertTrue(validate_issue_title("[기능][인증] 회원가입 API 추가").ok)
+        self.assertTrue(validate_issue_title("[Feature][인증] 회원가입 API 추가").ok)
         self.assertTrue(
             validate_pr_title("[구현][인증] 회원가입 API 1차 (#7)").ok
         )
@@ -241,7 +241,7 @@ class HappyPathTests(unittest.TestCase):
         enforce_commit_message(
             "✨ 추가\n\n변경 이유\n- a\n\n주요 변경 사항\n- b\n\n비고\n- 없음"
         )
-        enforce_issue_title("[기능] 인증 추가")
+        enforce_issue_title("[Feature] 인증 추가")
         enforce_pr_title("[구현] 인증 API 추가")
         enforce_issue_anchor(IssueAnchorContext(issue_number_hint=1))
 

--- a/tests/job_queue/test_github_work_order_executor.py
+++ b/tests/job_queue/test_github_work_order_executor.py
@@ -168,7 +168,7 @@ class _Fixture(unittest.TestCase):
 
     def _sample_plan(self, audit_reason: str = "template_used") -> Mapping[str, Any]:
         return {
-            "title": "[기능] 회원가입/검색 구현",
+            "title": "[Feature] 회원가입/검색 구현",
             "body": "## 어떤 기능인가요?\n> 본문\n",
             "labels": ["✨ Feature", "📃 Docs"],
             "assignees": [],
@@ -208,7 +208,7 @@ class AutoCreateBranchTests(_Fixture):
         # writer called with plan content
         self.assertEqual(len(self.writer.calls), 1)
         _, call_kwargs = self.writer.calls[0]
-        self.assertTrue(call_kwargs["title"].startswith("[기능]"))
+        self.assertTrue(call_kwargs["title"].startswith("[Feature]"))
         self.assertIn("✨ Feature", call_kwargs["labels"])
         # session extra anchor
         anchor = self.sessions.sessions["sess-1"].extra[SESSION_EXTRA_GITHUB_ISSUE_KEY]

--- a/tests/job_queue/test_github_work_order_issue_plan.py
+++ b/tests/job_queue/test_github_work_order_issue_plan.py
@@ -27,7 +27,7 @@ from yule_orchestrator.agents.job_queue.github_work_order import (
 
 def _sample_plan() -> dict:
     return {
-        "title": "[기능] 회원가입/검색 기능",
+        "title": "[Feature] 회원가입/검색 기능",
         "body": "## 어떤 기능인가요?\n> 본문\n",
         "labels": ["✨ Feature", "📃 Docs"],
         "assignees": [],

--- a/tests/job_queue/test_greenfield_bootstrap_live_diagnostics.py
+++ b/tests/job_queue/test_greenfield_bootstrap_live_diagnostics.py
@@ -93,13 +93,25 @@ def _full_stack_request() -> CodingExecuteRequest:
 
 class StartupAvailabilityAuditTests(unittest.TestCase):
     def test_availability_label_reflects_bootstrap_env_on(self) -> None:
-        """case 1 — env on → label says ``greenfield_bootstrap+record_only_delegate``."""
+        """case 1 — greenfield env on (live editor 미설정) → label 은
+        ``greenfield_bootstrap+record_only_delegate``.  P1-T 이후 blocker
+        는 빈 string 이 아니라 "live editor 켜면 non-greenfield real edit
+        path" 안내 — non-greenfield repo 가 record-only 로 빠지는 옛 회귀를
+        명시 surface 하기 위한 변경."""
 
-        with _env_scope(**{ENV_GREENFIELD_BOOTSTRAP_ENABLED: "1"}):
+        with _env_scope(
+            **{
+                ENV_GREENFIELD_BOOTSTRAP_ENABLED: "1",
+                "YULE_LIVE_EDITOR_ENABLED": None,
+                "YULE_LIVE_EDITOR_PROVIDER": None,
+            }
+        ):
             avail = detect_live_executor_availability(repo_root="/tmp/x")
         self.assertIn("greenfield_bootstrap", avail.code_editor)
         self.assertIn("delegate", avail.code_editor)
-        self.assertEqual(avail.code_editor_blocker, "")
+        # P1-T: blocker 가 live editor upgrade path 를 안내 — non-greenfield
+        # 에서 record-only 로 빠지는 회귀를 더 이상 silent 로 두지 않음.
+        self.assertIn("YULE_LIVE_EDITOR_ENABLED", avail.code_editor_blocker)
 
     def test_availability_label_reflects_bootstrap_env_off(self) -> None:
         """env off → label is disabled + blocker message names the env var."""

--- a/tests/job_queue/test_pr_merge_approval.py
+++ b/tests/job_queue/test_pr_merge_approval.py
@@ -154,13 +154,19 @@ class RenderSummaryTests(unittest.TestCase):
         )
 
     def test_renders_scope_and_risk(self) -> None:
+        # P1-R — render_pr_merge_summary 가 한국어 4 섹션 (작업 내용 /
+        # 목적 / 영향 범위 / 다음 단계) 형식으로 변경됨.  scope/risk 는
+        # "영향 범위" 섹션 안의 bullet 으로 들어감.
         text = render_pr_merge_summary(_proposal())
-        self.assertIn("영향 범위: docs / agents / tests", text)
-        self.assertIn("🟢 위험도: LOW", text)
+        self.assertIn("영향 범위", text)
+        self.assertIn("docs / agents / tests", text)
+        self.assertIn("🟢", text)
+        self.assertIn("LOW", text)
 
     def test_high_risk_emoji_red(self) -> None:
         text = render_pr_merge_summary(_proposal(risk="HIGH"))
-        self.assertIn("🔴 위험도: HIGH", text)
+        self.assertIn("🔴", text)
+        self.assertIn("HIGH", text)
 
     def test_includes_check_run_and_branch_protection_lines(self) -> None:
         text = render_pr_merge_summary(_proposal())

--- a/tests/job_queue/test_work_order_coding_continuation.py
+++ b/tests/job_queue/test_work_order_coding_continuation.py
@@ -60,7 +60,7 @@ def _anchor(issue_number: int = 77) -> Mapping[str, Any]:
     return {
         "issue_number": issue_number,
         "html_url": f"https://github.com/yule-studio/naver-search-clone/issues/{issue_number}",
-        "title": "[기능] 회원가입",
+        "title": "[Feature] 회원가입",
         "created_via": "auto_create",
         "approval_id": "a1",
         "approved_by": "masterway",

--- a/tests/job_queue/test_work_order_repo_recovery.py
+++ b/tests/job_queue/test_work_order_repo_recovery.py
@@ -136,7 +136,7 @@ class _Fixture(unittest.TestCase):
 
     def _sample_plan(self) -> Mapping[str, Any]:
         return {
-            "title": "[기능] live recover",
+            "title": "[Feature] live recover",
             "body": "## 어떤 기능인가요?\n> recover\n",
             "labels": ["✨ Feature"],
             "assignees": [],

--- a/tests/runtime/test_github_work_order_executor_runtime.py
+++ b/tests/runtime/test_github_work_order_executor_runtime.py
@@ -234,7 +234,7 @@ class RunUntilShutdownTests(unittest.TestCase):
             repo="yule-studio/naver-search-clone",
             dry_run=False,
             issue_auto_create_plan={
-                "title": "[기능] 회원가입",
+                "title": "[Feature] 회원가입",
                 "body": "## 어떤 기능인가요?\n> live\n",
                 "labels": ["✨ Feature"],
                 "assignees": [],


### PR DESCRIPTION
## 📌 요약 — 5 운영 규칙 hard enforcement

문서/권고가 아니라 실제 live path 에서 위반 시 차단되는 강제 layer 추가.

1. **Git Flow** — feature/bugfix/fix/hotfix/release/refactor/chore/docs/test/agent prefix 외 차단. protected branch (main/master/develop/...) 직접 작업 금지.
2. **Tag 정책** — release/hotfix 완료 시 semver tag (vX.Y.Z) 필수.
3. **Issue-first** — feature/bugfix/fix/refactor/agent branch 는 `issue-<n>` anchor 필수.
4. **Approval card 한국어 4 섹션** — `작업 내용 / 목적 / 영향 범위 / 다음 단계`. vague / machine-like / 영문-only 카드 차단.
5. **autonomous_merge / approval_required 명시화** — intake 시 결정 후 변경 금지.

## ✨ 변경 (4 commits)

### `58cc986` — validator 3종 + intake contract 확장
- `repo_write_policy.py` 에 `validate_git_flow_branch` / `validate_release_tag` / `validate_approval_card_quality` + 5 reason 토큰.
- `session_mode.py` 에 governance 축 3 추가: `branch_strategy=git_flow` / `release_strategy=tagged_release` / `issue_policy=issue_required`. `parse_mode_hints` 가 추가 토큰 인식.
- `apply_governance_hints` 헬퍼 + `prepare_coding_session_context` 가 7 키 모두 `extras_update` 에 surface.

### `8e2144f` — live path wiring
- `LocalGitWorktreeProvisioner.provision` 에 `enforce_git_flow_branch` 호출 추가.
- `render_pr_merge_summary` 가 한국어 4 섹션 형식으로 렌더링 (draft_escalation flag 분기 포함).
- `pr_merge_adapter._approval_request_from_proposal` 가 enqueue 직전 `enforce_approval_card_quality` 호출.

### `3de45e0` — SSoT 문서
- `docs/engineering-governance-modes.md` 신설 — 7 키 의미 / 모드별 운영 절차 / 8 enforcement 진입점 표.

### `c17f701` — 회귀 28 케이스
- `tests/governance/test_p1r_governance_enforcement.py` 24 신규 + 기존 4 갱신 (layout 변경).

## 🧪 회귀

- **신규 24 + 갱신 4 = 28 케이스 모두 통과.**
- **전체 sweep**: 5362 tests / 5 pre-existing errors (digest_crawler locale + gateway_shutdown — P1-R 무관) / **0 새 regression**.
- **governance/code_audit**: 위반 0 유지.

## 📦 머지 후 운영자 절차

1. main pull + 런타임 재기동.
2. 새 intake 가 자동으로 7 키 모두 영속 — `session.extra` 확인:
   ```python
   from yule_orchestrator.agents.workflow_state import load_session
   s = load_session("<sid>")
   for k in ("work_mode","topology","scope","branch_strategy","release_strategy","issue_policy","mode_decided_by"):
       print(k, "=", s.extra.get(k))
   ```
3. issue 없이 작업 시도 → `WorktreeProvisionError(reason=issue_required_for_repo_work)` 로 차단.
4. 임의 branch name 으로 작업 시도 → `invalid_git_flow_branch` 로 차단.
5. release/hotfix 완료 시 tag 없으면 `missing_release_tag` 로 차단.
6. approval card 가 4 섹션 누락 시 `approval_card_missing_sections` 로 게시 단계에서 차단.
7. SSoT 문서: [`docs/engineering-governance-modes.md`](https://github.com/yule-studio/yule-studio-agent/blob/main/docs/engineering-governance-modes.md).

## 🛡 새 차단 경로

| 시도 | blocker reason |
|---|---|
| `main` / `master` 직접 작업 | `protected_branch_direct_work` |
| `random-branch-name` 시도 | `invalid_git_flow_branch` |
| `feature/auth` (issue-N 없음) | `issue_required_for_repo_work` |
| release branch 완료 시 tag 없음 | `missing_release_tag` |
| `v1.4` 같은 잘못된 tag | `invalid_release_tag` |
| approval card body 가 4 섹션 누락 | `approval_card_missing_sections` |
| autonomous_merge 모드의 short body | 면제 (검증 skip) |