### PR TITLE
♻️ shim 제거 2차 — agent-memory/agent-runtime (agents/ 27→25)

### DIFF
--- a/apps/discord-gateway/src/yule_discord/engineering_channel_router/main.py
+++ b/apps/discord-gateway/src/yule_discord/engineering_channel_router/main.py
@@ -66,7 +66,7 @@ from yule_engineering.agents.routing import (
     is_non_actionable_prompt,
     list_open_sessions,
 )
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     ACTION_APPEND_CONTEXT as RUNTIME_ACTION_APPEND_CONTEXT,
     ACTION_ASK_CLARIFICATION as RUNTIME_ACTION_ASK_CLARIFICATION,
     ACTION_JOIN_SESSION as RUNTIME_ACTION_JOIN_SESSION,

--- a/apps/discord-gateway/src/yule_discord/engineering_channel_router/runtime_preflight.py
+++ b/apps/discord-gateway/src/yule_discord/engineering_channel_router/runtime_preflight.py
@@ -45,7 +45,7 @@ from yule_engineering.agents.routing import (
     ACTION_JOIN,
     EngineeringRoutingDecision,
 )
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     ACTION_APPEND_CONTEXT as RUNTIME_ACTION_APPEND_CONTEXT,
     ACTION_ASK_CLARIFICATION as RUNTIME_ACTION_ASK_CLARIFICATION,
     ACTION_JOIN_SESSION as RUNTIME_ACTION_JOIN_SESSION,
@@ -385,7 +385,7 @@ def _observation_for_runtime(input_: RuntimeInput):
     runtime loop's default observe (keeps the router's import surface
     small)."""
 
-    from yule_engineering.agents.runtime.models import RuntimeObservation
+    from yule_agent_runtime.models import RuntimeObservation
 
     text = input_.message_text or ""
     return RuntimeObservation(

--- a/apps/discord-gateway/src/yule_discord/engineering_channel_router/utils.py
+++ b/apps/discord-gateway/src/yule_discord/engineering_channel_router/utils.py
@@ -16,7 +16,7 @@ import os
 from dataclasses import replace
 from typing import Any, Optional
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     RecallCoverage,
     RuntimeRecallResult,
     compute_recall_coverage,

--- a/apps/engineering-agent/src/yule_engineering/agents/decision/context_pack.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/decision/context_pack.py
@@ -31,7 +31,7 @@ from typing import (
     Tuple,
 )
 
-from ..memory import MemoryPack
+from yule_agent_memory import MemoryPack
 
 
 # ---------------------------------------------------------------------------

--- a/apps/engineering-agent/src/yule_engineering/agents/engineering_team_runtime/_legacy.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/engineering_team_runtime/_legacy.py
@@ -823,7 +823,7 @@ def _render_role_runtime_preface(
     """
 
     try:
