### PR TITLE
♻️ core 공유 유틸 → packages/core 추출 (yule_core)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,50 @@
+# yule-core
+
+Pure-leaf platform utilities for Yule Studio agents. These are the
+lowest-level building blocks shared across the monolith and every
+extracted package: process environment loading, local-timezone helpers,
+TLS/CA-bundle fallback, and agent context-document loading. They are
+fully deterministic and testable in isolation.
+
+## Responsibility
+
+- **`env_loader`** — `load_env_files`: idempotent `.env` file loading
+  into `os.environ` (does not overwrite already-set vars).
+- **`timezone`** — `local_tz`, `local_tz_name`, `now_local`, `to_local`:
+  resolve the operator's local timezone (via env / zoneinfo) and produce
+  timezone-aware datetimes.
+- **`tls`** — `TLSCABundle`, `resolve_ca_bundle`,
+  `apply_ca_bundle_fallback`: detect an unusable default OpenSSL CA file
+  and fall back to a usable bundle so outbound HTTPS keeps working.
+- **`context_loader`** — `ContextDocument`, `LoadedContext`,
+  `ContextError`, `load_agent_context`, `render_context`: load and render
+  per-agent context documents.
+
+## Dependency rule
+
+`yule_core` depends on **the Python standard library only**
+(`dependencies = []`). It MUST NOT import `yule_orchestrator` runtime,
+agents, Discord, or any other package — it is a pure leaf at the bottom
+of the dependency graph.
+
+`tls` will *optionally* use `certifi` as a CA-bundle fallback **iff** it
+is already installed (`import certifi` inside a `try/except
+ImportError`); it is intentionally **not** declared as a runtime
+dependency, since absence is handled gracefully (the fallback simply
+returns `None`).
+
+## Compatibility
+
+`yule_orchestrator.core.{__init__,context_loader,env_loader,timezone,tls}`
+are thin compat shims. The submodule shims alias the moved modules via
+`sys.modules[__name__] = <yule_core module>`, preserving object identity
+so existing `from yule_orchestrator.core import ...` imports — and any
+monkeypatch/reload in the 13 external importers — keep resolving to the
+identical objects.
+
+## Public API
+
+`ContextError`, `ContextDocument`, `LoadedContext`, `TLSCABundle`,
+`apply_ca_bundle_fallback`, `load_agent_context`, `load_env_files`,
+`local_tz`, `local_tz_name`, `now_local`, `resolve_ca_bundle`,
+`render_context`, `to_local`.

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yule-core"
+version = "0.1.0"
+description = "Pure-leaf platform utilities for Yule Studio agents: env loading, timezone, TLS/CA fallback, agent context loading (stdlib only)."
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/core/src/yule_core/__init__.py
+++ b/packages/core/src/yule_core/__init__.py
@@ -1,0 +1,20 @@
+from .context_loader import ContextError, ContextDocument, LoadedContext, load_agent_context, render_context
+from .env_loader import load_env_files
+from .timezone import local_tz, local_tz_name, now_local, to_local
+from .tls import TLSCABundle, apply_ca_bundle_fallback, resolve_ca_bundle
+
+__all__ = [
+    "ContextError",
+    "ContextDocument",
+    "LoadedContext",
+    "TLSCABundle",
+    "apply_ca_bundle_fallback",
+    "load_agent_context",
+    "load_env_files",
+    "local_tz",
+    "local_tz_name",
+    "now_local",
+    "resolve_ca_bundle",
+    "render_context",
+    "to_local",
+]

