### PR TITLE
♻️ packages/agent-contracts 분리 — 공통 에이전트 계약 패키지 (monorepo 우선순위 1)

### DIFF
--- a/packages/agent-contracts/README.md
+++ b/packages/agent-contracts/README.md
@@ -1,0 +1,54 @@
+# yule-agent-contracts
+
+Shared **wire/interop contracts** for the Yule Studio agent platform. These are
+the types that `apps/*` and other `packages/*` use to talk to each other and to
+the Agent Town front-end.
+
+## Models
+
+| Model | Purpose |
+| --- | --- |
+| `AgentMessage` (+ `RequestedAction`, `Priority`, `ContextRef`) | Inter-member message protocol with request/reply/close round-trip helpers. |
+| `AgentRole` | Structured `<agent>/<role>` identity (round-trips to/from the address strings the protocol carries). |
+| `TaskRef` | Pointer to a task / issue / work item (session/brief id and/or repo + number). |
+| `AgentCommand` | Envelope for an instruction directed *into* an agent. |
+| `AgentEvent` | Envelope for something that *happened* inside an agent. |
+| `AgentStatus` | Coarse lifecycle state (`idle` / `running` / `blocked` / …). |
+
+## Dependency rule
+
+This package depends on the **standard library only**. It MUST NOT import
+`yule_orchestrator` (the app) or any `apps/*` code — the arrow always points the
+other way (`app → contracts`). This keeps the contracts importable from any
+side (backend runtime, Discord gateway, Agent Town UI bindings) without dragging
+in app internals.
+
+## Relationship to existing app types
+
+`AgentMessage` and friends were **relocated here** from
+`yule_orchestrator.agents.messaging.message`; that module is now a thin
+compatibility shim re-exporting from `yule_agent_contracts.messages`, so existing
+imports keep working.
+
+The other five models are **thin contracts** that sit alongside the heavyweight
+in-process domain types rather than replacing them:
+
+| Contract | Heavyweight domain type (stays put) |
+| --- | --- |
+| `AgentCommand` | `agents.job_queue.store.Job` (`job_type` + `payload`) |
+| `AgentEvent` | `agents.job_queue.completion_hook.JobCompletionEvent` |
+| `AgentStatus` | `SessionStatusReport` / `LifecycleStatus` / `ServiceStatus` |
+| `AgentRole` | `agents.role_profiles.RoleProfile` (mission/responsibilities engine) |
+| `TaskRef` | `agents.job_queue.store.Job` / `council.TaskBrief` |
+
+## Install / test
+
+The package is discovered by the root `pyproject.toml`
+(`[tool.setuptools.packages.find] where`), so `pip install -e .` at the repo root
+puts `yule_agent_contracts` on the path. It also ships its own `pyproject.toml`
+for standalone builds.
+
+```bash
+# from repo root, with the project venv active
+pytest packages/agent-contracts/tests
+```

--- a/packages/agent-contracts/pyproject.toml
+++ b/packages/agent-contracts/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yule-agent-contracts"
+version = "0.1.0"
+description = "Shared agent contracts (commands, events, status, messages) for the Yule Studio agent platform."
+requires-python = ">=3.9"
+# Standard-library only by design — contracts must not pull in app deps.
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/agent-contracts/src/yule_agent_contracts/__init__.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/__init__.py
@@ -1,0 +1,107 @@
+"""Shared agent contracts for the Yule Studio agent platform.
+
+This package holds the *wire/interop contracts* that ``apps/*`` and other
+``packages/*`` use to talk to each other and to the Agent Town front-end:
+
+- :class:`AgentMessage` (+ :class:`RequestedAction`, :class:`Priority`,
+  :class:`ContextRef`) — the inter-member message protocol.
+- :class:`AgentRole` — structured ``<agent>/<role>`` identity.
+- :class:`TaskRef` — a pointer to a task / issue / work item.
+- :class:`AgentCommand` — an instruction directed at an agent.
+- :class:`AgentEvent` — an event emitted by an agent.
+- :class:`AgentStatus` — coarse lifecycle state.
+
+Dependency rule: this package depends only on the standard library. It MUST
+NOT import ``yule_orchestrator`` (the app) or any ``apps/*`` code — the arrow
+points the other way (app → contracts).
+"""
+
+from __future__ import annotations
+
+from .messages import (
+    AgentMessage,
+    ContextRef,
+    Priority,
+    REPLY_ACTIONS,
+    REQUEST_ACTIONS,
+    RequestedAction,
+    TERMINAL_REPLY_ACTIONS,
+    close_thread,
+    new_request,
+    reply_to,
+    role_address,
+    with_thread_id,
+)
+from .roles import (
+    AgentRole,
+    ENGINEERING_AGENT,
+    GATEWAY,
+    PLANNING_AGENT,
+)
+from .tasks import (
+    KIND_BRIEF,
+    KIND_ISSUE,
+    KIND_PR,
+    KIND_SESSION,
+    KIND_TASK,
+    TaskRef,
+)
+from .commands import AgentCommand
+from .events import (
+    AgentEvent,
+    EVENT_APPROVAL_REQUESTED,
+    EVENT_BLOCKED,
+    EVENT_COMPLETED,
+    EVENT_FAILED,
+    EVENT_PROGRESS,
+    EVENT_STARTED,
+    EVENT_STATE_CHANGED,
+)
+from .status import (
+    AgentStatus,
+    STALLED_STATUSES,
+    TERMINAL_STATUSES,
+)
+
+__all__ = [
+    # messages
+    "AgentMessage",
+    "ContextRef",
+    "Priority",
+    "RequestedAction",
+    "REQUEST_ACTIONS",
+    "REPLY_ACTIONS",
+    "TERMINAL_REPLY_ACTIONS",
+    "new_request",
+    "reply_to",
+    "close_thread",
+    "with_thread_id",
+    "role_address",
+    # roles
+    "AgentRole",
+    "ENGINEERING_AGENT",
+    "PLANNING_AGENT",
+    "GATEWAY",
+    # tasks
+    "TaskRef",
+    "KIND_TASK",
+    "KIND_ISSUE",
+    "KIND_PR",
+    "KIND_SESSION",
+    "KIND_BRIEF",
+    # commands
+    "AgentCommand",
+    # events
+    "AgentEvent",
+    "EVENT_STARTED",
+    "EVENT_PROGRESS",
+    "EVENT_COMPLETED",
+    "EVENT_BLOCKED",
+    "EVENT_FAILED",
+    "EVENT_STATE_CHANGED",
+    "EVENT_APPROVAL_REQUESTED",
+    # status
+    "AgentStatus",
+    "STALLED_STATUSES",
+    "TERMINAL_STATUSES",
+]

