### PR TITLE
✨ Plan snapshot push to hompage

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -16,6 +16,11 @@ the same command — only the surrounding supervision differs.
 - `yule-run-service@.service` — template unit. `%i` is the service id.
 - `yule.target` — umbrella target so `systemctl start yule.target`
   brings up every enabled instance.
+- `yule-plan-snapshot.service` / `.timer` — periodically pushes
+  `DailyPlan` snapshot to the `hompage` repo so the homepage can render
+  today's plan without contacting the agent directly. Drives
+  `scripts/push_plan_snapshot.sh`. See `docs/calendar-notes.md` §Snapshot
+  push to hompage.
 
 ## Install
 

--- a/deploy/systemd/yule-plan-snapshot.service
+++ b/deploy/systemd/yule-plan-snapshot.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Push daily plan snapshot to hompage repo
+After=network-online.target
+Wants=network-online.target
+PartOf=yule.target
+
+[Service]
+Type=oneshot
+User=yule
+WorkingDirectory=/opt/yule-studio-agent
+EnvironmentFile=/etc/yule/yule-env.conf
+EnvironmentFile=-/etc/yule/yule-plan-snapshot.conf
+
+# scripts/push_plan_snapshot.sh 환경변수:
+#   HOMPAGE_DIR      hompage 로컬 클론 (예: /opt/hompage)
+#   HOMPAGE_REMOTE   default origin
+#   HOMPAGE_BRANCH   default main
+#   YULE_BIN         default "uv run yule" — venv 직접 호출이면
+#                    "/opt/yule-studio-agent/.venv/bin/yule"
+#   SKIP_PUSH        "1" 면 commit 만 (테스트 용)
+
+ExecStart=/bin/bash /opt/yule-studio-agent/scripts/push_plan_snapshot.sh
+
+# 일시적 네트워크 / git 에러는 자동 재시도, 영구 설정 오류는 멈춤.
+Restart=on-failure
+RestartSec=120s
+StartLimitIntervalSec=600
+StartLimitBurst=3
+
+StandardOutput=journal
+StandardError=journal
+
+# git 자격이 SSH key 면 ssh-agent / GIT_SSH_COMMAND 환경변수 설정 필요.
+# HTTPS + token 이면 /etc/yule/yule-plan-snapshot.conf 에
+# GIT_ASKPASS / GH_TOKEN 등 명시.