--- a/packages/core/src/yule_core/context_loader.py
+++ b/packages/core/src/yule_core/context_loader.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+
+class ContextError(Exception):
+    """Raised when agent context cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class ContextDocument:
+    label: str
+    path: Path
+    content: str
+
+
+@dataclass(frozen=True)
+class LoadedContext:
+    agent_id: str
+    manifest_path: Path
+    manifest: Dict[str, Any]
+    documents: Sequence[ContextDocument]
+    warnings: Sequence[str]
+
+
+def load_agent_context(repo_root: Path, agent_id: str) -> LoadedContext:
+    repo_root = repo_root.resolve()
+    manifest_path = repo_root / "agents" / agent_id / "manifest.json"
+    manifest = _load_manifest(manifest_path)
+    documents: List[ContextDocument] = []
+    warnings: List[str] = []
+
+    documents.append(_read_required_document(repo_root, "root_instructions", "CLAUDE.md"))
+
+    instruction_entry = manifest.get("instruction_entry")
+    if not isinstance(instruction_entry, str) or not instruction_entry:
+        raise ContextError(f"{_display_path(manifest_path, repo_root)} must define instruction_entry")
+    documents.append(_read_required_document(repo_root, "agent_instructions", instruction_entry))
+
+    policies = manifest.get("policies", [])
+    if not isinstance(policies, list):
+        raise ContextError(f"{_display_path(manifest_path, repo_root)} policies must be a list")
+
+    for policy_path in policies:
+        if not isinstance(policy_path, str):
+            warnings.append("Skipping non-string policy path in agent manifest.")
+            continue
+
+        document = _read_optional_document(repo_root, "policy", policy_path)
+        if document is None:
+            warnings.append(f"Missing policy file: {policy_path}")
+            continue
+        documents.append(document)
+
+    return LoadedContext(
+        agent_id=agent_id,
+        manifest_path=manifest_path,
+        manifest=manifest,
+        documents=documents,
+        warnings=warnings,
+    )
+
+
+def render_context(loaded_context: LoadedContext) -> str:
+    lines: List[str] = [
+        f"# Loaded Context: {loaded_context.agent_id}",
+        "",
+        f"Manifest: {_display_path(loaded_context.manifest_path, loaded_context.manifest_path.parents[2])}",
+        f"Execution Mode: {loaded_context.manifest.get('execution_mode', 'unknown')}",
+        f"Default Executor: {loaded_context.manifest.get('default_executor', 'unknown')}",
+        "",
+    ]
+
+    if loaded_context.warnings:
+        lines.append("## Warnings")
+        for warning in loaded_context.warnings:
+            lines.append(f"- {warning}")
+        lines.append("")
+
+    for document in loaded_context.documents:
+        lines.extend(
+            [
+                f"## {document.label}: {_display_path(document.path, loaded_context.manifest_path.parents[2])}",
+                "",
+                document.content.rstrip(),
+                "",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _load_manifest(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise ContextError(f"Agent manifest not found: {path}")
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ContextError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ContextError(f"Agent manifest must be a JSON object: {path}")
+
+    return data
+
+
+def _read_required_document(repo_root: Path, label: str, relative_path: str) -> ContextDocument:
+    path = _safe_join(repo_root, relative_path)
+    if not path.exists():
+        raise ContextError(f"Required context file not found: {relative_path}")
+    return ContextDocument(label=label, path=path, content=path.read_text(encoding="utf-8"))
+
+
+def _read_optional_document(repo_root: Path, label: str, relative_path: str) -> ContextDocument | None:
+    path = _safe_join(repo_root, relative_path)
+    if not path.exists():
+        return None
+    return ContextDocument(label=label, path=path, content=path.read_text(encoding="utf-8"))
+
+
+def _safe_join(repo_root: Path, relative_path: str) -> Path:
+    path = (repo_root / relative_path).resolve()
+    try:
+        path.relative_to(repo_root)
+    except ValueError as exc:
+        raise ContextError(f"Context path escapes repository root: {relative_path}") from exc
+    return path
+
+
+def _display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(path)

--- a/packages/core/src/yule_core/env_loader.py
+++ b/packages/core/src/yule_core/env_loader.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Sequence
+
+
+def load_env_files(repo_root: Path, filenames: Sequence[str] = (".env", ".env.local")) -> None:
+    repo_root = repo_root.resolve()
+    initial_env_keys = set(os.environ.keys())
+
+    for filename in filenames:
+        path = repo_root / filename
+        if not path.exists():
+            continue
+        _load_env_file(path, initial_env_keys)
+
+
+def _load_env_file(path: Path, initial_env_keys: set[str]) -> None:
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = _normalize_value(value.strip())
+
+        if not key:
+            continue
+
+        if key in initial_env_keys:
+            continue
+
+        os.environ[key] = value
+
+
+def _normalize_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value

--- a/packages/core/src/yule_core/timezone.py
+++ b/packages/core/src/yule_core/timezone.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, tzinfo
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+YULE_TIMEZONE_ENV = "YULE_TIMEZONE"
+
+
+def local_tz() -> tzinfo:
+    name = os.environ.get(YULE_TIMEZONE_ENV, "").strip()
+    if name:
+        try:
+            return ZoneInfo(name)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(
+                f"{YULE_TIMEZONE_ENV} must be a valid IANA zone name, got: {name!r}"
+            ) from exc
+
+    system_tz = datetime.now().astimezone().tzinfo
+    if system_tz is None:
+        return ZoneInfo("UTC")
+    return system_tz
+
+
+def local_tz_name() -> str:
+    name = os.environ.get(YULE_TIMEZONE_ENV, "").strip()
+    if name:
+        return name
+
+    system_name = datetime.now().astimezone().tzname()
+    return system_name or "local"
+
+
+def now_local() -> datetime:
+    return datetime.now(tz=local_tz())
+
+
+def to_local(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=local_tz())
+    return value.astimezone(local_tz())

--- a/packages/core/src/yule_core/tls.py
+++ b/packages/core/src/yule_core/tls.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import ssl
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TLSCABundle:
+    cafile: Optional[str]
+    source: str
+    detail: str
+    exists: bool
+
+
+def resolve_ca_bundle() -> TLSCABundle:
+    explicit_cafile = _normalize_path(os.getenv("SSL_CERT_FILE"))
+    if explicit_cafile is not None:
+        if explicit_cafile.exists():
+            return TLSCABundle(
+                cafile=str(explicit_cafile),
+                source="env",
+                detail="using SSL_CERT_FILE",
+                exists=True,
+            )
+        return TLSCABundle(
+            cafile=str(explicit_cafile),
+            source="env-missing",
+            detail="SSL_CERT_FILE points to a missing file",
+            exists=False,
+        )
+
+    default_paths = ssl.get_default_verify_paths()
+    default_cafile = _normalize_path(default_paths.cafile)
+    if default_cafile is not None and default_cafile.exists():
+        return TLSCABundle(
+            cafile=str(default_cafile),
+            source="default",
+            detail="using OpenSSL default cafile",
+            exists=True,
+        )
+
+    certifi_cafile = _load_certifi_cafile()
+    if certifi_cafile is not None and certifi_cafile.exists():
+        missing_detail = default_paths.cafile or "unset"
+        return TLSCABundle(
+            cafile=str(certifi_cafile),
+            source="certifi",
+            detail=f"default cafile is unavailable ({missing_detail}); certifi fallback is available",
+            exists=True,
+        )
+
+    missing_detail = default_paths.cafile or "unset"
+    return TLSCABundle(
+        cafile=None,
+        source="missing",
+        detail=f"no CA bundle is available (default cafile: {missing_detail})",
+        exists=False,
+    )
+
+
+def apply_ca_bundle_fallback() -> TLSCABundle:
+    bundle = resolve_ca_bundle()
+    if bundle.source == "certifi" and bundle.cafile is not None and "SSL_CERT_FILE" not in os.environ:
+        os.environ["SSL_CERT_FILE"] = bundle.cafile
+        return TLSCABundle(
+            cafile=bundle.cafile,
+            source="certifi-applied",
+            detail="using certifi CA bundle because the default OpenSSL cafile is unavailable",
+            exists=True,
+        )
+    return bundle
+
+
+def _load_certifi_cafile() -> Optional[Path]:
+    try:
+        import certifi
+    except ImportError:
+        return None
+
+    return _normalize_path(certifi.where())
+
+
+def _normalize_path(value: Optional[str]) -> Optional[Path]:
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    return Path(normalized).expanduser()

--- a/packages/core/tests/test_smoke.py
+++ b/packages/core/tests/test_smoke.py
@@ -1,0 +1,87 @@
+"""Smoke tests for the extracted ``yule_core`` package.
+
+Verifies the public surface imports without any ``yule_orchestrator``
+dependency, and that the ``yule_orchestrator.core`` compat shims alias
+the *same* module objects / functions (so monkeypatch/reload callers in
+the 13 external importers keep working).
+"""
+
+from __future__ import annotations
+
+import yule_core
+from yule_core import (
+    ContextDocument,
+    ContextError,
+    LoadedContext,
+    TLSCABundle,
+    apply_ca_bundle_fallback,
+    load_agent_context,
+    load_env_files,
+    local_tz,
+    local_tz_name,
+    now_local,
+    render_context,
+    resolve_ca_bundle,
+    to_local,
+)
+
+
+def test_public_api_is_importable() -> None:
+    assert callable(load_env_files)
+    assert callable(load_agent_context)
+    assert callable(render_context)
+    assert callable(local_tz)
+    assert callable(local_tz_name)
+    assert callable(now_local)
+    assert callable(to_local)
+    assert callable(apply_ca_bundle_fallback)
+    assert callable(resolve_ca_bundle)
+    assert ContextError is not None
+    assert ContextDocument is not None
+    assert LoadedContext is not None
+    assert TLSCABundle is not None
+
+
+def test_all_surface_matches_init() -> None:
+    expected = {
+        "ContextError",
+        "ContextDocument",
+        "LoadedContext",
+        "TLSCABundle",
+        "apply_ca_bundle_fallback",
+        "load_agent_context",
+        "load_env_files",
+        "local_tz",
+        "local_tz_name",
+        "now_local",
+        "resolve_ca_bundle",
+        "render_context",
+        "to_local",
+    }
+    assert set(yule_core.__all__) == expected
+    for name in expected:
+        assert hasattr(yule_core, name), name
+
+
+def test_timezone_now_local_is_tz_aware() -> None:
+    assert now_local().tzinfo is not None
+
+
+def test_shim_module_identity() -> None:
+    """The old import paths must alias the *same* module objects."""
+    from yule_orchestrator import core as shim_core
+    from yule_orchestrator.core import timezone as shim_timezone
+    from yule_orchestrator.core import env_loader as shim_env_loader
+    from yule_orchestrator.core import tls as shim_tls
+    from yule_orchestrator.core import context_loader as shim_context_loader
+
+    assert shim_timezone is yule_core.timezone
+    assert shim_env_loader is yule_core.env_loader
+    assert shim_tls is yule_core.tls
+    assert shim_context_loader is yule_core.context_loader
+
+    # Re-exported callables resolve to the identical objects.
+    assert shim_core.now_local is yule_core.now_local
+    assert shim_core.load_env_files is yule_core.load_env_files
+    assert shim_core.resolve_ca_bundle is yule_core.resolve_ca_bundle
+    assert shim_timezone.now_local is yule_core.now_local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,5 @@ where = [
     "packages/llm-gateway/src",
     "packages/runtime/src",
     "apps/planning-agent/src",
+    "packages/core/src",
 ]

--- a/src/yule_orchestrator/core/__init__.py
+++ b/src/yule_orchestrator/core/__init__.py
@@ -1,7 +1,31 @@
-from .context_loader import ContextError, ContextDocument, LoadedContext, load_agent_context, render_context
-from .env_loader import load_env_files
-from .timezone import local_tz, local_tz_name, now_local, to_local
-from .tls import TLSCABundle, apply_ca_bundle_fallback, resolve_ca_bundle
+"""Compatibility shim — platform core utils now live in ``yule_core``.
+
+Environment loading, timezone helpers, TLS/CA-bundle fallback, and agent
+context loading were extracted into the standalone ``yule-core`` package
+(a pure stdlib leaf with no ``yule_orchestrator`` imports). This module
+re-exports the same public names so every existing
+``from yule_orchestrator.core import ...`` keeps resolving to the
+identical objects. The submodule shims
+(``core.{context_loader,env_loader,timezone,tls}``) alias the moved
+modules via ``sys.modules`` so monkeypatch/reload tests stay valid.
+"""
+
+from yule_core import (
+    ContextDocument,
+    ContextError,
+    LoadedContext,
+    TLSCABundle,
+    apply_ca_bundle_fallback,
+    load_agent_context,
+    load_env_files,
+    local_tz,
+    local_tz_name,
+    now_local,
+    render_context,
+    resolve_ca_bundle,
+    to_local,
+)
+
 
 __all__ = [
     "ContextError",

--- a/src/yule_orchestrator/core/context_loader.py
+++ b/src/yule_orchestrator/core/context_loader.py
@@ -1,138 +1,15 @@
+"""Compat shim — moved to :mod:`yule_core.context_loader` (packages/core).
+
+This aliases the old import path
+(``yule_orchestrator.core.context_loader``) onto the new module so all
+existing imports — and any monkeypatching of module globals — keep
+operating on the *same* module object.
+"""
+
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, List, Sequence
+import sys
 
+from yule_core import context_loader as _module
 
-class ContextError(Exception):
-    """Raised when agent context cannot be loaded."""
-
-
-@dataclass(frozen=True)
-class ContextDocument:
-    label: str
-    path: Path
-    content: str
-
-
-@dataclass(frozen=True)
-class LoadedContext:
-    agent_id: str
-    manifest_path: Path
-    manifest: Dict[str, Any]
-    documents: Sequence[ContextDocument]
-    warnings: Sequence[str]
-
-
-def load_agent_context(repo_root: Path, agent_id: str) -> LoadedContext:
-    repo_root = repo_root.resolve()
-    manifest_path = repo_root / "agents" / agent_id / "manifest.json"
-    manifest = _load_manifest(manifest_path)
-    documents: List[ContextDocument] = []
-    warnings: List[str] = []
-
-    documents.append(_read_required_document(repo_root, "root_instructions", "CLAUDE.md"))
-
-    instruction_entry = manifest.get("instruction_entry")
-    if not isinstance(instruction_entry, str) or not instruction_entry:
-        raise ContextError(f"{_display_path(manifest_path, repo_root)} must define instruction_entry")
-    documents.append(_read_required_document(repo_root, "agent_instructions", instruction_entry))
-
-    policies = manifest.get("policies", [])
-    if not isinstance(policies, list):
-        raise ContextError(f"{_display_path(manifest_path, repo_root)} policies must be a list")
-
-    for policy_path in policies:
-        if not isinstance(policy_path, str):
-            warnings.append("Skipping non-string policy path in agent manifest.")
-            continue
-
-        document = _read_optional_document(repo_root, "policy", policy_path)
-        if document is None:
-            warnings.append(f"Missing policy file: {policy_path}")
-            continue
-        documents.append(document)
-
-    return LoadedContext(
-        agent_id=agent_id,
-        manifest_path=manifest_path,
-        manifest=manifest,
-        documents=documents,
-        warnings=warnings,
-    )
-
-
-def render_context(loaded_context: LoadedContext) -> str:
-    lines: List[str] = [
-        f"# Loaded Context: {loaded_context.agent_id}",
-        "",
-        f"Manifest: {_display_path(loaded_context.manifest_path, loaded_context.manifest_path.parents[2])}",
-        f"Execution Mode: {loaded_context.manifest.get('execution_mode', 'unknown')}",
-        f"Default Executor: {loaded_context.manifest.get('default_executor', 'unknown')}",
-        "",
-    ]
-
-    if loaded_context.warnings:
-        lines.append("## Warnings")
-        for warning in loaded_context.warnings:
-            lines.append(f"- {warning}")
-        lines.append("")
-
-    for document in loaded_context.documents:
-        lines.extend(
-            [
-                f"## {document.label}: {_display_path(document.path, loaded_context.manifest_path.parents[2])}",
-                "",
-                document.content.rstrip(),
-                "",
-            ]
-        )
-
-    return "\n".join(lines).rstrip() + "\n"
-
-
-def _load_manifest(path: Path) -> Dict[str, Any]:
-    if not path.exists():
-        raise ContextError(f"Agent manifest not found: {path}")
-
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ContextError(f"Invalid JSON in {path}: {exc}") from exc
-
-    if not isinstance(data, dict):
-        raise ContextError(f"Agent manifest must be a JSON object: {path}")
-
-    return data
-
-
-def _read_required_document(repo_root: Path, label: str, relative_path: str) -> ContextDocument:
-    path = _safe_join(repo_root, relative_path)
-    if not path.exists():
-        raise ContextError(f"Required context file not found: {relative_path}")
-    return ContextDocument(label=label, path=path, content=path.read_text(encoding="utf-8"))
-
-
-def _read_optional_document(repo_root: Path, label: str, relative_path: str) -> ContextDocument | None:
-    path = _safe_join(repo_root, relative_path)
-    if not path.exists():
-        return None
-    return ContextDocument(label=label, path=path, content=path.read_text(encoding="utf-8"))
-
-
-def _safe_join(repo_root: Path, relative_path: str) -> Path:
-    path = (repo_root / relative_path).resolve()
-    try:
-        path.relative_to(repo_root)
-    except ValueError as exc:
-        raise ContextError(f"Context path escapes repository root: {relative_path}") from exc
-    return path
-
-
-def _display_path(path: Path, repo_root: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
-    except ValueError:
-        return str(path)
+sys.modules[__name__] = _module

--- a/src/yule_orchestrator/core/env_loader.py
+++ b/src/yule_orchestrator/core/env_loader.py
@@ -1,47 +1,15 @@
+"""Compat shim — moved to :mod:`yule_core.env_loader` (packages/core).
+
+This aliases the old import path
+(``yule_orchestrator.core.env_loader``) onto the new module so all
+existing imports — and any monkeypatching of module globals — keep
+operating on the *same* module object.
+"""
+
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Sequence
+import sys
 
+from yule_core import env_loader as _module
 
-def load_env_files(repo_root: Path, filenames: Sequence[str] = (".env", ".env.local")) -> None:
-    repo_root = repo_root.resolve()
-    initial_env_keys = set(os.environ.keys())
-
-    for filename in filenames:
-        path = repo_root / filename
-        if not path.exists():
-            continue
-        _load_env_file(path, initial_env_keys)
-
-
-def _load_env_file(path: Path, initial_env_keys: set[str]) -> None:
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-
-        if line.startswith("export "):
-            line = line[len("export ") :].strip()
-
-        if "=" not in line:
-            continue
-
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = _normalize_value(value.strip())
-
-        if not key:
-            continue
-
-        if key in initial_env_keys:
-            continue
-
-        os.environ[key] = value
-
-
-def _normalize_value(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
+sys.modules[__name__] = _module

--- a/src/yule_orchestrator/core/timezone.py
+++ b/src/yule_orchestrator/core/timezone.py
@@ -1,43 +1,15 @@
+"""Compat shim — moved to :mod:`yule_core.timezone` (packages/core).
+
+This aliases the old import path
+(``yule_orchestrator.core.timezone``) onto the new module so all
+existing imports — and any monkeypatching of module globals — keep
+operating on the *same* module object.
+"""
+
 from __future__ import annotations
 
-import os
-from datetime import datetime, tzinfo
-from typing import Optional
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+import sys
 
-YULE_TIMEZONE_ENV = "YULE_TIMEZONE"
+from yule_core import timezone as _module
 
-
-def local_tz() -> tzinfo:
-    name = os.environ.get(YULE_TIMEZONE_ENV, "").strip()
-    if name:
-        try:
-            return ZoneInfo(name)
-        except ZoneInfoNotFoundError as exc:
-            raise ValueError(
-                f"{YULE_TIMEZONE_ENV} must be a valid IANA zone name, got: {name!r}"
-            ) from exc
-
-    system_tz = datetime.now().astimezone().tzinfo
-    if system_tz is None:
-        return ZoneInfo("UTC")
-    return system_tz
-
-
-def local_tz_name() -> str:
-    name = os.environ.get(YULE_TIMEZONE_ENV, "").strip()
-    if name:
-        return name
-
-    system_name = datetime.now().astimezone().tzname()
-    return system_name or "local"
-
-
-def now_local() -> datetime:
-    return datetime.now(tz=local_tz())
-
-
-def to_local(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=local_tz())
-    return value.astimezone(local_tz())
+sys.modules[__name__] = _module

--- a/src/yule_orchestrator/core/tls.py
+++ b/src/yule_orchestrator/core/tls.py
@@ -1,94 +1,14 @@
+"""Compat shim — moved to :mod:`yule_core.tls` (packages/core).
+
+This aliases the old import path (``yule_orchestrator.core.tls``) onto
+the new module so all existing imports — and any monkeypatching of
+module globals — keep operating on the *same* module object.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-import os
-from pathlib import Path
-import ssl
-from typing import Optional
+import sys
 