-        from yule_engineering.agents.runtime import (
+        from yule_agent_runtime import (
             RuntimeInput,
             role_policy_for,
             run_runtime_loop,

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/standalone_runners.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/standalone_runners.py
@@ -755,7 +755,7 @@ def _build_role_runner_input(
 
 def _safe_role_profile(role: str) -> Mapping[str, Any]:
     try:
-        from ..runtime.policies import role_policy_for
+        from yule_agent_runtime.policies import role_policy_for
     except Exception:  # noqa: BLE001 - partial install fallback
         return {"role": role}
     try:

--- a/apps/engineering-agent/src/yule_engineering/agents/memory/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/memory/__init__.py
@@ -1,8 +1,0 @@
-"""Compatibility shim — moved to `yule_agent_memory` (packages/memory).
-
-Re-exports the new package under the old `yule_engineering.agents.memory`
-path so existing imports keep resolving to the same objects.
-"""
-import yule_agent_memory as _m
-from yule_agent_memory import *  # noqa: F401,F403
-__all__ = list(getattr(_m, "__all__", []))

--- a/apps/engineering-agent/src/yule_engineering/agents/memory/long_term_memory.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/memory/long_term_memory.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_memory.long_term_memory."""
-import sys
-from yule_agent_memory import long_term_memory as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/memory/relevance_selector.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/memory/relevance_selector.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_memory.relevance_selector."""
-import sys
-from yule_agent_memory import relevance_selector as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/memory/sources.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/memory/sources.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_memory.sources."""
-import sys
-from yule_agent_memory import sources as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/memory/topic_index.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/memory/topic_index.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_memory.topic_index."""
-import sys
-from yule_agent_memory import topic_index as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/preamble/memory_inject.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/preamble/memory_inject.py
@@ -35,7 +35,7 @@ def inject_memory_summary(
         return rendered
 
     try:
-        from ..memory.long_term_memory import build_memory_pack
+        from yule_agent_memory.long_term_memory import build_memory_pack
     except ImportError:
         return rendered
 

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/__init__.py
@@ -1,8 +1,0 @@
-"""Compatibility shim — moved to `yule_agent_runtime` (packages/runtime).
-
-Re-exports the new package under the old `yule_engineering.agents.runtime`
-path so existing imports keep resolving to the same objects.
-"""
-import yule_agent_runtime as _m
-from yule_agent_runtime import *  # noqa: F401,F403
-__all__ = list(getattr(_m, "__all__", []))

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/decide.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/decide.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.decide."""
-import sys
-from yule_agent_runtime import decide as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/loop.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/loop.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.loop."""
-import sys
-from yule_agent_runtime import loop as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/models.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/models.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.models."""
-import sys
-from yule_agent_runtime import models as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/policies.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/policies.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.policies."""
-import sys
-from yule_agent_runtime import policies as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/recall.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/recall.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.recall."""
-import sys
-from yule_agent_runtime import recall as _module
-sys.modules[__name__] = _module

--- a/apps/engineering-agent/src/yule_engineering/agents/runtime/understand.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runtime/understand.py
@@ -1,4 +1,0 @@
-"""Compat shim — moved to yule_agent_runtime.understand."""
-import sys
-from yule_agent_runtime import understand as _module
-sys.modules[__name__] = _module

--- a/packages/agent-memory/README.md
+++ b/packages/agent-memory/README.md
@@ -3,4 +3,4 @@
 engineering-agent 코어(agents/memory)에서 추출한 stdlib leaf — 에이전트
 long-term memory(long_term_memory / relevance_selector / sources / topic_index).
 packages/memory(검색·FTS5 인덱스)와 이름 충돌을 피해 agent-prefix.
-옛 경로 `yule_engineering.agents.memory` 는 compat shim(sys.modules alias, identity 보존).
+옛 compat shim 은 제거됨 — 호출부가 패키지를 직접 import.

--- a/packages/agent-memory/tests/test_smoke.py
+++ b/packages/agent-memory/tests/test_smoke.py
@@ -1,12 +1,13 @@
+"""Smoke test for yule_agent_memory."""
 import unittest
+
 import yule_agent_memory
 from yule_agent_memory import long_term_memory
 
 
-class yule_agent_memorySmokeTests(unittest.TestCase):
-    def test_legacy_identity(self) -> None:
-        from yule_engineering.agents.agent-memory import long_term_memory as legacy
-        self.assertIs(legacy, yule_agent_memory.long_term_memory)
+class AgentMemorySmokeTests(unittest.TestCase):
+    def test_importable(self) -> None:
+        self.assertTrue(hasattr(long_term_memory, "__name__"))
 
 
 if __name__ == "__main__":

--- a/packages/agent-runtime/README.md
+++ b/packages/agent-runtime/README.md
@@ -3,4 +3,4 @@
 engineering-agent 코어(agents/runtime)에서 추출한 stdlib leaf — 에이전트
 runtime 루프(decide / loop / recall / understand / models / policies).
 packages/runtime(circuit_breaker·services·supervisor)와 이름 충돌을 피해 agent-prefix.
-옛 경로 `yule_engineering.agents.runtime` 는 compat shim(sys.modules alias, identity 보존).
+옛 compat shim 은 제거됨 — 호출부가 패키지를 직접 import.

--- a/packages/agent-runtime/tests/test_smoke.py
+++ b/packages/agent-runtime/tests/test_smoke.py
@@ -1,12 +1,14 @@
+"""Smoke test for yule_agent_runtime."""
 import unittest
+
 import yule_agent_runtime
-from yule_agent_runtime import loop
+from yule_agent_runtime import loop, decide
 
 
-class yule_agent_runtimeSmokeTests(unittest.TestCase):
-    def test_legacy_identity(self) -> None:
-        from yule_engineering.agents.agent-runtime import loop as legacy
-        self.assertIs(legacy, yule_agent_runtime.loop)
+class AgentRuntimeSmokeTests(unittest.TestCase):
+    def test_importable(self) -> None:
+        self.assertTrue(hasattr(loop, "__name__"))
+        self.assertTrue(hasattr(decide, "__name__"))
 
 
 if __name__ == "__main__":

--- a/plugins/claude-mem/manifest.json
+++ b/plugins/claude-mem/manifest.json
@@ -17,5 +17,5 @@
   "autonomy_level": "advisory",
   "paste_guard_required": true,
   "risk_class": "MEDIUM",
-  "module_path": "yule_engineering.agents.memory.long_term_memory"
+  "module_path": "yule_agent_memory.long_term_memory"
 }

--- a/tests/agents/test_long_term_memory.py
+++ b/tests/agents/test_long_term_memory.py
@@ -23,7 +23,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.memory import (
+from yule_agent_memory import (
     ENV_LONG_TERM_MEMORY_ENABLED,
     LongTermMemory,
     MemoryFilter,

--- a/tests/agents/test_preamble_memory_inject.py
+++ b/tests/agents/test_preamble_memory_inject.py
@@ -41,7 +41,7 @@ class _FakeMemory:
         self.sources = (_FakeSource(shards),)
 
 
-from yule_engineering.agents.memory.long_term_memory import RequestContext as _RealRequestContext
+from yule_agent_memory.long_term_memory import RequestContext as _RealRequestContext
 
 
 def _make_request():
@@ -65,7 +65,7 @@ class InjectMemorySummaryTests(unittest.TestCase):
         req = _make_request()
         # build_memory_pack 의 env 체크 우회
         with patch(
-            "yule_engineering.agents.memory.long_term_memory.long_term_memory_enabled",
+            "yule_agent_memory.long_term_memory.long_term_memory_enabled",
             return_value=True,
         ):
             out = inject_memory_summary(p, request_context=req, long_term_memory=mem)
@@ -77,7 +77,7 @@ class InjectMemorySummaryTests(unittest.TestCase):
         mem = _FakeMemory([])
         req = _make_request()
         with patch(
-            "yule_engineering.agents.memory.long_term_memory.long_term_memory_enabled",
+            "yule_agent_memory.long_term_memory.long_term_memory_enabled",
             return_value=True,
         ):
             out = inject_memory_summary(p, request_context=req, long_term_memory=mem)
@@ -88,7 +88,7 @@ class InjectMemorySummaryTests(unittest.TestCase):
         mem = _FakeMemory([_FakeMemoryShard()])
         req = _make_request()
         with patch(
-            "yule_engineering.agents.memory.long_term_memory.long_term_memory_enabled",
+            "yule_agent_memory.long_term_memory.long_term_memory_enabled",
             return_value=False,
         ):
             out = inject_memory_summary(p, request_context=req, long_term_memory=mem)

--- a/tests/agents/test_relevance_selector.py
+++ b/tests/agents/test_relevance_selector.py
@@ -21,12 +21,12 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.memory import (
+from yule_agent_memory import (
     MemoryShard,
     RequestContext,
     ShardKind,
 )
-from yule_engineering.agents.memory.relevance_selector import RelevanceSelector
+from yule_agent_memory.relevance_selector import RelevanceSelector
 
 
 def _shard(

--- a/tests/agents/test_topic_index.py
+++ b/tests/agents/test_topic_index.py
@@ -18,8 +18,8 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.memory import MemoryShard, ShardKind
-from yule_engineering.agents.memory.topic_index import TopicIndex
+from yule_agent_memory import MemoryShard, ShardKind
+from yule_agent_memory.topic_index import TopicIndex
 
 
 def _shard(

--- a/tests/engineering/runtime/test_decide.py
+++ b/tests/engineering/runtime/test_decide.py
@@ -14,7 +14,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     ACTION_APPEND_CONTEXT,
     ACTION_ASK_CLARIFICATION,
     ACTION_CREATE_SESSION,
@@ -36,7 +36,7 @@ from yule_engineering.agents.runtime import (
     RuntimeResearchPlan,
     SessionCandidate,
 )
-from yule_engineering.agents.runtime.decide import decide_default
+from yule_agent_runtime.decide import decide_default
 
 
 def _obs(text: str = "msg") -> RuntimeObservation:

--- a/tests/engineering/runtime/test_decide_gateway.py
+++ b/tests/engineering/runtime/test_decide_gateway.py
@@ -14,8 +14,8 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime.decide import decide_gateway
-from yule_engineering.agents.runtime.models import (
+from yule_agent_runtime.decide import decide_gateway
+from yule_agent_runtime.models import (
     ACTION_APPEND_CONTEXT,
     ACTION_ASK_CLARIFICATION,
     ACTION_JOIN_SESSION,

--- a/tests/engineering/runtime/test_loop.py
+++ b/tests/engineering/runtime/test_loop.py
@@ -16,7 +16,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     ACTION_NOOP,
     ACTION_REPLY,
     INTENT_GENERAL_CHAT,

--- a/tests/engineering/runtime/test_models.py
+++ b/tests/engineering/runtime/test_models.py
@@ -16,7 +16,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     ACTION_NOOP,
     ACTION_REPLY,
     INTENT_GENERAL_CHAT,

--- a/tests/engineering/runtime/test_policies.py
+++ b/tests/engineering/runtime/test_policies.py
@@ -9,7 +9,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime.policies import (
+from yule_agent_runtime.policies import (
     RolePolicy,
     all_role_policies,
     role_policy_for,

--- a/tests/engineering/runtime/test_recall.py
+++ b/tests/engineering/runtime/test_recall.py
@@ -20,7 +20,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     INTENT_APPEND_CONTEXT,
     INTENT_CONTINUE_EXISTING_WORK,
     INTENT_EXECUTE_EXISTING_STEP,
@@ -31,7 +31,7 @@ from yule_engineering.agents.runtime import (
     RuntimeIntent,
     RuntimeObservation,
 )
-from yule_engineering.agents.runtime.recall import (
+from yule_agent_runtime.recall import (
     AMBIGUITY_MARGIN,
     SCORE_HIGH,
     make_recall_fn,

--- a/tests/engineering/runtime/test_recall_coverage.py
+++ b/tests/engineering/runtime/test_recall_coverage.py
@@ -16,14 +16,14 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime.models import (
+from yule_agent_runtime.models import (
     COVERAGE_HIGH,
     COVERAGE_LOW,
     COVERAGE_MEDIUM,
     RuntimeRecallResult,
     SessionCandidate,
 )
-from yule_engineering.agents.runtime.recall import compute_recall_coverage
+from yule_agent_runtime.recall import compute_recall_coverage
 
 
 def _now() -> datetime:

--- a/tests/engineering/runtime/test_recall_memory.py
+++ b/tests/engineering/runtime/test_recall_memory.py
@@ -18,14 +18,14 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     INTENT_NEW_WORK_REQUEST,
     INTENT_SUMMARIZE_PREVIOUS_WORK,
     RuntimeInput,
     RuntimeIntent,
     RuntimeObservation,
 )
-from yule_engineering.agents.runtime.recall import make_recall_fn
+from yule_agent_runtime.recall import make_recall_fn
 
 
 @dataclass

--- a/tests/engineering/runtime/test_understand.py
+++ b/tests/engineering/runtime/test_understand.py
@@ -15,7 +15,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     INTENT_APPEND_CONTEXT,
     INTENT_CLARIFICATION_NEEDED,
     INTENT_CONTINUE_EXISTING_WORK,
@@ -29,7 +29,7 @@ from yule_engineering.agents.runtime import (
     RuntimeIntent,
     RuntimeObservation,
 )
-from yule_engineering.agents.runtime.understand import (
+from yule_agent_runtime.understand import (
     classify_intent_deterministic,
     make_understand_fn,
 )

--- a/tests/engineering/runtime/test_understand_loop_integration.py
+++ b/tests/engineering/runtime/test_understand_loop_integration.py
@@ -17,7 +17,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     INTENT_APPEND_CONTEXT,
     INTENT_CONTINUE_EXISTING_WORK,
     INTENT_DIAGNOSTIC_QUESTION,

--- a/tests/engineering/test_channel_router_forum.py
+++ b/tests/engineering/test_channel_router_forum.py
@@ -1056,7 +1056,7 @@ class RoleRuntimePrefaceTests(unittest.TestCase):
         )
 
         with patch(
-            "yule_engineering.agents.runtime.run_runtime_loop",
+            "yule_agent_runtime.run_runtime_loop",
             side_effect=_capture,
         ):
             outcome = handle_research_turn_message(
@@ -1087,7 +1087,7 @@ class RoleRuntimePrefaceTests(unittest.TestCase):
         )
 
         with patch(
-            "yule_engineering.agents.runtime.run_runtime_loop",
+            "yule_agent_runtime.run_runtime_loop",
             side_effect=RuntimeError("runtime down"),
         ):
             outcome = handle_research_turn_message(

--- a/tests/engineering/test_gateway_recall_first_flag.py
+++ b/tests/engineering/test_gateway_recall_first_flag.py
@@ -25,7 +25,7 @@ try:
 except ModuleNotFoundError:
     from tests import _bootstrap  # noqa: F401
 
-from yule_engineering.agents.runtime import (
+from yule_agent_runtime import (
     COVERAGE_HIGH,
     COVERAGE_LOW,
     RuntimeRecallResult,

--- a/tests/engineering/test_memory_unifier_governance.py
+++ b/tests/engineering/test_memory_unifier_governance.py
@@ -42,7 +42,7 @@ from yule_learning.mistake_ledger import (
     BlockerLevel,
     MistakeLedger,
 )
-from yule_engineering.agents.memory import (
+from yule_agent_memory import (
     ENV_LONG_TERM_MEMORY_ENABLED,
     AuditSource,
     DecisionSource,
@@ -222,7 +222,7 @@ class MemoryUnifierGovernanceTests(unittest.TestCase):
 
     # 8
     def test_public_surface_explicit(self) -> None:
-        import yule_engineering.agents.memory as memory_pkg
+        import yule_agent_memory as memory_pkg
 
         expected = {
             "AuditSource",


### PR DESCRIPTION
## 📌 관련 이슈

모노레포 분해 — agent-memory/agent-runtime 옛 경로 shim 제거(#204 후속). 전용 이슈 없음(요청 기반).

## ✨ 과제 내용

#203 에서 agent-prefix 로 추출한 `agent-memory`/`agent-runtime` 의 compat shim 을 제거하고 호출부를 새 패키지로 rewire. agents/ 하위 27→25.

### 핵심 난제 — 상대 깊이 충돌 해소
`from ..memory` 가 **파일 위치에 따라 다른 모듈**을 가리킨다:
- `agents/decision/context_pack.py` 의 `..memory` = `agents.memory`(**leaf** → rewire).
- `cli/memory.py` 의 `..memory` = `yule_engineering.memory`(**outer=packages/memory** → 유지).
- `job_queue/standalone_runners.py` 의 `...runtime.fallback` = `yule_engineering.runtime`(**outer=packages/runtime** → 유지).

→ 단순 패턴 치환 불가. **파일별로 상대 import 를 절대 모듈로 해소**하는 스크립트로 `yule_engineering.agents.{memory,runtime}` 타깃만 정확히 rewire.

### 범위
- 상대 import depth 해소 + 절대참조 + `plugins/claude-mem/manifest.json` module_path + import 문 갱신.
- shim dir `agents/{memory,runtime}` 삭제. 패키지 smoke legacy-identity 제거 + README.

### 테스트
- `unittest discover -s tests -t .`(CI 동일) → **Ran 5461, OK**.
- `sync_harness_skills.py --check` → drift 0.
- leaf 잔여 참조 0(outer 정확히 유지 확인).

### 이슈 linkage
없음. 후속: 외곽 shim(core/storage/integrations/memory/planning/discord) 제거는 더 큰 blast radius.

<details><summary>audit block</summary>

- agents/ 27→25 dir 실축소. 파일별 depth 해소로 leaf/outer 정확 분리.
- 커밋 2개(♻️ rewire+삭제 / ✅ smoke·README).
</details>

## :camera_with_flash: 스크린샷(선택)
해당 없음.

## 📚 레퍼런스
- 동명 leaf vs outer(agents.memory vs yule_engineering.memory)의 상대 import 는 dot-count 가 파일 깊이에 의존 → 패턴 치환 대신 파일별 절대-해소 필요.