--- a/deploy/systemd/yule-plan-snapshot.timer
+++ b/deploy/systemd/yule-plan-snapshot.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Trigger daily plan snapshot push to hompage
+PartOf=yule.target
+
+[Timer]
+# 매 정시 + 30분 마다 = 30분 간격으로 push.
+# 신선도 (~30분 이내) 가 충분하다는 가정. 더 짧게 하려면 OnCalendar 변경.
+OnCalendar=*:00,30
+# 부팅 후에도 1분 안 첫 실행 (놓친 만큼 catch-up).
+Persistent=true
+AccuracySec=30s
+Unit=yule-plan-snapshot.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/calendar-notes.md
+++ b/docs/calendar-notes.md
@@ -35,3 +35,85 @@ CalDAV 연동 거동과 캐시 운영 노하우를 정리한다.
 ```
 
 이 구조에서는 Discord 봇이 브리핑 시점에 캘린더나 GitHub API 응답을 기다리지 않는다.
+
+## Snapshot push to hompage
+
+`yule-studio/hompage` 의 Calendar 페이지가 오늘 플랜을 표시하려면 agent 가
+`DailyPlan.to_dict()` 결과를 `hompage/public/plan-snapshot.json` 로 push 해야
+한다. hompage 는 그 정적 JSON 만 읽는다 (agent 24/7 배포 불필요).
+
+### 흐름
+
+```
+yule planning daily --json    →   plan-snapshot.json (envelope)
+                                  ↓ git commit / push
+                          hompage repo main
+                                  ↓ GitHub Pages deploy
+                          https://yule-studio.github.io/hompage/plan-snapshot.json
+                                  ↓ usePlanSnapshot()
+                          Calendar 페이지의 "오늘 플랜" 섹션
+```
+
+### 일회성 수동 푸시
+
+```bash
+HOMPAGE_DIR=$HOME/local-dev/hompage \
+  scripts/push_plan_snapshot.sh
+```
+
+스크립트는 (1) hompage repo rebase pull → (2) `yule planning daily --json`
+→ (3) `public/plan-snapshot.json` 에 write → (4) diff 있으면 commit + push.
+변경 없으면 zero-op.
+
+### 주기 푸시 — systemd timer
+
+```bash
+sudo cp deploy/systemd/yule-plan-snapshot.service /etc/systemd/system/
+sudo cp deploy/systemd/yule-plan-snapshot.timer   /etc/systemd/system/
+
+# 환경변수 — HOMPAGE_DIR 등
+sudo tee /etc/yule/yule-plan-snapshot.conf <<'EOF'
+HOMPAGE_DIR=/opt/hompage
+HOMPAGE_REMOTE=origin
+HOMPAGE_BRANCH=main
+YULE_BIN=/opt/yule-studio-agent/.venv/bin/yule
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now yule-plan-snapshot.timer
+```
+
+기본 cadence: 30분 간격 (`OnCalendar=*:00,30`). 더 빠르게 / 느리게 하려면
+`yule-plan-snapshot.timer` 의 `OnCalendar` 수정 후 `systemctl daemon-reload
+&& systemctl restart yule-plan-snapshot.timer`.
+
+### 상태 확인
+
+```bash
+systemctl list-timers yule-plan-snapshot.timer    # 다음 트리거 시각
+journalctl -u yule-plan-snapshot.service -n 50     # 최근 실행 로그
+```
+
+### git 인증
+
+스크립트가 `git push` 까지 하려면 user `yule` 의 git 자격이 필요:
+
+- **HTTPS + PAT**: `git config --global credential.helper store` + 한 번
+  `git push` 로 PAT 입력하면 `~/.git-credentials` 저장.
+- **SSH key**: `/etc/yule/yule-plan-snapshot.conf` 에
+  `GIT_SSH_COMMAND="ssh -i /home/yule/.ssh/hompage_deploy_key"` 같이 주입.
+
+### 실패 모드
+
+| 증상 | 원인 / 해결 |
+| --- | --- |
+| exit 2 (pull rebase 실패) | hompage 에 충돌 — 사람이 main 정리 |
+| exit 3 (`yule planning daily` 실패) | CalDAV / GitHub 일시 장애 — timer 재시도 시 자동 회복 |
+| snapshot 이 stale (어제 날짜) | `yule planning daily` 의 plan_date 가 오늘이 아님 — 시간대 확인 |
+| hompage 측에서 안 보임 | hompage Pages deploy 가 끝났는지 + browser hard refresh |
+
+### hompage 측 (참고)
+
+hompage 의 `src/pages/Calendar/Calendar.tsx` 가 `usePlanSnapshot()` 으로
+fetch. `plan_date` 가 오늘 (Asia/Seoul) 아니면 자동 숨김 → stale 데이터 노출
+X. receiver 구조는 hompage 의 `src/data/planSnapshot.ts` 참고.

--- a/scripts/push_plan_snapshot.sh
+++ b/scripts/push_plan_snapshot.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────
+# push_plan_snapshot.sh — yule planning snapshot → hompage repo
+#
+# 흐름:
+#   1. yule planning daily --json 으로 오늘 plan envelope JSON 생성
+#   2. hompage repo 의 public/plan-snapshot.json 으로 write
+#   3. diff 가 있으면 git add + commit + push
+#
+# 환경변수:
+#   HOMPAGE_DIR   hompage 로컬 클론 경로 (default: $HOME/local-dev/hompage)
+#   HOMPAGE_REMOTE 원격 이름 (default: origin)
+#   HOMPAGE_BRANCH 푸시할 브랜치 (default: main)
+#   YULE_BIN      yule CLI 경로 (default: uv run yule)
+#   SKIP_PUSH     "1" 이면 git push 생략 (테스트용)
+#
+# cron / systemd timer 에서 호출하기 좋게 idempotent + non-zero exit
+# 만 의미 있는 실패로 반환.
+# ─────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+HOMPAGE_DIR="${HOMPAGE_DIR:-$HOME/local-dev/hompage}"
+HOMPAGE_REMOTE="${HOMPAGE_REMOTE:-origin}"
+HOMPAGE_BRANCH="${HOMPAGE_BRANCH:-main}"
+YULE_BIN="${YULE_BIN:-uv run yule}"
+
+SNAPSHOT_PATH="$HOMPAGE_DIR/public/plan-snapshot.json"
+TMP_OUTPUT="$(mktemp -t yule-plan-XXXXXX.json)"
+trap 'rm -f "$TMP_OUTPUT"' EXIT
+
+log() { printf '[push-plan-snapshot %s] %s\n' "$(date -Iseconds)" "$*"; }
+
+if [[ ! -d "$HOMPAGE_DIR/.git" ]]; then
+  log "ERROR: hompage 클론 디렉터리가 아님 — HOMPAGE_DIR=$HOMPAGE_DIR"
+  exit 1
+fi
+if [[ ! -d "$HOMPAGE_DIR/public" ]]; then
+  log "ERROR: $HOMPAGE_DIR/public/ 가 없음 — hompage 가 맞는지 확인"
+  exit 1
+fi
+
+# 1. 최신 main 으로 sync (rebase 충돌 시 abort — 사람 개입 필요)
+log "sync hompage main"
+git -C "$HOMPAGE_DIR" fetch --quiet "$HOMPAGE_REMOTE" "$HOMPAGE_BRANCH"
+git -C "$HOMPAGE_DIR" checkout --quiet "$HOMPAGE_BRANCH"
+git -C "$HOMPAGE_DIR" pull --quiet --rebase "$HOMPAGE_REMOTE" "$HOMPAGE_BRANCH" || {
+  log "ERROR: git pull --rebase 실패 — 충돌이 있으면 사람이 정리해야 함"
+  exit 2
+}
+
+# 2. snapshot 생성 (envelope.to_dict() 그대로)
+log "generate snapshot via yule planning daily"
+if ! $YULE_BIN planning daily --json > "$TMP_OUTPUT" 2>/tmp/yule-plan-snapshot.err; then
+  log "ERROR: yule planning daily 실패. stderr:"
+  cat /tmp/yule-plan-snapshot.err >&2
+  exit 3
+fi
+
+# generated_at 추가 (UI 가 신선도 표시할 때 사용). jq 가 있으면 사용,
+# 없으면 root 객체에 그냥 append (간단 sed).
+if command -v jq >/dev/null 2>&1; then
+  jq --arg ts "$(date -Iseconds)" '. + {generated_at: $ts}' "$TMP_OUTPUT" \
+    > "$TMP_OUTPUT.with_ts" && mv "$TMP_OUTPUT.with_ts" "$TMP_OUTPUT"
+else
+  log "WARN: jq 없음 — generated_at 미주입. 권장: brew install jq / apt install jq"
+fi
+
+# 3. 변경 있는지 비교 후 write
+if [[ -f "$SNAPSHOT_PATH" ]] && diff -q "$TMP_OUTPUT" "$SNAPSHOT_PATH" >/dev/null 2>&1; then
+  log "snapshot unchanged, skip git operations"
+  exit 0
+fi
+
+cp "$TMP_OUTPUT" "$SNAPSHOT_PATH"
+log "wrote $SNAPSHOT_PATH"
+
+# 4. git commit + push
+cd "$HOMPAGE_DIR"
+git add public/plan-snapshot.json
+
+if git diff --cached --quiet; then
+  log "no staged changes after copy (race condition?) — skip"
+  exit 0
+fi
+
+PLAN_DATE="$(jq -r .daily_plan.plan_date "$SNAPSHOT_PATH" 2>/dev/null \
+  || jq -r .plan_date "$SNAPSHOT_PATH" 2>/dev/null \
+  || date +%Y-%m-%d)"
+
+git commit -m "🔧 plan-snapshot — ${PLAN_DATE} ($(date +%H:%M))" >/dev/null
+
+if [[ "${SKIP_PUSH:-0}" == "1" ]]; then
+  log "SKIP_PUSH=1, commit 만 하고 종료"
+  exit 0
+fi
+
+git push --quiet "$HOMPAGE_REMOTE" "$HOMPAGE_BRANCH"
+log "pushed plan-snapshot for $PLAN_DATE to $HOMPAGE_REMOTE/$HOMPAGE_BRANCH"


### PR DESCRIPTION
## Summary
- `scripts/push_plan_snapshot.sh` — `yule planning daily --json` 결과를 `hompage/public/plan-snapshot.json` 으로 commit/push (idempotent — diff 없으면 zero-op).
- `deploy/systemd/yule-plan-snapshot.{service,timer}` — 30분 간격 자동.
- `docs/calendar-notes.md` — 흐름 / 수동 명령 / systemd 설치 / git 인증 / 실패 모드.

## Why
hompage 가 24/7 agent 배포 없이 오늘 플랜을 보여주려면 정적 JSON 만 받으면 됨. 다른 fetcher (`github-stats.json` / `projects.json` / `blog.json` ...) 와 동일한 push 패턴.

## Test plan
- [ ] CI 통과 (있다면)
- [ ] 로컬에서 `HOMPAGE_DIR=/Users/masterway/local-dev/hompage scripts/push_plan_snapshot.sh` 한 번 돌려 hompage 로 commit/push 되는지 확인 (`SKIP_PUSH=1` 로 dry-run)
- [ ] hompage 의 Calendar 페이지에 'Today plan' 카드 표시 확인 (별도 PR #12 머지 후)

## 다음 단계
- hompage PR #12 (calendar redesign + receiver) 머지
- 1회 수동 푸시로 동작 검증
- systemd timer 활성화 (`systemctl enable --now yule-plan-snapshot.timer`)