+from yule_core import tls as _module
 
-@dataclass(frozen=True)
-class TLSCABundle:
-    cafile: Optional[str]
-    source: str
-    detail: str
-    exists: bool
-
-
-def resolve_ca_bundle() -> TLSCABundle:
-    explicit_cafile = _normalize_path(os.getenv("SSL_CERT_FILE"))
-    if explicit_cafile is not None:
-        if explicit_cafile.exists():
-            return TLSCABundle(
-                cafile=str(explicit_cafile),
-                source="env",
-                detail="using SSL_CERT_FILE",
-                exists=True,
-            )
-        return TLSCABundle(
-            cafile=str(explicit_cafile),
-            source="env-missing",
-            detail="SSL_CERT_FILE points to a missing file",
-            exists=False,
-        )
-
-    default_paths = ssl.get_default_verify_paths()
-    default_cafile = _normalize_path(default_paths.cafile)
-    if default_cafile is not None and default_cafile.exists():
-        return TLSCABundle(
-            cafile=str(default_cafile),
-            source="default",
-            detail="using OpenSSL default cafile",
-            exists=True,
-        )
-
-    certifi_cafile = _load_certifi_cafile()
-    if certifi_cafile is not None and certifi_cafile.exists():
-        missing_detail = default_paths.cafile or "unset"
-        return TLSCABundle(
-            cafile=str(certifi_cafile),
-            source="certifi",
-            detail=f"default cafile is unavailable ({missing_detail}); certifi fallback is available",
-            exists=True,
-        )
-
-    missing_detail = default_paths.cafile or "unset"
-    return TLSCABundle(
-        cafile=None,
-        source="missing",
-        detail=f"no CA bundle is available (default cafile: {missing_detail})",
-        exists=False,
-    )
-
-
-def apply_ca_bundle_fallback() -> TLSCABundle:
-    bundle = resolve_ca_bundle()
-    if bundle.source == "certifi" and bundle.cafile is not None and "SSL_CERT_FILE" not in os.environ:
-        os.environ["SSL_CERT_FILE"] = bundle.cafile
-        return TLSCABundle(
-            cafile=bundle.cafile,
-            source="certifi-applied",
-            detail="using certifi CA bundle because the default OpenSSL cafile is unavailable",
-            exists=True,
-        )
-    return bundle
-
-
-def _load_certifi_cafile() -> Optional[Path]:
-    try:
-        import certifi
-    except ImportError:
-        return None
-
-    return _normalize_path(certifi.where())
-
-
-def _normalize_path(value: Optional[str]) -> Optional[Path]:
-    if value is None:
-        return None
-
-    normalized = value.strip()
-    if not normalized:
-        return None
-
-    return Path(normalized).expanduser()
+sys.modules[__name__] = _module


