### PR TITLE
♻️ shim 제거 1차 — git/security/learning 옛 경로 제거 (agents/ 30→27)

### DIFF
--- a/apps/discord-gateway/src/yule_discord/commands/__init__.py
+++ b/apps/discord-gateway/src/yule_discord/commands/__init__.py
@@ -863,7 +863,7 @@ def _extract_repo_from_session(session: Any, prompt_text: str) -> Optional[str]:
     """
 
     try:
-        from yule_engineering.agents.git.github_url import parse_github_target
+        from yule_vcs.github_url import parse_github_target
     except Exception:  # noqa: BLE001 - partial install
         return None
 

--- a/apps/discord-gateway/src/yule_discord/integrations/github_workos_adapter.py
+++ b/apps/discord-gateway/src/yule_discord/integrations/github_workos_adapter.py
@@ -67,7 +67,7 @@ from yule_engineering.agents.job_queue.approval_worker import (
     ApprovalRequest,
     ApprovalWorker,
 )
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.github_workos.issue_auto_create import (
     AUDIT_TEMPLATE_FALLBACK,
     IssueAutoCreateOutcome,

--- a/apps/engineering-agent/src/yule_engineering/agents/coding/coding_bootstrap.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/coding/coding_bootstrap.py
@@ -198,7 +198,7 @@ def _has_github_repo(
             return True
     # Fall back to scanning user_links — defer parser import.
     try:
-        from ..git.github_url import parse_github_targets
+        from yule_vcs.github_url import parse_github_targets
     except Exception:  # noqa: BLE001
         return False
     targets = parse_github_targets(user_links or ())

--- a/apps/engineering-agent/src/yule_engineering/agents/coding/coding_session_context.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/coding/coding_session_context.py
@@ -3,7 +3,7 @@
 Single entry point that ties together the 5 stage-2 building blocks:
 
   1. :func:`agents.git.github_url.parse_github_targets` — URL parse.
-  2. :func:`agents.git.repo_contract.discover_repo_contract` — RepoContract.
+  2. :func:`yule_vcs.repo_contract.discover_repo_contract` — RepoContract.
   3. :func:`agents.lifecycle.session_mode.ensure_session_mode` — ask-once mode.
   4. :func:`agents.coding.handoff_packet.build_coding_handoff_packet` — tech-lead envelope.
 
@@ -27,8 +27,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from ..git.github_url import GithubTarget, parse_github_targets
-from ..git.repo_contract import RepoContract, discover_repo_contract
+from yule_vcs.github_url import GithubTarget, parse_github_targets
+from yule_vcs.repo_contract import RepoContract, discover_repo_contract
 from ..lifecycle.session_mode import (
     SessionMode,
     SessionModeDecision,

--- a/apps/engineering-agent/src/yule_engineering/agents/git/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/git/__init__.py
@@ -1,6 +1,0 @@
-"""Compatibility shim — git/repo utilities moved to ``packages/vcs`` (yule_vcs).
-
-The canonical home is now the ``yule_vcs`` package. This shim re-exports it
-under the old ``yule_engineering.agents.git`` path so existing imports keep
-resolving to the same objects. New code should import from ``yule_vcs``.
-"""

--- a/apps/engineering-agent/src/yule_engineering/agents/git/github_url.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/git/github_url.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_vcs.github_url (packages/vcs)."""
-import sys
-from yule_vcs import github_url as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/git/repo_contract.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/git/repo_contract.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_vcs.repo_contract (packages/vcs)."""
-import sys
-from yule_vcs import repo_contract as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/github_workos/issue_auto_create.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/github_workos/issue_auto_create.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
 
-from ..git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 
 
 # ---------------------------------------------------------------------------

--- a/apps/engineering-agent/src/yule_engineering/agents/governance/code_audit_signals.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/governance/code_audit_signals.py
@@ -209,7 +209,7 @@ def record_governance_mistakes(
     곳에서 결정한다.
     """
 
