### PR TITLE
✨ 책임분리 — coding_executor_worker.py 1194→987 (reason/progress 추출)

### DIFF
--- a/apps/engineering-agent/src/yule_engineering/agents/governance/code_audit.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/governance/code_audit.py
@@ -106,11 +106,6 @@ SPLIT_NOW_PENDING: Mapping[str, Dict[str, str]] = {
         "owner": "codwithyc",
         "axes": "router, formatting",
     },
-    "apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_worker.py": {
-        "deadline": "2026-06-14",
-        "owner": "codwithyc",
-        "axes": "process_job pipeline, reason classification, progress stamping",
-    },
     "apps/engineering-agent/src/yule_engineering/runtime/coding_executor_runner.py": {
         "deadline": "2026-06-21",
         "owner": "codwithyc",

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_progress.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_progress.py
@@ -1,0 +1,170 @@
+"""Progress stamping for the coding executor worker.
+
+Side-effecting (session.extra) progress-marker writers extracted out of
+:mod:`coding_executor_worker` (#73 follow-up) so the worker keeps the
+``process_job`` pipeline while *progress stamping* lives in one cohesive
+module.
+
+Both functions are best-effort: a storage hiccup never breaks the
+executor pipeline — the queue row result still carries the same audit so
+``#봇-상태`` can recover. The ``..workflow_state`` import happens at call
+time (inside each function) so test seams that monkey-patch
+``workflow_state.load_session`` / ``update_session`` keep working.
+
+This module imports *nothing* from the worker — one-way dependency, no
+cycle.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+from .pr_merge_continuation import (
+    EXTRA_PR_MERGE_AUDIT,
+    EXTRA_PR_MERGE_STAGE,
+    PostPRAction,
+    decide_post_pr_action,
+)
+from .work_order_coding_continuation import stamp_progress_marker
+
+
+def stamp_progress(
+    *,
+    session_id: str,
+    marker: str,
+    detail: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Persist a progress marker on ``session.extra`` — best-effort.
+
+    Uses :func:`agents.job_queue.work_order_coding_continuation.stamp_progress_marker`
+    which is the SSoT for the 5 progress markers (issue_created /
+    coding_dispatch_queued / coding_in_progress / draft_pr_opened /
+    coding_blocked). Storage failure is swallowed so the executor
+    pipeline never breaks on a session cache hiccup — the queue row
+    result still carries the same audit so #봇-상태 can recover.
+    """
+
+    if not session_id:
+        return
+    try:
+        from ..workflow_state import load_session as _load
+        from ..workflow_state import update_session as _update
+        from dataclasses import replace as _replace
+    except Exception:  # noqa: BLE001 - partial install
+        return
+    try:
+        session = _load(session_id)
+    except Exception:  # noqa: BLE001
+        return
+    if session is None:
+        return
+    try:
+        existing_extra = getattr(session, "extra", None) or {}
+        if not isinstance(existing_extra, Mapping):
+            existing_extra = {}
+        new_extra = stamp_progress_marker(
+            session_extra=existing_extra,
+            marker=marker,
+            detail=dict(detail or {}),
+        )
+        updated = _replace(session, extra=dict(new_extra))
+        _update(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def stamp_pr_merge_continuation(
+    *,
+    session_id: str,
+    job_id: str,
+    repo_full_name: Optional[str],
+    pr_number: Optional[int],
+    pr_url: Optional[str],
+    head_sha: Optional[str],
+    base_branch: str,
+    dry_run: bool,
+) -> None:
+    """P1-L — draft PR 직후 work_mode 분기 stage 를 session.extra 에 stamp.
+
+    세션이 없거나 PR 메타가 부족하면 silent skip (caller flow 영향 X).
+    autonomous_merge 분기는 background 머지 루프가 pick, approval_required
+    분기는 background producer 가 approval card 를 올릴 신호.
+    """
+
+    if not session_id or dry_run:
+        return
+    try:
+        from ..workflow_state import load_session as _load
+        from ..workflow_state import update_session as _update
+        from dataclasses import replace as _replace
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        session = _load(session_id)
+    except Exception:  # noqa: BLE001
+        return
+    if session is None:
+        return
+
+    existing_extra = getattr(session, "extra", None) or {}
+    if not isinstance(existing_extra, Mapping):
+        existing_extra = {}
+
+    decision = decide_post_pr_action(
+        session_id=session_id,
+        session_extra=existing_extra,
+        repo_full_name=repo_full_name,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        head_sha=head_sha,
+        base_branch=base_branch,
+        dry_run=dry_run,
+    )
+    if decision.action == PostPRAction.SKIP:
+        return
+
+    merged_extra = dict(existing_extra)
+    for key, value in decision.extra_updates.items():
+        merged_extra[key] = value
+    audit_entry = {
+        "stage": merged_extra.get(EXTRA_PR_MERGE_STAGE),
+        "action": decision.action.value,
+        "reason": decision.reason,
+        "job_id": job_id,
+        "pr_number": pr_number,
+        "pr_url": pr_url,
+        "head_sha": head_sha,
+        "at": datetime.now(tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        ),
+    }
+    existing_audit = list(merged_extra.get(EXTRA_PR_MERGE_AUDIT) or ())
+    existing_audit.append(audit_entry)
+    merged_extra[EXTRA_PR_MERGE_AUDIT] = existing_audit
+
+    try:
+        updated = _replace(session, extra=merged_extra)
+        _update(updated, now=datetime.now(tz=timezone.utc))
+    except Exception:  # noqa: BLE001
+        return
+
+    # Operator-visible 줄. progress marker 도 한 줄 같이 찍어서 #봇-상태
+    # 가 stage 변화를 timeline 위에서 본다.
+    stamp_progress(
+        session_id=session_id,
+        marker="pr_merge_pending",
+        detail={
+            "job_id": job_id,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "work_mode_action": decision.action.value,
+            "reason": decision.reason,
+        },
+    )
+
+
+__all__ = (
+    "stamp_progress",
+    "stamp_pr_merge_continuation",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_reason.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_reason.py
@@ -1,0 +1,185 @@
+"""Reason classification for the coding executor worker.
+
+Pure-data + pure-function home for the ``coding_execute`` reason tokens
+and the small classification helpers (`is_protected_branch`,
+`_tests_passed`, `_short`). Split out of
+:mod:`coding_executor_worker` (#73 follow-up) so the worker keeps the
+``process_job`` pipeline while the *failure / outcome reason* vocabulary
+lives in one cohesive, side-effect-free module.
+
+The worker re-exports every public symbol below, so existing importers
+(``from .coding_executor_worker import REASON_TEST_FAILED`` etc.) keep
+working unchanged. This module imports *nothing* from the worker — one
+way dependency, no cycle.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Mapping
+
+from ..governance.runtime_policy import derive_standard_branch_name
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .coding_executor_worker import CodingExecuteRequest
+
+
+# ---------------------------------------------------------------------------
+# Service / job-type identity
+# ---------------------------------------------------------------------------
+
+
+JOB_TYPE_CODING_EXECUTE: str = "coding_execute"
+SERVICE_ID_CODING_EXECUTOR: str = "eng-coding-executor"
+
+
+# ---------------------------------------------------------------------------
+# Outcome / skip reasons
+# ---------------------------------------------------------------------------
+
+
+# Outcome reasons surfaced via :class:`CodingExecuteOutcome`.
+SKIPPED_DUPLICATE: str = "duplicate_in_flight"
+SKIPPED_CLAIMED: str = "claimed_by_other_worker"
+SKIPPED_VAULT_UNAVAILABLE: str = "worktree_root_unavailable"
+
+REASON_PROTECTED_BRANCH: str = "protected_branch_blocked"
+REASON_BRANCH_POLICY_VIOLATION: str = "branch_policy_violation"
+REASON_FORCE_PUSH_BLOCKED: str = "force_push_blocked"
+REASON_DRY_RUN: str = "dry_run"
+REASON_TEST_FAILED: str = "test_failed"
+REASON_PUSH_FAILED: str = "push_failed"
+REASON_PR_FAILED: str = "draft_pr_failed"
+REASON_EDIT_FAILED: str = "edit_failed"
+REASON_COMMIT_FAILED: str = "commit_failed"
+REASON_NOT_IMPLEMENTED: str = "executor_not_wired_yet"
+REASON_INVALID_REQUEST: str = "invalid_request"
+# P1-B — worktree / target repo specific failures (generic subprocess
+# exit 255 대신 operator 가 즉시 이해 가능한 token 으로 분기).
+REASON_TARGET_REPO_MISSING: str = "target_repo_checkout_missing"
+REASON_WORKTREE_FAILED: str = "worktree_provision_failed"
+# P1-G — repo 가 detectable stack 이 하나도 없어 ``test_failed`` 가
+# 의미 없음. record-only editor + greenfield 조합 이면 sub-reason 에
+# editor capability 정보까지 포함 (e.g.
+# ``bootstrap_required:empty_or_greenfield_repo+editor_record_only_insufficient``).
+REASON_BOOTSTRAP_REQUIRED: str = "bootstrap_required"
+# P1-M F — non-greenfield + record-only editor + ``YULE_CODING_EXECUTOR_
+# PLANNING_ONLY_PR_FORBIDDEN=1`` 일 때. planning-only PR 가 production 까지
+# 반복되는 회귀를 차단하기 위한 honest blocker.
+REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE: str = (
+    "non_greenfield_real_edit_unavailable"
+)
+
+
+# ---------------------------------------------------------------------------
+# Branch protection classification
+# ---------------------------------------------------------------------------
+
+
+_PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
+    {"main", "master", "develop", "dev", "prod", "release"}
+)
+
+
+def is_protected_branch(name: str) -> bool:
+    """Return True for canonically protected branches.
+
+    Mirrors the more conservative subset of
+    :func:`agents.github_workos.branching.is_protected_branch` — the
+    full check includes regex-shaped runtime-managed branches and is
+    deferred to that module when the executor wires through G3.
+    """
+
+    if not name:
+        return True
+    candidate = str(name).strip().lower()
+    if candidate in _PROTECTED_BRANCH_NAMES:
+        return True
+    if candidate.startswith("release/") or candidate.startswith("hotfix/"):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test-result + error classification
+# ---------------------------------------------------------------------------
+
+
+def _tests_passed(summary: Mapping[str, Any]) -> bool:
+    if not isinstance(summary, Mapping):
+        return False
+    if summary.get("dry_run"):
+        return True
+    status = str(summary.get("status") or "").lower()
+    if status in {"ok", "passed", "success"}:
+        return True
+    if status in {"failed", "fail", "error"}:
+        return False
+    # Unknown status — fall back to failures count if present.
+    if "failures" in summary:
+        return summary.get("failures") in (0, "0", "")
+    if "failed" in summary:
+        return summary.get("failed") in (0, "0", "")
+    return False
+
+
+def _short(exc: BaseException) -> str:
+    text = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+    return f"{type(exc).__name__}: {text}"[:200]
+
+
+def suggest_branch(request: "CodingExecuteRequest") -> str:
+    """Return a branch name when caller didn't pass a hint.
+
+    Default convention: ``agent/<role>/issue-<n>-coding-execute`` —
+    기존 G3 호환. issue 가 있으면 추가로 :func:`derive_standard_branch_name`
+    의 표준 prefix (`feat/`) 로 안전 fallback 도 제공 (request 의
+    metadata['use_standard_prefix'] 가 True 일 때).
+    """
+
+    metadata = request.metadata or {}
+    use_standard = False
+    if isinstance(metadata, Mapping):
+        use_standard = bool(metadata.get("use_standard_prefix"))
+
+    if use_standard and request.issue_number is not None:
+        short = (
+            request.executor_role.split("-", 1)[0]
+            if request.executor_role
+            else "work"
+        )
+        return derive_standard_branch_name(
+            kind="feat",
+            short_purpose=short,
+            issue_number=int(request.issue_number),
+        )
+    if request.issue_number is not None:
+        return f"agent/{request.executor_role}/issue-{int(request.issue_number)}-coding-execute"
+    ts = int((time.time())) % 10_000
+    return f"agent/{request.executor_role}/coding-execute-{ts}"
+
+
+__all__ = (
+    "JOB_TYPE_CODING_EXECUTE",
+    "SERVICE_ID_CODING_EXECUTOR",
+    "SKIPPED_DUPLICATE",
+    "SKIPPED_CLAIMED",
+    "SKIPPED_VAULT_UNAVAILABLE",
+    "REASON_PROTECTED_BRANCH",
+    "REASON_BRANCH_POLICY_VIOLATION",
+    "REASON_FORCE_PUSH_BLOCKED",
+    "REASON_DRY_RUN",
+    "REASON_TEST_FAILED",
+    "REASON_PUSH_FAILED",
+    "REASON_PR_FAILED",
+    "REASON_EDIT_FAILED",
+    "REASON_COMMIT_FAILED",
+    "REASON_NOT_IMPLEMENTED",
+    "REASON_INVALID_REQUEST",
+    "REASON_TARGET_REPO_MISSING",
+    "REASON_WORKTREE_FAILED",
+    "REASON_BOOTSTRAP_REQUIRED",
+    "REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE",
+    "is_protected_branch",
+    "suggest_branch",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_worker.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/job_queue/coding_executor_worker.py
@@ -30,104 +30,41 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import (
     Any,
-    Awaitable,
-    Callable,
     Mapping,
     Optional,
     Protocol,
-    Sequence,
     Tuple,
 )
 
-from ..governance.runtime_policy import (
-    BranchPolicyResult,
-    derive_standard_branch_name,
-    validate_branch_name,
-)
+from ..governance.runtime_policy import validate_branch_name
 from .heartbeat import HeartbeatStore
 from .state_machine import JobState
 from .store import Job, JobQueue
-from .pr_merge_continuation import (
-    EXTRA_PR_MERGE_AUDIT,
-    EXTRA_PR_MERGE_STAGE,
-    PostPRAction,
-    decide_post_pr_action,
-)
 from .work_order_coding_continuation import (
     PROGRESS_CODING_BLOCKED,
     PROGRESS_CODING_IN_PROGRESS,
     PROGRESS_DRAFT_PR_OPENED,
-    stamp_progress_marker,
 )
 
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-
-JOB_TYPE_CODING_EXECUTE: str = "coding_execute"
-SERVICE_ID_CODING_EXECUTOR: str = "eng-coding-executor"
-
-
-# Outcome reasons surfaced via :class:`CodingExecuteOutcome`.
-SKIPPED_DUPLICATE: str = "duplicate_in_flight"
-SKIPPED_CLAIMED: str = "claimed_by_other_worker"
-SKIPPED_VAULT_UNAVAILABLE: str = "worktree_root_unavailable"
-
-REASON_PROTECTED_BRANCH: str = "protected_branch_blocked"
-REASON_BRANCH_POLICY_VIOLATION: str = "branch_policy_violation"
-REASON_FORCE_PUSH_BLOCKED: str = "force_push_blocked"
-REASON_DRY_RUN: str = "dry_run"
-REASON_TEST_FAILED: str = "test_failed"
-REASON_PUSH_FAILED: str = "push_failed"
-REASON_PR_FAILED: str = "draft_pr_failed"
-REASON_EDIT_FAILED: str = "edit_failed"
-REASON_COMMIT_FAILED: str = "commit_failed"
-REASON_NOT_IMPLEMENTED: str = "executor_not_wired_yet"
-REASON_INVALID_REQUEST: str = "invalid_request"
-# P1-B — worktree / target repo specific failures (generic subprocess
-# exit 255 대신 operator 가 즉시 이해 가능한 token 으로 분기).
-REASON_TARGET_REPO_MISSING: str = "target_repo_checkout_missing"
-REASON_WORKTREE_FAILED: str = "worktree_provision_failed"
-# P1-G — repo 가 detectable stack 이 하나도 없어 ``test_failed`` 가
-# 의미 없음. record-only editor + greenfield 조합 이면 sub-reason 에
-# editor capability 정보까지 포함 (e.g.
-# ``bootstrap_required:empty_or_greenfield_repo+editor_record_only_insufficient``).
-REASON_BOOTSTRAP_REQUIRED: str = "bootstrap_required"
-# P1-M F — non-greenfield + record-only editor + ``YULE_CODING_EXECUTOR_
-# PLANNING_ONLY_PR_FORBIDDEN=1`` 일 때. planning-only PR 가 production 까지
-# 반복되는 회귀를 차단하기 위한 honest blocker.
-REASON_NON_GREENFIELD_REAL_EDIT_UNAVAILABLE: str = (
-    "non_greenfield_real_edit_unavailable"
+# Reason classification (constants + branch/test/error classifiers) and
+# progress stamping were split into sibling modules (#73 follow-up).
+# ``import *`` re-exports the reason module's public ``__all__`` so existing
+# importers (``from .coding_executor_worker import REASON_TEST_FAILED`` etc.)
+# keep working unchanged; the private helpers used internally are imported
+# explicitly below.
+from .coding_executor_reason import *  # noqa: F401,F403
+from .coding_executor_reason import (
+    _PROTECTED_BRANCH_NAMES,
+    _short,
+    _tests_passed,
+    suggest_branch as _suggest_branch_fn,
 )
-
-
-_PROTECTED_BRANCH_NAMES: frozenset[str] = frozenset(
-    {"main", "master", "develop", "dev", "prod", "release"}
+from .coding_executor_progress import (
+    stamp_pr_merge_continuation as _stamp_pr_merge_continuation_fn,
+    stamp_progress as _stamp_progress_fn,
 )
-
-
-def is_protected_branch(name: str) -> bool:
-    """Return True for canonically protected branches.
-
-    Mirrors the more conservative subset of
-    :func:`agents.github_workos.branching.is_protected_branch` — the
-    full check includes regex-shaped runtime-managed branches and is
-    deferred to that module when the executor wires through G3.
-    """
-
-    if not name:
-        return True
-    candidate = str(name).strip().lower()
-    if candidate in _PROTECTED_BRANCH_NAMES:
-        return True
-    if candidate.startswith("release/") or candidate.startswith("hotfix/"):
-        return True
-    return False
 
 
 # ---------------------------------------------------------------------------
@@ -909,34 +846,9 @@ class CodingExecutorWorker:
     # ------------------------------------------------------------------
 
     def _suggest_branch(self, request: CodingExecuteRequest) -> str:
-        """Return a branch name when caller didn't pass a hint.
+        """Thin delegator — see :func:`coding_executor_reason.suggest_branch`."""
 
-        Default convention: ``agent/<role>/issue-<n>-coding-execute`` —
-        기존 G3 호환. issue 가 있으면 추가로 :func:`derive_standard_branch_name`
-        의 표준 prefix (`feat/`) 로 안전 fallback 도 제공 (request 의
-        metadata['use_standard_prefix'] 가 True 일 때).
-        """
-
-        metadata = request.metadata or {}
-        use_standard = False
-        if isinstance(metadata, Mapping):
-            use_standard = bool(metadata.get("use_standard_prefix"))
-
-        if use_standard and request.issue_number is not None:
-            short = (
-                request.executor_role.split("-", 1)[0]
-                if request.executor_role
-                else "work"
-            )
-            return derive_standard_branch_name(
-                kind="feat",
-                short_purpose=short,
-                issue_number=int(request.issue_number),
-            )
-        if request.issue_number is not None:
-            return f"agent/{request.executor_role}/issue-{int(request.issue_number)}-coding-execute"
-        ts = int((time.time())) % 10_000
-        return f"agent/{request.executor_role}/coding-execute-{ts}"
+        return _suggest_branch_fn(request)
 
     def _stamp_progress(
         self,
@@ -945,43 +857,11 @@ class CodingExecutorWorker:
         marker: str,
         detail: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        """Persist a progress marker on ``session.extra`` — best-effort.
+        """Thin delegator — see :func:`coding_executor_progress.stamp_progress`."""
 
-        Uses :func:`agents.job_queue.work_order_coding_continuation.stamp_progress_marker`
-        which is the SSoT for the 5 progress markers (issue_created /
-        coding_dispatch_queued / coding_in_progress / draft_pr_opened /
-        coding_blocked). Storage failure is swallowed so the executor
-        pipeline never breaks on a session cache hiccup — the queue row
-        result still carries the same audit so #봇-상태 can recover.
-        """
-
-        if not session_id:
-            return
-        try:
-            from ..workflow_state import load_session as _load
-            from ..workflow_state import update_session as _update
-            from dataclasses import replace as _replace
-        except Exception:  # noqa: BLE001 - partial install
-            return
-        try:
-            session = _load(session_id)
-        except Exception:  # noqa: BLE001
-            return
-        if session is None:
-            return
-        try:
-            existing_extra = getattr(session, "extra", None) or {}
-            if not isinstance(existing_extra, Mapping):
-                existing_extra = {}
-            new_extra = stamp_progress_marker(
-                session_extra=existing_extra,
-                marker=marker,
-                detail=dict(detail or {}),
-            )
-            updated = _replace(session, extra=dict(new_extra))
-            _update(updated, now=datetime.now(tz=timezone.utc))
-        except Exception:  # noqa: BLE001
-            pass
+        _stamp_progress_fn(
+            session_id=session_id, marker=marker, detail=detail
+        )
 
     def _stamp_pr_merge_continuation(
         self,
@@ -995,82 +875,18 @@ class CodingExecutorWorker:
         base_branch: str,
         dry_run: bool,
     ) -> None:
-        """P1-L — draft PR 직후 work_mode 분기 stage 를 session.extra 에 stamp.
+        """Thin delegator — see
+        :func:`coding_executor_progress.stamp_pr_merge_continuation`."""
 
-        세션이 없거나 PR 메타가 부족하면 silent skip (caller flow 영향 X).
-        autonomous_merge 분기는 background 머지 루프가 pick, approval_required
-        분기는 background producer 가 approval card 를 올릴 신호.
-        """
-
-        if not session_id or dry_run:
-            return
-        try:
-            from ..workflow_state import load_session as _load
-            from ..workflow_state import update_session as _update
-            from dataclasses import replace as _replace
-        except Exception:  # noqa: BLE001
-            return
-        try:
-            session = _load(session_id)
-        except Exception:  # noqa: BLE001
-            return
-        if session is None:
-            return
-
-        existing_extra = getattr(session, "extra", None) or {}
-        if not isinstance(existing_extra, Mapping):
-            existing_extra = {}
-
-        decision = decide_post_pr_action(
+        _stamp_pr_merge_continuation_fn(
             session_id=session_id,
-            session_extra=existing_extra,
+            job_id=job_id,
             repo_full_name=repo_full_name,
             pr_number=pr_number,
             pr_url=pr_url,
             head_sha=head_sha,
             base_branch=base_branch,
             dry_run=dry_run,
-        )
-        if decision.action == PostPRAction.SKIP:
-            return
-
-        merged_extra = dict(existing_extra)
-        for key, value in decision.extra_updates.items():
-            merged_extra[key] = value
-        audit_entry = {
-            "stage": merged_extra.get(EXTRA_PR_MERGE_STAGE),
-            "action": decision.action.value,
-            "reason": decision.reason,
-            "job_id": job_id,
-            "pr_number": pr_number,
-            "pr_url": pr_url,
-            "head_sha": head_sha,
-            "at": datetime.now(tz=timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%S+00:00"
-            ),
-        }
-        existing_audit = list(merged_extra.get(EXTRA_PR_MERGE_AUDIT) or ())
-        existing_audit.append(audit_entry)
-        merged_extra[EXTRA_PR_MERGE_AUDIT] = existing_audit
-
-        try:
-            updated = _replace(session, extra=merged_extra)
-            _update(updated, now=datetime.now(tz=timezone.utc))
-        except Exception:  # noqa: BLE001
-            return
-
-        # Operator-visible 줄. progress marker 도 한 줄 같이 찍어서 #봇-상태
-        # 가 stage 변화를 timeline 위에서 본다.
-        self._stamp_progress(
-            session_id=session_id,
-            marker="pr_merge_pending",
-            detail={
-                "job_id": job_id,
-                "pr_number": pr_number,
-                "pr_url": pr_url,
-                "work_mode_action": decision.action.value,
-                "reason": decision.reason,
-            },
         )
 
     def _fail(
@@ -1137,29 +953,6 @@ class CodingExecutorWorker:
             pr_url=pr_url,
             test_summary=test_summary,
         )
-
-
-def _tests_passed(summary: Mapping[str, Any]) -> bool:
-    if not isinstance(summary, Mapping):
-        return False
-    if summary.get("dry_run"):
-        return True
-    status = str(summary.get("status") or "").lower()
-    if status in {"ok", "passed", "success"}:
-        return True
-    if status in {"failed", "fail", "error"}:
-        return False
-    # Unknown status — fall back to failures count if present.
-    if "failures" in summary:
-        return summary.get("failures") in (0, "0", "")
-    if "failed" in summary:
-        return summary.get("failed") in (0, "0", "")
-    return False
-
-
-def _short(exc: BaseException) -> str:
-    text = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
-    return f"{type(exc).__name__}: {text}"[:200]
 
 
 __all__ = (


### PR DESCRIPTION
## 📌 관련 이슈
초대형 파일 책임분리(#217 후속). 요청 기반.

## ✨ 과제 내용
`job_queue/coding_executor_worker.py`(1194)를 선언 축으로 분리:
- `coding_executor_reason.py`(184): REASON_*/SKIPPED_* 상수 + is_protected_branch/_tests_passed/suggest_branch 등 reason 분류.
- `coding_executor_progress.py`(170): stamp_progress/stamp_pr_merge_continuation.
- worker(**987**): process_job 7-step 파이프라인 잔류, _stamp_*/_suggest_branch 는 thin delegator.

### 리스크
- 순수 이동, 동작 불변. 두 sibling→worker 미import(reason 의 CodingExecuteRequest 는 TYPE_CHECKING). worker re-export → import-time 순환 없음. 외부 importer 무변경.

### 테스트
- `unittest discover` → **Ran 5461, OK** (main 병합 후, code_audit 충돌 해소).

<details><summary>audit block</summary>

- worker 1194→987, reason 184/progress 170(<1000). SPLIT_NOW_PENDING 제거. 커밋 3개+병합.
</details>

## :camera_with_flash: 스크린샷(선택)
해당 없음.