### PR DESCRIPTION
## 📌 관련 이슈

모노레포 공유 인프라 추출 1 — apps→monolith 과도기 부채를 없애기 위해 공유 leaf 인프라를 packages/ 로 선추출. 전용 이슈 없음(요청 기반). 선행: #192(planning 이주).

## ✨ 과제 내용

`src/yule_orchestrator/core/`(5파일·684줄, env/timezone/tls/context-loading 유틸)를 **순수 leaf 패키지** `yule_core` 로 추출.

### 목적
- planning-agent 등 apps 가 `yule_orchestrator.core` 대신 packages 를 의존하도록 하는 토대.
- core 는 내부 의존 0 → 가장 안전한 첫 인프라 추출.

### 범위
- `git mv` core 5파일 → `packages/core/src/yule_core/`(이력 보존). parent import 없음(leaf) — 재작성 불필요.
- 옛 경로 `src/yule_orchestrator/core/`: `__init__` public 13 re-export + 4 submodule `sys.modules` alias shim → 13 importer 무손상, identity 보존.
- `packages/core/pyproject.toml`(yule-core, deps=[]) + 루트 `where` += `packages/core/src` + smoke + README.

### 리스크
- 낮음 — leaf 추출, shim 으로 기존 import 전부 보존.
- `certifi` 는 tls.py 의 optional try/except fallback → deps=[] 유지(루트엔 기존대로 존재).

### 테스트
- `compileall src packages apps` → OK.
- `pytest tests packages/core/tests` → **5400 passed, 1 skipped**.
- identity: `yule_orchestrator.core.timezone is yule_core.timezone` → True.

### 이슈 linkage
없음(요청 기반). 후속: storage+integrations → packages/ (병렬 진행 중), 이후 planning 의 core import 를 yule_core 로 정리.

<details><summary>audit block</summary>

- code_audit green 유지(이동 파일 apps/packages 로 빠짐, 새 위반 없음). deadline 미변경.
- 의존성: yule_core stdlib-only, yule_orchestrator 미import.
- 커밋 3개(♻️ 이동 / ♻️ shim+wiring / ✨ pyproject+smoke+README).
</details>

## :camera_with_flash: 스크린샷(선택)

해당 없음.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- 머지 후 `pip install -e .` 재실행으로 editable .pth 갱신.
- 후속: apps/packages 의 `yule_orchestrator.core` import 를 `yule_core` 직접 import 로 점진 전환(shim 제거).