-    from ..learning.mistake_ledger import BlockerLevel  # local import
+    from yule_learning.mistake_ledger import BlockerLevel  # local import
 
     records: List[Any] = []
     if file_size_audit is not None:

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_live.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_live.py
@@ -1689,7 +1689,7 @@ class LiveCodeEditor:
         # Imported lazily so the module stays importable in
         # environments that strip the security subpackage (e.g.
         # the planning-agent worker that never touches LLM I/O).
-        from yule_engineering.agents.security.paste_guard import (
+        from yule_security.paste_guard import (
             OutboundChannel,
             guard_outbound,
         )

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/github_work_order_executor.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/github_work_order_executor.py
@@ -551,7 +551,7 @@ class GitHubWorkOrderWorker:
         """
 
         try:
-            from ..git.github_url import parse_github_target
+            from yule_vcs.github_url import parse_github_target
         except Exception:  # noqa: BLE001 - partial install
             return None
 

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/github_work_order_recovery.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/github_work_order_recovery.py
@@ -108,7 +108,7 @@ def _minimal_repo_contract(repo: str):
     if not owner or not name:
         return None
     try:
-        from ..git.repo_contract import RepoContract
+        from yule_vcs.repo_contract import RepoContract
     except Exception:  # noqa: BLE001 - partial install
         return None
     return RepoContract(

--- a/apps/engineering-agent/src/yule_engineering/agents/learning/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/learning/__init__.py
@@ -1,8 +1,0 @@
-"""Compatibility shim — moved to `yule_learning` (packages/learning).
-
-Re-exports the new package under the old `yule_engineering.agents.learning`
-path so existing imports keep resolving to the same objects.
-"""
-import yule_learning as _m
-from yule_learning import *  # noqa: F401,F403
-__all__ = list(getattr(_m, "__all__", []))

--- a/apps/engineering-agent/src/yule_engineering/agents/learning/mistake_ledger.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/learning/mistake_ledger.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_learning.mistake_ledger (packages/learning)."""
-import sys
-from yule_learning import mistake_ledger as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/learning/preflight.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/learning/preflight.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_learning.preflight (packages/learning)."""
-import sys
-from yule_learning import preflight as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/obsidian/vault_auto_push.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/obsidian/vault_auto_push.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
-from ..security.paste_guard import OutboundChannel, guard_outbound
+from yule_security.paste_guard import OutboundChannel, guard_outbound
 
 
 ENV_AUTOPUSH_ENABLED = "YULE_VAULT_AUTOPUSH_ENABLED"

--- a/apps/engineering-agent/src/yule_engineering/agents/release/auto_merge_decider.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/release/auto_merge_decider.py
@@ -48,7 +48,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Mapping, Optional, Sequence, Tuple
 
-from ..learning.mistake_ledger import BlockerLevel, MistakeLedger
+from yule_learning.mistake_ledger import BlockerLevel, MistakeLedger
 
 
 # ---------------------------------------------------------------------------

--- a/apps/engineering-agent/src/yule_engineering/agents/research/collector.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/research/collector.py
@@ -318,7 +318,7 @@ def parse_github_url(url: Optional[str]) -> Optional[Mapping[str, Any]]:
     surrounding source-classification fall-through is unchanged.
     """
 
-    from ..git.github_url import parse_github_url as _delegate
+    from yule_vcs.github_url import parse_github_url as _delegate
 
     return _delegate(url)
 

--- a/apps/engineering-agent/src/yule_engineering/agents/research/security_compat.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/research/security_compat.py
@@ -1,6 +1,6 @@
 """PasteGuard integration shim for research live providers (F5 / #92).
 
-본 모듈은 :mod:`yule_engineering.agents.security.paste_guard` 의
+본 모듈은 :mod:`yule_security.paste_guard` 의
 :func:`guard_outbound` 를 live provider 내부에서 부르기 쉽게 감싼다.
 
 * :func:`guard_text` — text 한 줄 (title / summary / tag) 에 대한 PasteGuard
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from ..security.paste_guard import OutboundChannel, guard_outbound
+from yule_security.paste_guard import OutboundChannel, guard_outbound
 
 
 def guard_text(value: str) -> str:

--- a/apps/engineering-agent/src/yule_engineering/agents/safety/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/safety/__init__.py
@@ -2,7 +2,7 @@
 
 This package houses the *tool-call* axis of the safety stack. It is
 intentionally a different layer from
-:mod:`yule_engineering.agents.security.paste_guard`:
+:mod:`yule_security.paste_guard`:
 
   * :mod:`paste_guard` runs on *outbound payloads* (LLM prompts,
     Discord posts, GitHub comments, Vault writes). It scrubs the

--- a/apps/engineering-agent/src/yule_engineering/agents/safety/tool_call_gate.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/safety/tool_call_gate.py
@@ -280,7 +280,7 @@ def _register_block_signature(
     The ledger object must expose ``record_mistake(role=,
     pattern=, signature=, blocker_level=)`` — that's the
     public surface of
-    :class:`yule_engineering.agents.learning.mistake_ledger.MistakeLedger`.
+    :class:`yule_learning.mistake_ledger.MistakeLedger`.
     Any other shape (or any exception) is swallowed so a failing
     ledger never silently leaks into the gate verdict.
     """
@@ -293,7 +293,7 @@ def _register_block_signature(
         # Late import keeps the safety package independent of
         # learning at import time — the gate only needs the
         # ``record_mistake`` duck-typed call site.
-        from ..learning.mistake_ledger import BlockerLevel  # noqa: WPS433
+        from yule_learning.mistake_ledger import BlockerLevel  # noqa: WPS433
 
         role = (ctx.role or "engineering-agent").strip() or "engineering-agent"
         pattern = f"tool_call_gate.{risk.value.lower()}"

--- a/apps/engineering-agent/src/yule_engineering/agents/security/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/security/__init__.py
@@ -1,8 +1,0 @@
-"""Compatibility shim — moved to `yule_security` (packages/security).
-
-Re-exports the new package under the old `yule_engineering.agents.security`
-path so existing imports keep resolving to the same objects.
-"""
-import yule_security as _m
-from yule_security import *  # noqa: F401,F403
-__all__ = list(getattr(_m, "__all__", []))

--- a/apps/engineering-agent/src/yule_engineering/agents/security/paste_guard.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/security/paste_guard.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_security.paste_guard (packages/security)."""
-import sys
-from yule_security import paste_guard as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/static_analysis/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/static_analysis/__init__.py
@@ -13,7 +13,7 @@ Hard rails (governance-tested):
   * ``YULE_LSP_PREFLIGHT_ENABLED`` defaults to ``false``; with the
     env OFF the verdict is always advisory and no subprocess runs.
   * Every subprocess ``stderr`` tail is passed through
-    :func:`yule_engineering.agents.security.paste_guard.guard_outbound`
+    :func:`yule_security.paste_guard.guard_outbound`
     (``channel=VAULT``) so masked output is the only artefact that
     leaves the runner.
 """

--- a/apps/engineering-agent/src/yule_engineering/agents/static_analysis/lsp_preflight.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/static_analysis/lsp_preflight.py
@@ -169,7 +169,7 @@ class LspResult:
 class PreflightLspLevel(str, enum.Enum):
     """Aggregated verdict level.
 
-    Mirrors :class:`~yule_engineering.agents.learning.mistake_ledger.BlockerLevel`
+    Mirrors :class:`~yule_learning.mistake_ledger.BlockerLevel`
     naming so downstream consumers (retry loop / mistake ledger
     surface) can switch on a single string without translation.
     """

--- a/apps/engineering-agent/src/yule_engineering/agents/static_analysis/runners/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/static_analysis/runners/__init__.py
@@ -103,7 +103,7 @@ def mask_stderr(stderr: str) -> str:
 
 def _redact_via_paste_guard(stderr: str) -> str:
     try:
-        from yule_engineering.agents.security.paste_guard import (
+        from yule_security.paste_guard import (
             OutboundChannel,
             guard_outbound,
         )

--- a/packages/learning/README.md
+++ b/packages/learning/README.md
@@ -1,4 +1,3 @@
 # yule-learning
 
-engineering-agent 코어(agents/learning)에서 추출한 leaf 패키지. 옛 경로
-`yule_engineering.agents.learning` 는 compat shim 으로 유지.
+engineering-agent 코어(agents/learning)에서 추출한 leaf 패키지. 옛 compat shim 은 제거됨 — 호출부가 패키지를 직접 import.

--- a/packages/learning/src/yule_learning/__init__.py
+++ b/packages/learning/src/yule_learning/__init__.py
@@ -15,7 +15,7 @@ worker).
 The two modules **do not import each other** by design — a recurring
 mistake recorded on the session-extra ledger is promoted to this
 durable ledger by the postmortem producer (see
-:func:`yule_engineering.agents.learning.mistake_ledger.mistake_candidate_from_postmortem`)
+:func:`yule_learning.mistake_ledger.mistake_candidate_from_postmortem`)
 so the seam remains explicit.
 
 Hard rails (the kind every later integration must respect):

--- a/packages/learning/tests/test_smoke.py
+++ b/packages/learning/tests/test_smoke.py
@@ -1,12 +1,14 @@
+"""Smoke test for yule_learning."""
 import unittest
+
 import yule_learning
-from yule_learning import mistake_ledger
+from yule_learning import mistake_ledger, preflight
 
 
-class yule_learningSmokeTests(unittest.TestCase):
-    def test_legacy_identity(self) -> None:
-        from yule_engineering.agents.learning import mistake_ledger as legacy
-        self.assertIs(legacy, yule_learning.mistake_ledger)
+class LearningSmokeTests(unittest.TestCase):
+    def test_importable(self) -> None:
+        self.assertTrue(hasattr(mistake_ledger, "__name__"))
+        self.assertTrue(hasattr(preflight, "__name__"))
 
 
 if __name__ == "__main__":

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,4 +1,3 @@
 # yule-security
 
-engineering-agent 코어(agents/security)에서 추출한 leaf 패키지. 옛 경로
-`yule_engineering.agents.security` 는 compat shim 으로 유지.
+engineering-agent 코어(agents/security)에서 추출한 leaf 패키지. 옛 compat shim 은 제거됨 — 호출부가 패키지를 직접 import.

--- a/packages/security/tests/test_smoke.py
+++ b/packages/security/tests/test_smoke.py
@@ -1,12 +1,13 @@
+"""Smoke test for yule_security."""
 import unittest
+
 import yule_security
 from yule_security import paste_guard
 
 
-class yule_securitySmokeTests(unittest.TestCase):
-    def test_legacy_identity(self) -> None:
-        from yule_engineering.agents.security import paste_guard as legacy
-        self.assertIs(legacy, yule_security.paste_guard)
+class SecuritySmokeTests(unittest.TestCase):
+    def test_importable(self) -> None:
+        self.assertTrue(hasattr(paste_guard, "__name__"))
 
 
 if __name__ == "__main__":

--- a/packages/vcs/README.md
+++ b/packages/vcs/README.md
@@ -6,5 +6,4 @@ Version-control utilities extracted from the engineering-agent core (구
 - `github_url` — GitHub URL/owner-repo 파싱.
 - `repo_contract` — repo write/tag 정책 contract.
 
-옛 경로 `yule_engineering.agents.git[.github_url|.repo_contract]` 는 `yule_vcs`
-를 가리키는 compat shim(sys.modules alias, identity 보존)으로 유지된다.
+(옛 yule_engineering.agents.git compat shim 은 제거됨 — 호출부가 yule_vcs 직접 import).

--- a/packages/vcs/tests/test_smoke.py
+++ b/packages/vcs/tests/test_smoke.py
@@ -1,4 +1,4 @@
-"""Smoke test for the relocated yule_vcs package + old-path identity."""
+"""Smoke test for yule_vcs."""
 import unittest
 
 import yule_vcs
@@ -9,12 +9,6 @@ class VcsSmokeTests(unittest.TestCase):
     def test_submodules_importable(self) -> None:
         self.assertTrue(hasattr(github_url, "__name__"))
         self.assertTrue(hasattr(repo_contract, "__name__"))
-
-    def test_legacy_path_aliases_same_objects(self) -> None:
-        from yule_engineering.agents.git import github_url as gu
-        from yule_engineering.agents.git import repo_contract as rc
-        self.assertIs(gu, yule_vcs.github_url)
-        self.assertIs(rc, yule_vcs.repo_contract)
 
 
 if __name__ == "__main__":

--- a/plugins/hookify/manifest.json
+++ b/plugins/hookify/manifest.json
@@ -17,5 +17,5 @@
   "autonomy_level": "advisory",
   "paste_guard_required": true,
   "risk_class": "MEDIUM",
-  "module_path": "yule_engineering.agents.learning.mistake_ledger"
+  "module_path": "yule_learning.mistake_ledger"
 }

--- a/plugins/paste-guard/manifest.json
+++ b/plugins/paste-guard/manifest.json
@@ -14,5 +14,5 @@
   "autonomy_level": "supervised",
   "paste_guard_required": false,
   "risk_class": "HIGH",
-  "module_path": "yule_engineering.agents.security.paste_guard"
+  "module_path": "yule_security.paste_guard"
 }