--- a/packages/agent-contracts/src/yule_agent_contracts/commands.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/commands.py
@@ -1,0 +1,42 @@
+"""Agent command contract.
+
+``AgentCommand`` is the department-agnostic envelope for "do this" instructions
+flowing *into* an agent (from the gateway, from another agent, or from the
+Agent Town front-end). It is intentionally thin: the heavyweight in-process
+representation is ``yule_orchestrator.agents.job_queue.store.Job``, whose
+``job_type`` + ``payload`` map onto ``command`` + ``payload`` here. Keeping the
+contract separate from the queue row lets transports (Discord, HTTP, sockets)
+speak a stable shape without importing the queue internals.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+from .roles import AgentRole
+from .tasks import TaskRef
+
+
+@dataclass(frozen=True)
+class AgentCommand:
+    """An instruction directed at an agent.
+
+    - ``command``: the verb / job type (e.g. ``"research_collect"``,
+      ``"role_take"``, ``"coding_execute"``).
+    - ``target``: which agent/role should execute it (optional — the gateway
+      may leave routing to the runtime).
+    - ``task``: the work item the command concerns.
+    - ``payload``: command-specific parameters (kept as a plain mapping so the
+      contract does not need to know every command's shape).
+    """
+
+    command: str
+    target: Optional[AgentRole] = None
+    task: Optional[TaskRef] = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    issued_by: Optional[str] = None
+    command_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/packages/agent-contracts/src/yule_agent_contracts/events.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/events.py
@@ -1,0 +1,49 @@
+"""Agent event contract.
+
+``AgentEvent`` is the department-agnostic envelope for things that *happen*
+inside an agent and need to be observed elsewhere (the gateway, sibling agents,
+the Agent Town front-end): a job completed, a seat got blocked, a lifecycle
+stage advanced. The heavyweight in-process counterpart is
+``yule_orchestrator.agents.job_queue.completion_hook.JobCompletionEvent``; this
+contract is the stable wire/observation shape it can project onto.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+from .roles import AgentRole
+from .tasks import TaskRef
+
+# Well-known event names. Free-form is allowed; these avoid typos.
+EVENT_STARTED = "started"
+EVENT_PROGRESS = "progress"
+EVENT_COMPLETED = "completed"
+EVENT_BLOCKED = "blocked"
+EVENT_FAILED = "failed"
+EVENT_STATE_CHANGED = "state_changed"
+EVENT_APPROVAL_REQUESTED = "approval_requested"
+
+
+@dataclass(frozen=True)
+class AgentEvent:
+    """An event emitted by an agent.
+
+    - ``event``: what happened (see the ``EVENT_*`` constants).
+    - ``source``: which agent/role emitted it.
+    - ``task``: the work item the event concerns.
+    - ``status`` / ``reason``: optional outcome detail.
+    - ``payload``: event-specific metadata.
+    """
+
+    event: str
+    source: Optional[AgentRole] = None
+    task: Optional[TaskRef] = None
+    status: Optional[str] = None
+    reason: str = ""
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    event_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/packages/agent-contracts/src/yule_agent_contracts/messages.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/messages.py
@@ -1,0 +1,318 @@
+"""Inter-member message protocol for engineering-agent (and future departments).
+
+The schema is intentionally department-agnostic: ``from_role`` / ``to_role``
+are free-form strings shaped as ``"<agent>/<role>"`` (e.g.
+``"engineering-agent/tech-lead"``). When cto-agent, design-agent, and
+marketing-agent come online they use the same dataclass without changes.
+
+Round-trip pattern:
+
+    tech-lead --new_request--> backend-engineer
+                                   │
+                                   └── reply_to(parent) ──> tech-lead
+                                                              │
+                                                              └── close_thread(parent_chain) ──▶ session
+
+Persistence and transport (in-process queue / Discord thread / socket) are
+out of scope for this module. Consumers are expected to wrap these
+dataclasses into whichever channel they own.
+
+.. note::
+   This module is the canonical home of the agent message contract. It was
+   relocated here from ``yule_orchestrator.agents.messaging.message`` as part
+   of the ``agent-contracts`` package extraction. The old import path remains
+   a compatibility shim that re-exports everything defined here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+
+class RequestedAction(str, Enum):
+    """Verbs that say what the recipient is being asked to do (or did).
+
+    Outgoing intent (tech-lead → role): ANALYZE / ADVISE / IMPLEMENT /
+    REVIEW / TEST / DESIGN / INVESTIGATE / HANDOFF.
+    Replies (role → tech-lead): COMPLETED / IN_PROGRESS / NEEDS_CLARIFICATION
+    / BLOCKED / REJECTED.
+    The schema does not enforce direction; helpers in this module produce
+    well-formed pairs.
+    """
+
+    ANALYZE = "analyze"
+    ADVISE = "advise"
+    IMPLEMENT = "implement"
+    REVIEW = "review"
+    TEST = "test"
+    DESIGN = "design"
+    INVESTIGATE = "investigate"
+    HANDOFF = "handoff"
+    ACKNOWLEDGE = "acknowledge"
+
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    NEEDS_CLARIFICATION = "needs_clarification"
+    BLOCKED = "blocked"
+    REJECTED = "rejected"
+
+
+REQUEST_ACTIONS = frozenset(
+    {
+        RequestedAction.ANALYZE,
+        RequestedAction.ADVISE,
+        RequestedAction.IMPLEMENT,
+        RequestedAction.REVIEW,
+        RequestedAction.TEST,
+        RequestedAction.DESIGN,
+        RequestedAction.INVESTIGATE,
+        RequestedAction.HANDOFF,
+        RequestedAction.ACKNOWLEDGE,
+    }
+)
+
+REPLY_ACTIONS = frozenset(
+    {
+        RequestedAction.IN_PROGRESS,
+        RequestedAction.COMPLETED,
+        RequestedAction.NEEDS_CLARIFICATION,
+        RequestedAction.BLOCKED,
+        RequestedAction.REJECTED,
+    }
+)
+
+TERMINAL_REPLY_ACTIONS = frozenset(
+    {RequestedAction.COMPLETED, RequestedAction.REJECTED}
+)
+
+
+class Priority(str, Enum):
+    P0 = "P0"  # urgent / blocker
+    P1 = "P1"  # high
+    P2 = "P2"  # normal — default
+    P3 = "P3"  # low
+
+
+@dataclass(frozen=True)
+class ContextRef:
+    """Pointer to an external artifact (PR / issue / file / discord message)."""
+
+    kind: str
+    value: str
+    label: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AgentMessage:
+    """One message between two agent/role pairs.
+
+    Fields fall into four groups:
+
+    - **Routing**: ``from_role``, ``to_role``.
+    - **Task framing**: ``task_type``, ``topic``, ``content``,
+      ``requested_action``, ``priority``.
+    - **Threading**: ``thread_id``, ``run_id``, ``parent_message_id``,
+      ``message_id``, ``created_at``.
+    - **Reference pack** (UI/UX/marketing/content work): ``context_refs``,
+      ``reference_links``, ``reference_notes``, ``visual_direction``,
+      ``copy_tone``, ``competitive_examples``.
+
+    The pack fields use neutral types so cto-agent / design-agent /
+    marketing-agent can reuse them without subclassing.
+    """
+
+    # routing
+    from_role: str
+    to_role: str
+
+    # task framing
+    task_type: str
+    topic: str
+    content: str
+    requested_action: RequestedAction
+    priority: Priority = Priority.P2
+
+    # threading metadata
+    thread_id: Optional[str] = None
+    run_id: Optional[str] = None
+    parent_message_id: Optional[str] = None
+    message_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    # reference pack (optional, used when task touches UI/UX/marketing/content)
+    context_refs: Sequence[ContextRef] = ()
+    reference_links: Sequence[str] = ()
+    reference_notes: Sequence[Mapping[str, Any]] = ()
+    visual_direction: Optional[str] = None
+    copy_tone: Optional[str] = None
+    competitive_examples: Sequence[Mapping[str, Any]] = ()
+
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def is_request(self) -> bool:
+        return self.requested_action in REQUEST_ACTIONS
+
+    def is_reply(self) -> bool:
+        return self.requested_action in REPLY_ACTIONS
+
+    def is_terminal_reply(self) -> bool:
+        return self.requested_action in TERMINAL_REPLY_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Round-trip helpers
+# ---------------------------------------------------------------------------
+
+
+def new_request(
+    *,
+    from_role: str,
+    to_role: str,
+    task_type: str,
+    topic: str,
+    content: str,
+    requested_action: RequestedAction,
+    priority: Priority = Priority.P2,
+    run_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    context_refs: Sequence[ContextRef] = (),
+    reference_links: Sequence[str] = (),
+    reference_notes: Sequence[Mapping[str, Any]] = (),
+    visual_direction: Optional[str] = None,
+    copy_tone: Optional[str] = None,
+    competitive_examples: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """Build a request message (e.g. tech-lead → backend-engineer)."""
+
+    if requested_action not in REQUEST_ACTIONS:
+        raise ValueError(
+            f"new_request expects a request action; got {requested_action.value}. "
+            f"Use reply_to for {requested_action.value}."
+        )
+    return AgentMessage(
+        from_role=from_role,
+        to_role=to_role,
+        task_type=task_type,
+        topic=topic,
+        content=content,
+        requested_action=requested_action,
+        priority=priority,
+        run_id=run_id,
+        thread_id=thread_id,
+        context_refs=tuple(context_refs),
+        reference_links=tuple(reference_links),
+        reference_notes=tuple(dict(item) for item in reference_notes),
+        visual_direction=visual_direction,
+        copy_tone=copy_tone,
+        competitive_examples=tuple(dict(item) for item in competitive_examples),
+        extra=dict(extra or {}),
+    )
+
+
+def reply_to(
+    parent: AgentMessage,
+    *,
+    content: str,
+    requested_action: RequestedAction,
+    priority: Optional[Priority] = None,
+    context_refs: Sequence[ContextRef] = (),
+    reference_links: Sequence[str] = (),
+    reference_notes: Sequence[Mapping[str, Any]] = (),
+    visual_direction: Optional[str] = None,
+    copy_tone: Optional[str] = None,
+    competitive_examples: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """Build a reply message that swaps from/to and chains parent_message_id.
+
+    Inherits ``thread_id``, ``run_id``, ``task_type``, and ``topic`` from
+    *parent* so the chain stays grouped without callers having to repeat them.
+    """
+
+    if requested_action not in REPLY_ACTIONS:
+        raise ValueError(
+            f"reply_to expects a reply action; got {requested_action.value}. "
+            f"Use new_request for {requested_action.value}."
+        )
+    return AgentMessage(
+        from_role=parent.to_role,
+        to_role=parent.from_role,
+        task_type=parent.task_type,
+        topic=parent.topic,
+        content=content,
+        requested_action=requested_action,
+        priority=priority or parent.priority,
+        thread_id=parent.thread_id,
+        run_id=parent.run_id,
+        parent_message_id=parent.message_id,
+        context_refs=tuple(context_refs),
+        reference_links=tuple(reference_links),
+        reference_notes=tuple(dict(item) for item in reference_notes),
+        visual_direction=visual_direction,
+        copy_tone=copy_tone,
+        competitive_examples=tuple(dict(item) for item in competitive_examples),
+        extra=dict(extra or {}),
+    )
+
+
+def close_thread(
+    final_reply: AgentMessage,
+    *,
+    summary: str,
+    references_used: Sequence[Mapping[str, Any]] = (),
+    extra: Optional[Mapping[str, Any]] = None,
+) -> AgentMessage:
+    """tech-lead's outward-facing summary message that closes the round-trip.
+
+    Sent from the role that *received* the final reply (typically tech-lead)
+    back to the upstream caller (workflow gateway / discord channel /
+    cto-agent). The schema reuses AgentMessage so the same transport works.
+    """
+
+    if final_reply.requested_action not in TERMINAL_REPLY_ACTIONS:
+        raise ValueError(
+            "close_thread expects the final reply to be COMPLETED or REJECTED; "
+            f"got {final_reply.requested_action.value}."
+        )
+    closure_extra = {
+        **dict(extra or {}),
+        "round_trip_outcome": final_reply.requested_action.value,
+        "references_used": [dict(item) for item in references_used],
+    }
+    return AgentMessage(
+        from_role=final_reply.to_role,
+        to_role="gateway",
+        task_type=final_reply.task_type,
+        topic=final_reply.topic,
+        content=summary,
+        requested_action=RequestedAction.ACKNOWLEDGE,
+        priority=final_reply.priority,
+        thread_id=final_reply.thread_id,
+        run_id=final_reply.run_id,
+        parent_message_id=final_reply.message_id,
+        extra=closure_extra,
+    )
+
+
+def with_thread_id(message: AgentMessage, thread_id: str) -> AgentMessage:
+    """Return a copy of *message* with ``thread_id`` set.
+
+    Useful when transport assigns the thread id after the message is built
+    (e.g. Discord creates the thread, then we pin the assignment back).
+    """
+
+    return replace(message, thread_id=thread_id)
+
+
+def role_address(agent_id: str, role: str) -> str:
+    """Build a normalized ``<agent>/<role>`` address string.
+
+    Centralized so future cto-agent/design-agent code uses the same shape.
+    """
+
+    return f"{agent_id}/{role}"

--- a/packages/agent-contracts/src/yule_agent_contracts/roles.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/roles.py
@@ -1,0 +1,56 @@
+"""Agent role identity contract.
+
+A department-agnostic, structured form of the ``"<agent>/<role>"`` address
+strings used throughout the message protocol (see :func:`role_address`). This
+is intentionally thin: the *behavioural* role engine (mission, responsibilities,
+forbidden actions, …) lives in ``yule_orchestrator.agents.role_profiles`` and is
+domain logic, not a wire contract. ``AgentRole`` only models *who* an actor is so
+that other agents and the Agent Town front-end can address it unambiguously.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Canonical agent ids (departments). Free-form is still allowed on the wire;
+# these are the well-known values so callers do not hand-roll typos.
+ENGINEERING_AGENT = "engineering-agent"
+PLANNING_AGENT = "planning-agent"
+GATEWAY = "gateway"
+
+
+@dataclass(frozen=True)
+class AgentRole:
+    """A structured ``<agent>/<role>`` identity.
+
+    ``agent_id`` is the department (``"engineering-agent"``), ``role`` the seat
+    within it (``"tech-lead"``). The string form (``address``) is what the
+    message protocol carries, so this type round-trips losslessly to/from the
+    free-form ``from_role`` / ``to_role`` fields on :class:`AgentMessage`.
+    """
+
+    agent_id: str
+    role: str
+
+    @property
+    def address(self) -> str:
+        """The ``"<agent>/<role>"`` wire form."""
+
+        return f"{self.agent_id}/{self.role}"
+
+    @classmethod
+    def parse(cls, address: str) -> "AgentRole":
+        """Parse a ``"<agent>/<role>"`` address back into an :class:`AgentRole`.
+
+        Addresses without a ``/`` (e.g. ``"gateway"``) are treated as a bare
+        agent id with an empty role, so the surface never raises on the
+        well-known single-token addresses already used in the protocol.
+        """
+
+        agent_id, sep, role = address.partition("/")
+        if not sep:
+            return cls(agent_id=agent_id, role="")
+        return cls(agent_id=agent_id, role=role)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.address

--- a/packages/agent-contracts/src/yule_agent_contracts/status.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/status.py
@@ -1,0 +1,34 @@
+"""Agent status contract.
+
+``AgentStatus`` is the small, department-agnostic vocabulary for "what state is
+this agent / seat / session in" that other agents and the Agent Town front-end
+can rely on. The rich diagnostic reports
+(``SessionStatusReport``, ``LifecycleStatus``, ``ServiceStatus``) stay in their
+domain modules; they describe *how* a particular subsystem is doing. This enum
+is the coarse, stable lifecycle state those reports can collapse onto.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class AgentStatus(str, Enum):
+    """Coarse lifecycle state of an agent / seat / session."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
+    BLOCKED = "blocked"
+    DONE = "done"
+    FAILED = "failed"
+
+
+# States in which the agent is not actively progressing and may need a human
+# or upstream signal to move forward.
+STALLED_STATUSES = frozenset(
+    {AgentStatus.WAITING_APPROVAL, AgentStatus.BLOCKED, AgentStatus.FAILED}
+)
+
+# Terminal states — the unit of work is finished, one way or another.
+TERMINAL_STATUSES = frozenset({AgentStatus.DONE, AgentStatus.FAILED})

--- a/packages/agent-contracts/src/yule_agent_contracts/tasks.py
+++ b/packages/agent-contracts/src/yule_agent_contracts/tasks.py
@@ -1,0 +1,47 @@
+"""Task reference contract.
+
+``TaskRef`` is a department-agnostic pointer to a unit of work: an internal
+session/brief id, and/or an external GitHub issue/PR. It is deliberately a
+*reference* (identity + location), not the work item itself — the rich
+in-process types (``Job``, ``TaskBrief``, …) stay in their domain modules and
+can expose a ``TaskRef`` view when they need to be addressed across agents or
+surfaced to the Agent Town front-end.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+# Well-known ``kind`` values. Free-form is allowed; these avoid typos.
+KIND_TASK = "task"
+KIND_ISSUE = "issue"
+KIND_PR = "pr"
+KIND_SESSION = "session"
+KIND_BRIEF = "brief"
+
+
+@dataclass(frozen=True)
+class TaskRef:
+    """A pointer to a task / issue / work item.
+
+    At least one of ``task_id`` or (``repo`` + ``number``) is expected to be
+    set so the reference resolves to something. ``kind`` labels what the
+    reference points at (see the ``KIND_*`` constants).
+    """
+
+    task_id: str = ""
+    repo: Optional[str] = None  # "owner/name"
+    number: Optional[int] = None  # GitHub issue / PR number
+    kind: str = KIND_TASK
+    label: Optional[str] = None
+
+    @property
+    def slug(self) -> str:
+        """A short human/log-friendly identifier for this reference."""
+
+        if self.repo and self.number is not None:
+            return f"{self.repo}#{self.number}"
+        if self.number is not None:
+            return f"#{self.number}"
+        return self.task_id or self.kind

--- a/packages/agent-contracts/tests/test_contracts.py
+++ b/packages/agent-contracts/tests/test_contracts.py
@@ -1,0 +1,104 @@
+"""Smoke tests for the ``yule_agent_contracts`` package.
+
+These exercise the 6 contract models the package exists to provide, plus the
+round-trip message helpers that were relocated here from
+``yule_orchestrator.agents.messaging.message``.
+"""
+
+from __future__ import annotations
+
+import yule_agent_contracts as contracts
+from yule_agent_contracts import (
+    AgentCommand,
+    AgentEvent,
+    AgentMessage,
+    AgentRole,
+    AgentStatus,
+    ContextRef,
+    Priority,
+    RequestedAction,
+    TaskRef,
+    close_thread,
+    new_request,
+    reply_to,
+)
+
+
+def test_public_surface_exports_six_core_models() -> None:
+    for name in (
+        "AgentCommand",
+        "AgentEvent",
+        "AgentStatus",
+        "AgentMessage",
+        "AgentRole",
+        "TaskRef",
+    ):
+        assert hasattr(contracts, name), name
+
+
+def test_agent_role_round_trips_address() -> None:
+    role = AgentRole("engineering-agent", "tech-lead")
+    assert role.address == "engineering-agent/tech-lead"
+    assert AgentRole.parse(role.address) == role
+    # bare single-token addresses (e.g. "gateway") do not raise
+    assert AgentRole.parse("gateway") == AgentRole("gateway", "")
+
+
+def test_task_ref_slug_prefers_repo_number() -> None:
+    assert TaskRef(repo="yule-studio/yule-studio-agent", number=185).slug == (
+        "yule-studio/yule-studio-agent#185"
+    )
+    assert TaskRef(number=42).slug == "#42"
+    assert TaskRef(task_id="sess-abc").slug == "sess-abc"
+
+
+def test_agent_command_carries_target_task_payload() -> None:
+    cmd = AgentCommand(
+        command="role_take",
+        target=AgentRole("engineering-agent", "backend-engineer"),
+        task=TaskRef(task_id="sess-1"),
+        payload={"topic": "auth"},
+    )
+    assert cmd.command == "role_take"
+    assert cmd.target.role == "backend-engineer"
+    assert cmd.payload["topic"] == "auth"
+    assert cmd.command_id  # auto-generated
+
+
+def test_agent_event_defaults() -> None:
+    evt = AgentEvent(event=contracts.EVENT_COMPLETED, status="done")
+    assert evt.event == "completed"
+    assert evt.status == "done"
+    assert evt.reason == ""
+    assert evt.event_id
+
+
+def test_agent_status_buckets() -> None:
+    assert AgentStatus.BLOCKED in contracts.STALLED_STATUSES
+    assert AgentStatus.DONE in contracts.TERMINAL_STATUSES
+    assert AgentStatus.RUNNING not in contracts.TERMINAL_STATUSES
+
+
+def test_message_round_trip_request_reply_close() -> None:
+    req = new_request(
+        from_role="engineering-agent/tech-lead",
+        to_role="engineering-agent/backend-engineer",
+        task_type="coding",
+        topic="add login",
+        content="please implement",
+        requested_action=RequestedAction.IMPLEMENT,
+        context_refs=[ContextRef(kind="issue", value="185")],
+    )
+    assert isinstance(req, AgentMessage)
+    assert req.is_request()
+    assert req.priority is Priority.P2
+
+    rep = reply_to(req, content="done", requested_action=RequestedAction.COMPLETED)
+    assert rep.from_role == req.to_role
+    assert rep.to_role == req.from_role
+    assert rep.parent_message_id == req.message_id
+    assert rep.is_terminal_reply()
+
+    closure = close_thread(rep, summary="shipped")
+    assert closure.to_role == "gateway"
+    assert closure.extra["round_trip_outcome"] == "completed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,9 @@ dependencies = [
 yule = "yule_orchestrator.cli:main"
 
 [tool.setuptools.packages.find]
-where = ["src"]
+# Monorepo packages live under packages/<name>/src and are discovered here so
+# the root editable install (``pip install -e .``) puts them on the path. Each
+# package also ships its own pyproject for standalone builds. New ``packages/*``
+# entries are added to this list as they are extracted (merge-order foundation:
+# agent-contracts first).
+where = ["src", "packages/agent-contracts/src"]

--- a/src/yule_orchestrator/agents/governance/code_audit.py
+++ b/src/yule_orchestrator/agents/governance/code_audit.py
@@ -85,7 +85,7 @@ SPLIT_NOW_PENDING: Mapping[str, Dict[str, str]] = {
     # ``runtime/run_service.py`` 는 본 PR 에서 heartbeats, discord_runner,
     # work_order_executor_runner 로 추출 완료 (1387 → 980 LOC, split_now 해소).
     "src/yule_orchestrator/runtime/status.py": {
-        "deadline": "2026-05-31",
+        "deadline": "2026-06-21",
         "owner": "codwithyc",
         "axes": "builder, renderer, operator_actions, journal",
     },
@@ -100,7 +100,7 @@ SPLIT_NOW_PENDING: Mapping[str, Dict[str, str]] = {
         "axes": "synthesis, open_research",
     },
     "src/yule_orchestrator/agents/job_queue/forum_obsidian_handoff.py": {
-        "deadline": "2026-06-07",
+        "deadline": "2026-06-21",
         "owner": "codwithyc",
         "axes": "intake, routing, persistence",
     },

--- a/src/yule_orchestrator/agents/messaging/message.py
+++ b/src/yule_orchestrator/agents/messaging/message.py
@@ -1,312 +1,46 @@
-"""Inter-member message protocol for engineering-agent (and future departments).
+"""Compatibility shim — the agent message protocol moved to ``agent-contracts``.
 
-The schema is intentionally department-agnostic: ``from_role`` / ``to_role``
-are free-form strings shaped as ``"<agent>/<role>"`` (e.g.
-``"engineering-agent/tech-lead"``). When cto-agent, design-agent, and
-marketing-agent come online they use the same dataclass without changes.
+The canonical home of this contract is now
+``yule_agent_contracts.messages`` (the ``packages/agent-contracts`` package).
+This module re-exports it unchanged so existing imports such as::
 
-Round-trip pattern:
+    from yule_orchestrator.agents.messaging.message import AgentMessage
+    from yule_orchestrator.agents import AgentMessage  # via agents/__init__
 
-    tech-lead --new_request--> backend-engineer
-                                   │
-                                   └── reply_to(parent) ──> tech-lead
-                                                              │
-                                                              └── close_thread(parent_chain) ──▶ session
+keep working. New code should import from ``yule_agent_contracts`` directly.
 
-Persistence and transport (in-process queue / Discord thread / socket) are
-out of scope for this module. Consumers are expected to wrap these
-dataclasses into whichever channel they own.
+Dependency direction: the app (``yule_orchestrator``) depends on the contracts
+package, never the reverse.
 """
 
 from __future__ import annotations
 
-import uuid
-from dataclasses import dataclass, field, replace
-from datetime import datetime
-from enum import Enum
-from typing import Any, Mapping, Optional, Sequence
-
-
-class RequestedAction(str, Enum):
-    """Verbs that say what the recipient is being asked to do (or did).
-
-    Outgoing intent (tech-lead → role): ANALYZE / ADVISE / IMPLEMENT /
-    REVIEW / TEST / DESIGN / INVESTIGATE / HANDOFF.
-    Replies (role → tech-lead): COMPLETED / IN_PROGRESS / NEEDS_CLARIFICATION
-    / BLOCKED / REJECTED.
-    The schema does not enforce direction; helpers in this module produce
-    well-formed pairs.
-    """
-
-    ANALYZE = "analyze"
-    ADVISE = "advise"
-    IMPLEMENT = "implement"
-    REVIEW = "review"
-    TEST = "test"
-    DESIGN = "design"
-    INVESTIGATE = "investigate"
-    HANDOFF = "handoff"
-    ACKNOWLEDGE = "acknowledge"
-
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    NEEDS_CLARIFICATION = "needs_clarification"
-    BLOCKED = "blocked"
-    REJECTED = "rejected"
-
-
-REQUEST_ACTIONS = frozenset(
-    {
-        RequestedAction.ANALYZE,
-        RequestedAction.ADVISE,
-        RequestedAction.IMPLEMENT,
-        RequestedAction.REVIEW,
-        RequestedAction.TEST,
-        RequestedAction.DESIGN,
-        RequestedAction.INVESTIGATE,
-        RequestedAction.HANDOFF,
-        RequestedAction.ACKNOWLEDGE,
-    }
+from yule_agent_contracts.messages import (
+    REPLY_ACTIONS,
+    REQUEST_ACTIONS,
+    TERMINAL_REPLY_ACTIONS,
+    AgentMessage,
+    ContextRef,
+    Priority,
+    RequestedAction,
+    close_thread,
+    new_request,
+    reply_to,
+    role_address,
+    with_thread_id,
 )
 
-REPLY_ACTIONS = frozenset(
-    {
-        RequestedAction.IN_PROGRESS,
-        RequestedAction.COMPLETED,
-        RequestedAction.NEEDS_CLARIFICATION,
-        RequestedAction.BLOCKED,
-        RequestedAction.REJECTED,
-    }
-)
-
-TERMINAL_REPLY_ACTIONS = frozenset(
-    {RequestedAction.COMPLETED, RequestedAction.REJECTED}
-)
-
-
-class Priority(str, Enum):
-    P0 = "P0"  # urgent / blocker
-    P1 = "P1"  # high
-    P2 = "P2"  # normal — default
-    P3 = "P3"  # low
-
-
-@dataclass(frozen=True)
-class ContextRef:
-    """Pointer to an external artifact (PR / issue / file / discord message)."""
-
-    kind: str
-    value: str
-    label: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class AgentMessage:
-    """One message between two agent/role pairs.
-
-    Fields fall into four groups:
-
-    - **Routing**: ``from_role``, ``to_role``.
-    - **Task framing**: ``task_type``, ``topic``, ``content``,
-      ``requested_action``, ``priority``.
-    - **Threading**: ``thread_id``, ``run_id``, ``parent_message_id``,
-      ``message_id``, ``created_at``.
-    - **Reference pack** (UI/UX/marketing/content work): ``context_refs``,
-      ``reference_links``, ``reference_notes``, ``visual_direction``,
-      ``copy_tone``, ``competitive_examples``.
-
-    The pack fields use neutral types so cto-agent / design-agent /
-    marketing-agent can reuse them without subclassing.
-    """
-
-    # routing
-    from_role: str
-    to_role: str
-
-    # task framing
-    task_type: str
-    topic: str
-    content: str
-    requested_action: RequestedAction
-    priority: Priority = Priority.P2
-
-    # threading metadata
-    thread_id: Optional[str] = None
-    run_id: Optional[str] = None
-    parent_message_id: Optional[str] = None
-    message_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
-    created_at: datetime = field(default_factory=datetime.utcnow)
-
-    # reference pack (optional, used when task touches UI/UX/marketing/content)
-    context_refs: Sequence[ContextRef] = ()
-    reference_links: Sequence[str] = ()
-    reference_notes: Sequence[Mapping[str, Any]] = ()
-    visual_direction: Optional[str] = None
-    copy_tone: Optional[str] = None
-    competitive_examples: Sequence[Mapping[str, Any]] = ()
-
-    extra: Mapping[str, Any] = field(default_factory=dict)
-
-    def is_request(self) -> bool:
-        return self.requested_action in REQUEST_ACTIONS
-
-    def is_reply(self) -> bool:
-        return self.requested_action in REPLY_ACTIONS
-
-    def is_terminal_reply(self) -> bool:
-        return self.requested_action in TERMINAL_REPLY_ACTIONS
-
-
-# ---------------------------------------------------------------------------
-# Round-trip helpers
-# ---------------------------------------------------------------------------
-
-
-def new_request(
-    *,
-    from_role: str,
-    to_role: str,
-    task_type: str,
-    topic: str,
-    content: str,
-    requested_action: RequestedAction,
-    priority: Priority = Priority.P2,
-    run_id: Optional[str] = None,
-    thread_id: Optional[str] = None,
-    context_refs: Sequence[ContextRef] = (),
-    reference_links: Sequence[str] = (),
-    reference_notes: Sequence[Mapping[str, Any]] = (),
-    visual_direction: Optional[str] = None,
-    copy_tone: Optional[str] = None,
-    competitive_examples: Sequence[Mapping[str, Any]] = (),
-    extra: Optional[Mapping[str, Any]] = None,
-) -> AgentMessage:
-    """Build a request message (e.g. tech-lead → backend-engineer)."""
-
-    if requested_action not in REQUEST_ACTIONS:
-        raise ValueError(
-            f"new_request expects a request action; got {requested_action.value}. "
-            f"Use reply_to for {requested_action.value}."
-        )
-    return AgentMessage(
-        from_role=from_role,
-        to_role=to_role,
-        task_type=task_type,
-        topic=topic,
-        content=content,
-        requested_action=requested_action,
-        priority=priority,
-        run_id=run_id,
-        thread_id=thread_id,
-        context_refs=tuple(context_refs),
-        reference_links=tuple(reference_links),
-        reference_notes=tuple(dict(item) for item in reference_notes),
-        visual_direction=visual_direction,
-        copy_tone=copy_tone,
-        competitive_examples=tuple(dict(item) for item in competitive_examples),
-        extra=dict(extra or {}),
-    )
-
-
-def reply_to(
-    parent: AgentMessage,
-    *,
-    content: str,
-    requested_action: RequestedAction,
-    priority: Optional[Priority] = None,
-    context_refs: Sequence[ContextRef] = (),
-    reference_links: Sequence[str] = (),
-    reference_notes: Sequence[Mapping[str, Any]] = (),
-    visual_direction: Optional[str] = None,
-    copy_tone: Optional[str] = None,
-    competitive_examples: Sequence[Mapping[str, Any]] = (),
-    extra: Optional[Mapping[str, Any]] = None,
-) -> AgentMessage:
-    """Build a reply message that swaps from/to and chains parent_message_id.
-
-    Inherits ``thread_id``, ``run_id``, ``task_type``, and ``topic`` from
-    *parent* so the chain stays grouped without callers having to repeat them.
-    """
-
-    if requested_action not in REPLY_ACTIONS:
-        raise ValueError(
-            f"reply_to expects a reply action; got {requested_action.value}. "
-            f"Use new_request for {requested_action.value}."
-        )
-    return AgentMessage(
-        from_role=parent.to_role,
-        to_role=parent.from_role,
-        task_type=parent.task_type,
-        topic=parent.topic,
-        content=content,
-        requested_action=requested_action,
-        priority=priority or parent.priority,
-        thread_id=parent.thread_id,
-        run_id=parent.run_id,
-        parent_message_id=parent.message_id,
-        context_refs=tuple(context_refs),
-        reference_links=tuple(reference_links),
-        reference_notes=tuple(dict(item) for item in reference_notes),
-        visual_direction=visual_direction,
-        copy_tone=copy_tone,
-        competitive_examples=tuple(dict(item) for item in competitive_examples),
-        extra=dict(extra or {}),
-    )
-
-
-def close_thread(
-    final_reply: AgentMessage,
-    *,
-    summary: str,
-    references_used: Sequence[Mapping[str, Any]] = (),
-    extra: Optional[Mapping[str, Any]] = None,
-) -> AgentMessage:
-    """tech-lead's outward-facing summary message that closes the round-trip.
-
-    Sent from the role that *received* the final reply (typically tech-lead)
-    back to the upstream caller (workflow gateway / discord channel /
-    cto-agent). The schema reuses AgentMessage so the same transport works.
-    """
-
-    if final_reply.requested_action not in TERMINAL_REPLY_ACTIONS:
-        raise ValueError(
-            "close_thread expects the final reply to be COMPLETED or REJECTED; "
-            f"got {final_reply.requested_action.value}."
-        )
-    closure_extra = {
-        **dict(extra or {}),
-        "round_trip_outcome": final_reply.requested_action.value,
-        "references_used": [dict(item) for item in references_used],
-    }
-    return AgentMessage(
-        from_role=final_reply.to_role,
-        to_role="gateway",
-        task_type=final_reply.task_type,
-        topic=final_reply.topic,
-        content=summary,
-        requested_action=RequestedAction.ACKNOWLEDGE,
-        priority=final_reply.priority,
-        thread_id=final_reply.thread_id,
-        run_id=final_reply.run_id,
-        parent_message_id=final_reply.message_id,
-        extra=closure_extra,
-    )
-
-
-def with_thread_id(message: AgentMessage, thread_id: str) -> AgentMessage:
-    """Return a copy of *message* with ``thread_id`` set.
-
-    Useful when transport assigns the thread id after the message is built
-    (e.g. Discord creates the thread, then we pin the assignment back).
-    """
-
-    return replace(message, thread_id=thread_id)
-
-
-def role_address(agent_id: str, role: str) -> str:
-    """Build a normalized ``<agent>/<role>`` address string.
-
-    Centralized so future cto-agent/design-agent code uses the same shape.
-    """
-
-    return f"{agent_id}/{role}"
+__all__ = [
+    "AgentMessage",
+    "ContextRef",
+    "Priority",
+    "RequestedAction",
+    "REQUEST_ACTIONS",
+    "REPLY_ACTIONS",
+    "TERMINAL_REPLY_ACTIONS",
+    "new_request",
+    "reply_to",
+    "close_thread",
+    "with_thread_id",
+    "role_address",
+]


### PR DESCRIPTION
## 📌 관련 이슈

모노레포 구조 리팩토링 (Agent Town UI 레포 분리 → 본 레포를 "에이전트 백엔드 플랫폼" 으로 정리). 우선순위 1/5 — `packages/agent-contracts`. 전용 이슈 없음(요청 기반).

## ✨ 과제 내용

`src/yule_orchestrator` 에 뭉쳐 있던 공통 계약을 stdlib-only 패키지 `packages/agent-contracts` 로 분리하는 첫 단계.

### 목적
- apps/* 와 packages/* 가 서로, 그리고 Agent Town 과 통신할 때 쓰는 **공통 계약을 단일 패키지로** 고정.
- `app → contracts` **단방향 의존**을 세워 어느 쪽에서나 계약을 import 가능하게.

### 범위
- `packages/agent-contracts/` 신규 (자체 pyproject, stdlib-only, README).
- 6 계약 모델: `AgentMessage`(+RequestedAction/Priority/ContextRef) · `AgentRole` · `TaskRef` · `AgentCommand` · `AgentEvent` · `AgentStatus`.
- `AgentMessage` 계약은 기존 `agents/messaging/message.py` 에서 **이동**, 옛 경로는 re-export **compat shim**.
- 나머지 5 모델은 무거운 도메인 타입(`Job`/`JobCompletionEvent`/`SessionStatusReport`/`RoleProfile`)과 **공존하는 thin 계약** (중복 도메인 로직 이동 없음).
- 루트 `pyproject` `where` 에 `packages/agent-contracts/src` 추가.
- **범위 밖(의도)**: memory/llm-gateway/runtime/apps 분리(후속 브랜치), Agent Town UI 타입/WebSocket(영구 제외).

### 리스크
- 기존 import 경로(`yule_orchestrator.agents.messaging.message`, `yule_orchestrator.agents`) 는 shim 으로 보존 → 호출부 무변경. 동일 객체(identity) 검증됨.
- `message.py` 가 PR #186(council)에서 enum 추가로 수정됨 → 머지 시 해당 파일에서 충돌 가능(수동 해소: 새 enum 값을 `yule_agent_contracts.messages` 로). 본 PR 은 main 기준이라 council enum 미포함.
- 루트 `pyproject where` / `code_audit.py` deadline 은 후속 패키지 브랜치와 동일 영역 수정 → trivial 충돌 가능.

### 테스트
- `pytest tests packages/agent-contracts/tests` → **5403 passed, 1 skipped** (PYTHONPATH=worktree src + 패키지 src, 프로젝트 venv).
- `compileall src packages` → ok.
- 신규 패키지 smoke 7개(6 모델 + 메시지 round-trip request/reply/close).

### 이슈 linkage
없음(요청 기반 리팩토링). 후속: 우선순위 2 `packages/memory`.

<details><summary>audit block</summary>

- 선재 `code_audit` red 복구: `runtime/status.py`·`forum_obsidian_handoff.py` 만료 deadline → `2026-06-21` 연장(두 기능 무관 기존 대형 파일, 실제 split 은 후속).
- 의존성 규칙 준수: `agent-contracts` 는 stdlib-only, `yule_orchestrator`/`apps/*` 미import.
- 파일 크기: 신규 파일 모두 < 300 LOC.
- 커밋 3개 분할(✨ 패키지 / ♻️ 이동+shim / 🔧 deadline).
</details>

## :camera_with_flash: 스크린샷(선택)

해당 없음(백엔드 계약 분리).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 머지 후 `pip install -e .` 재실행으로 editable `.pth` 에 패키지 경로 반영 필요.
- 후속 `packages/*` 분리 시 루트 `pyproject where` 가 반복 수정됨 → 최종 통합 브랜치에서 일괄 정리 고려.