--- a/tests/agents/git/test_github_url.py
+++ b/tests/agents/git/test_github_url.py
@@ -13,7 +13,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.github_url import (
+from yule_vcs.github_url import (
     GithubTarget,
     parse_github_target,
     parse_github_targets,

--- a/tests/agents/git/test_repo_contract.py
+++ b/tests/agents/git/test_repo_contract.py
@@ -23,7 +23,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import (
+from yule_vcs.repo_contract import (
     RepoContract,
     discover_repo_contract,
 )

--- a/tests/agents/git/test_repo_contract_tag_policy.py
+++ b/tests/agents/git/test_repo_contract_tag_policy.py
@@ -20,7 +20,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import (
+from yule_vcs.repo_contract import (
     RepoContract,
     derive_tag_policy,
     discover_repo_contract,

--- a/tests/agents/test_auto_merge_decider.py
+++ b/tests/agents/test_auto_merge_decider.py
@@ -18,7 +18,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )

--- a/tests/agents/test_extension_loader.py
+++ b/tests/agents/test_extension_loader.py
@@ -34,7 +34,7 @@ _PLUGIN_VALID = {
     "autonomy_level": "supervised",
     "paste_guard_required": False,
     "risk_class": "HIGH",
-    "module_path": "yule_engineering.agents.security.paste_guard",
+    "module_path": "yule_security.paste_guard",
 }
 
 _AGENT_VALID = {
@@ -88,7 +88,7 @@ class DiscoverManifestsTests(unittest.TestCase):
                 "hooks_provided": ["PREFLIGHT", "COMPLETION"],
                 "paste_guard_required": True,
                 "autonomy_level": "advisory",
-                "module_path": "yule_engineering.agents.learning.mistake_ledger",
+                "module_path": "yule_learning.mistake_ledger",
             }
         )
         _write_manifest(self.plugins_dir, "hookify", hookify)

--- a/tests/agents/test_extension_manifest.py
+++ b/tests/agents/test_extension_manifest.py
@@ -35,7 +35,7 @@ _VALID_PLUGIN_DICT = {
     "autonomy_level": "supervised",
     "paste_guard_required": False,
     "risk_class": "HIGH",
-    "module_path": "yule_engineering.agents.security.paste_guard",
+    "module_path": "yule_security.paste_guard",
 }
 
 _VALID_AGENT_DICT = {

--- a/tests/agents/test_live_code_editor.py
+++ b/tests/agents/test_live_code_editor.py
@@ -260,7 +260,7 @@ class PasteGuardPreflightTests(unittest.TestCase):
         #
         # Simpler: poke guard_outbound by monkey-patching to return
         # ``blocked=True`` so we exercise the editor branch directly.
-        from yule_engineering.agents.security import paste_guard as pg_mod
+        from yule_security import paste_guard as pg_mod
 
         original = pg_mod.guard_outbound
 

--- a/tests/agents/test_mistake_ledger_persistent.py
+++ b/tests/agents/test_mistake_ledger_persistent.py
@@ -31,7 +31,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
     MistakeRecord,

--- a/tests/agents/test_paste_guard.py
+++ b/tests/agents/test_paste_guard.py
@@ -22,7 +22,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.security.paste_guard import (
+from yule_security.paste_guard import (
     GuardVerdict,
     OutboundChannel,
     PasteGuardError,
@@ -236,7 +236,7 @@ class GuardFailClosedTests(unittest.TestCase):
     """``fail_closed=True`` must drop the payload on internal error."""
 
     def test_fail_closed_returns_empty_redacted_on_exception(self) -> None:
-        import yule_engineering.agents.security.paste_guard as pg
+        import yule_security.paste_guard as pg
 
         original = pg.redact_payload
 
@@ -259,7 +259,7 @@ class GuardFailClosedTests(unittest.TestCase):
         self.assertTrue(verdict.original_hash.startswith("sha256:"))
 
     def test_fail_open_propagates_exception(self) -> None:
-        import yule_engineering.agents.security.paste_guard as pg
+        import yule_security.paste_guard as pg
 
         original = pg.scan_payload
 

--- a/tests/agents/test_preflight.py
+++ b/tests/agents/test_preflight.py
@@ -25,11 +25,11 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )
-from yule_engineering.agents.learning.preflight import (
+from yule_learning.preflight import (
     DEFAULT_PREFLIGHT_SIMILARITY,
     PreflightHookResult,
     PreflightVerdict,

--- a/tests/agents/test_tool_call_gate.py
+++ b/tests/agents/test_tool_call_gate.py
@@ -20,7 +20,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )

--- a/tests/discord/test_github_workos_adapter_issue_bootstrap.py
+++ b/tests/discord/test_github_workos_adapter_issue_bootstrap.py
@@ -23,7 +23,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.job_queue.approval_worker import (
     ApprovalRequest,
     ApprovalWorker,

--- a/tests/engineering/test_auto_merge_governance.py
+++ b/tests/engineering/test_auto_merge_governance.py
@@ -30,7 +30,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )

--- a/tests/engineering/test_coding_session_context_p0h.py
+++ b/tests/engineering/test_coding_session_context_p0h.py
@@ -224,7 +224,7 @@ class RepoContractIntegrationTests(unittest.TestCase):
         from yule_engineering.agents.coding import (
             coding_session_context as csc,
         )
-        from yule_engineering.agents.git.repo_contract import RepoContract
+        from yule_vcs.repo_contract import RepoContract
 
         def fake_discover(*, owner, repo, **kwargs):
             return RepoContract(

--- a/tests/engineering/test_github_work_order_issueless_plan.py
+++ b/tests/engineering/test_github_work_order_issueless_plan.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
 
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.job_queue.approval_worker import (
     APPROVAL_KIND_ENGINEERING_WRITE,
     ApprovalRequest,

--- a/tests/engineering/test_handoff_packet_p0h.py
+++ b/tests/engineering/test_handoff_packet_p0h.py
@@ -27,8 +27,8 @@ from yule_engineering.agents.coding.handoff_packet import (
     TRACKING_STANDALONE,
     build_coding_handoff_packet,
 )
-from yule_engineering.agents.git.github_url import parse_github_target
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.github_url import parse_github_target
+from yule_vcs.repo_contract import RepoContract
 
 
 class TrackingModeDerivationTests(unittest.TestCase):

--- a/tests/engineering/test_hookify_governance.py
+++ b/tests/engineering/test_hookify_governance.py
@@ -32,12 +32,12 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
     mistake_candidate_from_postmortem,
 )
-from yule_engineering.agents.learning.preflight import (
+from yule_learning.preflight import (
     judge_preflight,
     preflight_pipeline_hook,
 )

--- a/tests/engineering/test_issue_autocreate_end_to_end.py
+++ b/tests/engineering/test_issue_autocreate_end_to_end.py
@@ -30,7 +30,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import discover_repo_contract
+from yule_vcs.repo_contract import discover_repo_contract
 from yule_engineering.agents.github_workos.audit import (
     ACTION_GITHUB_ISSUE_CREATE,
     OUTCOME_OK,

--- a/tests/engineering/test_issue_quality_and_repair.py
+++ b/tests/engineering/test_issue_quality_and_repair.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
 
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.github_workos.issue_auto_create import (
     AUDIT_TEMPLATE_FALLBACK,
     build_default_issue_body,

--- a/tests/engineering/test_issueless_bootstrap_end_to_end.py
+++ b/tests/engineering/test_issueless_bootstrap_end_to_end.py
@@ -33,7 +33,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.github_workos.audit import OUTCOME_OK
 from yule_engineering.agents.job_queue.approval_worker import (
     APPROVAL_KIND_ENGINEERING_WRITE,

--- a/tests/engineering/test_live_editor_governance.py
+++ b/tests/engineering/test_live_editor_governance.py
@@ -19,7 +19,7 @@ Rails pinned (D-73-10 cost-budget gate + #88 PasteGuard fail-closed):
      lands in a separate PR with cost-budget review.
 
   3. ``LiveCodeEditor`` consults
-     :func:`yule_engineering.agents.security.paste_guard.guard_outbound`
+     :func:`yule_security.paste_guard.guard_outbound`
      on every call. A blocked verdict raises BlockedLiveEditorError.
 
   4. ``coding_executor_worker.is_protected_branch`` continues to flag
@@ -113,7 +113,7 @@ class LiveEditorGovernanceTests(unittest.TestCase):
 
     # 3 — PasteGuard preflight is mandatory.
     def test_paste_guard_blocked_verdict_refuses_call(self) -> None:
-        from yule_engineering.agents.security import paste_guard as pg_mod
+        from yule_security import paste_guard as pg_mod
 
         original = pg_mod.guard_outbound
 

--- a/tests/engineering/test_memory_unifier_governance.py
+++ b/tests/engineering/test_memory_unifier_governance.py
@@ -38,7 +38,7 @@ from yule_engineering.agents.decision.context_pack import (
     ContextPack,
     build_context_pack,
 )
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )
@@ -57,7 +57,7 @@ from yule_engineering.agents.memory import (
     ShardKind,
     build_memory_pack,
 )
-from yule_engineering.agents.security.paste_guard import (
+from yule_security.paste_guard import (
     OutboundChannel,
     guard_outbound,
 )

--- a/tests/engineering/test_paste_guard_governance.py
+++ b/tests/engineering/test_paste_guard_governance.py
@@ -44,7 +44,7 @@ from yule_engineering.agents.job_queue.coding_executor_live import (
 from yule_engineering.agents.job_queue.coding_executor_worker import (
     is_protected_branch,
 )
-from yule_engineering.agents.security.paste_guard import (
+from yule_security.paste_guard import (
     GuardVerdict,
     OutboundChannel,
     RISK_ADVISORY,

--- a/tests/engineering/test_tool_gate_governance.py
+++ b/tests/engineering/test_tool_gate_governance.py
@@ -31,7 +31,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )
@@ -48,7 +48,7 @@ from yule_engineering.agents.safety.tool_call_gate import (
     ToolGateVerdict,
     gate_tool_call,
 )
-from yule_engineering.agents.security.paste_guard import (
+from yule_security.paste_guard import (
     OutboundChannel,
     guard_outbound,
 )

--- a/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
+++ b/tests/engineering/test_workorder_to_coding_continuation_end_to_end.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:
 
 from yule_engineering.agents.coding.job import STATUS_READY
 from yule_engineering.agents.github_workos.audit import OUTCOME_OK
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.job_queue.approval_worker import (
     ApprovalRequest,
     ApprovalWorker,

--- a/tests/github_workos/test_issue_auto_create.py
+++ b/tests/github_workos/test_issue_auto_create.py
@@ -26,7 +26,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.git.repo_contract import RepoContract
+from yule_vcs.repo_contract import RepoContract
 from yule_engineering.agents.github_workos.issue_auto_create import (
     AUDIT_EXISTING_ISSUE_REUSED,
     AUDIT_TEMPLATE_AMBIGUOUS,

--- a/tests/governance/test_code_audit_signals.py
+++ b/tests/governance/test_code_audit_signals.py
@@ -31,7 +31,7 @@ from yule_engineering.agents.governance.code_audit_signals import (
     audit_to_signals,
     record_governance_mistakes,
 )
-from yule_engineering.agents.learning.mistake_ledger import (
+from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )


### PR DESCRIPTION
## 📌 관련 이슈

모노레포 분해 Phase 3(shim 제거). 추출 완료한 leaf 의 옛 경로 compat shim 을 실제로 제거해 agents/ 를 축소. 전용 이슈 없음(요청 기반).

## ✨ 과제 내용

vcs/security/learning(이미 packages 로 추출됨)의 호출부를 **새 패키지 경로로 rewire** 하고 옛 경로 shim dir 을 **삭제**. agents/ 하위 30→27.

### 범위 (shim 제거의 진짜 blast radius)
- from-import: `from ..git.X`/`yule_engineering.agents.git.X` → `yule_vcs.X` (security→yule_security, learning→yule_learning). git\./git import 정밀 패턴으로 github_app/workos prefix 충돌 회피.
- **동적 import 문자열**: `plugins/{paste-guard,hookify}/manifest.json` 의 module_path + extension 테스트 fixture 문자열 + `import X` 문.
- docstring(:func:/:mod:) 참조.
- shim dir `agents/{git,security,learning}/` 삭제.
- 패키지 smoke 의 legacy-identity 테스트 제거(옛 경로 없음) + README 정리.

### 리스크
- shim 제거는 **동적 import(plugin module_path) 까지** 챙겨야 함을 확인 — 전 형태(from/import/string/manifest) 갱신. 잔여 옛 경로 0(github 제외).

### 테스트
- `unittest discover -s tests -t .`(CI 동일) → **Ran 5461, OK**.
- `sync_harness_skills.py --check` → drift 0.

### 이슈 linkage
없음. 후속: agent-memory/agent-runtime shim 제거(`..memory` vs `...memory` 깊이 충돌 → 파일별 해소 필요), 외곽 shim(core/storage/integrations/memory/planning/discord).

<details><summary>audit block</summary>

- agents/ 실축소(30→27 dir). 옛 경로 동적/정적 참조 0.
- 커밋 2개(♻️ rewire+삭제 / ✅ smoke·README).
</details>

## :camera_with_flash: 스크린샷(선택)
해당 없음.

## 📚 레퍼런스
- shim 제거는 from-import 뿐 아니라 **plugin manifest 의 module_path 문자열·`import` 문·docstring** 까지 포함 — 동적 로딩 경로 누락 시 런타임에서만 터짐.