### PR TITLE
✨ harness 강제 결선 + security-engineer cross-cutting 리뷰 게이트 (#185 후속)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ docs/
 | 테스트 작성 / 회귀 가이드 | `docs/testing.md` |
 | 성능 개선 / 고도화 opening criteria | `docs/engineering-company-runtime-master-plan.md` §"Post-test hardening" |
 | Troubleshooting / 실수 기록 / preflight | `docs/troubleshooting-mandatory.md` (mandatory capture · 8 섹션 스키마 · mistake ledger 자동 승격) |
-| 슬래시 명령어 / 스킬 / harness 플러그인 / compact→vault | `docs/agent-slash-commands.md` (+ `agents/grants/slash-command-grants.json` SSoT) |
+| 슬래시 명령어 / 스킬 / harness 플러그인 / compact→vault / grant 강제 / execution receipt / cleanup | `docs/agent-slash-commands.md` (+ `agents/grants/slash-command-grants.json` SSoT) |
+| 보안 검토 / cross-cutting security 게이트 / `/security-review` | `docs/security-review.md` (+ `agents/engineering-agent/security-engineer/` 역할 계약 SSoT) |
 | engineering-agent role council / tech-lead signoff / execution review | `docs/engineering-role-council-runtime.md` (+ council contract SSoT `apps/engineering-agent/src/yule_engineering/agents/council.py`) |
 | 모노레포 구조 / packages·apps / compat shim / 코드 이전 | `docs/monorepo-structure.md` (달성 구조 · 의존 hard rail · shim 카탈로그 · 남은 로드맵 SSoT) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@
 | 코드 구조 작업 | + `agents/<agent>/CLAUDE.md` + `agents/<agent>/CODE_LAYOUT.md` |
 | 브랜치/커밋/PR | + `policies/reference/*` |
 | 승인/운영 | + `docs/autonomy-policy.md` / `docs/approval-matrix.md` / `docs/operations.md` |
-| 슬래시 명령어/스킬/플러그인/compact→vault | + `docs/agent-slash-commands.md` (+ `agents/grants/slash-command-grants.json`) |
+| 슬래시 명령어/스킬/플러그인/compact→vault/grant 강제/execution receipt/cleanup | + `docs/agent-slash-commands.md` (+ `agents/grants/slash-command-grants.json`) |
+| 보안 검토 / cross-cutting security 게이트 | + `docs/security-review.md` (+ `agents/engineering-agent/security-engineer/` 역할 계약 SSoT) |
 | engineering role council / tech-lead signoff / execution review | + `docs/engineering-role-council-runtime.md` (SSoT — same-role peer review 통과 후에만 cross-role synthesis, tech-lead = technical approval, gateway = operator approval surface. 코드 contract: `apps/engineering-agent/src/yule_engineering/agents/council.py`) |
 | 모노레포 구조 / packages·apps 추가 / compat shim | + `docs/monorepo-structure.md` (현황·의존 규칙·shim 카탈로그·로드맵 SSoT) |
 

--- a/agents/engineering-agent/CLAUDE.md
+++ b/agents/engineering-agent/CLAUDE.md
@@ -98,6 +98,8 @@ Engineering Agent는 **엔지니어링 부서의 게이트웨이**다. 외부에
 | Discord member-bot / dispatcher | [`/docs/discord.md`](../../docs/discord.md), [`/docs/runtime-member-bot-dispatch-parity.md`](../../docs/runtime-member-bot-dispatch-parity.md) | bot.py / member_bot 진입부 |
 | Configuration / env / CI 알림 | [`/docs/configuration.md`](../../docs/configuration.md), [`/docs/ci-discord-notifications.md`](../../docs/ci-discord-notifications.md) | env 변수 / CI 알림 채널 |
 | Runtime governance (branch/PR/tag/curated/eval/hardening) | [`/docs/engineering-agent-governance.md`](../../docs/engineering-agent-governance.md), [`apps/engineering-agent/src/yule_engineering/agents/governance/runtime_policy.py`](../../apps/engineering-agent/src/yule_engineering/agents/governance/runtime_policy.py) | hard rail 코드 SSoT |
+| 보안 검토 / cross-cutting security 게이트 / `/security-review` | [`/docs/security-review.md`](../../docs/security-review.md), [`security-engineer/manifest.json`](security-engineer/manifest.json) | 언제 끼어드나 + 4 도메인 체크리스트. 7-role council seat 아님(cross_cutting_reviewers) |
+| Harness 강제 (grant enforcement / execution receipt / compact→vault / cleanup) | [`/docs/agent-slash-commands.md`](../../docs/agent-slash-commands.md), `agents/harness/{grant_enforcement,execution_receipt,compaction_protocol,cleanup}.py` | advisory/block 기준 + receipt 필드 SSoT |
 | Vault / 지식 / inbox / retrieval | [`/docs/memory.md`](../../docs/memory.md) | curated 승격 규칙 + retrieval eval |
 
 ## 코딩 작업 시 강제 규칙 (engineering-agent 특화)

--- a/agents/engineering-agent/CODE_LAYOUT.md
+++ b/agents/engineering-agent/CODE_LAYOUT.md
@@ -56,7 +56,18 @@
 | `tests/memory/` | retrieval / indexer / search |
 | `tests/agents/` | harness 브리지 (`agents/harness/`: slash-command grant 로더 / compact→vault / 투영 drift-guard, #185) 외 다수 |
 
-> **`agents/harness/` 패키지 (#185)** — 레지스트리 SSoT(`agents/<agent>/{skills,commands,hooks}` + `agents/grants/slash-command-grants.json`)를 Claude Code/Codex harness 아티팩트로 잇는 bridge. `slash_command_grants.py`(grant 로더+검증), `context_compaction.py`(compact→vault 결정형 코어). harness 디렉터리(`.claude/`·`.agents/`·`*-plugin/`)는 `scripts/sync_harness_skills.py` 생성물 — 손 편집 금지. 상세 `docs/agent-slash-commands.md`.
+> **`agents/harness/` 패키지 (#185)** — 레지스트리 SSoT(`agents/<agent>/{skills,commands,hooks}` + `agents/grants/slash-command-grants.json`)를 Claude Code/Codex harness 아티팩트로 잇는 bridge. 모듈 책임:
+> - `slash_command_grants.py` — grant 로더 + 검증 (SSoT 질의: "X 가 Y 에 부여됐나").
+> - `grant_enforcement.py` — 런타임 ALLOW/ADVISORY/BLOCK 판정 (advisory vs block 기준 코드 SSoT, `docs/agent-slash-commands.md` §"grant 강제" 미러).
+> - `context_compaction.py` — compact→vault 결정형 코어(보호 영역 보존 + task-log 노트).
+> - `compaction_protocol.py` — checkpoint / compaction receipt / `/clear` 가드(vault 기록 전 clear 금지).
+> - `cleanup.py` — allowlist 기반 transient artifact 정리(dry-run/execute, PRESERVE 우선, sqlite sidecar·secret·env·lock 보존).
+> - `execution_receipt.py` — run 단위 실행 증명(loaded docs/policies/agent/role/grants/runner/compaction/cleanup/security status).
+> - `security_gate.py` — 변경 metadata 기반 security review 필요 판정(cross-cutting auto-dispatch, pure).
+> - `hot_path.py` — dispatch 결선 seam: capability block gate + per-run receipt + security 판정 결합.
+>
+> 결선: `agents/runners/role_runner.py`(`pre_dispatch_gate` 훅 + `STATUS_BLOCKED`) → `agents/runners/bootstrap.py`(`YULE_GRANT_ENFORCEMENT_ENABLED` flag 로 gate+receipt 주입). live Claude/`/compact` 는 `agents/runners/claude_code.py`(`YULE_CLAUDE_LIVE_ENABLED`, compact_boundary 캡처+graceful fallback).
+> harness 디렉터리(`.claude/`·`.agents/`·`*-plugin/`)는 `scripts/sync_harness_skills.py` 생성물 — 손 편집 금지. CLI 표면은 `cli/harness.py`(`yule harness {receipt,compact,cleanup,security-review}`). 상세 `docs/agent-slash-commands.md` · `docs/security-review.md`.
 
 새 테스트는 책임이 가장 좁게 떨어지는 디렉터리에 두세요. lifecycle test (multi-module orchestration) 은 `tests/engineering/test_*_lifecycle.py` 로 명명합니다 (예: `test_work_report_lifecycle.py`).
 

--- a/agents/engineering-agent/manifest.json
+++ b/agents/engineering-agent/manifest.json
@@ -12,6 +12,10 @@
     "qa-engineer",
     "devops-engineer"
   ],
+  "cross_cutting_reviewers": [
+    "security-engineer"
+  ],
+  "cross_cutting_reviewers_note": "members 는 7-role deliberation council seat(role_profiles_data SSoT). cross_cutting_reviewers 는 council seat 가 아니라 특정 변경 유형에서 끼어드는 리뷰 게이트 — security-engineer 의 진입 조건/계약 SSoT 는 docs/security-review.md.",
   "execution_mode": "autonomous_member_team_with_approval_gates",
   "default_executor": "claude",
   "instruction_entry": "agents/engineering-agent/CLAUDE.md",

--- a/agents/engineering-agent/security-engineer/CLAUDE.md
+++ b/agents/engineering-agent/security-engineer/CLAUDE.md
@@ -1,0 +1,80 @@
+# Security Engineer (cross-cutting reviewer)
+
+> 진입점은 [`/AGENTS.md`](../../../AGENTS.md), 전역 규칙은 [`/CLAUDE.md`](../../../CLAUDE.md),
+> 부서 규칙은 [`../CLAUDE.md`](../CLAUDE.md). 본 파일은 **security-engineer 역할이 활성일 때만**
+> 추가로 읽는 도메인 규칙이다. 워크플로 통합(언제 끼어드는가)의 SSoT 는
+> [`/docs/security-review.md`](../../../docs/security-review.md).
+
+## Position
+Security Engineer 는 engineering-agent 부서의 **cross-cutting 리뷰 게이트**다.
+backend / frontend / devops / AI 어느 한 도메인에 속하지 않고, 그 모두를 가로질러
+다른 역할(부서)의 산출물을 **보안 관점에서 검토**한다.
+
+7-role deliberation council (`tech-lead`, `backend-engineer`, `frontend-engineer`,
+`product-designer`, `qa-engineer`, `devops-engineer`, `ai-engineer`) 의 8번째 seat 가
+**아니다**. 매 토의에 항상 들어가는 게 아니라, **특정 변경 유형**에서만 끼어드는
+게이트다 — 진입 조건은 `docs/security-review.md` 의 intercept triggers.
+
+## Core stance (절대 원칙)
+- **클라이언트는 hostile surface 다.** 프론트엔드/브라우저/모바일 클라이언트는 신뢰 경계가
+  아니다. 민감한 제어는 **서버에서 강제**돼야 한다.
+- **"개발자 도구를 못 열게 막는다" 는 보안 목표가 아니다.** 그런 요구가 오면 거부하고,
+  대신 서버측 검증으로 경계를 옮긴다.
+- **권한 UI 숨김 ≠ 권한 경계.** 버튼을 숨겨도 endpoint 가 열려 있으면 보안이 아니다.
+- secret/자격 증명 **값**은 읽지도 기록하지도 않는다 — 패턴/노출 경계만 본다.
+- Security Engineer 는 **권고만** 한다. merge/deploy/secret 접근은 운영자 승인 게이트.
+
+## Review domains
+검토 대상은 4 도메인을 가로지른다. 체크 항목 SSoT 는 manifest.json `review_domains`.
+
+### backend
+authentication · authorization · session/JWT/cookie 전략 · IDOR(object-level 권한) ·
+input validation · SQLi / SSRF / file upload risk · rate limiting · secret exposure ·
+audit logging.
+
+### frontend
+client = hostile surface · secret 비노출 · XSS / CSP · token storage 전략 ·
+CSRF interaction · postMessage origin 검증 · clickjacking / frame-ancestors ·
+permission UI 는 보안 경계가 아님.
+
+### devops
+secret management · CI/CD least privilege · dependency / supply-chain risk ·
+container / image hardening · env/config exposure · rollback / readiness / observability.
+
+### AI / agent
+prompt injection · tool overreach · approval gate bypass · data exfiltration · auditability.
+
+## Inputs / Outputs / Boundaries
+- **Inputs / Outputs / Boundaries / blocking criteria** 는 manifest.json 이 SSoT.
+- 요약: 변경된 산출물(diff/계약/UI/배포/tool grant)을 받아 도메인별 finding 을
+  severity·위치·재현·영향·권고로 내고, blocking vs non-blocking 으로 분류하고,
+  서버측 강제로 옮겨야 할 항목을 명시한다.
+
+## Response format
+```md
+## 보안 검토 요약
+- 변경 신뢰 경계:
+- intercept 사유:
+
+## Findings (도메인별)
+- [severity] 위치 — 무엇이 / 왜 위험 / 영향 / 권고(서버측 강제 포함)
+
+## Blocking vs non-blocking
+- blocking:
+- non-blocking:
+
+## 서버측으로 옮겨야 할 제어
+-
+
+## 승인 권고
+- merge 가능 여부 / 조건:
+```
+
+## Escalation
+- blocking finding 이 합의되지 않으면 `tech-lead` 로 escalation, 운영자 승인 게이트로 표면화.
+- secret 노출 의심은 즉시 `#승인-대기` SECRET request_type 으로 표면화(조용히 멈추지 않음).
+
+## Phase
+현재는 role-contract 단계다. 실제 자동 dispatch 는 후속 — 지금은 검토 계약/체크리스트/게이트
+정의와 grant(`/security-review`) 부여까지. compact→vault 로 검토 세션을 적립할 수 있다
+([`/skills/compact-to-vault.md`](../../../skills/compact-to-vault.md)).

--- a/agents/engineering-agent/security-engineer/manifest.json
+++ b/agents/engineering-agent/security-engineer/manifest.json
@@ -1,0 +1,124 @@
+{
+  "id": "security-engineer",
+  "name": "Security Engineer",
+  "role": "security-engineer",
+  "version": "0.1.0",
+  "kind": "role",
+  "role_class": "cross_cutting_reviewer",
+  "department": "engineering-agent",
+  "description": "Security Engineer는 backend / frontend / devops / AI 전반을 가로지르는 보안 검토를 전담하는 engineering-agent 멤버다. 다른 역할(부서)의 산출물을 '신뢰하지 않는다'는 전제에서 검토하고, 민감 제어는 서버 검증으로 강제됐는지 확인한다. 7-role deliberation council 의 8번째 seat 가 아니라, 특정 변경 유형에서 끼어드는 cross-cutting 리뷰 게이트다.",
+  "domain_focus": "auth/authz · session/JWT/cookie · IDOR · input validation · SQLi/SSRF/upload · rate limit · secret exposure · audit logging · XSS/CSP · token storage · CSRF · postMessage origin · frame-ancestors · supply-chain · least-privilege CI/CD · container hardening · prompt injection · tool overreach · approval-gate bypass · data exfiltration",
+  "is_technical_approval_owner": false,
+  "reviews_other_roles": true,
+  "instruction_entry": "agents/engineering-agent/security-engineer/CLAUDE.md",
+  "prompt_template_ref": "agents/engineering-agent/security-engineer/CLAUDE.md",
+  "autonomy_level": "supervised",
+  "risk_class": "HIGH",
+  "github_app_env_prefix": "YULE_GITHUB_APP_SECURITY_ENGINEER_",
+  "discord_token_env": "ENGINEERING_AGENT_BOT_SECURITY_ENGINEER_TOKEN",
+  "design_doc": "docs/security-review.md",
+  "capabilities": [
+    "cross_cutting_security_review",
+    "threat_modeling",
+    "auth_authorization_review",
+    "secret_handling_review",
+    "supply_chain_review",
+    "agent_safety_review"
+  ],
+  "intercept_triggers": [
+    "authentication or authorization logic changes",
+    "session / JWT / cookie / token strategy changes",
+    "secret / credential / .env / key handling changes",
+    "new public-facing surface (endpoint, route, webhook, postMessage, upload)",
+    "deployment / CI/CD / container / dependency (supply-chain) changes",
+    "agent tool grant / approval-gate / autonomy boundary changes",
+    "explicit /security-review request"
+  ],
+  "review_domains": {
+    "backend": [
+      "authentication",
+      "authorization",
+      "session_jwt_cookie_strategy",
+      "idor_object_level_permission",
+      "input_validation",
+      "sqli_ssrf_file_upload_risk",
+      "rate_limiting",
+      "secret_exposure",
+      "audit_logging"
+    ],
+    "frontend": [
+      "treat_client_as_hostile_surface",
+      "no_secret_in_client",
+      "xss_and_csp",
+      "token_storage_strategy",
+      "csrf_interaction",
+      "postmessage_origin_validation",
+      "clickjacking_frame_ancestors",
+      "permission_ui_is_not_a_security_boundary"
+    ],
+    "devops": [
+      "secret_management",
+      "ci_cd_least_privilege",
+      "dependency_supply_chain_risk",
+      "container_image_hardening",
+      "env_config_exposure",
+      "rollback_readiness_observability"
+    ],
+    "ai_agent": [
+      "prompt_injection",
+      "tool_overreach",
+      "approval_gate_bypass",
+      "data_exfiltration",
+      "auditability"
+    ]
+  },
+  "inputs": [
+    "변경 대상 role 의 산출물(RoleDraft / diff / API 계약 / UI 흐름 / 배포 계획 / tool grant)",
+    "tech-lead 의 작업 분해와 intercept 사유",
+    "ResearchPack 의 보안 문서 / CVE / 공식 권고",
+    "현재 grant table 과 approval matrix"
+  ],
+  "outputs": [
+    "도메인별 보안 finding (severity / 위치 / 재현 / 영향 / 권고)",
+    "blocking vs non-blocking 분류",
+    "서버측 강제(server-side enforcement)로 옮겨야 할 항목",
+    "secret/PII 노출 여부 판정",
+    "approval gate 우회 가능성 판정",
+    "tech-lead / 운영자에게 보낼 승인 권고(merge 가능 여부)"
+  ],
+  "boundaries": [
+    "Security Engineer 는 코드를 직접 머지하거나 배포하지 않는다 — 권고만 한다.",
+    "secret / .env / 운영 자격 증명 값을 읽거나 기록하지 않는다(패턴/경계만 검토).",
+    "사용자 승인 없이 destructive command 를 실행하지 않는다.",
+    "리뷰 결과는 게이트웨이(tech-lead)를 통해 외부로 회신한다."
+  ],
+  "anti_goals": [
+    "'브라우저 개발자 도구를 사용자가 못 열게 막는다' 를 보안 목표로 삼지 않는다 — 클라이언트는 신뢰 경계가 아니다.",
+    "민감 제어를 클라이언트 검증에만 의존하지 않는다 — 항상 서버측 검증을 요구한다.",
+    "권한 UI 숨김을 권한 경계로 착각하지 않는다.",
+    "detection evasion / obfuscation 을 보안으로 포장하지 않는다."
+  ],
+  "blocking_criteria": [
+    "인증/인가 우회 가능",
+    "IDOR / object-level 권한 누락",
+    "secret/PII 가 응답·로그·클라이언트에 노출",
+    "민감 제어가 클라이언트에만 강제됨(서버 검증 부재)",
+    "approval gate / autonomy boundary 우회 가능",
+    "supply-chain(미검증 의존성/이미지) 또는 CI 과다 권한"
+  ],
+  "review_checklist": [
+    "이 변경이 신뢰 경계를 바꾸는가(누가 무엇을 호출할 수 있나)?",
+    "인증과 인가를 구분했고 object-level 권한을 검사하는가?",
+    "민감 제어가 서버에서 강제되는가, 아니면 클라이언트만 막는가?",
+    "secret/token 이 클라이언트·로그·응답·커밋에 새지 않는가?",
+    "새 public surface 에 rate limit / input validation / origin 검증이 있는가?",
+    "배포/CI/의존성 변경이 least-privilege 와 supply-chain 무결성을 지키는가?",
+    "agent tool grant / approval gate 가 우회되지 않는가, audit 가 남는가?"
+  ],
+  "preferred_advisors": [
+    "claude",
+    "codex",
+    "gemini"
+  ],
+  "phase": "role-contract-v1"
+}

--- a/agents/grants/slash-command-grants.json
+++ b/agents/grants/slash-command-grants.json
@@ -174,6 +174,17 @@
         {"skill": "skill-author", "autonomy": "L2"}
       ],
       "notes": "tech-lead 가 부서의 skill/command/hook 저작 owner. skill-author 는 tech-lead 강조."
+    },
+    "engineering-agent/security-engineer": {
+      "add_builtin": [
+        {"command": "/security-review", "autonomy": "L1"},
+        {"command": "/diff", "autonomy": "L0"}
+      ],
+      "add_skills": [
+        {"skill": "compact-to-vault", "autonomy": "L2"},
+        {"skill": "vault-curate", "autonomy": "L3"}
+      ],
+      "notes": "cross-cutting 보안 리뷰 게이트. /security-review 를 강조 부여하고, 검토 세션은 compact-to-vault 로 적립한다. 진입 조건/계약 SSoT 는 docs/security-review.md."
     }
   }
 }

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/__init__.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/__init__.py
@@ -15,9 +15,15 @@ Surfaces:
   * :mod:`slash_command_grants` — load + validate the per-department
     slash-command / skill grant table. Pure-Python, deterministic, no
     side effects on import.
-
-Out of scope (follow-up PRs): runtime enforcement of grants inside the
-RoleRunner dispatch; live ``/compact`` invocation wiring.
+  * :mod:`grant_enforcement` — runtime ALLOW/ADVISORY/BLOCK verdicts over the
+    grant table (item C).
+  * :mod:`context_compaction` — deterministic compact→vault core.
+  * :mod:`compaction_protocol` — checkpoints, compaction receipt, /clear guard
+    (item F).
+  * :mod:`cleanup` — allowlist-based artifact cleanup with dry-run/execute
+    (item G).
+  * :mod:`execution_receipt` — the per-run execution proof binding the above
+    (item D).
 """
 
 from __future__ import annotations
@@ -35,6 +41,45 @@ from .slash_command_grants import (
     default_grants_path,
     load_grant_table,
 )
+from .grant_enforcement import (
+    CapabilityKind,
+    GrantDecision,
+    GrantVerdict,
+    evaluate_capability,
+    evaluate_command,
+    evaluate_skill,
+)
+from .compaction_protocol import (
+    Checkpoint,
+    ClearBlockedError,
+    ClearDecision,
+    CompactionCandidate,
+    CompactionReceipt,
+    compaction_candidates,
+    evaluate_clear,
+    require_clear_allowed,
+    run_compaction_to_vault,
+)
+from .cleanup import (
+    CleanupEntry,
+    CleanupReceipt,
+    Classification,
+    classify,
+    run_cleanup,
+    scan,
+)
+from .execution_receipt import ExecutionReceipt, build_execution_receipt
+from .security_gate import (
+    SecurityReviewDecision,
+    assess_security_review,
+    security_review_required,
+)
+from .hot_path import (
+    build_capability_block_gate,
+    dispatch_receipt,
+    evaluate_input_capabilities,
+    requested_capabilities,
+)
 
 __all__ = (
     "BuiltinCommand",
@@ -48,4 +93,40 @@ __all__ = (
     "SkillGrant",
     "default_grants_path",
     "load_grant_table",
+    # grant enforcement (C)
+    "CapabilityKind",
+    "GrantDecision",
+    "GrantVerdict",
+    "evaluate_capability",
+    "evaluate_command",
+    "evaluate_skill",
+    # compaction protocol (F)
+    "Checkpoint",
+    "ClearBlockedError",
+    "ClearDecision",
+    "CompactionCandidate",
+    "CompactionReceipt",
+    "compaction_candidates",
+    "evaluate_clear",
+    "require_clear_allowed",
+    "run_compaction_to_vault",
+    # cleanup (G)
+    "CleanupEntry",
+    "CleanupReceipt",
+    "Classification",
+    "classify",
+    "run_cleanup",
+    "scan",
+    # execution receipt (D)
+    "ExecutionReceipt",
+    "build_execution_receipt",
+    # hot-path seam (gate + receipt wiring)
+    "build_capability_block_gate",
+    "dispatch_receipt",
+    "evaluate_input_capabilities",
+    "requested_capabilities",
+    # security auto-dispatch gate (C)
+    "SecurityReviewDecision",
+    "assess_security_review",
+    "security_review_required",
 )

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/cleanup.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/cleanup.py
@@ -1,0 +1,404 @@
+"""Allowlist-based Claude Code artifact cleanup (issue #185 follow-up).
+
+Goal (per the operator brief): NOT "delete every trace of past sessions" but
+"after the summary is vaulted, *safely* reclaim space". Cleanup is allowlist
+based and **deny-list-first** — anything not positively classified as
+transient/generated is PRESERVED.
+
+Three classifications:
+
+  * ``DELETABLE``       — transient / regeneratable artifacts (pycache, test
+    caches, ``*.tmp`` / ``*.log``, snapshot exports, files carrying an explicit
+    ``YULE-CLEANUP-SAFE`` marker). Removed only in execute mode.
+  * ``PRESERVE``        — audit / canonical artifacts that must never be
+    deleted: ``*.sqlite3`` workflow stores (they carry real operator
+    sessions), ``agent_ops_audit`` traces, vault canonical notes
+    (``00-inbox`` / ``10-projects`` / ``20-areas`` …), prompt / decision /
+    synthesis / approval bodies, ``.git`` and source/policy/test/docs files.
+    Default for anything unmatched.
+  * ``APPROVAL_NEEDED`` — regeneratable but tracked (generated harness dirs:
+    ``.claude/skills`` / ``.agents/skills`` / ``*-plugin``) or large exports.
+    Listed, never auto-deleted.
+
+Modes: dry-run (default) reports only; execute requires BOTH ``execute=True``
+*and* ``confirm=True`` (the "명시 승인 또는 강한 안전장치"). Only ``DELETABLE``
+entries are ever removed; ``PRESERVE`` always wins over every other rule.
+
+The receipt carries: scanned paths, matched rules, deleted count, reclaimed
+bytes estimate, skipped/protected paths, approval-needed items.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+# Explicit opt-in marker a generator can drop into a file to mark it
+# regeneratable/safe-to-delete even if it would otherwise be preserved.
+CLEANUP_SAFE_MARKER = "YULE-CLEANUP-SAFE"
+
+
+class Classification(str, Enum):
+    DELETABLE = "deletable"
+    PRESERVE = "preserve"
+    APPROVAL_NEEDED = "approval_needed"
+
+
+# Directory basenames handled as whole units.
+_PRESERVE_DIR_NAMES = frozenset({".git", ".hg", ".svn"})
+_DELETABLE_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", ".cache_tmp"}
+)
+
+# Substrings that force PRESERVE regardless of any other rule (deny-list).
+_PRESERVE_SUBSTRINGS: Tuple[str, ...] = (
+    "agent_ops_audit",
+    "execution_receipt",
+    "/00-inbox/",
+    "/10-projects/",
+    "/20-areas/",
+    "/30-resources/",
+    "/40-archive/",
+    "/decisions/",
+    "/policies/",
+    "/docs/",
+    "/tests/",
+    "/.git/",
+    "/.github/",
+    "/.ssh/",
+    "/migrations/",
+)
+_PRESERVE_SUFFIXES: Tuple[str, ...] = (
+    # operational data stores + their sqlite sidecars (deleting a -wal/-shm
+    # sidecar corrupts the live DB — always preserve)
+    ".sqlite3",
+    ".sqlite",
+    ".db",
+    "-wal",
+    "-shm",
+    "-journal",
+    # source / config / secrets — never transient
+    ".py",
+    ".env",
+    ".pem",
+    ".key",
+    ".lock",
+)
+# Filename tokens that mark canonical/audit/secret bodies — preserve.
+_PRESERVE_NAME_TOKENS: Tuple[str, ...] = (
+    "prompt",
+    "decision",
+    "synthesis",
+    "approval",
+    "task-log",
+    "agent_ops_audit",
+    "credential",
+    "secret",
+    ".env",
+)
+
+_DELETABLE_SUFFIXES: Tuple[str, ...] = (
+    ".tmp",
+    ".temp",
+    ".pyc",
+    ".pyo",
+    ".log",
+)
+_DELETABLE_NAME_SUBSTRINGS: Tuple[str, ...] = (
+    "-snapshot-",
+    ".generated.",
+    "tmp-",
+)
+
+# Generated-but-tracked harness projection roots → approval needed.
+_APPROVAL_SUBSTRINGS: Tuple[str, ...] = (
+    "/.claude/skills/",
+    "/.agents/skills/",
+    "/.claude-plugin/",
+    "/.codex-plugin/",
+)
+_LARGE_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB unclassified file → approval needed
+
+
+@dataclass(frozen=True)
+class CleanupEntry:
+    rel_path: str
+    abs_path: str
+    classification: Classification
+    rule: str
+    reason: str
+    size_bytes: int
+    is_dir: bool
+
+
+@dataclass(frozen=True)
+class CleanupReceipt:
+    root: str
+    scanned_count: int
+    matched_rules: Tuple[Tuple[str, str, int], ...]  # (rule, classification, count)
+    deletable: Tuple[CleanupEntry, ...]
+    protected: Tuple[CleanupEntry, ...]
+    approval_needed: Tuple[CleanupEntry, ...]
+    deleted_count: int
+    reclaimed_bytes: int
+    executed: bool
+    warnings: Tuple[str, ...] = ()
+
+    @property
+    def reclaimable_bytes(self) -> int:
+        return sum(e.size_bytes for e in self.deletable)
+
+    @property
+    def status(self) -> str:
+        if self.executed:
+            return "executed"
+        return "dry_run"
+
+    def to_dict(self) -> dict:
+        return {
+            "root": self.root,
+            "status": self.status,
+            "scanned_count": self.scanned_count,
+            "matched_rules": [
+                {"rule": r, "classification": c, "count": n}
+                for (r, c, n) in self.matched_rules
+            ],
+            "deletable_count": len(self.deletable),
+            "deleted_count": self.deleted_count,
+            "reclaimable_bytes": self.reclaimable_bytes,
+            "reclaimed_bytes": self.reclaimed_bytes,
+            "protected_count": len(self.protected),
+            "approval_needed_count": len(self.approval_needed),
+            "approval_needed": [e.rel_path for e in self.approval_needed],
+            "warnings": list(self.warnings),
+        }
+
+
+def _entry_size(path: Path) -> int:
+    try:
+        if path.is_dir():
+            total = 0
+            for dirpath, _dirs, files in os.walk(path):
+                for f in files:
+                    fp = Path(dirpath) / f
+                    try:
+                        total += fp.stat().st_size
+                    except OSError:
+                        continue
+            return total
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def classify(rel_path: str, *, is_dir: bool, size_bytes: int = 0) -> Tuple[Classification, str, str]:
+    """Classify a path. Deny-list (PRESERVE) wins; default is PRESERVE.
+
+    Returns ``(classification, rule, reason)``.
+    """
+
+    name = rel_path.rsplit("/", 1)[-1]
+    lowered = ("/" + rel_path + "/").lower()
+    name_l = name.lower()
+
+    # 1. PRESERVE wins — audit / canonical / source.
+    for token in _PRESERVE_NAME_TOKENS:
+        if token in name_l:
+            return Classification.PRESERVE, "preserve:name-token", f"name carries '{token}'"
+    for sub in _PRESERVE_SUBSTRINGS:
+        if sub in lowered:
+            return Classification.PRESERVE, "preserve:path", f"under protected path '{sub}'"
+    for suf in _PRESERVE_SUFFIXES:
+        if name_l.endswith(suf):
+            return Classification.PRESERVE, "preserve:suffix", f"protected suffix '{suf}'"
+
+    # 2. Whole-dir deletable caches.
+    if is_dir and name in _DELETABLE_DIR_NAMES:
+        return Classification.DELETABLE, "deletable:cache-dir", f"regeneratable cache dir '{name}'"
+
+    # 3. DELETABLE transient/generated files.
+    if not is_dir:
+        for suf in _DELETABLE_SUFFIXES:
+            if name_l.endswith(suf):
+                return Classification.DELETABLE, "deletable:suffix", f"transient suffix '{suf}'"
+        for sub in _DELETABLE_NAME_SUBSTRINGS:
+            if sub in name_l:
+                return (
+                    Classification.DELETABLE,
+                    "deletable:name",
+                    f"regeneratable artifact name contains '{sub}'",
+                )
+
+    # 4. APPROVAL_NEEDED — generated-but-tracked or large.
+    for sub in _APPROVAL_SUBSTRINGS:
+        if sub in lowered:
+            return (
+                Classification.APPROVAL_NEEDED,
+                "approval:generated-harness",
+                f"generated-but-tracked harness path '{sub}'",
+            )
+    if not is_dir and size_bytes >= _LARGE_FILE_BYTES:
+        return (
+            Classification.APPROVAL_NEEDED,
+            "approval:large-file",
+            f"large unclassified file ({size_bytes} bytes)",
+        )
+
+    # 5. Default — preserve (safe).
+    return Classification.PRESERVE, "preserve:default", "unmatched — preserved by default"
+
+
+def scan(root: Path, *, marker_optin: bool = True) -> List[CleanupEntry]:
+    """Walk *root* and classify each entry. Does not delete anything."""
+
+    root = Path(root)
+    entries: List[CleanupEntry] = []
+    if not root.exists():
+        return entries
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dpath = Path(dirpath)
+        # Prune PRESERVE dirs from recursion; emit DELETABLE cache dirs whole.
+        pruned: List[str] = []
+        for d in list(dirnames):
+            full = dpath / d
+            rel = _rel(full, root)
+            if d in _PRESERVE_DIR_NAMES:
+                dirnames.remove(d)
+                continue
+            if d in _DELETABLE_DIR_NAMES:
+                size = _entry_size(full)
+                cls, rule, reason = classify(rel, is_dir=True, size_bytes=size)
+                entries.append(
+                    CleanupEntry(rel, str(full), cls, rule, reason, size, True)
+                )
+                dirnames.remove(d)  # do not descend; handled as a unit
+                continue
+            pruned.append(d)
+        dirnames[:] = pruned
+
+        for f in filenames:
+            full = dpath / f
+            rel = _rel(full, root)
+            try:
+                size = full.stat().st_size
+            except OSError:
+                size = 0
+            cls, rule, reason = classify(rel, is_dir=False, size_bytes=size)
+            # Explicit opt-in marker can promote an otherwise-preserved file.
+            if (
+                marker_optin
+                and cls is Classification.PRESERVE
+                and not rule.startswith("preserve:suffix")
+                and not rule.startswith("preserve:name-token")
+                and not _path_is_protected(rel)
+                and _has_marker(full)
+            ):
+                cls, rule, reason = (
+                    Classification.DELETABLE,
+                    "deletable:marker",
+                    f"carries explicit {CLEANUP_SAFE_MARKER} marker",
+                )
+            entries.append(CleanupEntry(rel, str(full), cls, rule, reason, size, False))
+
+    entries.sort(key=lambda e: e.rel_path)
+    return entries
+
+
+def run_cleanup(
+    root: Path,
+    *,
+    execute: bool = False,
+    confirm: bool = False,
+    marker_optin: bool = True,
+) -> CleanupReceipt:
+    """Scan *root* and, only when ``execute and confirm``, delete DELETABLE entries.
+
+    Dry-run (default) deletes nothing. Execute requires *both* flags — a single
+    accidental ``execute=True`` is not enough to remove files.
+    """
+
+    root = Path(root)
+    warnings: List[str] = []
+    if not root.exists():
+        warnings.append(f"scan root does not exist: {root}")
+    entries = scan(root, marker_optin=marker_optin)
+
+    deletable = tuple(e for e in entries if e.classification is Classification.DELETABLE)
+    protected = tuple(e for e in entries if e.classification is Classification.PRESERVE)
+    approval = tuple(e for e in entries if e.classification is Classification.APPROVAL_NEEDED)
+
+    # Aggregate matched rules.
+    counts: dict[Tuple[str, str], int] = {}
+    for e in entries:
+        key = (e.rule, e.classification.value)
+        counts[key] = counts.get(key, 0) + 1
+    matched_rules = tuple(
+        sorted(((r, c, n) for (r, c), n in counts.items()), key=lambda t: (t[1], t[0]))
+    )
+
+    deleted_count = 0
+    reclaimed_bytes = 0
+    will_execute = bool(execute and confirm)
+    if execute and not confirm:
+        warnings.append("execute requested without confirm=True — refusing to delete (safety)")
+    if will_execute:
+        for e in deletable:
+            target = Path(e.abs_path)
+            try:
+                if e.is_dir:
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+                deleted_count += 1
+                reclaimed_bytes += e.size_bytes
+            except OSError as exc:
+                warnings.append(f"failed to delete {e.rel_path}: {exc}")
+
+    return CleanupReceipt(
+        root=str(root),
+        scanned_count=len(entries),
+        matched_rules=matched_rules,
+        deletable=deletable,
+        protected=protected,
+        approval_needed=approval,
+        deleted_count=deleted_count,
+        reclaimed_bytes=reclaimed_bytes,
+        executed=will_execute,
+        warnings=tuple(warnings),
+    )
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _path_is_protected(rel: str) -> bool:
+    cls, _rule, _reason = classify(rel, is_dir=False)
+    return cls is Classification.PRESERVE and _rule != "preserve:default"
+
+
+def _has_marker(path: Path) -> bool:
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            return CLEANUP_SAFE_MARKER in fh.read(4096)
+    except OSError:
+        return False
+
+
+__all__ = (
+    "CLEANUP_SAFE_MARKER",
+    "Classification",
+    "CleanupEntry",
+    "CleanupReceipt",
+    "classify",
+    "scan",
+    "run_cleanup",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/compaction_protocol.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/compaction_protocol.py
@@ -1,0 +1,302 @@
+"""compact→vault *protocol* — checkpoints, receipt, and the /clear guard (issue #185 follow-up).
+
+``context_compaction`` holds the deterministic *core* (fold turns → summary →
+vault task-log note). This module turns that core into an enforced **work
+protocol**:
+
+  * :class:`Checkpoint` — the moments a long session should surface a
+    compaction candidate (big implementation step done, just before
+    test/verification, just before session end, on context-threshold).
+  * :func:`compaction_candidates` — given the active checkpoints + an
+    estimated context ratio, decide whether compaction should be *offered*.
+    Honors the ``YULE_COMPACT_TO_VAULT_ENABLED`` flag for *automatic* offers
+    while leaving explicit (operator-requested) compaction always available.
+  * :func:`run_compaction_to_vault` — run the core and produce a
+    :class:`CompactionReceipt` (session_id / focus / pre_tokens / post_tokens /
+    task_log_note_path / committed / warnings).
+  * :class:`ClearGuard` — refuses ``/clear`` (history reset) until a vault
+    record exists for the session. "vault 기록 전 clear 금지" is a hard rail:
+    clearing history before the summary is persisted destroys the audit root.
+
+Hard rails (mirrors ``skills/compact-to-vault.md`` + ``context-compression.md``):
+  * Writing the note touches the working tree only; commit/push is the gated
+    L3 step (``commit=False`` here always).
+  * Protected regions (prompt / decision / synthesis) are never folded — that
+    is enforced in the core (:data:`PROTECTED_KINDS`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from .context_compaction import (
+    ENABLE_ENV,
+    CompactionNote,
+    CompactionSummary,
+    CompactionTurn,
+    build_compaction_summary,
+    compaction_enabled,
+    write_compaction_note,
+)
+
+# Context-ratio at/above which an automatic compaction candidate is surfaced,
+# even mid-session. Aligns with context-compression.md §3.1 (50% for Claude).
+DEFAULT_THRESHOLD_RATIO: float = 0.5
+
+
+class Checkpoint(str, Enum):
+    """A moment in a session where compaction should be considered."""
+
+    BIG_IMPL_DONE = "big_impl_done"          # 큰 구현 단계 종료 시
+    PRE_VERIFICATION = "pre_verification"    # 테스트/검증 완료 직전
+    SESSION_END = "session_end"              # 세션 종료 직전
+    CONTEXT_THRESHOLD = "context_threshold"  # context threshold 도달 시
+
+
+# Checkpoints that *always* warrant a compaction candidate when reached
+# (independent of the context ratio).
+_ALWAYS_OFFER: frozenset[Checkpoint] = frozenset(
+    {Checkpoint.BIG_IMPL_DONE, Checkpoint.PRE_VERIFICATION, Checkpoint.SESSION_END}
+)
+
+
+@dataclass(frozen=True)
+class CompactionCandidate:
+    checkpoint: Checkpoint
+    reason: str
+    auto: bool  # True if auto-trigger (flag on); False = explicit/operator only
+
+
+@dataclass(frozen=True)
+class CompactionReceipt:
+    """Proof of one compact→vault run (D/F: shown in execution receipt)."""
+
+    session_id: str
+    focus: Optional[str]
+    checkpoint: Optional[str]
+    enabled: bool
+    pre_tokens: int
+    post_tokens: int
+    saved_tokens: int
+    task_log_note_path: Optional[str]
+    committed: bool
+    warnings: Tuple[str, ...] = ()
+    token_source: str = "estimate"  # estimate | live_compact_boundary
+
+    @property
+    def status(self) -> str:
+        if self.task_log_note_path is None:
+            return "not_run"
+        return "committed" if self.committed else "written"
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "focus": self.focus,
+            "checkpoint": self.checkpoint,
+            "enabled": self.enabled,
+            "status": self.status,
+            "pre_tokens": self.pre_tokens,
+            "post_tokens": self.post_tokens,
+            "saved_tokens": self.saved_tokens,
+            "token_source": self.token_source,
+            "task_log_note_path": self.task_log_note_path,
+            "committed": self.committed,
+            "warnings": list(self.warnings),
+        }
+
+
+def compaction_candidates(
+    checkpoints: Sequence[Checkpoint],
+    *,
+    context_ratio: float = 0.0,
+    threshold_ratio: float = DEFAULT_THRESHOLD_RATIO,
+    enabled: Optional[bool] = None,
+) -> List[CompactionCandidate]:
+    """Return compaction candidates for the reached *checkpoints*.
+
+    *enabled* defaults to :func:`compaction_enabled` (the
+    ``YULE_COMPACT_TO_VAULT_ENABLED`` flag). When the flag is off, candidates
+    are still returned but marked ``auto=False`` — i.e. surfaced for an
+    explicit/operator decision, never auto-run. CONTEXT_THRESHOLD only fires
+    when *context_ratio* has reached *threshold_ratio*.
+    """
+
+    flag_on = compaction_enabled() if enabled is None else enabled
+    out: List[CompactionCandidate] = []
+    seen: set[Checkpoint] = set()
+    for cp in checkpoints:
+        if cp in seen:
+            continue
+        seen.add(cp)
+        if cp is Checkpoint.CONTEXT_THRESHOLD:
+            if context_ratio < threshold_ratio:
+                continue
+            reason = (
+                f"context ratio {context_ratio:.0%} ≥ threshold {threshold_ratio:.0%}"
+            )
+        elif cp in _ALWAYS_OFFER:
+            reason = f"checkpoint reached: {cp.value}"
+        else:  # pragma: no cover - enum exhaustiveness guard
+            continue
+        out.append(CompactionCandidate(checkpoint=cp, reason=reason, auto=flag_on))
+    return out
+
+
+def run_compaction_to_vault(
+    turns: Sequence[CompactionTurn],
+    *,
+    session_id: str,
+    vault_root: Path,
+    project: str,
+    focus: Optional[str] = None,
+    checkpoint: Optional[Checkpoint] = None,
+    created_at: Optional[datetime] = None,
+    issue: Optional[int] = None,
+    original_prompt: Optional[str] = None,
+    enabled: Optional[bool] = None,
+    compact_boundary: Optional[Any] = None,
+) -> Tuple[Optional[CompactionNote], CompactionReceipt]:
+    """Run the deterministic compact→vault core and emit a receipt.
+
+    Never commits (``commit=False``); committing is the gated L3 step. If
+    *turns* is empty the run is a no-op and the receipt status is ``not_run``.
+
+    *compact_boundary* (optional, duck-typed: ``.parsed`` / ``.pre_tokens`` /
+    ``.post_tokens`` / ``.warning``) lets a live ``/compact`` capture override
+    the deterministic token estimate. When it is present but unparsed, its
+    warning is recorded and the estimate is kept (graceful fallback).
+    """
+
+    flag_on = compaction_enabled() if enabled is None else enabled
+    warnings: List[str] = []
+    if not turns:
+        warnings.append("no turns to compact — session empty or unresolved")
+        receipt = CompactionReceipt(
+            session_id=session_id,
+            focus=focus,
+            checkpoint=checkpoint.value if checkpoint else None,
+            enabled=flag_on,
+            pre_tokens=0,
+            post_tokens=0,
+            saved_tokens=0,
+            task_log_note_path=None,
+            committed=False,
+            warnings=tuple(warnings),
+        )
+        return None, receipt
+
+    summary: CompactionSummary = build_compaction_summary(
+        turns, session_id=session_id, focus=focus
+    )
+    note = write_compaction_note(
+        summary,
+        vault_root=vault_root,
+        project=project,
+        created_at=created_at,
+        issue=issue,
+        original_prompt=original_prompt,
+        commit=False,
+    )
+
+    # Token accounting: deterministic estimate, optionally overridden by a live
+    # /compact compact_boundary capture (graceful fallback + warning otherwise).
+    pre_tokens = summary.pre_tokens
+    post_tokens = summary.post_tokens
+    token_source = "estimate"
+    if compact_boundary is not None:
+        if getattr(compact_boundary, "parsed", False):
+            pre_tokens = int(getattr(compact_boundary, "pre_tokens"))
+            post_tokens = int(getattr(compact_boundary, "post_tokens"))
+            token_source = "live_compact_boundary"
+        else:
+            cb_warning = getattr(compact_boundary, "warning", None)
+            warnings.append(
+                "live /compact token capture unavailable — using estimate"
+                + (f" ({cb_warning})" if cb_warning else "")
+            )
+    saved_tokens = max(0, pre_tokens - post_tokens)
+
+    receipt = CompactionReceipt(
+        session_id=session_id,
+        focus=focus,
+        checkpoint=checkpoint.value if checkpoint else None,
+        enabled=flag_on,
+        pre_tokens=pre_tokens,
+        post_tokens=post_tokens,
+        saved_tokens=saved_tokens,
+        task_log_note_path=note.relative_path,
+        committed=note.committed,
+        warnings=tuple(warnings),
+        token_source=token_source,
+    )
+    return note, receipt
+
+
+# ---------------------------------------------------------------------------
+# /clear (history reset) guard
+# ---------------------------------------------------------------------------
+
+
+class ClearBlockedError(RuntimeError):
+    """Raised when ``/clear`` is attempted before the session is vaulted."""
+
+
+@dataclass(frozen=True)
+class ClearDecision:
+    session_id: str
+    allowed: bool
+    reason: str
+
+
+def evaluate_clear(receipt: Optional[CompactionReceipt], *, session_id: str) -> ClearDecision:
+    """Decide whether ``/clear`` (history reset) is allowed for a session.
+
+    Allowed only when a compaction receipt exists and a vault task-log note was
+    written (``task_log_note_path`` set). "vault 기록 전 clear 금지" — clearing
+    before the summary is persisted would destroy the audit root.
+    """
+
+    if receipt is None:
+        return ClearDecision(session_id, False, "no compaction receipt — vault record missing")
+    if receipt.task_log_note_path is None:
+        return ClearDecision(
+            session_id, False, "compaction did not write a vault task-log note yet"
+        )
+    if receipt.session_id != session_id:
+        return ClearDecision(
+            session_id, False,
+            f"receipt session_id={receipt.session_id} != {session_id}",
+        )
+    return ClearDecision(
+        session_id, True,
+        f"vaulted at {receipt.task_log_note_path} — safe to clear",
+    )
+
+
+def require_clear_allowed(receipt: Optional[CompactionReceipt], *, session_id: str) -> ClearDecision:
+    decision = evaluate_clear(receipt, session_id=session_id)
+    if not decision.allowed:
+        raise ClearBlockedError(
+            f"/clear blocked for session {session_id}: {decision.reason}"
+        )
+    return decision
+
+
+__all__ = (
+    "ENABLE_ENV",
+    "DEFAULT_THRESHOLD_RATIO",
+    "Checkpoint",
+    "CompactionCandidate",
+    "CompactionReceipt",
+    "ClearBlockedError",
+    "ClearDecision",
+    "compaction_candidates",
+    "run_compaction_to_vault",
+    "evaluate_clear",
+    "require_clear_allowed",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/execution_receipt.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/execution_receipt.py
@@ -1,0 +1,267 @@
+"""Execution proof — the per-run receipt (issue #185 follow-up, item D).
+
+An :class:`ExecutionReceipt` is "what this run actually loaded and what it was
+allowed to do". It binds together the four enforcement surfaces:
+
+  * the layered context load (:class:`LoadedContext` — docs + policies + the
+    selected agent/role + warnings),
+  * the grant table (granted skills/commands + blocked/missing capabilities,
+    via :mod:`grant_enforcement`),
+  * the selected runner,
+  * compaction + cleanup statuses (:class:`CompactionReceipt` /
+    :class:`CleanupReceipt`).
+
+It renders to both human text and a JSON-able dict so at least one CLI / debug
+surface (``yule engineer receipt``) can print it and a test can assert its
+contents. It is pure-Python and deterministic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence, Tuple
+
+from yule_core.context_loader import (
+    LABEL_AGENT,
+    LABEL_ENTRYPOINT,
+    LABEL_POLICY,
+    LABEL_ROLE,
+    LABEL_ROOT,
+    LoadedContext,
+)
+
+from .cleanup import CleanupReceipt
+from .compaction_protocol import CompactionReceipt
+from .grant_enforcement import (
+    CapabilityKind,
+    GrantDecision,
+    GrantVerdict,
+    evaluate_capability,
+)
+from .slash_command_grants import GrantTable
+
+_DOC_LABEL_ORDER = (LABEL_ENTRYPOINT, LABEL_ROOT, LABEL_AGENT, LABEL_ROLE)
+
+
+@dataclass(frozen=True)
+class ExecutionReceipt:
+    selected_agent: str
+    selected_role: Optional[str]
+    selected_runner: Optional[str]
+    loaded_docs: Tuple[Tuple[str, str], ...]       # (label, rel_path)
+    loaded_policies: Tuple[str, ...]               # rel_path
+    granted_commands: Tuple[str, ...]
+    granted_skills: Tuple[str, ...]
+    capability_decisions: Tuple[GrantDecision, ...]
+    warnings: Tuple[str, ...]
+    compaction_status: str
+    cleanup_status: str
+    compaction: Optional[CompactionReceipt] = None
+    cleanup: Optional[CleanupReceipt] = None
+    security_status: str = "not_evaluated"
+    security: Optional[Any] = None  # SecurityReviewDecision (duck-typed)
+
+    @property
+    def blocked_or_missing(self) -> Tuple[GrantDecision, ...]:
+        """Requested capabilities that were not cleanly allowed."""
+
+        return tuple(d for d in self.capability_decisions if d.verdict is not GrantVerdict.ALLOW)
+
+    def to_dict(self) -> dict:
+        return {
+            "selected_agent": self.selected_agent,
+            "selected_role": self.selected_role,
+            "selected_runner": self.selected_runner,
+            "loaded_docs": [
+                {"label": label, "path": path} for (label, path) in self.loaded_docs
+            ],
+            "loaded_policies": list(self.loaded_policies),
+            "granted_commands": list(self.granted_commands),
+            "granted_skills": list(self.granted_skills),
+            "capability_decisions": [
+                {
+                    "kind": d.kind.value,
+                    "capability": d.capability,
+                    "verdict": d.verdict.value,
+                    "reason": d.reason,
+                }
+                for d in self.capability_decisions
+            ],
+            "blocked_or_missing": [
+                {"capability": d.capability, "verdict": d.verdict.value, "reason": d.reason}
+                for d in self.blocked_or_missing
+            ],
+            "warnings": list(self.warnings),
+            "compaction_status": self.compaction_status,
+            "cleanup_status": self.cleanup_status,
+            "security_status": self.security_status,
+            "compaction": self.compaction.to_dict() if self.compaction else None,
+            "cleanup": self.cleanup.to_dict() if self.cleanup else None,
+            "security": self.security.to_dict() if self.security is not None else None,
+        }
+
+    def render(self) -> str:
+        lines: List[str] = ["# Execution Receipt", ""]
+        lines.append(f"- selected agent: {self.selected_agent}")
+        lines.append(f"- selected role: {self.selected_role or '(none — role not selected)'}")
+        lines.append(f"- selected runner: {self.selected_runner or '(unset)'}")
+        lines.append("")
+
+        lines.append("## Loaded docs")
+        for label, path in self.loaded_docs:
+            lines.append(f"- [{label}] {path}")
+        lines.append("")
+
+        lines.append("## Loaded policies")
+        if self.loaded_policies:
+            for path in self.loaded_policies:
+                lines.append(f"- {path}")
+        else:
+            lines.append("- (none)")
+        lines.append("")
+
+        lines.append("## Granted skills / commands")
+        lines.append(f"- commands: {', '.join(self.granted_commands) or '(none)'}")
+        lines.append(f"- skills: {', '.join(self.granted_skills) or '(none)'}")
+        lines.append("")
+
+        lines.append("## Blocked or missing skills")
+        if self.blocked_or_missing:
+            for d in self.blocked_or_missing:
+                lines.append(f"- {d.surface()}")
+        else:
+            lines.append("- (none requested / all granted)")
+        lines.append("")
+
+        lines.append(f"## Compaction status: {self.compaction_status}")
+        if self.compaction is not None:
+            c = self.compaction
+            lines.append(
+                f"- session={c.session_id} note={c.task_log_note_path or '-'} "
+                f"saved_tokens={c.saved_tokens} committed={c.committed}"
+            )
+        lines.append("")
+
+        lines.append(f"## Cleanup status: {self.cleanup_status}")
+        if self.cleanup is not None:
+            cl = self.cleanup
+            lines.append(
+                f"- reclaimable_bytes={cl.reclaimable_bytes} deleted={cl.deleted_count} "
+                f"protected={len(cl.protected)} approval_needed={len(cl.approval_needed)}"
+            )
+        lines.append("")
+
+        lines.append(f"## Security review: {self.security_status}")
+        if self.security is not None:
+            lines.append(f"- {self.security.surface()}")
+            for reason in getattr(self.security, "reasons", ()) or ():
+                lines.append(f"  - {reason}")
+        lines.append("")
+
+        lines.append("## Warnings")
+        if self.warnings:
+            for w in self.warnings:
+                lines.append(f"- {w}")
+        else:
+            lines.append("- (none)")
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def build_execution_receipt(
+    loaded_context: LoadedContext,
+    grant_table: GrantTable,
+    *,
+    actor_id: Optional[str] = None,
+    selected_runner: Optional[str] = None,
+    requested_capabilities: Sequence[str] = (),
+    compaction: Optional[CompactionReceipt] = None,
+    cleanup: Optional[CleanupReceipt] = None,
+    security: Optional[Any] = None,
+) -> ExecutionReceipt:
+    """Assemble an :class:`ExecutionReceipt` from the run's enforcement surfaces.
+
+    *actor_id* defaults to ``"<agent>/<role>"`` when a role is selected, else the
+    bare agent id. *requested_capabilities* are evaluated against the grant
+    table (each ``/cmd`` is a command, anything else a skill) and any non-ALLOW
+    verdict surfaces under "blocked or missing".
+    """
+
+    agent_id = loaded_context.agent_id
+    role_id = loaded_context.role_id
+    if actor_id is None:
+        actor_id = f"{agent_id}/{role_id}" if role_id else agent_id
+
+    repo_root = loaded_context.manifest_path.parents[2]
+    loaded_docs: List[Tuple[str, str]] = []
+    loaded_policies: List[str] = []
+    for doc in loaded_context.documents:
+        rel = _display(doc.path, repo_root)
+        if doc.label == LABEL_POLICY:
+            loaded_policies.append(rel)
+        else:
+            loaded_docs.append((doc.label, rel))
+    loaded_docs.sort(key=lambda t: (_DOC_LABEL_ORDER.index(t[0]) if t[0] in _DOC_LABEL_ORDER else 99, t[1]))
+
+    eff = grant_table.effective_grants(actor_id)
+    granted_commands = tuple(sorted(g.command for g in eff.builtin)) if eff else ()
+    granted_skills = tuple(sorted(g.skill for g in eff.skills)) if eff else ()
+
+    decisions = tuple(
+        evaluate_capability(grant_table, actor_id, cap) for cap in requested_capabilities
+    )
+
+    warnings: List[str] = list(loaded_context.warnings)
+    if eff is None:
+        warnings.append(f"actor '{actor_id}' has no grant-table entry")
+    for d in decisions:
+        if d.verdict is GrantVerdict.BLOCK:
+            warnings.append(f"blocked capability: {d.capability} — {d.reason}")
+        elif d.verdict is GrantVerdict.ADVISORY:
+            warnings.append(f"advisory capability: {d.capability} — {d.reason}")
+    if compaction is not None:
+        warnings.extend(compaction.warnings)
+    if cleanup is not None:
+        warnings.extend(cleanup.warnings)
+
+    compaction_status = compaction.status if compaction is not None else "not_run"
+    cleanup_status = cleanup.status if cleanup is not None else "not_run"
+    if security is None:
+        security_status = "not_evaluated"
+    elif getattr(security, "skip_reason", None):
+        security_status = "skipped"
+    elif getattr(security, "required", False):
+        security_status = "required"
+        warnings.append(f"security review required: {', '.join(getattr(security, 'triggers', ()))}")
+    else:
+        security_status = "not_required"
+
+    return ExecutionReceipt(
+        selected_agent=agent_id,
+        selected_role=role_id,
+        selected_runner=selected_runner,
+        loaded_docs=tuple(loaded_docs),
+        loaded_policies=tuple(loaded_policies),
+        granted_commands=granted_commands,
+        granted_skills=granted_skills,
+        capability_decisions=decisions,
+        warnings=tuple(warnings),
+        compaction_status=compaction_status,
+        cleanup_status=cleanup_status,
+        compaction=compaction,
+        cleanup=cleanup,
+        security_status=security_status,
+        security=security,
+    )
+
+
+def _display(path, repo_root) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+__all__ = (
+    "ExecutionReceipt",
+    "build_execution_receipt",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/grant_enforcement.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/grant_enforcement.py
@@ -1,0 +1,183 @@
+"""Runtime enforcement of the slash-command / skill grant table (issue #185 follow-up).
+
+The grant *table* (``slash_command_grants``) is the SSoT for "is X granted to
+Y?". This module is the *enforcement* layer the runtime calls when an actor
+(department or ``<dept>/<role>``) is about to use a built-in slash command or a
+custom skill. It turns a grant lookup into one of three verdicts:
+
+    ALLOW     — granted; proceed.
+    ADVISORY  — a *known, grantable* capability that this actor does not hold;
+                surface a warning but let the gateway/operator decide. The
+                capability is benign-by-catalog (it could be granted), so a
+                hard stop would be over-blocking.
+    BLOCK     — a capability that must never be used by this actor: an unknown
+                capability (not in the catalog at all) or a non-grantable
+                built-in (interactive / operator-only UI). Also blocks unknown
+                actors (no department in the table).
+
+The advisory-vs-block line is fixed here in code, mirrored in
+``docs/agent-slash-commands.md`` §"grant 강제", and locked by
+``tests/agents/test_grant_enforcement.py``:
+
+    | situation                                  | verdict  |
+    | ------------------------------------------ | -------- |
+    | granted to actor                           | ALLOW    |
+    | ungranted, known builtin, grantable=true   | ADVISORY |
+    | ungranted, known custom skill              | ADVISORY |
+    | ungranted, builtin grantable=false         | BLOCK    |
+    | unknown command / skill (not in catalog)   | BLOCK    |
+    | unknown actor (no department)              | BLOCK    |
+
+This module is pure-Python and deterministic — no side effects on import, no
+live CLI. It only reads a :class:`GrantTable`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .slash_command_grants import GrantTable
+
+
+class CapabilityKind(str, Enum):
+    COMMAND = "command"
+    SKILL = "skill"
+
+
+class GrantVerdict(str, Enum):
+    ALLOW = "allow"
+    ADVISORY = "advisory"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class GrantDecision:
+    """Outcome of evaluating one capability use for one actor."""
+
+    actor_id: str
+    kind: CapabilityKind
+    capability: str
+    verdict: GrantVerdict
+    reason: str
+
+    @property
+    def allowed(self) -> bool:
+        return self.verdict is GrantVerdict.ALLOW
+
+    @property
+    def blocked(self) -> bool:
+        return self.verdict is GrantVerdict.BLOCK
+
+    @property
+    def advisory(self) -> bool:
+        return self.verdict is GrantVerdict.ADVISORY
+
+    def surface(self) -> str:
+        """One-line human-facing surface string (for receipts / logs)."""
+
+        icon = {
+            GrantVerdict.ALLOW: "✅",
+            GrantVerdict.ADVISORY: "⚠️",
+            GrantVerdict.BLOCK: "⛔",
+        }[self.verdict]
+        return f"{icon} {self.verdict.value.upper()} {self.kind.value} {self.capability} — {self.reason}"
+
+
+def evaluate_command(table: GrantTable, actor_id: str, command: str) -> GrantDecision:
+    """Evaluate a built-in slash command use for *actor_id*."""
+
+    eff = table.effective_grants(actor_id)
+    if eff is None:
+        return _decision(
+            actor_id, CapabilityKind.COMMAND, command, GrantVerdict.BLOCK,
+            f"unknown actor '{actor_id}' — no department in grant table",
+        )
+
+    if eff.grants_command(command):
+        return _decision(
+            actor_id, CapabilityKind.COMMAND, command, GrantVerdict.ALLOW,
+            "granted to actor",
+        )
+
+    spec = table.builtin_commands.get(command)
+    if spec is None:
+        return _decision(
+            actor_id, CapabilityKind.COMMAND, command, GrantVerdict.BLOCK,
+            "unknown command — not in built-in catalog",
+        )
+    if not spec.grantable:
+        return _decision(
+            actor_id, CapabilityKind.COMMAND, command, GrantVerdict.BLOCK,
+            "non-grantable command (interactive / operator-only UI)",
+        )
+    return _decision(
+        actor_id, CapabilityKind.COMMAND, command, GrantVerdict.ADVISORY,
+        "ungranted but grantable — gateway/operator may extend the grant",
+    )
+
+
+def evaluate_skill(table: GrantTable, actor_id: str, skill: str) -> GrantDecision:
+    """Evaluate a custom skill use for *actor_id*."""
+
+    eff = table.effective_grants(actor_id)
+    if eff is None:
+        return _decision(
+            actor_id, CapabilityKind.SKILL, skill, GrantVerdict.BLOCK,
+            f"unknown actor '{actor_id}' — no department in grant table",
+        )
+
+    if eff.grants_skill(skill):
+        return _decision(
+            actor_id, CapabilityKind.SKILL, skill, GrantVerdict.ALLOW,
+            "granted to actor",
+        )
+
+    if skill not in table.custom_skills:
+        return _decision(
+            actor_id, CapabilityKind.SKILL, skill, GrantVerdict.BLOCK,
+            "unknown skill — not in custom-skill catalog",
+        )
+    return _decision(
+        actor_id, CapabilityKind.SKILL, skill, GrantVerdict.ADVISORY,
+        "ungranted but registered — gateway/operator may extend the grant",
+    )
+
+
+def evaluate_capability(
+    table: GrantTable, actor_id: str, capability: str, *, kind: Optional[CapabilityKind] = None
+) -> GrantDecision:
+    """Evaluate a command or skill; infers *kind* from the ``/`` prefix if omitted."""
+
+    if kind is None:
+        kind = CapabilityKind.COMMAND if capability.startswith("/") else CapabilityKind.SKILL
+    if kind is CapabilityKind.COMMAND:
+        return evaluate_command(table, actor_id, capability)
+    return evaluate_skill(table, actor_id, capability)
+
+
+def _decision(
+    actor_id: str,
+    kind: CapabilityKind,
+    capability: str,
+    verdict: GrantVerdict,
+    reason: str,
+) -> GrantDecision:
+    return GrantDecision(
+        actor_id=actor_id,
+        kind=kind,
+        capability=capability,
+        verdict=verdict,
+        reason=reason,
+    )
+
+
+__all__ = (
+    "CapabilityKind",
+    "GrantVerdict",
+    "GrantDecision",
+    "evaluate_command",
+    "evaluate_skill",
+    "evaluate_capability",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/hot_path.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/hot_path.py
@@ -1,0 +1,192 @@
+"""Hot-path enforcement seam — grant gate + per-run receipt (issue #185 follow-up).
+
+This module is the *wiring* between the deterministic harness primitives
+(:mod:`grant_enforcement`, :mod:`execution_receipt`) and the live role-runner
+dispatch path (:mod:`agents.runners.role_runner` /
+:mod:`agents.runners.bootstrap`). It is intentionally thin and pure:
+
+  * :func:`build_capability_block_gate` returns a ``pre_dispatch_gate`` callable
+    the dispatcher runs *before* contacting any provider. It reads the requested
+    capabilities off ``RoleRunnerInput.metadata['capabilities']`` and, if any is
+    a hard BLOCK under the grant table, short-circuits the take with a
+    ``STATUS_BLOCKED`` output. ADVISORY / ALLOW never block — advisories are
+    surfaced in the receipt, not enforced as a stop.
+  * :func:`dispatch_receipt` builds the per-run :class:`ExecutionReceipt`
+    (loaded docs/policies, agent/role, granted skills, blocked-or-missing,
+    selected runner, warnings, compaction/cleanup status) from a finished
+    dispatch.
+
+Decoupling rule: this module imports from ``agents.runners.role_runner`` (which
+has no harness dependency), so ``agents.runners.bootstrap`` must import this
+module *lazily* (inside functions) to avoid an import cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence, Tuple
+
+from ..runners.role_runner import (
+    STATUS_BLOCKED,
+    RoleRunnerInput,
+    RoleRunnerOutput,
+)
+from .execution_receipt import ExecutionReceipt, build_execution_receipt
+from .grant_enforcement import GrantDecision, GrantVerdict, evaluate_capability
+from .security_gate import assess_security_review
+from .slash_command_grants import GrantTable
+
+# Optional change-context for security auto-dispatch, read off input metadata.
+CHANGE_METADATA_KEY = "change"
+
+# Where a caller declares the capabilities (skills / slash commands) a take will
+# use, so the gate can enforce grants for them.
+CAPABILITIES_METADATA_KEY = "capabilities"
+# Optional explicit actor override; otherwise derived as "<agent>/<role>".
+ACTOR_METADATA_KEY = "actor_id"
+
+DEFAULT_AGENT_ID = "engineering-agent"
+
+# Provider label stamped on a gate-blocked output (never a real backend).
+GATE_PROVIDER = "grant-gate"
+
+
+def actor_id_for(input_: RoleRunnerInput, *, agent_id: str = DEFAULT_AGENT_ID) -> str:
+    """Resolve the grant-table actor for *input_*.
+
+    Honors an explicit ``metadata['actor_id']``; otherwise builds
+    ``"<agent_id>/<role>"`` (role normalized to its last path segment), or the
+    bare agent id when no role is present.
+    """
+
+    md = input_.metadata or {}
+    explicit = md.get(ACTOR_METADATA_KEY)
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    role = (input_.role or "").split("/", 1)[-1].strip()
+    return f"{agent_id}/{role}" if role else agent_id
+
+
+def requested_capabilities(input_: RoleRunnerInput) -> Tuple[str, ...]:
+    """Capabilities declared on ``metadata['capabilities']`` (list of str)."""
+
+    md = input_.metadata or {}
+    raw = md.get(CAPABILITIES_METADATA_KEY)
+    out: list[str] = []
+    if isinstance(raw, (list, tuple)):
+        for cap in raw:
+            if isinstance(cap, str) and cap.strip():
+                out.append(cap.strip())
+    return tuple(out)
+
+
+def evaluate_input_capabilities(
+    table: GrantTable, input_: RoleRunnerInput, *, agent_id: str = DEFAULT_AGENT_ID
+) -> Tuple[str, Tuple[GrantDecision, ...]]:
+    """Return ``(actor_id, decisions)`` for *input_*'s requested capabilities."""
+
+    actor = actor_id_for(input_, agent_id=agent_id)
+    caps = requested_capabilities(input_)
+    decisions = tuple(evaluate_capability(table, actor, cap) for cap in caps)
+    return actor, decisions
+
+
+def split_decisions(
+    decisions: Sequence[GrantDecision],
+) -> Tuple[Tuple[GrantDecision, ...], Tuple[GrantDecision, ...], Tuple[GrantDecision, ...]]:
+    """Split into ``(blocked, advisory, allowed)``."""
+
+    blocked = tuple(d for d in decisions if d.verdict is GrantVerdict.BLOCK)
+    advisory = tuple(d for d in decisions if d.verdict is GrantVerdict.ADVISORY)
+    allowed = tuple(d for d in decisions if d.verdict is GrantVerdict.ALLOW)
+    return blocked, advisory, allowed
+
+
+def block_output(
+    input_: RoleRunnerInput, blocked: Sequence[GrantDecision]
+) -> RoleRunnerOutput:
+    """A ``STATUS_BLOCKED`` take naming the blocked capabilities."""
+
+    reasons = "; ".join(d.surface() for d in blocked) or "ungranted capability"
+    return RoleRunnerOutput(
+        provider=GATE_PROVIDER,
+        status=STATUS_BLOCKED,
+        text="",
+        detail=f"grant gate blocked dispatch: {reasons}",
+        used_fallback=False,
+        metrics={
+            "blocked_capabilities": [d.capability for d in blocked],
+            "actor_id": actor_id_for(input_),
+        },
+    )
+
+
+def build_capability_block_gate(
+    table: GrantTable, *, agent_id: str = DEFAULT_AGENT_ID
+):
+    """Build a ``pre_dispatch_gate`` that blocks BLOCK-verdict capabilities.
+
+    ALLOW and ADVISORY both return ``None`` (proceed). Only a hard BLOCK
+    short-circuits the take. Never raises — a take with no declared
+    capabilities always proceeds.
+    """
+
+    def _gate(session: Any, input_: RoleRunnerInput) -> Optional[RoleRunnerOutput]:
+        _actor, decisions = evaluate_input_capabilities(table, input_, agent_id=agent_id)
+        blocked, _advisory, _allowed = split_decisions(decisions)
+        if blocked:
+            return block_output(input_, blocked)
+        return None
+
+    return _gate
+
+
+def dispatch_receipt(
+    loaded_context: Any,
+    table: GrantTable,
+    input_: RoleRunnerInput,
+    output: RoleRunnerOutput,
+    *,
+    agent_id: str = DEFAULT_AGENT_ID,
+    compaction: Any = None,
+    cleanup: Any = None,
+) -> ExecutionReceipt:
+    """Build the per-run execution receipt for a finished dispatch.
+
+    ``selected_runner`` is the winning provider (or ``grant-gate`` on a block);
+    requested capabilities flow through so blocked/advisory ones surface under
+    "blocked or missing".
+    """
+
+    actor = actor_id_for(input_, agent_id=agent_id)
+    # Security auto-dispatch: when the take carries change-context metadata,
+    # evaluate whether security-engineer review must intercept and record it.
+    security = None
+    md = getattr(input_, "metadata", None) or {}
+    change = md.get(CHANGE_METADATA_KEY)
+    if isinstance(change, dict):
+        security = assess_security_review(change)
+    return build_execution_receipt(
+        loaded_context,
+        table,
+        actor_id=actor,
+        selected_runner=output.provider,
+        requested_capabilities=requested_capabilities(input_),
+        compaction=compaction,
+        cleanup=cleanup,
+        security=security,
+    )
+
+
+__all__ = (
+    "CAPABILITIES_METADATA_KEY",
+    "ACTOR_METADATA_KEY",
+    "DEFAULT_AGENT_ID",
+    "GATE_PROVIDER",
+    "actor_id_for",
+    "requested_capabilities",
+    "evaluate_input_capabilities",
+    "split_decisions",
+    "block_output",
+    "build_capability_block_gate",
+    "dispatch_receipt",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/harness/security_gate.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/harness/security_gate.py
@@ -1,0 +1,207 @@
+"""Security auto-dispatch gate — when does security-engineer review intercept?
+(issue #185 follow-up C).
+
+A pure, deterministic decision over a change's metadata (paths + summary +
+labels + flags) that answers: *does this change require cross-cutting security
+review?* It mirrors the ``intercept_triggers`` of the security-engineer role
+contract (``agents/engineering-agent/security-engineer/manifest.json``) and the
+workflow SSoT (``docs/security-review.md``).
+
+The output is advisory-by-construction: it returns a
+:class:`SecurityReviewDecision` (required / triggers / reasons) that callers
+surface on the execution receipt and route to the security-engineer gate. It
+does **not** mutate code or block by itself — enforcement is the operator/tech-lead
+approval gate.
+
+False-positive / false-negative tradeoff (documented, locked by tests):
+  * Heuristics are **keyword/path** based, so they over-trigger (false positive)
+    rather than miss (false negative) — security review is cheap relative to a
+    missed auth/secret bug. A matched trigger always sets ``required=True``.
+  * Detectors are intentionally broad (e.g. any path segment ``auth`` →
+    AUTH). Callers can pass ``force_skip_reason`` to record an explicit,
+    audited skip — silence is never a skip.
+
+Security stance (hard rail, from the role contract): this gate never treats
+"block the browser devtools" as a control. The recommended mitigation is always
+**server-side enforcement**; client is a hostile surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+# Severities the gate can emit.
+SEVERITY_NONE = "none"
+SEVERITY_REQUIRED = "required"
+
+# Anti-goal note attached so a downstream surface never misreads the gate as a
+# "lock the client" recommendation.
+ANTI_GOAL_NOTE = (
+    "클라이언트는 신뢰 경계가 아니다 — 민감 제어는 서버측 검증으로 강제한다. "
+    "'개발자 도구 차단' 류는 보안 목표가 아니다."
+)
+
+
+@dataclass(frozen=True)
+class TriggerMatch:
+    trigger: str          # category id (auth / secret / public_surface / ...)
+    reason: str           # human reason
+    evidence: str         # the matched token/path
+
+
+@dataclass(frozen=True)
+class SecurityReviewDecision:
+    required: bool
+    severity: str
+    triggers: Tuple[str, ...]
+    matches: Tuple[TriggerMatch, ...]
+    reasons: Tuple[str, ...]
+    skip_reason: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "required": self.required,
+            "severity": self.severity,
+            "triggers": list(self.triggers),
+            "reasons": list(self.reasons),
+            "matches": [
+                {"trigger": m.trigger, "reason": m.reason, "evidence": m.evidence}
+                for m in self.matches
+            ],
+            "skip_reason": self.skip_reason,
+            "anti_goal_note": ANTI_GOAL_NOTE,
+        }
+
+    def surface(self) -> str:
+        if self.skip_reason:
+            return f"security-review: skipped — {self.skip_reason}"
+        if not self.required:
+            return "security-review: not required (no sensitive change detected)"
+        return f"security-review: REQUIRED — triggers={', '.join(self.triggers)}"
+
+
+# Category id → (human label, keyword tokens). Tokens are matched case-
+# insensitively against the joined summary + labels + path segments.
+_DETECTORS: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
+    (
+        "auth",
+        "authentication / authorization 변경",
+        ("auth", "login", "logout", "authorize", "authorization", "permission",
+         "rbac", "role-check", "session", "jwt", "oauth", "access-control", "idor"),
+    ),
+    (
+        "secret",
+        "secret / credential handling 변경",
+        ("secret", "credential", ".env", "apikey", "api-key", "api_key",
+         "private-key", "private_key", "password", "token-store", "vault", "keystore"),
+    ),
+    (
+        "public_surface",
+        "공개 surface 추가 (endpoint / webhook / upload / postMessage)",
+        ("endpoint", "route", "webhook", "upload", "postmessage", "public-api",
+         "open-api", "cors", "graphql", "handler", "controller"),
+    ),
+    (
+        "deployment",
+        "deployment / CI / supply-chain 변경",
+        ("deploy", "ci/cd", "ci-cd", "github-actions", "workflow", "dockerfile",
+         "container", "image", "dependency", "requirements", "package.json",
+         "lockfile", "pipeline", "privilege"),
+    ),
+    (
+        "client_security",
+        "CSP / token storage / CSRF / XSS 민감 변경",
+        ("csp", "xss", "csrf", "frame-ancestors", "clickjacking", "token-storage",
+         "localstorage", "sessionstorage", "cookie", "samesite", "content-security-policy"),
+    ),
+    (
+        "agent_safety",
+        "agent tool / approval gate / autonomy 변경",
+        ("prompt-injection", "prompt injection", "tool-grant", "tool grant",
+         "approval-gate", "approval gate", "autonomy", "tool-overreach",
+         "exfiltration", "grant", "guardrail"),
+    ),
+)
+
+
+def _haystack(change: Mapping[str, Any]) -> Tuple[str, Tuple[str, ...]]:
+    """Build a lowercased search blob + the discrete evidence tokens."""
+
+    tokens: list[str] = []
+    summary = str(change.get("summary") or "")
+    if summary:
+        tokens.append(summary)
+    for key in ("labels", "diff_markers", "flags"):
+        raw = change.get(key)
+        if isinstance(raw, (list, tuple)):
+            tokens.extend(str(x) for x in raw)
+    paths = change.get("paths")
+    path_list: list[str] = []
+    if isinstance(paths, (list, tuple)):
+        path_list = [str(p) for p in paths]
+        tokens.extend(path_list)
+    blob = " \n ".join(tokens).lower()
+    return blob, tuple(path_list)
+
+
+def assess_security_review(
+    change: Mapping[str, Any],
+    *,
+    force_skip_reason: Optional[str] = None,
+) -> SecurityReviewDecision:
+    """Decide whether *change* needs security-engineer review.
+
+    *change* keys (all optional): ``summary`` (str), ``paths`` (list[str]),
+    ``labels`` / ``diff_markers`` / ``flags`` (list[str]).
+
+    *force_skip_reason* records an explicit, audited skip (e.g. "operator
+    waived — docs-only"). A skip is never implicit.
+    """
+
+    if force_skip_reason:
+        return SecurityReviewDecision(
+            required=False,
+            severity=SEVERITY_NONE,
+            triggers=(),
+            matches=(),
+            reasons=(),
+            skip_reason=force_skip_reason,
+        )
+
+    blob, _paths = _haystack(change)
+    matches: list[TriggerMatch] = []
+    triggers: list[str] = []
+    reasons: list[str] = []
+    for trigger_id, label, tokens in _DETECTORS:
+        hit = next((tok for tok in tokens if tok in blob), None)
+        if hit is None:
+            continue
+        triggers.append(trigger_id)
+        reasons.append(label)
+        matches.append(TriggerMatch(trigger=trigger_id, reason=label, evidence=hit))
+
+    required = bool(triggers)
+    return SecurityReviewDecision(
+        required=required,
+        severity=SEVERITY_REQUIRED if required else SEVERITY_NONE,
+        triggers=tuple(triggers),
+        matches=tuple(matches),
+        reasons=tuple(reasons),
+        skip_reason=None,
+    )
+
+
+def security_review_required(change: Mapping[str, Any]) -> bool:
+    return assess_security_review(change).required
+
+
+__all__ = (
+    "SEVERITY_NONE",
+    "SEVERITY_REQUIRED",
+    "ANTI_GOAL_NOTE",
+    "TriggerMatch",
+    "SecurityReviewDecision",
+    "assess_security_review",
+    "security_review_required",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/runners/bootstrap.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runners/bootstrap.py
@@ -80,6 +80,13 @@ logger = logging.getLogger(__name__)
 ENV_PROVIDERS: str = "YULE_ROLE_RUNNER_PROVIDERS"
 # Optional Ollama endpoint override (only the URL — no token).
 ENV_OLLAMA_ENDPOINT: str = "YULE_ROLE_RUNNER_OLLAMA_ENDPOINT"
+# Opt-in to runtime grant enforcement + per-run execution receipts on the live
+# dispatch hot path. Default off so existing flows are unchanged; the gate +
+# receipt are always available to callers that pass a grant_table explicitly.
+ENV_GRANT_ENFORCEMENT: str = "YULE_GRANT_ENFORCEMENT_ENABLED"
+# Cap on per-session execution receipts kept in session.extra (audit append is
+# never trimmed; this only bounds the receipt observability bucket).
+_RECEIPT_BUCKET_CAP: int = 50
 
 
 _KNOWN_PROVIDERS: Tuple[str, ...] = (
@@ -474,10 +481,26 @@ def _utc_now_iso() -> str:
 # ---------------------------------------------------------------------------
 
 
+def grant_enforcement_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """True if :data:`ENV_GRANT_ENFORCEMENT` opts into hot-path enforcement."""
+
+    env_map = env if env is not None else os.environ
+    return (env_map.get(ENV_GRANT_ENFORCEMENT) or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def build_role_runner_dispatch_from_env(
     env: Optional[Mapping[str, str]] = None,
     *,
     audit_writer: Optional[Callable[[Any, Mapping[str, Any]], None]] = None,
+    grant_table: Optional[Any] = None,
+    receipt_sink: Optional[Callable[[Any, Any], None]] = None,
+    repo_root: Optional[Any] = None,
+    agent_id: str = "engineering-agent",
 ) -> Tuple[Callable[[Any, RoleRunnerInput], RoleRunnerOutput], RunnerWiringTrace]:
     """Build a session-aware dispatch callable from *env*.
 
@@ -485,23 +508,39 @@ def build_role_runner_dispatch_from_env(
     :func:`agents.runtime.engineering_team_runtime.set_role_runner_dispatch`
     signature ``(session, input_) → RoleRunnerOutput``. Each invocation
     builds a fresh per-call dispatcher so the dispatcher's audit writer
-    can capture the session passed to *that* call — the dispatcher
-    itself takes a record-only writer, so we wrap session capture
-    around it.
+    can capture the session passed to *that* call.
 
-    *audit_writer* receives ``(session, record)`` and is responsible
-    for persisting the audit row. Defaults to
-    :func:`_build_session_audit_writer` which appends to
-    ``session.extra['agent_ops_audit']``. Tests inject a stub.
+    *audit_writer* receives ``(session, record)`` and persists the audit row.
+
+    Hot-path enforcement (opt-in): when *grant_table* is supplied, a
+    pre-dispatch grant gate blocks BLOCK-verdict capabilities declared on
+    ``input_.metadata['capabilities']`` before any provider is contacted. When
+    *receipt_sink* is also supplied, a per-run :class:`ExecutionReceipt` is
+    built (loaded docs/policies + agent/role + grants + selected runner) and
+    handed to the sink. Both default to off so existing flows are unchanged.
     """
 
     candidates, trace = build_role_runner_candidates(env)
     record_writer = audit_writer or _build_session_audit_writer()
 
-    # Build one dispatcher per call so the inner record-only writer
-    # can close over the current session. Dispatcher construction is
-    # cheap (just closures); avoiding it would require a contextvar
-    # which is harder to reason about during shutdown.
+    # Lazy harness import (avoids an import cycle: harness.hot_path imports
+    # runners.role_runner, and runners.__init__ imports this module).
+    gate = None
+    if grant_table is not None:
+        try:
+            from ..harness.hot_path import build_capability_block_gate
+
+            gate = build_capability_block_gate(grant_table, agent_id=agent_id)
+        except Exception:  # noqa: BLE001 - enforcement must not break bootstrap
+            logger.warning(
+                "grant gate construction failed; dispatch proceeds ungated",
+                exc_info=True,
+            )
+            gate = None
+
+    resolved_root = _resolve_repo_root(repo_root)
+    context_cache: dict = {}
+
     def _session_aware_dispatch(
         session: Any, input_: RoleRunnerInput
     ) -> RoleRunnerOutput:
@@ -517,10 +556,102 @@ def build_role_runner_dispatch_from_env(
         dispatch = build_role_runner_dispatcher(
             candidates=candidates,
             audit_writer=_record_only,
+            pre_dispatch_gate=gate,
         )
-        return dispatch(session, input_)
+        output = dispatch(session, input_)
+
+        if receipt_sink is not None and grant_table is not None:
+            _emit_dispatch_receipt(
+                session=session,
+                input_=input_,
+                output=output,
+                grant_table=grant_table,
+                repo_root=resolved_root,
+                agent_id=agent_id,
+                context_cache=context_cache,
+                receipt_sink=receipt_sink,
+            )
+        return output
 
     return _session_aware_dispatch, trace
+
+
+def _resolve_repo_root(repo_root: Optional[Any]) -> Optional[Any]:
+    from pathlib import Path
+
+    if repo_root is not None:
+        return Path(repo_root)
+    env_root = (os.environ.get("YULE_REPO_ROOT") or "").strip()
+    if env_root:
+        return Path(env_root)
+    return None
+
+
+def _emit_dispatch_receipt(
+    *,
+    session: Any,
+    input_: Any,
+    output: Any,
+    grant_table: Any,
+    repo_root: Optional[Any],
+    agent_id: str,
+    context_cache: dict,
+    receipt_sink: Callable[[Any, Any], None],
+) -> None:
+    """Best-effort: build + hand a per-run execution receipt to *receipt_sink*.
+
+    Any failure (no repo root, context load error, sink raises) degrades to a
+    debug log — a receipt must never break the dispatch hot path.
+    """
+
+    if repo_root is None:
+        return
+    try:
+        from ..harness.hot_path import actor_id_for, dispatch_receipt
+
+        role = (getattr(input_, "role", "") or "").split("/", 1)[-1].strip() or None
+        cache_key = role or ""
+        loaded = context_cache.get(cache_key)
+        if loaded is None:
+            from yule_core.context_loader import load_agent_context
+
+            loaded = load_agent_context(
+                repo_root=repo_root, agent_id=agent_id, role_id=role
+            )
+            context_cache[cache_key] = loaded
+        receipt = dispatch_receipt(
+            loaded, grant_table, input_, output, agent_id=agent_id
+        )
+        receipt_sink(session, receipt)
+    except Exception:  # noqa: BLE001 - receipt is observability only
+        logger.debug("dispatch receipt emission failed; dropping", exc_info=True)
+
+
+def _build_session_receipt_sink() -> Callable[[Any, Any], None]:
+    """Return ``write(session, receipt)`` that appends an execution receipt onto
+    ``session.extra['execution_receipts']`` (capped, JSON-safe). Append-only —
+    never trims audit; only bounds the receipt observability bucket.
+    """
+
+    def _write(session: Any, receipt: Any) -> None:
+        if session is None:
+            return
+        try:
+            payload = receipt.to_dict()
+        except Exception:  # noqa: BLE001
+            return
+        extra = getattr(session, "extra", None)
+        if not isinstance(extra, dict):
+            return
+        bucket = extra.get("execution_receipts")
+        if not isinstance(bucket, list):
+            bucket = []
+        bucket.append(payload)
+        if len(bucket) > _RECEIPT_BUCKET_CAP:
+            bucket = bucket[-_RECEIPT_BUCKET_CAP:]
+        extra["execution_receipts"] = bucket
+
+    return _write
 
 
 # ---------------------------------------------------------------------------
@@ -569,9 +700,32 @@ def install_engineering_role_runner_dispatch(
             )
         return None
 
+    # Opt-in hot-path enforcement: load the grant table + receipt sink only
+    # when YULE_GRANT_ENFORCEMENT_ENABLED is set, so default installs are
+    # byte-for-byte unchanged.
+    grant_table = None
+    receipt_sink = None
+    if grant_enforcement_enabled(env):
+        try:
+            from ..harness import load_grant_table
+
+            grant_table = load_grant_table()
+            receipt_sink = _build_session_receipt_sink()
+        except Exception as exc:  # noqa: BLE001 - enforcement must not crash boot
+            logger.warning(
+                "grant enforcement opt-in failed to load grant table; "
+                "dispatch proceeds ungated",
+                exc_info=True,
+            )
+            grant_table = None
+            receipt_sink = None
+
     try:
         dispatch, trace = build_role_runner_dispatch_from_env(
-            env=env, audit_writer=audit_writer
+            env=env,
+            audit_writer=audit_writer,
+            grant_table=grant_table,
+            receipt_sink=receipt_sink,
         )
         set_role_runner_dispatch(dispatch)
     except Exception as exc:  # noqa: BLE001
@@ -594,8 +748,10 @@ def install_engineering_role_runner_dispatch(
 
 
 __all__ = (
+    "ENV_GRANT_ENFORCEMENT",
     "ENV_OLLAMA_ENDPOINT",
     "ENV_PROVIDERS",
+    "grant_enforcement_enabled",
     "REASON_AVAILABILITY_RAISED",
     "REASON_CLI_NOT_FOUND",
     "REASON_CONSTRUCTOR_RAISED",

--- a/apps/engineering-agent/src/yule_engineering/agents/runners/claude_code.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runners/claude_code.py
@@ -1,7 +1,32 @@
+"""Claude Code (``claude`` CLI) runner — live submit + /compact (issue #185 follow-up B).
+
+The MVP body deferred ``submit`` to ``dry_run``. This wires a *real* headless
+submit path plus a ``/compact`` token-capture, both guarded so default installs
+are unchanged and any failure degrades gracefully:
+
+  * ``submit`` shells out to ``claude -p <prompt>`` **only** when the live flag
+    (:data:`ENV_LIVE`) is set *and* the CLI is on PATH. Otherwise it keeps the
+    deterministic dry-run contract. Any subprocess failure / timeout returns a
+    ``RunnerStatus.ERROR`` response (so the role-runner dispatcher walks to the
+    next candidate — the graceful fallback) with a sanitised warning detail.
+  * ``compact`` invokes ``claude`` with ``/compact`` and parses a
+    ``compact_boundary`` stream event for ``pre_tokens`` / ``post_tokens``. If
+    the boundary cannot be parsed (CLI shape drift, non-stream output), it
+    returns a :class:`CompactBoundary` with ``None`` tokens and a clear warning
+    rather than guessing — the caller records the warning on the receipt.
+
+The actual subprocess call is injectable (``config['invoke']``) so tests cover
+both success and failure without a real CLI.
+"""
+
 from __future__ import annotations
 
+import json
+import os
 import shutil
-from typing import Sequence
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
 
 from .base import (
     AgentRequest,
@@ -11,13 +36,57 @@ from .base import (
     RunnerStatus,
 )
 
+# Opt-in flag for the live CLI submit path. Default off → dry-run (unchanged).
+ENV_LIVE: str = "YULE_CLAUDE_LIVE_ENABLED"
+_DEFAULT_CLI: str = "claude"
+_DEFAULT_TIMEOUT: int = 120
+
+# (returncode, stdout, stderr)
+InvokeResult = Tuple[int, str, str]
+InvokeFn = Callable[[Sequence[str], Optional[str], int], InvokeResult]
+
+
+@dataclass(frozen=True)
+class CompactBoundary:
+    """Token accounting captured from a ``/compact`` run.
+
+    ``pre_tokens`` / ``post_tokens`` are ``None`` when the boundary could not be
+    parsed; ``warning`` then explains why so the caller can surface it.
+    """
+
+    pre_tokens: Optional[int]
+    post_tokens: Optional[int]
+    raw: str = ""
+    warning: Optional[str] = None
+
+    @property
+    def parsed(self) -> bool:
+        return self.pre_tokens is not None and self.post_tokens is not None
+
+    @property
+    def saved_tokens(self) -> Optional[int]:
+        if not self.parsed:
+            return None
+        return max(0, (self.pre_tokens or 0) - (self.post_tokens or 0))
+
+
+def _default_invoke(args: Sequence[str], input_text: Optional[str], timeout: int) -> InvokeResult:
+    proc = subprocess.run(
+        list(args),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
 
 class ClaudeCodeRunner(AgentRunner):
     """Wraps the local ``claude`` CLI from Anthropic's Claude Code package.
 
-    MVP body is intentionally a stub: ``submit`` defers to ``dry_run`` so the
-    rest of the engineering-agent (registry, dispatcher, hooks) can be wired
-    up before we shell out to the real CLI.
+    Live submit is opt-in (:data:`ENV_LIVE`); without it the runner keeps the
+    deterministic dry-run contract so the rest of the engineering-agent can be
+    exercised without consuming tokens.
     """
 
     runner_id = "claude"
@@ -29,8 +98,29 @@ class ClaudeCodeRunner(AgentRunner):
         RunnerCapability.PATCH_PROPOSE,
     )
 
+    def __init__(
+        self,
+        *,
+        config: Optional[Mapping[str, Any]] = None,
+        hooks: Optional[Any] = None,
+    ) -> None:
+        super().__init__(config=config, hooks=hooks)
+        self._cli = str(self.config.get("cli") or _DEFAULT_CLI)
+        self._timeout = int(self.config.get("timeout_seconds") or _DEFAULT_TIMEOUT)
+        invoke = self.config.get("invoke")
+        self._invoke: InvokeFn = invoke if callable(invoke) else _default_invoke
+
     def is_available(self) -> bool:
-        return shutil.which("claude") is not None
+        # An injected invoke (tests) implies availability without a real CLI.
+        if callable(self.config.get("invoke")):
+            return True
+        return shutil.which(self._cli) is not None
+
+    def live_enabled(self) -> bool:
+        cfg = self.config.get("live_enabled")
+        if cfg is not None:
+            return bool(cfg)
+        return (os.environ.get(ENV_LIVE) or "").strip().lower() in {"1", "true", "yes", "on"}
 
     def submit(self, request: AgentRequest) -> AgentResponse:
         if not self.is_available():
@@ -40,4 +130,133 @@ class ClaudeCodeRunner(AgentRunner):
                 text="",
                 detail="claude CLI not found on PATH",
             )
-        return self.dry_run(request)
+        if not self.live_enabled():
+            # Default contract preserved: deterministic dry-run, no tokens spent.
+            return self.dry_run(request)
+        return self._live_submit(request)
+
+    def _live_submit(self, request: AgentRequest) -> AgentResponse:
+        args = [self._cli, "-p", request.prompt]
+        try:
+            returncode, stdout, stderr = self._invoke(args, None, self._timeout)
+        except subprocess.TimeoutExpired:
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.ERROR,
+                text="",
+                detail=f"claude live submit timed out after {self._timeout}s",
+            )
+        except Exception as exc:  # noqa: BLE001 - never propagate a wiring error
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.ERROR,
+                text="",
+                detail=f"claude live submit failed: {type(exc).__name__}",
+            )
+        if returncode != 0:
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.ERROR,
+                text="",
+                detail=f"claude exited {returncode}: {_sanitise(stderr)}",
+            )
+        text = (stdout or "").strip()
+        if not text:
+            return AgentResponse(
+                runner_id=self.runner_id,
+                status=RunnerStatus.ERROR,
+                text="",
+                detail="claude returned empty output",
+            )
+        return AgentResponse(
+            runner_id=self.runner_id,
+            status=RunnerStatus.OK,
+            text=text,
+            detail="claude live submit",
+            metrics={"live": True},
+        )
+
+    def compact(self, *, focus: Optional[str] = None) -> CompactBoundary:
+        """Invoke ``/compact`` and capture ``compact_boundary`` token metadata.
+
+        Returns a :class:`CompactBoundary`. On any failure / unparseable output
+        the tokens are ``None`` and ``warning`` explains the fallback. Live flag
+        + CLI availability are required; otherwise a warning-only boundary is
+        returned (deterministic estimate stays the caller's responsibility).
+        """
+
+        if not self.is_available():
+            return CompactBoundary(None, None, warning="claude CLI not available — token capture skipped")
+        if not self.live_enabled():
+            return CompactBoundary(
+                None, None, warning=f"{ENV_LIVE} not set — live /compact token capture skipped"
+            )
+        instruction = "/compact" + (f" {focus}" if focus else "")
+        args = [self._cli, "-p", instruction, "--output-format", "stream-json", "--verbose"]
+        try:
+            returncode, stdout, stderr = self._invoke(args, None, self._timeout)
+        except subprocess.TimeoutExpired:
+            return CompactBoundary(None, None, warning=f"/compact timed out after {self._timeout}s")
+        except Exception as exc:  # noqa: BLE001
+            return CompactBoundary(None, None, warning=f"/compact failed: {type(exc).__name__}")
+        if returncode != 0:
+            return CompactBoundary(None, None, raw=stdout or "", warning=f"/compact exited {returncode}")
+        return parse_compact_boundary(stdout or "")
+
+
+def parse_compact_boundary(stdout: str) -> CompactBoundary:
+    """Scan ``claude`` stream-json output for a ``compact_boundary`` event.
+
+    Lenient: tolerates non-JSON lines and several key spellings
+    (``pre_tokens`` / ``preTokens`` / ``pre_compaction_tokens``). Returns a
+    warning-only boundary when no parsable event is found.
+    """
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or "compact_boundary" not in line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        meta = obj.get("compact_metadata")
+        if not isinstance(meta, dict):
+            meta = obj
+        pre = _first_int(meta, ("pre_tokens", "preTokens", "pre_compaction_tokens"))
+        post = _first_int(meta, ("post_tokens", "postTokens", "post_compaction_tokens"))
+        if pre is None and post is None:
+            continue
+        return CompactBoundary(pre_tokens=pre, post_tokens=post, raw=line)
+    return CompactBoundary(
+        None, None, raw=stdout, warning="no compact_boundary event in claude output"
+    )
+
+
+def _first_int(meta: Mapping[str, Any], keys: Sequence[str]) -> Optional[int]:
+    for key in keys:
+        value = meta.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.strip().isdigit():
+            return int(value.strip())
+    return None
+
+
+def _sanitise(text: str) -> str:
+    """Trim stderr to a short, non-secret-bearing snippet for a detail line."""
+
+    flat = " ".join((text or "").split())
+    return flat[:160]
+
+
+__all__ = (
+    "ENV_LIVE",
+    "ClaudeCodeRunner",
+    "CompactBoundary",
+    "parse_compact_boundary",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/runners/role_runner.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/runners/role_runner.py
@@ -74,6 +74,9 @@ STATUS_FALLBACK: str = "fallback"
 STATUS_UNAVAILABLE: str = "unavailable"
 STATUS_ERROR: str = "error"
 STATUS_INACTIVE_ROLE: str = "inactive_role"
+# A pre-dispatch gate (grant enforcement) blocked this take before any
+# provider was contacted. Empty text; caller must surface the block reason.
+STATUS_BLOCKED: str = "blocked"
 
 
 # ---------------------------------------------------------------------------
@@ -451,11 +454,15 @@ class _CandidateInvocation:
     detail: Optional[str]
 
 
+PreDispatchGate = Callable[[Any, "RoleRunnerInput"], Optional["RoleRunnerOutput"]]
+
+
 def build_role_runner_dispatcher(
     *,
     candidates: Sequence[RoleRunner],
     audit_writer: Optional[AuditWriter] = None,
     active_role_predicate: Optional[Callable[[Any, str], bool]] = None,
+    pre_dispatch_gate: Optional[PreDispatchGate] = None,
 ) -> Callable[[Any, RoleRunnerInput], RoleRunnerOutput]:
     """Return a callable ``(session, input_) → RoleRunnerOutput``.
 
@@ -498,6 +505,31 @@ def build_role_runner_dispatcher(
                 ),
             )
             return output
+
+        # Pre-dispatch grant gate (hot-path enforcement). When supplied and it
+        # returns a non-None output, the take is BLOCKED before any provider is
+        # contacted. The gate must never raise; a raise degrades to "no block"
+        # so a buggy gate cannot wedge the dispatcher.
+        if pre_dispatch_gate is not None:
+            try:
+                gate_output = pre_dispatch_gate(session, input_)
+            except Exception:  # noqa: BLE001 - gate must never break dispatch
+                logger.warning(
+                    "role-runner pre_dispatch_gate raised; proceeding without block",
+                    exc_info=True,
+                )
+                gate_output = None
+            if gate_output is not None:
+                _safe_audit(
+                    writer,
+                    build_audit_record(
+                        session_id=input_.session_id,
+                        role=input_.role,
+                        output=gate_output,
+                        attempts=(),
+                    ),
+                )
+                return gate_output
 
         attempts: list[_CandidateInvocation] = []
         for runner in candidates_with_terminal:
@@ -648,11 +680,13 @@ __all__ = (
     "RoleRunner",
     "RoleRunnerInput",
     "RoleRunnerOutput",
+    "STATUS_BLOCKED",
     "STATUS_ERROR",
     "STATUS_FALLBACK",
     "STATUS_INACTIVE_ROLE",
     "STATUS_OK",
     "STATUS_UNAVAILABLE",
+    "PreDispatchGate",
     "build_audit_record",
     "build_role_runner_dispatcher",
     "claude_role_runner",

--- a/apps/engineering-agent/src/yule_engineering/cli/harness.py
+++ b/apps/engineering-agent/src/yule_engineering/cli/harness.py
@@ -1,0 +1,201 @@
+"""CLI surface for the harness enforcement layer (issue #185 follow-up).
+
+  * ``yule harness receipt`` — print the execution receipt (loaded docs /
+    policies / agent / role / granted skills / blocked-or-missing / runner /
+    warnings / compaction / cleanup status). Item D's debug surface.
+  * ``yule harness compact`` — run compact→vault for a session and print the
+    compaction receipt. Working-tree write only (never commits). Item F.
+  * ``yule harness cleanup`` — allowlist cleanup; dry-run by default, execute
+    requires ``--execute --yes``. Prints the cleanup receipt. Item G.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from yule_core.context_loader import load_agent_context
+
+from ..agents.harness import (
+    assess_security_review,
+    build_execution_receipt,
+    load_grant_table,
+    run_cleanup,
+    run_compaction_to_vault,
+)
+from ..agents.harness.context_compaction import from_workflow_session
+from ..agents.harness.grant_enforcement import GrantVerdict, evaluate_skill
+
+
+def run_harness_receipt_command(
+    repo_root: Path,
+    agent_id: str,
+    *,
+    role: Optional[str],
+    runner: Optional[str],
+    capabilities: Sequence[str],
+    change_paths: Sequence[str] = (),
+    change_summary: Optional[str] = None,
+    json_output: bool,
+) -> int:
+    loaded = load_agent_context(repo_root=repo_root, agent_id=agent_id, role_id=role)
+    table = load_grant_table()
+    security = None
+    if change_paths or change_summary:
+        security = assess_security_review(
+            {"paths": list(change_paths), "summary": change_summary or ""}
+        )
+    receipt = build_execution_receipt(
+        loaded,
+        table,
+        selected_runner=runner,
+        requested_capabilities=list(capabilities),
+        security=security,
+    )
+    if json_output:
+        print(json.dumps(receipt.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(receipt.render())
+    return 0
+
+
+def run_harness_compact_command(
+    repo_root: Path,
+    agent_id: str,
+    *,
+    session_id: str,
+    vault_path: str,
+    project: str,
+    focus: Optional[str],
+    issue: Optional[int],
+    role: Optional[str] = None,
+    live: bool = False,
+    json_output: bool,
+) -> int:
+    # Grant enforcement (hot path): the actor must be granted compact-to-vault.
+    table = load_grant_table()
+    actor = f"{agent_id}/{role}" if role else agent_id
+    decision = evaluate_skill(table, actor, "compact-to-vault")
+    if decision.verdict is GrantVerdict.BLOCK:
+        print(f"blocked: {decision.surface()}", file=sys.stderr)
+        return 1
+    if decision.verdict is GrantVerdict.ADVISORY:
+        print(f"advisory: {decision.surface()}", file=sys.stderr)
+
+    # Resolve the session through the engineering orchestrator (read-only get).
+    from ..agents import Dispatcher, WorkflowOrchestrator, build_participants_pool
+
+    pool = build_participants_pool(repo_root, agent_id)
+    orchestrator = WorkflowOrchestrator(Dispatcher(pool))
+    session = orchestrator.get(session_id)
+    if session is None:
+        raise ValueError(f"session {session_id} not found")
+
+    # Optional live /compact token capture (graceful fallback + warning).
+    compact_boundary = None
+    if live:
+        try:
+            from ..agents.runners.claude_code import ClaudeCodeRunner
+
+            compact_boundary = ClaudeCodeRunner().compact(focus=focus)
+        except Exception as exc:  # noqa: BLE001 - live capture is best-effort
+            print(f"warning: live /compact capture failed: {exc}", file=sys.stderr)
+
+    turns = from_workflow_session(session)
+    note, receipt = run_compaction_to_vault(
+        turns,
+        session_id=session_id,
+        vault_root=Path(vault_path),
+        project=project,
+        focus=focus,
+        issue=issue,
+        original_prompt=getattr(session, "prompt", None),
+        compact_boundary=compact_boundary,
+    )
+    if json_output:
+        print(json.dumps(receipt.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(f"compaction status: {receipt.status}")
+        if note is not None:
+            print(f"task-log note: {note.relative_path} (committed={receipt.committed})")
+        print(
+            f"pre_tokens={receipt.pre_tokens} post_tokens={receipt.post_tokens} "
+            f"saved={receipt.saved_tokens} token_source={receipt.token_source}"
+        )
+        for w in receipt.warnings:
+            print(f"warning: {w}", file=sys.stderr)
+    return 0
+
+
+def run_harness_security_command(
+    repo_root: Path,
+    *,
+    paths: Sequence[str],
+    summary: Optional[str],
+    json_output: bool,
+) -> int:
+    decision = assess_security_review({"paths": list(paths), "summary": summary or ""})
+    if json_output:
+        print(json.dumps(decision.to_dict(), ensure_ascii=False, indent=2))
+        return 0
+    print(decision.surface())
+    for reason in decision.reasons:
+        print(f"  - {reason}")
+    # Non-zero exit when review is required so CI / gates can act on it.
+    return 2 if decision.required else 0
+
+
+def run_harness_cleanup_command(
+    repo_root: Path,
+    *,
+    root: Optional[str],
+    execute: bool,
+    yes: bool,
+    json_output: bool,
+) -> int:
+    scan_root = Path(root) if root else _default_cleanup_root(repo_root)
+    receipt = run_cleanup(scan_root, execute=execute, confirm=yes)
+    if json_output:
+        print(json.dumps(receipt.to_dict(), ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"cleanup status: {receipt.status}  root={receipt.root}")
+    print(f"scanned={receipt.scanned_count} reclaimable_bytes={receipt.reclaimable_bytes}")
+    print(
+        f"deletable={len(receipt.deletable)} deleted={receipt.deleted_count} "
+        f"protected={len(receipt.protected)} approval_needed={len(receipt.approval_needed)}"
+    )
+    if receipt.approval_needed:
+        print("approval-needed:")
+        for e in receipt.approval_needed:
+            print(f"  - {e.rel_path} ({e.reason})")
+    if not receipt.executed and receipt.deletable:
+        print("(dry-run — re-run with --execute --yes to reclaim)")
+    for w in receipt.warnings:
+        print(f"warning: {w}", file=sys.stderr)
+    return 0
+
+
+def _default_cleanup_root(repo_root: Path) -> Path:
+    """Default scan root: the local cache dir if present, else repo root.
+
+    ``.cache`` holds the regeneratable harness/runtime scratch; the operator
+    workflow ``*.sqlite3`` inside it is PRESERVED by the allowlist regardless.
+    """
+
+    env = os.environ.get("YULE_CACHE_DIR")
+    if env:
+        return Path(env)
+    cache = repo_root / ".cache"
+    return cache if cache.exists() else repo_root
+
+
+__all__ = (
+    "run_harness_receipt_command",
+    "run_harness_compact_command",
+    "run_harness_cleanup_command",
+    "run_harness_security_command",
+)

--- a/apps/engineering-agent/src/yule_engineering/cli/main.py
+++ b/apps/engineering-agent/src/yule_engineering/cli/main.py
@@ -32,6 +32,12 @@ from .engineer import (
     run_engineer_show_command,
 )
 from ..agents.workflow import WorkflowError
+from .harness import (
+    run_harness_cleanup_command,
+    run_harness_compact_command,
+    run_harness_receipt_command,
+    run_harness_security_command,
+)
 from .doctor import run_doctor_command
 from .github import run_github_issues_command
 from .github_workos import (
@@ -56,6 +62,7 @@ from .parsers import (
     add_doctor_parser,
     add_engineer_parser,
     add_github_parser,
+    add_harness_parser,
     add_memory_parser,
     add_obsidian_parser,
     add_planning_parser,
@@ -88,6 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_runtime_parser(subparsers)
     add_run_service_parser(subparsers)
     add_engineer_parser(subparsers)
+    add_harness_parser(subparsers)
     add_obsidian_parser(subparsers)
     add_supervisor_parser(subparsers)
     add_memory_parser(subparsers)
@@ -300,6 +308,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
 
         if args.command == "engineer":
             return _dispatch_engineer_command(repo_root, args)
+        if args.command == "harness":
+            return _dispatch_harness_command(repo_root, args)
         if args.command == "supervisor" and args.supervisor_command == "run":
             return run_supervisor_run_once_command(
                 limit=args.limit,
@@ -383,3 +393,46 @@ def _dispatch_engineer_command(repo_root: Path, args) -> int:
     if args.engineer_command == "show":
         return run_engineer_show_command(repo_root, args.agent, args.session)
     raise ValueError(f"unknown engineer command: {args.engineer_command}")
+
+
+def _dispatch_harness_command(repo_root: Path, args) -> int:
+    if args.harness_command == "receipt":
+        return run_harness_receipt_command(
+            repo_root,
+            args.agent,
+            role=args.role,
+            runner=args.runner,
+            capabilities=args.capability,
+            change_paths=args.change_path,
+            change_summary=args.change_summary,
+            json_output=args.json_output,
+        )
+    if args.harness_command == "compact":
+        return run_harness_compact_command(
+            repo_root,
+            args.agent,
+            session_id=args.session,
+            vault_path=args.vault_path,
+            project=args.project,
+            focus=args.focus,
+            issue=args.issue,
+            role=args.role,
+            live=args.live,
+            json_output=args.json_output,
+        )
+    if args.harness_command == "security-review":
+        return run_harness_security_command(
+            repo_root,
+            paths=args.change_path,
+            summary=args.change_summary,
+            json_output=args.json_output,
+        )
+    if args.harness_command == "cleanup":
+        return run_harness_cleanup_command(
+            repo_root,
+            root=args.root,
+            execute=args.execute,
+            yes=args.yes,
+            json_output=args.json_output,
+        )
+    raise ValueError(f"unknown harness command: {args.harness_command}")

--- a/apps/engineering-agent/src/yule_engineering/cli/parsers.py
+++ b/apps/engineering-agent/src/yule_engineering/cli/parsers.py
@@ -823,6 +823,94 @@ def add_engineer_parser(subparsers: argparse._SubParsersAction) -> None:
     engineer_show_parser.add_argument("--session", required=True, help="Session id.")
 
 
+def add_harness_parser(subparsers: argparse._SubParsersAction) -> None:
+    harness_parser = subparsers.add_parser(
+        "harness",
+        help="Harness enforcement surfaces: execution receipt, compact→vault, cleanup.",
+    )
+    harness_subparsers = harness_parser.add_subparsers(dest="harness_command", required=True)
+
+    receipt_parser = harness_subparsers.add_parser(
+        "receipt",
+        help="Print the execution receipt (loaded docs/policies, agent/role, grants, statuses).",
+    )
+    receipt_parser.add_argument(
+        "--agent", default="engineering-agent", help="Department agent id."
+    )
+    receipt_parser.add_argument("--role", help="Active role id (e.g. security-engineer).")
+    receipt_parser.add_argument("--runner", help="Selected runner id (e.g. claude).")
+    receipt_parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        help="Capability to evaluate against grants (repeatable). /cmd => command, else skill.",
+    )
+    receipt_parser.add_argument(
+        "--change-path",
+        action="append",
+        default=[],
+        help="Changed path to evaluate for security auto-dispatch (repeatable).",
+    )
+    receipt_parser.add_argument(
+        "--change-summary", help="Change summary for security auto-dispatch."
+    )
+    receipt_parser.add_argument("--json", dest="json_output", action="store_true")
+
+    compact_parser = harness_subparsers.add_parser(
+        "compact",
+        help="Run compact→vault for a session; writes a task-log note (no commit).",
+    )
+    compact_parser.add_argument("--agent", default="engineering-agent", help="Department agent id.")
+    compact_parser.add_argument("--role", help="Active role id (refines grant actor).")
+    compact_parser.add_argument("--session", required=True, help="Session id to compact.")
+    compact_parser.add_argument(
+        "--vault-path", required=True, help="Vault root to write the task-log note under."
+    )
+    compact_parser.add_argument(
+        "--project", default="yule-studio-agent", help="Project folder under 10-projects/."
+    )
+    compact_parser.add_argument("--focus", help="Optional compaction focus topic.")
+    compact_parser.add_argument("--issue", type=int, help="Optional issue number suffix.")
+    compact_parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Attempt live /compact token capture (graceful fallback to estimate).",
+    )
+    compact_parser.add_argument("--json", dest="json_output", action="store_true")
+
+    security_parser = harness_subparsers.add_parser(
+        "security-review",
+        help="Assess whether a change requires security-engineer review. Exit 2 when required.",
+    )
+    security_parser.add_argument(
+        "--change-path",
+        action="append",
+        default=[],
+        help="Changed path (repeatable).",
+    )
+    security_parser.add_argument("--change-summary", help="Change summary text.")
+    security_parser.add_argument("--json", dest="json_output", action="store_true")
+
+    cleanup_parser = harness_subparsers.add_parser(
+        "cleanup",
+        help="Allowlist cleanup of transient artifacts. Dry-run unless --execute --yes.",
+    )
+    cleanup_parser.add_argument(
+        "--root", help="Scan root. Defaults to .cache if present, else repo root."
+    )
+    cleanup_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually delete DELETABLE entries. Requires --yes.",
+    )
+    cleanup_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm destructive execute. Without it --execute is refused.",
+    )
+    cleanup_parser.add_argument("--json", dest="json_output", action="store_true")
+
+
 def add_obsidian_parser(subparsers: argparse._SubParsersAction) -> None:
     obsidian_parser = subparsers.add_parser(
         "obsidian",

--- a/docs/agent-slash-commands.md
+++ b/docs/agent-slash-commands.md
@@ -82,6 +82,63 @@
 - 스킬 spec: [`compact-to-vault.md`](../skills/compact-to-vault.md).
 - 자동 트리거는 `YULE_COMPACT_TO_VAULT_ENABLED`(기본 off) 뒤에서만. live `/compact` 토큰 캡처는 후속 PR.
 
+## 4b. grant 강제 (runtime enforcement)
+
+grant table 은 "X 가 Y 에 부여됐나" 의 SSoT 이고, 런타임 강제는
+[`agents/harness/grant_enforcement.py`](../apps/engineering-agent/src/yule_engineering/agents/harness/grant_enforcement.py)
+가 책임진다. actor(부서 또는 `<부서>/<role>`)가 슬래시 명령어/스킬을 쓰려 할 때 세 판정 중 하나를 낸다.
+
+| 상황 | 판정 |
+| --- | --- |
+| actor 에 grant 됨 | **ALLOW** |
+| 미부여, 카탈로그에 존재 + grantable built-in | **ADVISORY** (경고 surface, 게이트웨이/운영자가 grant 확장 결정) |
+| 미부여, 등록된 custom skill | **ADVISORY** |
+| 미부여, grantable=false built-in (운영자 대화형 전용) | **BLOCK** |
+| 카탈로그에 없는 명령어/스킬 | **BLOCK** |
+| grant table 에 없는 actor | **BLOCK** |
+
+advisory vs block 의 경계는 **코드에 고정**(`grant_enforcement.evaluate_command/skill`)되고
+[`tests/agents/test_grant_enforcement.py`](../tests/agents/test_grant_enforcement.py) 가 잠근다.
+원칙: *알려진(=카탈로그에 있고 부여 가능한) 능력의 미보유*는 over-block 하지 않고 advisory 로
+surface; *알 수 없거나 grant 자체가 금지된 능력*은 block.
+
+**hot-path 결선(실 dispatch).** role-runner dispatch 가 provider 를 부르기 직전,
+`role_runner.build_role_runner_dispatcher(pre_dispatch_gate=…)` 가 gate 를 실행한다 — BLOCK
+이면 provider 호출 없이 `STATUS_BLOCKED` take 를 반환(`agents/harness/hot_path.build_capability_block_gate`).
+게이트웨이 결선은 `bootstrap.build_role_runner_dispatch_from_env(grant_table=…, receipt_sink=…)`
+이며 `YULE_GRANT_ENFORCEMENT_ENABLED` 로 opt-in(기본 off, 미설정 시 기존 동작 그대로). capability 는
+`RoleRunnerInput.metadata['capabilities']` 로 선언한다. ADVISORY 는 차단하지 않고 receipt 에 남는다.
+회귀: [`tests/runners/test_role_runner_gate.py`](../tests/runners/test_role_runner_gate.py) ·
+[`tests/runners/test_runner_bootstrap_enforcement.py`](../tests/runners/test_runner_bootstrap_enforcement.py) ·
+[`tests/agents/test_hot_path.py`](../tests/agents/test_hot_path.py).
+
+## 4c. execution receipt (실행 증명)
+
+이번 run 이 무엇을 로드했고 무엇이 허용됐는지를
+[`agents/harness/execution_receipt.py`](../apps/engineering-agent/src/yule_engineering/agents/harness/execution_receipt.py)
+가 `ExecutionReceipt` 로 묶는다. 필드: loaded docs / loaded policies / selected agent · role /
+granted skills · commands / blocked or missing / selected runner / warnings / compaction status /
+cleanup status / security status. CLI: `yule harness receipt [--role <r>] [--runner <id>] [--capability …]
+[--change-path …] [--change-summary …] [--json]`.
+
+**매 run 결선.** enforcement opt-in(`YULE_GRANT_ENFORCEMENT_ENABLED`) 시 게이트웨이 dispatch 가
+끝날 때마다 `hot_path.dispatch_receipt` 가 receipt 를 만들어 `session.extra['execution_receipts']`
+(append-only, cap 50 — audit 는 트리밍하지 않음)에 적립한다.
+
+**live `/compact` 토큰.** `claude_code.ClaudeCodeRunner.compact()` 가 `--output-format stream-json`
+의 `compact_boundary` 이벤트에서 pre/post 토큰을 캡처한다(`YULE_CLAUDE_LIVE_ENABLED` opt-in). 파싱
+실패/비live 면 deterministic 추정치로 graceful fallback 하고 receipt 에 `token_source=estimate`
++ warning 을 남긴다. CLI: `yule harness compact --live …`.
+
+## 4d. cleanup (용량/잔여 artifact 안전 정리)
+
+[`agents/harness/cleanup.py`](../apps/engineering-agent/src/yule_engineering/agents/harness/cleanup.py)
+는 allowlist 기반으로만 정리한다. 분류: `DELETABLE`(transient/regeneratable) ·
+`PRESERVE`(audit/canonical — `*.sqlite3` 세션, agent_ops_audit, vault canonical, 원문
+prompt/decision/synthesis/approval, 소스/정책/테스트) · `APPROVAL_NEEDED`(generated-but-tracked
+harness 디렉터리, 대용량). **PRESERVE 가 항상 우선**, default 도 PRESERVE. dry-run 이 기본이며
+execute 는 `--execute --yes` 둘 다 필요. CLI: `yule harness cleanup [--root …] [--execute --yes] [--json]`.
+
 ## 5. 에이전트가 스킬/플러그인을 직접 저작하는 절차
 
 harness 디렉터리는 생성물이므로 직접 만들지 않는다. 항상 **SSoT → 생성** 경로:
@@ -143,8 +200,11 @@ approval_policy = "untrusted"          # 파괴적 작업 전 승인 — 본 레
 
 - 8개 부서 전체 custom 스킬 spec 확충(현재는 cross-cutting 위주).
 - live `/compact` wiring — `ClaudeCodeRunner` 구현(현재 stub) 후 port 주입 + `compact_boundary` 캡처.
-- grant 매트릭스 런타임 강제 — RoleRunner dispatch 시 미부여 슬래시 차단.
-- MCP 서버 표준 wiring(보안 검토) + Codex 멀티에이전트 연동.
+- ✅ grant 매트릭스 런타임 강제 — `grant_enforcement.py` (§4b) + **RoleRunner dispatch hot-path 결선**(`role_runner.pre_dispatch_gate` + `bootstrap`, `YULE_GRANT_ENFORCEMENT_ENABLED`).
+- ✅ execution receipt(§4c) — 매 run 결선(`session.extra['execution_receipts']`) · ✅ compact→vault 프로토콜 + `/clear` 가드 · ✅ cleanup(§4d, hardened).
+- ✅ live `/compact` 토큰 캡처 — `claude_code.ClaudeCodeRunner.{submit,compact}`(`YULE_CLAUDE_LIVE_ENABLED`, compact_boundary + graceful fallback).
+- ✅ security review cross-cutting 게이트 + **auto-dispatch 판정**(`security_gate.assess_security_review`) — `docs/security-review.md`.
+- 남은 후속: provider 별 live submit(codex/gemini) · MCP 서버 표준 wiring · Codex 멀티에이전트 연동 · 변경 metadata 를 dispatch 입력에 자동 채우는 producer 결선.
 
 ## 10. 관련 문서
 

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -1,0 +1,140 @@
+# Security Review — cross-cutting 보안 검토 워크플로 (SSoT)
+
+> 본 문서는 `engineering-agent / security-engineer` (cross-cutting 리뷰 게이트)의
+> **사람용 SSoT** 다. 역할 계약 코드 SSoT 는
+> [`agents/engineering-agent/security-engineer/manifest.json`](../agents/engineering-agent/security-engineer/manifest.json) +
+> [`CLAUDE.md`](../agents/engineering-agent/security-engineer/CLAUDE.md).
+> 거버넌스/승인은 [`approval-matrix.md`](approval-matrix.md) ·
+> [`autonomy-policy.md`](autonomy-policy.md) · [`engineering-agent-governance.md`](engineering-agent-governance.md)
+> 와 cross-link.
+
+## 1. 왜 별도 주체인가 (구조 선택)
+
+보안은 backend / frontend / devops / AI 를 **가로지르는 cross-cutting concern** 이다.
+각 역할이 자기 도메인 보안을 1차로 보지만, 도메인 경계를 넘는 위협(서버는 검증하는데
+프론트가 토큰을 노출, CI 가 과다 권한, agent tool 이 승인 게이트 우회)은 단일 도메인
+리뷰에서 새기 쉽다.
+
+**1차 rollout 은 `security-agent` 별도 부서가 아니라 `engineering-agent/security-engineer`
+역할이다.** 이유:
+
+- 현재 context loader / grant table / role manifest / council runtime 이 모두
+  engineering-agent 부서 + role 멤버 구조 위에 서 있다. 역할로 도입하면 기존 계약을
+  재사용하며 **최소 변경**으로 end-to-end 가 닫힌다.
+- 별도 부서는 org-chart SSoT(8 부서 고정, `test_slash_command_grants` 가 정확 집합을 핀)
+  변경 + 새 manifest + runner pool + grant 부서 추가를 요구한다 — 더 큰 변경이고 이번
+  슬라이스 범위를 넘는다.
+- **단, 이 역할은 7-role deliberation council 의 8번째 seat 가 아니다.** council registry
+  (`role_profiles_data.py`, `test_registry_covers_seven_engineering_roles` 가 고정)는
+  그대로 두고, security-engineer 는 manifest 의 `cross_cutting_reviewers` 에 둔다 — 매
+  토의에 항상 들어가는 게 아니라 **특정 변경 유형에서만 끼어드는 게이트**다.
+- 장기적으로 root `CLAUDE.md`/`agents/engineering-agent/CLAUDE.md` 의 org diagram 이 예고한
+  `(future) security-agent` 부서로 승격 가능 — 마이그레이션 경로는 §7.
+
+## 2. 언제 끼어드는가 (intercept triggers)
+
+다음 변경 유형 중 하나라도 해당하면 security-engineer 리뷰가 **필수 게이트**로 들어온다.
+코드 SSoT 는 manifest 의 `intercept_triggers`.
+
+| 트리거 | 예시 |
+| --- | --- |
+| auth / authz 변경 | 로그인, 권한 검사, 토큰 발급/검증, 세션 전략 |
+| secret handling 변경 | `.env`, key, credential, secret store 접근/저장 |
+| public surface 추가 | 새 endpoint / route / webhook / upload / postMessage 핸들러 |
+| deployment / security-sensitive | CI/CD 권한, container/image, 의존성(supply-chain), env/config 노출 |
+| agent 경계 변경 | tool grant 추가, approval gate / autonomy boundary 수정 |
+| 명시 요청 | `/security-review` 슬래시 또는 운영자 요청 |
+
+트리거가 없으면 게이트는 **열리지 않는다** — 모든 작업에 보안 리뷰를 강제하지 않는다
+(noise 방지). 트리거 판정은 tech-lead 의 intake/triage 에서 1차로 내린다.
+
+## 3. Inputs / Outputs / Boundaries
+
+### Inputs
+- 변경 대상 역할의 산출물(RoleDraft / diff / API 계약 / UI 흐름 / 배포 계획 / tool grant)
+- tech-lead 의 작업 분해 + intercept 사유
+- ResearchPack 의 보안 문서 / CVE / 공식 권고
+- 현재 grant table + approval matrix
+
+### Outputs
+- 도메인별 finding: `[severity] 위치 — 무엇이/왜 위험/영향/권고(서버측 강제 포함)`
+- blocking vs non-blocking 분류
+- 서버측 강제로 옮겨야 할 제어 목록
+- secret/PII 노출 판정, approval gate 우회 가능성 판정
+- tech-lead / 운영자에게 보낼 merge 가능 여부 권고
+
+### Boundaries (하드레일)
+- **코드를 직접 머지/배포하지 않는다 — 권고만.**
+- secret 값을 읽거나 기록하지 않는다(패턴/경계만).
+- 사용자 승인 없이 destructive command 금지.
+- 결과는 게이트웨이(tech-lead)를 통해 외부 회신.
+
+## 4. 검토 범위 체크리스트 (4 도메인)
+
+체크 항목 코드 SSoT 는 manifest `review_domains`. 요약:
+
+- **backend** — authentication · authorization · session/JWT/cookie · IDOR(object-level
+  권한) · input validation · SQLi / SSRF / file upload · rate limiting · secret exposure ·
+  audit logging.
+- **frontend** — client = hostile surface · secret 비노출 · XSS / CSP · token storage ·
+  CSRF · postMessage origin 검증 · clickjacking / frame-ancestors · permission UI 는
+  보안 경계가 아님.
+- **devops** — secret management · CI/CD least privilege · dependency / supply-chain ·
+  container / image hardening · env/config exposure · rollback / readiness / observability.
+- **AI / agent** — prompt injection · tool overreach · approval gate bypass · data
+  exfiltration · auditability.
+
+## 5. 절대 금지 (anti-goals)
+
+- **"브라우저 개발자 도구를 사용자가 못 열게 막는다" 를 보안 목표로 정의하지 않는다.**
+  클라이언트는 신뢰 경계가 아니다. 민감 제어는 **서버 검증으로 강제**한다.
+- 권한 UI 숨김을 권한 경계로 착각하지 않는다.
+- detection evasion / obfuscation 을 보안으로 포장하지 않는다.
+
+## 6. `/security-review` 흐름과 grant
+
+- `/security-review` 는 built-in 슬래시(카탈로그: `agents/grants/slash-command-grants.json`).
+  engineering-agent 부서에 L1 로 부여돼 있고, `engineering-agent/security-engineer`
+  role override 가 이를 **강조 부여**한다(+`/diff`, +`compact-to-vault`, +`vault-curate`).
+- 런타임 grant 강제(advisory/block)는 [`agent-slash-commands.md`](agent-slash-commands.md)
+  §"grant 강제" 참조 — security-engineer 가 `/security-review` 를 호출하면 ALLOW.
+- 검토 세션은 `compact-to-vault` 로 vault task-log 에 적립할 수 있다(검토 추적성).
+
+### auto-dispatch (변경 감지 → 게이트 판정)
+
+[`agents/harness/security_gate.py`](../apps/engineering-agent/src/yule_engineering/agents/harness/security_gate.py)
+의 `assess_security_review(change)` 가 변경 metadata(`paths` / `summary` / `labels`)를 보고 §2 의
+intercept trigger 6종(auth / secret / public_surface / deployment / client_security / agent_safety)을
+매칭해 `SecurityReviewDecision(required, triggers, reasons)` 를 낸다.
+
+- 결과는 execution receipt 의 `security_status`(`required` / `not_required` / `skipped` /
+  `not_evaluated`)에 남고, dispatch 결선에서는 `RoleRunnerInput.metadata['change']` 로 전달돼
+  receipt 에 자동 기록된다(`hot_path.dispatch_receipt`).
+- CLI: `yule harness security-review --change-path <p> --change-summary <s>` (required 면 exit 2).
+  `yule harness receipt --change-path … --change-summary …` 로도 security 판정이 receipt 에 표면화.
+
+**false-positive / false-negative tradeoff(의도된 설계).** 휴리스틱은 키워드/경로 기반이라
+**과탐(over-trigger)** 쪽으로 기운다 — 누락(미탐)보다 낫다(보안 검토는 auth/secret 버그 누락보다
+싸다). 매칭이 하나라도 잡히면 `required=True`. skip 은 절대 암묵적이지 않고 `force_skip_reason` 으로
+명시·감사된다(silence ≠ skip). 코드 SSoT 와 회귀는
+[`security_gate.py`](../apps/engineering-agent/src/yule_engineering/agents/harness/security_gate.py) +
+[`tests/agents/test_security_gate.py`](../tests/agents/test_security_gate.py).
+
+## 7. 후속 / 마이그레이션
+
+- security-engineer 가 deliberation 에서 1급 참여자가 돼야 하면 `role_profiles_data.py`
+  레지스트리에 8번째 profile 을 추가하고 `_EXPECTED_ROLES` 핀을 갱신한다(별도 PR).
+- 보안 책임이 부서 규모로 커지면 `security-agent` 부서로 승격: org-chart SSoT + grant
+  부서 추가 + `_EXPECTED_DEPARTMENTS` 갱신.
+- ✅ 자동 dispatch 판정(`security_gate.assess_security_review`)은 결선 완료(§6). 남은 후속:
+  변경 metadata 를 dispatch 입력에 자동 채우는 producer 결선(현재는 caller 가
+  `metadata['change']` 를 채워 넘긴다)과, required 판정 시 security-engineer review 를 실제
+  job 으로 auto-insert 하는 큐 결선.
+
+## 8. 관련 문서
+
+- 역할 계약: [`security-engineer/manifest.json`](../agents/engineering-agent/security-engineer/manifest.json) · [`CLAUDE.md`](../agents/engineering-agent/security-engineer/CLAUDE.md)
+- 슬래시/grant/enforcement: [`agent-slash-commands.md`](agent-slash-commands.md)
+- 승인/자율: [`approval-matrix.md`](approval-matrix.md) · [`autonomy-policy.md`](autonomy-policy.md)
+- 거버넌스 hard rail: [`engineering-agent-governance.md`](engineering-agent-governance.md)
+- outbound secret redaction: `packages/security/src/yule_security/paste_guard.py`

--- a/packages/core/src/yule_core/context_loader.py
+++ b/packages/core/src/yule_core/context_loader.py
@@ -3,11 +3,33 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 
 class ContextError(Exception):
     """Raised when agent context cannot be loaded."""
+
+
+# Canonical load order (high → low specificity), per
+# ``policies/runtime/common/context-loading.md`` and ``AGENTS.md`` §1:
+#
+#   1. AGENTS.md          — repo entrypoint / doc-navigation (required)
+#   2. CLAUDE.md          — global rules for every agent/task (required)
+#   3. agent instruction  — active agent's instruction_entry (required)
+#   4. role instruction   — active role's instruction_entry (optional)
+#   5. policies           — manifest-listed policy files (optional)
+#
+# A missing *optional* file is reported as a warning and the load continues
+# (context-loading policy: "report it and continue with the available
+# context"). A missing *required* file raises ``ContextError``.
+ENTRYPOINT_DOC = "AGENTS.md"
+ROOT_INSTRUCTIONS_DOC = "CLAUDE.md"
+
+LABEL_ENTRYPOINT = "entrypoint"
+LABEL_ROOT = "root_instructions"
+LABEL_AGENT = "agent_instructions"
+LABEL_ROLE = "role_instructions"
+LABEL_POLICY = "policy"
 
 
 @dataclass(frozen=True)
@@ -24,22 +46,65 @@ class LoadedContext:
     manifest: Dict[str, Any]
     documents: Sequence[ContextDocument]
     warnings: Sequence[str]
+    role_id: Optional[str] = None
+    role_manifest: Optional[Dict[str, Any]] = None
+
+    def documents_by_label(self, label: str) -> Sequence[ContextDocument]:
+        return tuple(doc for doc in self.documents if doc.label == label)
+
+    def has_role_instructions(self) -> bool:
+        return any(doc.label == LABEL_ROLE for doc in self.documents)
 
 
-def load_agent_context(repo_root: Path, agent_id: str) -> LoadedContext:
+def load_agent_context(
+    repo_root: Path,
+    agent_id: str,
+    *,
+    role_id: Optional[str] = None,
+) -> LoadedContext:
+    """Load the layered instruction context for *agent_id* (and *role_id*).
+
+    The load order follows ``AGENTS.md`` §1 and the context-loading policy:
+    ``AGENTS.md`` → root ``CLAUDE.md`` → agent ``instruction_entry`` →
+    (when *role_id* is given) role ``instruction_entry`` → policies.
+
+    Two cases are handled explicitly:
+
+      * *role_id is None* — no role selected yet. Only the agent layer is
+        loaded; no role document and no role warning are emitted.
+      * *role_id is given* — the role layer is loaded from
+        ``agents/<agent_id>/<role_id>/manifest.json``. A missing role
+        manifest / ``instruction_entry`` / file is recorded as a warning
+        (philosophy preserved) instead of raising, because role contracts
+        are an additive layer over the always-present agent layer.
+    """
+
     repo_root = repo_root.resolve()
     manifest_path = repo_root / "agents" / agent_id / "manifest.json"
     manifest = _load_manifest(manifest_path)
     documents: List[ContextDocument] = []
     warnings: List[str] = []
 
-    documents.append(_read_required_document(repo_root, "root_instructions", "CLAUDE.md"))
+    # 1. entrypoint + 2. root rules (both required — they always exist at the
+    # repo root and anchor every agent/role load).
+    documents.append(_read_required_document(repo_root, LABEL_ENTRYPOINT, ENTRYPOINT_DOC))
+    documents.append(_read_required_document(repo_root, LABEL_ROOT, ROOT_INSTRUCTIONS_DOC))
 
+    # 3. active agent instruction_entry (required).
     instruction_entry = manifest.get("instruction_entry")
     if not isinstance(instruction_entry, str) or not instruction_entry:
         raise ContextError(f"{_display_path(manifest_path, repo_root)} must define instruction_entry")
-    documents.append(_read_required_document(repo_root, "agent_instructions", instruction_entry))
+    documents.append(_read_required_document(repo_root, LABEL_AGENT, instruction_entry))
 
+    # 4. active role instruction_entry (optional — only when a role is selected).
+    role_manifest: Optional[Dict[str, Any]] = None
+    if role_id:
+        role_manifest, role_warnings = _load_role_layer(
+            repo_root, agent_id, role_id, documents
+        )
+        warnings.extend(role_warnings)
+
+    # 5. policies listed in the agent manifest (optional).
     policies = manifest.get("policies", [])
     if not isinstance(policies, list):
         raise ContextError(f"{_display_path(manifest_path, repo_root)} policies must be a list")
@@ -49,7 +114,7 @@ def load_agent_context(repo_root: Path, agent_id: str) -> LoadedContext:
             warnings.append("Skipping non-string policy path in agent manifest.")
             continue
 
-        document = _read_optional_document(repo_root, "policy", policy_path)
+        document = _read_optional_document(repo_root, LABEL_POLICY, policy_path)
         if document is None:
             warnings.append(f"Missing policy file: {policy_path}")
             continue
@@ -61,14 +126,70 @@ def load_agent_context(repo_root: Path, agent_id: str) -> LoadedContext:
         manifest=manifest,
         documents=documents,
         warnings=warnings,
+        role_id=role_id,
+        role_manifest=role_manifest,
     )
 
 
+def _load_role_layer(
+    repo_root: Path,
+    agent_id: str,
+    role_id: str,
+    documents: List[ContextDocument],
+) -> tuple[Optional[Dict[str, Any]], List[str]]:
+    """Append the role instruction document; return (role_manifest, warnings).
+
+    Never raises — a malformed/missing role layer degrades to warnings so the
+    agent layer (already loaded) still wins. This keeps the "missing file →
+    report and continue" philosophy for the additive role tier.
+    """
+
+    warnings: List[str] = []
+    role_manifest_path = repo_root / "agents" / agent_id / role_id / "manifest.json"
+    if not role_manifest_path.exists():
+        warnings.append(
+            f"Missing role manifest for {agent_id}/{role_id}: "
+            f"{_display_path(role_manifest_path, repo_root)}"
+        )
+        return None, warnings
+
+    try:
+        role_manifest = json.loads(role_manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        warnings.append(f"Invalid JSON in role manifest {agent_id}/{role_id}: {exc}")
+        return None, warnings
+    if not isinstance(role_manifest, dict):
+        warnings.append(f"Role manifest must be a JSON object: {agent_id}/{role_id}")
+        return None, warnings
+
+    role_entry = role_manifest.get("instruction_entry")
+    if not isinstance(role_entry, str) or not role_entry:
+        warnings.append(
+            f"Role {agent_id}/{role_id} manifest missing instruction_entry"
+        )
+        return role_manifest, warnings
+
+    document = _read_optional_document(repo_root, LABEL_ROLE, role_entry)
+    if document is None:
+        warnings.append(f"Missing role instruction file: {role_entry}")
+        return role_manifest, warnings
+
+    documents.append(document)
+    return role_manifest, warnings
+
+
 def render_context(loaded_context: LoadedContext) -> str:
+    repo_root = loaded_context.manifest_path.parents[2]
+    role_line = (
+        f"Active Role: {loaded_context.role_id}"
+        if loaded_context.role_id
+        else "Active Role: (none — role not yet selected)"
+    )
     lines: List[str] = [
         f"# Loaded Context: {loaded_context.agent_id}",
         "",
-        f"Manifest: {_display_path(loaded_context.manifest_path, loaded_context.manifest_path.parents[2])}",
+        f"Manifest: {_display_path(loaded_context.manifest_path, repo_root)}",
+        role_line,
         f"Execution Mode: {loaded_context.manifest.get('execution_mode', 'unknown')}",
         f"Default Executor: {loaded_context.manifest.get('default_executor', 'unknown')}",
         "",
@@ -83,7 +204,7 @@ def render_context(loaded_context: LoadedContext) -> str:
     for document in loaded_context.documents:
         lines.extend(
             [
-                f"## {document.label}: {_display_path(document.path, loaded_context.manifest_path.parents[2])}",
+                f"## {document.label}: {_display_path(document.path, repo_root)}",
                 "",
                 document.content.rstrip(),
                 "",

--- a/tests/agents/test_claude_live_runner.py
+++ b/tests/agents/test_claude_live_runner.py
@@ -1,0 +1,118 @@
+"""ClaudeCodeRunner live submit + /compact token capture (issue #185 follow-up B)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.runners.base import AgentRequest, RunnerStatus
+from yule_engineering.agents.runners.claude_code import (
+    ClaudeCodeRunner,
+    CompactBoundary,
+    parse_compact_boundary,
+)
+
+
+def _req() -> AgentRequest:
+    return AgentRequest(prompt="설명해줘", role="qa-engineer", task_id="t1")
+
+
+def _invoke_ok(args, input_text, timeout):
+    return 0, "라이브 응답입니다", ""
+
+
+def _invoke_fail(args, input_text, timeout):
+    return 3, "", "boom"
+
+
+def _invoke_timeout(args, input_text, timeout):
+    raise subprocess.TimeoutExpired(cmd=args, timeout=timeout)
+
+
+class SubmitTests(unittest.TestCase):
+    def test_non_live_is_dry_run(self) -> None:
+        # injected invoke ⇒ available, but live flag off ⇒ dry-run contract kept
+        runner = ClaudeCodeRunner(config={"invoke": _invoke_ok, "live_enabled": False})
+        resp = runner.submit(_req())
+        self.assertEqual(resp.status, RunnerStatus.DRY_RUN)
+
+    def test_live_ok(self) -> None:
+        runner = ClaudeCodeRunner(config={"invoke": _invoke_ok, "live_enabled": True})
+        resp = runner.submit(_req())
+        self.assertEqual(resp.status, RunnerStatus.OK)
+        self.assertEqual(resp.text, "라이브 응답입니다")
+        self.assertTrue(resp.metrics.get("live"))
+
+    def test_live_nonzero_exit_is_error(self) -> None:
+        runner = ClaudeCodeRunner(config={"invoke": _invoke_fail, "live_enabled": True})
+        resp = runner.submit(_req())
+        self.assertEqual(resp.status, RunnerStatus.ERROR)
+        self.assertIn("exited 3", resp.detail or "")
+
+    def test_live_timeout_is_error(self) -> None:
+        runner = ClaudeCodeRunner(
+            config={"invoke": _invoke_timeout, "live_enabled": True, "timeout_seconds": 5}
+        )
+        resp = runner.submit(_req())
+        self.assertEqual(resp.status, RunnerStatus.ERROR)
+        self.assertIn("timed out", resp.detail or "")
+
+    def test_unavailable_when_no_cli_and_no_invoke(self) -> None:
+        runner = ClaudeCodeRunner(config={"cli": "definitely-not-a-real-cli-xyz", "live_enabled": True})
+        resp = runner.submit(_req())
+        self.assertEqual(resp.status, RunnerStatus.UNAVAILABLE)
+
+
+class CompactBoundaryParseTests(unittest.TestCase):
+    def test_parse_stream_event(self) -> None:
+        line = json.dumps(
+            {"type": "compact_boundary", "compact_metadata": {"pre_tokens": 1000, "post_tokens": 250}}
+        )
+        cb = parse_compact_boundary("noise\n" + line + "\nmore")
+        self.assertTrue(cb.parsed)
+        self.assertEqual(cb.pre_tokens, 1000)
+        self.assertEqual(cb.post_tokens, 250)
+        self.assertEqual(cb.saved_tokens, 750)
+
+    def test_parse_alt_key_spelling(self) -> None:
+        line = json.dumps({"type": "compact_boundary", "preTokens": 800, "postTokens": 300})
+        cb = parse_compact_boundary(line)
+        self.assertTrue(cb.parsed)
+        self.assertEqual(cb.pre_tokens, 800)
+
+    def test_parse_fallback_warns(self) -> None:
+        cb = parse_compact_boundary("just regular output, no boundary")
+        self.assertFalse(cb.parsed)
+        self.assertIsNotNone(cb.warning)
+        self.assertIsNone(cb.saved_tokens)
+
+
+class CompactMethodTests(unittest.TestCase):
+    def test_compact_not_live_warns(self) -> None:
+        runner = ClaudeCodeRunner(config={"invoke": _invoke_ok, "live_enabled": False})
+        cb = runner.compact()
+        self.assertFalse(cb.parsed)
+        self.assertIn("live", (cb.warning or "").lower())
+
+    def test_compact_live_parses(self) -> None:
+        line = json.dumps(
+            {"type": "compact_boundary", "compact_metadata": {"pre_tokens": 500, "post_tokens": 100}}
+        )
+
+        def _invoke(args, input_text, timeout):
+            return 0, line, ""
+
+        runner = ClaudeCodeRunner(config={"invoke": _invoke, "live_enabled": True})
+        cb = runner.compact(focus="결제")
+        self.assertTrue(cb.parsed)
+        self.assertEqual(cb.saved_tokens, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_cleanup.py
+++ b/tests/agents/test_cleanup.py
@@ -1,0 +1,129 @@
+"""Allowlist cleanup — classification, dry-run/execute, protected non-deletion (item G)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness.cleanup import (
+    CLEANUP_SAFE_MARKER,
+    Classification,
+    classify,
+    run_cleanup,
+    scan,
+)
+
+
+def _build_tree(root: Path) -> None:
+    # PRESERVE — audit / canonical / source
+    (root / "workflow.sqlite3").write_text("binary-ish", encoding="utf-8")
+    (root / "keep.py").write_text("print('x')", encoding="utf-8")
+    (root / "10-projects" / "p" / "task-logs").mkdir(parents=True)
+    (root / "10-projects" / "p" / "task-logs" / "task-log-x.md").write_text("note", encoding="utf-8")
+    (root / "agent_ops_audit.json").write_text("[]", encoding="utf-8")
+    # DELETABLE — transient / generated
+    (root / "__pycache__").mkdir()
+    (root / "__pycache__" / "mod.pyc").write_text("cache", encoding="utf-8")
+    (root / "data.tmp").write_text("temp", encoding="utf-8")
+    (root / "report-snapshot-2026.json").write_text("snap", encoding="utf-8")
+    (root / "marker.txt").write_text(f"safe {CLEANUP_SAFE_MARKER} regen", encoding="utf-8")
+    # APPROVAL_NEEDED — generated-but-tracked harness
+    (root / ".claude" / "skills" / "x").mkdir(parents=True)
+    (root / ".claude" / "skills" / "x" / "SKILL.md").write_text("gen", encoding="utf-8")
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_preserve_wins_over_transient_location(self) -> None:
+        # a sqlite inside an exports dir is still preserved
+        cls, rule, _ = classify("exports/workflow.sqlite3", is_dir=False)
+        self.assertEqual(cls, Classification.PRESERVE)
+
+    def test_pyc_is_deletable(self) -> None:
+        cls, _r, _ = classify("build/mod.pyc", is_dir=False)
+        self.assertEqual(cls, Classification.DELETABLE)
+
+    def test_generated_harness_needs_approval(self) -> None:
+        cls, _r, _ = classify(".claude/skills/x/SKILL.md", is_dir=False)
+        self.assertEqual(cls, Classification.APPROVAL_NEEDED)
+
+    def test_unmatched_defaults_to_preserve(self) -> None:
+        cls, rule, _ = classify("weird/thing.bin", is_dir=False)
+        self.assertEqual(cls, Classification.PRESERVE)
+        self.assertEqual(rule, "preserve:default")
+
+
+class ScanDryRunTests(unittest.TestCase):
+    def test_dry_run_deletes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _build_tree(root)
+            receipt = run_cleanup(root)  # dry-run default
+            self.assertEqual(receipt.status, "dry_run")
+            self.assertEqual(receipt.deleted_count, 0)
+            self.assertTrue((root / "data.tmp").exists())  # still there
+            # classifications populated
+            rels = {e.rel_path for e in receipt.deletable}
+            self.assertIn("data.tmp", rels)
+            self.assertIn("report-snapshot-2026.json", rels)
+            self.assertIn("__pycache__", rels)  # whole-dir unit
+            self.assertIn("marker.txt", rels)  # promoted by marker
+            approval = {e.rel_path for e in receipt.approval_needed}
+            self.assertIn(".claude/skills/x/SKILL.md", approval)
+            self.assertGreater(receipt.reclaimable_bytes, 0)
+
+    def test_protected_are_listed_protected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _build_tree(root)
+            receipt = run_cleanup(root)
+            protected = {e.rel_path for e in receipt.protected}
+            self.assertIn("workflow.sqlite3", protected)
+            self.assertIn("keep.py", protected)
+            self.assertIn("agent_ops_audit.json", protected)
+            self.assertIn("10-projects/p/task-logs/task-log-x.md", protected)
+
+
+class ExecuteTests(unittest.TestCase):
+    def test_execute_without_confirm_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _build_tree(root)
+            receipt = run_cleanup(root, execute=True, confirm=False)
+            self.assertEqual(receipt.status, "dry_run")
+            self.assertEqual(receipt.deleted_count, 0)
+            self.assertTrue((root / "data.tmp").exists())
+            self.assertTrue(any("refusing to delete" in w for w in receipt.warnings))
+
+    def test_execute_with_confirm_removes_only_deletable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _build_tree(root)
+            receipt = run_cleanup(root, execute=True, confirm=True)
+            self.assertEqual(receipt.status, "executed")
+            self.assertGreater(receipt.deleted_count, 0)
+            # deletable gone
+            self.assertFalse((root / "data.tmp").exists())
+            self.assertFalse((root / "__pycache__").exists())
+            self.assertFalse((root / "report-snapshot-2026.json").exists())
+            # PROTECTED survive — audit/canonical never deleted
+            self.assertTrue((root / "workflow.sqlite3").exists())
+            self.assertTrue((root / "keep.py").exists())
+            self.assertTrue((root / "agent_ops_audit.json").exists())
+            self.assertTrue((root / "10-projects" / "p" / "task-logs" / "task-log-x.md").exists())
+            # APPROVAL_NEEDED survive — never auto-deleted
+            self.assertTrue((root / ".claude" / "skills" / "x" / "SKILL.md").exists())
+
+    def test_missing_root_warns(self) -> None:
+        receipt = run_cleanup(Path("/nonexistent/yule/cleanup/root"))
+        self.assertTrue(any("does not exist" in w for w in receipt.warnings))
+        self.assertEqual(receipt.scanned_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_cleanup_hardening.py
+++ b/tests/agents/test_cleanup_hardening.py
@@ -1,0 +1,70 @@
+"""Cleanup hardening — sqlite sidecars / secrets / new transient paths (item D)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness.cleanup import (
+    CLEANUP_SAFE_MARKER,
+    Classification,
+    classify,
+    run_cleanup,
+)
+
+
+class HardenedClassifyTests(unittest.TestCase):
+    def test_sqlite_wal_shm_journal_preserved(self) -> None:
+        for name in ("cache.sqlite3-wal", "cache.sqlite3-shm", "cache.sqlite3-journal"):
+            cls, _r, _ = classify(f".cache/yule/{name}", is_dir=False)
+            self.assertEqual(cls, Classification.PRESERVE, name)
+
+    def test_secrets_and_env_preserved(self) -> None:
+        for rel in (".env", "config/.env.local", "keys/server.pem", "id_rsa.key", "creds/credentials.json"):
+            cls, _r, _ = classify(rel, is_dir=False)
+            self.assertEqual(cls, Classification.PRESERVE, rel)
+
+    def test_lockfile_preserved(self) -> None:
+        cls, _r, _ = classify("poetry.lock", is_dir=False)
+        self.assertEqual(cls, Classification.PRESERVE)
+
+    def test_git_internal_preserved(self) -> None:
+        cls, _r, _ = classify(".git/config", is_dir=False)
+        self.assertEqual(cls, Classification.PRESERVE)
+
+
+class NewTransientPathTests(unittest.TestCase):
+    def test_new_export_dir_preserves_db_deletes_tmp(self) -> None:
+        # A *new* transient location must not break preserve rules: the sqlite
+        # operational store survives, sibling .tmp scratch is reclaimable.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            exp = root / ".cache" / "yule" / "exports"
+            exp.mkdir(parents=True)
+            (exp / "session.sqlite3").write_text("db", encoding="utf-8")
+            (exp / "session.sqlite3-wal").write_text("wal", encoding="utf-8")
+            (exp / "scratch.tmp").write_text("x", encoding="utf-8")
+            receipt = run_cleanup(root, execute=True, confirm=True)
+            self.assertTrue((exp / "session.sqlite3").exists())
+            self.assertTrue((exp / "session.sqlite3-wal").exists())
+            self.assertFalse((exp / "scratch.tmp").exists())
+
+    def test_marker_cannot_promote_protected_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # a .env carrying the marker must still be preserved (suffix wins)
+            (root / ".env").write_text(f"SECRET=1 {CLEANUP_SAFE_MARKER}", encoding="utf-8")
+            receipt = run_cleanup(root, execute=True, confirm=True)
+            self.assertTrue((root / ".env").exists())
+            protected = {e.rel_path for e in receipt.protected}
+            self.assertIn(".env", protected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_compaction_protocol.py
+++ b/tests/agents/test_compaction_protocol.py
@@ -1,0 +1,158 @@
+"""compact→vault protocol — checkpoints, receipt, /clear guard (issue #185, item F)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness.compaction_protocol import (
+    Checkpoint,
+    ClearBlockedError,
+    compaction_candidates,
+    evaluate_clear,
+    require_clear_allowed,
+    run_compaction_to_vault,
+)
+from yule_engineering.agents.harness.context_compaction import CompactionTurn
+
+
+def _turns():
+    # enough middle 'take' turns that some fold past the head/tail protection
+    middle = [
+        CompactionTurn(i, f"role{i}", "take", "x" * 200, audit_id=f"a{i}")
+        for i in range(1, 9)
+    ]
+    return [
+        CompactionTurn(0, "user", "prompt", "원문 요청: 결제 연동"),
+        *middle,
+        CompactionTurn(9, "tech-lead", "synthesis", "합의: 1차 스코프"),
+    ]
+
+
+class CheckpointTests(unittest.TestCase):
+    def test_always_offer_checkpoint_yields_candidate(self) -> None:
+        cands = compaction_candidates([Checkpoint.BIG_IMPL_DONE], enabled=False)
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0].checkpoint, Checkpoint.BIG_IMPL_DONE)
+        self.assertFalse(cands[0].auto)  # flag off → explicit/operator only
+
+    def test_context_threshold_respects_ratio(self) -> None:
+        below = compaction_candidates(
+            [Checkpoint.CONTEXT_THRESHOLD], context_ratio=0.3, enabled=True
+        )
+        self.assertEqual(below, [])
+        above = compaction_candidates(
+            [Checkpoint.CONTEXT_THRESHOLD], context_ratio=0.6, enabled=True
+        )
+        self.assertEqual(len(above), 1)
+        self.assertTrue(above[0].auto)
+
+    def test_dedup_checkpoints(self) -> None:
+        cands = compaction_candidates(
+            [Checkpoint.SESSION_END, Checkpoint.SESSION_END], enabled=True
+        )
+        self.assertEqual(len(cands), 1)
+
+
+class RunCompactionTests(unittest.TestCase):
+    def test_writes_note_and_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            note, receipt = run_compaction_to_vault(
+                _turns(),
+                session_id="sess-f",
+                vault_root=Path(tmp),
+                project="yule-studio-agent",
+                checkpoint=Checkpoint.PRE_VERIFICATION,
+                original_prompt="원문 요청: 결제 연동",
+            )
+            self.assertIsNotNone(note)
+            self.assertEqual(receipt.status, "written")
+            self.assertFalse(receipt.committed)  # never commits (L3 gate)
+            self.assertEqual(receipt.checkpoint, "pre_verification")
+            self.assertGreater(receipt.saved_tokens, 0)
+            self.assertEqual(receipt.token_source, "estimate")
+            self.assertTrue((Path(tmp) / receipt.task_log_note_path).is_file())
+
+    def test_live_compact_boundary_overrides_tokens(self) -> None:
+        class _Boundary:
+            parsed = True
+            pre_tokens = 9000
+            post_tokens = 1200
+            warning = None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _note, receipt = run_compaction_to_vault(
+                _turns(),
+                session_id="sess-live",
+                vault_root=Path(tmp),
+                project="yule-studio-agent",
+                compact_boundary=_Boundary(),
+            )
+            self.assertEqual(receipt.token_source, "live_compact_boundary")
+            self.assertEqual(receipt.pre_tokens, 9000)
+            self.assertEqual(receipt.saved_tokens, 7800)
+
+    def test_unparsed_boundary_falls_back_to_estimate(self) -> None:
+        class _Boundary:
+            parsed = False
+            pre_tokens = None
+            post_tokens = None
+            warning = "no compact_boundary event"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _note, receipt = run_compaction_to_vault(
+                _turns(),
+                session_id="sess-fb",
+                vault_root=Path(tmp),
+                project="yule-studio-agent",
+                compact_boundary=_Boundary(),
+            )
+            self.assertEqual(receipt.token_source, "estimate")
+            self.assertTrue(any("live /compact token capture unavailable" in w for w in receipt.warnings))
+
+    def test_empty_turns_is_not_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            note, receipt = run_compaction_to_vault(
+                [], session_id="empty", vault_root=Path(tmp), project="yule-studio-agent"
+            )
+            self.assertIsNone(note)
+            self.assertEqual(receipt.status, "not_run")
+            self.assertTrue(receipt.warnings)
+
+
+class ClearGuardTests(unittest.TestCase):
+    def _receipt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _note, receipt = run_compaction_to_vault(
+                _turns(),
+                session_id="sess-f",
+                vault_root=Path(tmp),
+                project="yule-studio-agent",
+            )
+            return receipt
+
+    def test_clear_blocked_without_receipt(self) -> None:
+        decision = evaluate_clear(None, session_id="sess-f")
+        self.assertFalse(decision.allowed)
+
+    def test_clear_allowed_after_vault_record(self) -> None:
+        decision = evaluate_clear(self._receipt(), session_id="sess-f")
+        self.assertTrue(decision.allowed)
+
+    def test_clear_blocked_on_session_mismatch(self) -> None:
+        decision = evaluate_clear(self._receipt(), session_id="other")
+        self.assertFalse(decision.allowed)
+
+    def test_require_clear_raises_when_blocked(self) -> None:
+        with self.assertRaises(ClearBlockedError):
+            require_clear_allowed(None, session_id="sess-f")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_execution_receipt.py
+++ b/tests/agents/test_execution_receipt.py
@@ -1,0 +1,130 @@
+"""Execution receipt — execution proof (issue #185 follow-up, item D)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_core.context_loader import load_agent_context
+from yule_engineering.agents.harness import (
+    Checkpoint,
+    build_execution_receipt,
+    load_grant_table,
+    run_cleanup,
+    run_compaction_to_vault,
+)
+from yule_engineering.agents.harness.context_compaction import CompactionTurn
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ExecutionReceiptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def _loaded(self, role=None):
+        return load_agent_context(
+            repo_root=_REPO_ROOT, agent_id="engineering-agent", role_id=role
+        )
+
+    def test_receipt_has_required_fields(self) -> None:
+        receipt = build_execution_receipt(
+            self._loaded(),
+            self.table,
+            selected_runner="claude",
+            requested_capabilities=["/compact", "/model", "compact-to-vault", "no-such-skill"],
+        )
+        self.assertEqual(receipt.selected_agent, "engineering-agent")
+        self.assertIsNone(receipt.selected_role)
+        self.assertEqual(receipt.selected_runner, "claude")
+        # loaded docs include entrypoint + root + agent
+        labels = {label for (label, _path) in receipt.loaded_docs}
+        self.assertIn("entrypoint", labels)
+        self.assertIn("root_instructions", labels)
+        self.assertIn("agent_instructions", labels)
+        self.assertTrue(receipt.loaded_policies)
+        self.assertIn("compact-to-vault", receipt.granted_skills)
+
+    def test_blocked_or_missing_surfaces_non_allow(self) -> None:
+        receipt = build_execution_receipt(
+            self._loaded(),
+            self.table,
+            requested_capabilities=["/compact", "/model", "no-such-skill"],
+        )
+        caps = {d.capability: d.verdict.value for d in receipt.blocked_or_missing}
+        self.assertNotIn("/compact", caps)  # granted → not surfaced
+        self.assertEqual(caps.get("/model"), "block")
+        self.assertEqual(caps.get("no-such-skill"), "block")
+
+    def test_role_actor_resolves(self) -> None:
+        receipt = build_execution_receipt(
+            self._loaded(role="security-engineer"),
+            self.table,
+            requested_capabilities=["/security-review"],
+        )
+        self.assertEqual(receipt.selected_role, "security-engineer")
+        self.assertEqual(receipt.blocked_or_missing, ())  # /security-review granted via override
+
+    def test_statuses_default_not_run(self) -> None:
+        receipt = build_execution_receipt(self._loaded(), self.table)
+        self.assertEqual(receipt.compaction_status, "not_run")
+        self.assertEqual(receipt.cleanup_status, "not_run")
+        self.assertEqual(receipt.security_status, "not_evaluated")
+
+    def test_security_decision_surfaces_in_receipt(self) -> None:
+        from yule_engineering.agents.harness import assess_security_review
+
+        decision = assess_security_review({"paths": ["src/auth/login.py"], "summary": "jwt"})
+        receipt = build_execution_receipt(self._loaded(), self.table, security=decision)
+        self.assertEqual(receipt.security_status, "required")
+        d = receipt.to_dict()
+        self.assertEqual(d["security_status"], "required")
+        self.assertIn("auth", d["security"]["triggers"])
+        self.assertIn("## Security review: required", receipt.render())
+
+    def test_render_and_dict(self) -> None:
+        receipt = build_execution_receipt(
+            self._loaded(), self.table, requested_capabilities=["/model"]
+        )
+        text = receipt.render()
+        self.assertIn("# Execution Receipt", text)
+        self.assertIn("## Loaded docs", text)
+        self.assertIn("## Blocked or missing skills", text)
+        self.assertIn("## Compaction status", text)
+        self.assertIn("## Cleanup status", text)
+        d = receipt.to_dict()
+        self.assertEqual(d["selected_agent"], "engineering-agent")
+        self.assertIn("blocked_or_missing", d)
+
+    def test_receipt_binds_compaction_and_cleanup_statuses(self) -> None:
+        turns = [
+            CompactionTurn(0, "user", "prompt", "원문 요청"),
+            CompactionTurn(1, "tech-lead", "synthesis", "합의"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _note, comp = run_compaction_to_vault(
+                turns,
+                session_id="sess-d",
+                vault_root=Path(tmp) / "vault",
+                project="yule-studio-agent",
+                checkpoint=Checkpoint.SESSION_END,
+            )
+            clean = run_cleanup(Path(tmp) / "vault")
+            receipt = build_execution_receipt(
+                self._loaded(), self.table, compaction=comp, cleanup=clean
+            )
+            self.assertEqual(receipt.compaction_status, "written")
+            self.assertEqual(receipt.cleanup_status, "dry_run")
+            self.assertIsNotNone(receipt.compaction)
+            self.assertIsNotNone(receipt.cleanup)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_grant_enforcement.py
+++ b/tests/agents/test_grant_enforcement.py
@@ -1,0 +1,100 @@
+"""Grant runtime enforcement — ALLOW/ADVISORY/BLOCK (issue #185 follow-up, item C).
+
+Locks the advisory-vs-block line described in
+``docs/agent-slash-commands.md`` §"grant 강제".
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness import load_grant_table
+from yule_engineering.agents.harness.grant_enforcement import (
+    CapabilityKind,
+    GrantVerdict,
+    evaluate_capability,
+    evaluate_command,
+    evaluate_skill,
+)
+
+
+class CommandEnforcementTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def test_granted_command_allows(self) -> None:
+        d = evaluate_command(self.table, "engineering-agent", "/compact")
+        self.assertEqual(d.verdict, GrantVerdict.ALLOW)
+        self.assertTrue(d.allowed)
+
+    def test_ungranted_but_grantable_is_advisory(self) -> None:
+        # marketing-agent is not granted /diff, but /diff is a grantable builtin
+        d = evaluate_command(self.table, "marketing-agent", "/diff")
+        self.assertEqual(d.verdict, GrantVerdict.ADVISORY)
+        self.assertTrue(d.advisory)
+
+    def test_non_grantable_command_blocks(self) -> None:
+        d = evaluate_command(self.table, "engineering-agent", "/model")
+        self.assertEqual(d.verdict, GrantVerdict.BLOCK)
+        self.assertTrue(d.blocked)
+
+    def test_unknown_command_blocks(self) -> None:
+        d = evaluate_command(self.table, "engineering-agent", "/does-not-exist")
+        self.assertEqual(d.verdict, GrantVerdict.BLOCK)
+
+    def test_unknown_actor_blocks(self) -> None:
+        d = evaluate_command(self.table, "ghost-agent", "/compact")
+        self.assertEqual(d.verdict, GrantVerdict.BLOCK)
+
+
+class SkillEnforcementTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def test_granted_skill_allows(self) -> None:
+        d = evaluate_skill(self.table, "engineering-agent", "compact-to-vault")
+        self.assertEqual(d.verdict, GrantVerdict.ALLOW)
+
+    def test_ungranted_registered_skill_advisory(self) -> None:
+        # marketing-agent is not granted skill-author, but it is registered
+        d = evaluate_skill(self.table, "marketing-agent", "skill-author")
+        self.assertEqual(d.verdict, GrantVerdict.ADVISORY)
+
+    def test_unknown_skill_blocks(self) -> None:
+        d = evaluate_skill(self.table, "engineering-agent", "no-such-skill")
+        self.assertEqual(d.verdict, GrantVerdict.BLOCK)
+
+    def test_role_override_grants_security_review(self) -> None:
+        d = evaluate_command(
+            self.table, "engineering-agent/security-engineer", "/security-review"
+        )
+        self.assertEqual(d.verdict, GrantVerdict.ALLOW)
+
+
+class InferKindTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def test_slash_prefix_infers_command(self) -> None:
+        d = evaluate_capability(self.table, "engineering-agent", "/compact")
+        self.assertEqual(d.kind, CapabilityKind.COMMAND)
+
+    def test_non_slash_infers_skill(self) -> None:
+        d = evaluate_capability(self.table, "engineering-agent", "compact-to-vault")
+        self.assertEqual(d.kind, CapabilityKind.SKILL)
+
+    def test_surface_string_includes_verdict(self) -> None:
+        d = evaluate_command(self.table, "engineering-agent", "/model")
+        self.assertIn("BLOCK", d.surface())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_hot_path.py
+++ b/tests/agents/test_hot_path.py
@@ -1,0 +1,120 @@
+"""Hot-path seam — capability gate + dispatch receipt (issue #185 follow-up A/C)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_core.context_loader import load_agent_context
+from yule_engineering.agents.harness import load_grant_table
+from yule_engineering.agents.harness.hot_path import (
+    actor_id_for,
+    build_capability_block_gate,
+    dispatch_receipt,
+    evaluate_input_capabilities,
+    requested_capabilities,
+)
+from yule_engineering.agents.runners.role_runner import (
+    STATUS_BLOCKED,
+    STATUS_OK,
+    RoleRunnerInput,
+    RoleRunnerOutput,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _input(role="security-engineer", caps=None, change=None):
+    md = {}
+    if caps is not None:
+        md["capabilities"] = caps
+    if change is not None:
+        md["change"] = change
+    return RoleRunnerInput(role=role, session_id="s1", prompt="p", metadata=md)
+
+
+class ActorAndCapabilityTests(unittest.TestCase):
+    def test_actor_id_from_role(self) -> None:
+        self.assertEqual(actor_id_for(_input(role="qa-engineer")), "engineering-agent/qa-engineer")
+
+    def test_actor_id_explicit_override(self) -> None:
+        inp = RoleRunnerInput(role="x", session_id="s", prompt="p", metadata={"actor_id": "legal-agent"})
+        self.assertEqual(actor_id_for(inp), "legal-agent")
+
+    def test_requested_capabilities(self) -> None:
+        self.assertEqual(
+            requested_capabilities(_input(caps=["/compact", "  ", "compact-to-vault"])),
+            ("/compact", "compact-to-vault"),
+        )
+
+
+class GateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def test_blocks_non_grantable_command(self) -> None:
+        gate = build_capability_block_gate(self.table)
+        out = gate(None, _input(role="qa-engineer", caps=["/model"]))
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, STATUS_BLOCKED)
+        self.assertIn("/model", out.metrics["blocked_capabilities"])
+
+    def test_allows_granted(self) -> None:
+        gate = build_capability_block_gate(self.table)
+        self.assertIsNone(gate(None, _input(role="security-engineer", caps=["/security-review"])))
+
+    def test_advisory_does_not_block(self) -> None:
+        gate = build_capability_block_gate(self.table)
+        # marketing-agent not granted /diff but it is grantable → advisory, not block
+        inp = RoleRunnerInput(
+            role="x", session_id="s", prompt="p",
+            metadata={"actor_id": "marketing-agent", "capabilities": ["/diff"]},
+        )
+        self.assertIsNone(gate(None, inp))
+
+    def test_no_capabilities_proceeds(self) -> None:
+        gate = build_capability_block_gate(self.table)
+        self.assertIsNone(gate(None, _input(role="qa-engineer")))
+
+
+class DispatchReceiptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+        cls.loaded = load_agent_context(
+            repo_root=_REPO_ROOT, agent_id="engineering-agent", role_id="security-engineer"
+        )
+
+    def test_receipt_captures_runner_and_role(self) -> None:
+        out = RoleRunnerOutput(provider="claude", status=STATUS_OK, text="t")
+        receipt = dispatch_receipt(self.loaded, self.table, _input(), out)
+        self.assertEqual(receipt.selected_runner, "claude")
+        self.assertEqual(receipt.selected_role, "security-engineer")
+        labels = {l for (l, _p) in receipt.loaded_docs}
+        self.assertIn("entrypoint", labels)
+        self.assertIn("role_instructions", labels)
+
+    def test_receipt_security_required_from_change(self) -> None:
+        out = RoleRunnerOutput(provider="claude", status=STATUS_OK, text="t")
+        inp = _input(change={"paths": ["src/auth/login.py"], "summary": "JWT session"})
+        receipt = dispatch_receipt(self.loaded, self.table, inp, out)
+        self.assertEqual(receipt.security_status, "required")
+        self.assertIn("auth", receipt.security.triggers)
+
+    def test_receipt_blocked_capability_surfaces(self) -> None:
+        out = RoleRunnerOutput(provider="grant-gate", status=STATUS_BLOCKED, text="")
+        inp = _input(role="qa-engineer", caps=["/model"])
+        receipt = dispatch_receipt(self.loaded, self.table, inp, out, agent_id="engineering-agent")
+        caps = {d.capability for d in receipt.blocked_or_missing}
+        self.assertIn("/model", caps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_security_gate.py
+++ b/tests/agents/test_security_gate.py
@@ -1,0 +1,83 @@
+"""Security auto-dispatch gate (issue #185 follow-up C)."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness.security_gate import (
+    ANTI_GOAL_NOTE,
+    SEVERITY_REQUIRED,
+    assess_security_review,
+    security_review_required,
+)
+
+
+class TriggerTests(unittest.TestCase):
+    def test_auth_change_requires_review(self) -> None:
+        d = assess_security_review({"paths": ["src/auth/login.py"], "summary": "add login"})
+        self.assertTrue(d.required)
+        self.assertIn("auth", d.triggers)
+        self.assertEqual(d.severity, SEVERITY_REQUIRED)
+
+    def test_secret_change_requires_review(self) -> None:
+        d = assess_security_review({"summary": "rotate API key in credential store"})
+        self.assertIn("secret", d.triggers)
+
+    def test_public_surface_requires_review(self) -> None:
+        d = assess_security_review({"paths": ["api/routes/webhook.py"]})
+        self.assertIn("public_surface", d.triggers)
+
+    def test_deployment_requires_review(self) -> None:
+        d = assess_security_review({"paths": [".github/workflows/deploy.yml"]})
+        self.assertIn("deployment", d.triggers)
+
+    def test_client_security_requires_review(self) -> None:
+        d = assess_security_review({"summary": "tighten CSP and token storage in localStorage"})
+        self.assertIn("client_security", d.triggers)
+
+    def test_agent_safety_requires_review(self) -> None:
+        d = assess_security_review({"summary": "add tool grant for new approval-gate"})
+        self.assertIn("agent_safety", d.triggers)
+
+    def test_multiple_triggers(self) -> None:
+        d = assess_security_review(
+            {"summary": "new public endpoint with jwt auth", "paths": ["api/auth/route.py"]}
+        )
+        self.assertIn("auth", d.triggers)
+        self.assertIn("public_surface", d.triggers)
+
+    def test_benign_change_not_required(self) -> None:
+        d = assess_security_review({"paths": ["README.md"], "summary": "fix typo"})
+        self.assertFalse(d.required)
+        self.assertFalse(security_review_required({"summary": "rename a variable"}))
+
+
+class SkipAndAntiGoalTests(unittest.TestCase):
+    def test_explicit_skip_recorded(self) -> None:
+        d = assess_security_review(
+            {"paths": ["src/auth/x.py"]}, force_skip_reason="operator waived: revert"
+        )
+        self.assertFalse(d.required)
+        self.assertEqual(d.skip_reason, "operator waived: revert")
+
+    def test_anti_goal_note_in_payload(self) -> None:
+        d = assess_security_review({"summary": "auth change"})
+        payload = d.to_dict()
+        self.assertEqual(payload["anti_goal_note"], ANTI_GOAL_NOTE)
+        self.assertIn("서버", ANTI_GOAL_NOTE)
+        self.assertIn("개발자 도구", ANTI_GOAL_NOTE)
+
+    def test_surface_strings(self) -> None:
+        req = assess_security_review({"summary": "jwt auth"})
+        self.assertIn("REQUIRED", req.surface())
+        skip = assess_security_review({"summary": "auth"}, force_skip_reason="waived")
+        self.assertIn("skipped", skip.surface())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_security_role_contract.py
+++ b/tests/agents/test_security_role_contract.py
@@ -1,0 +1,142 @@
+"""Security-engineer cross-cutting reviewer contract (issue #185 follow-up, item A/E).
+
+Locks the role contract, its wiring into the department manifest + grant table,
+and the governance doc — so the security review subject cannot silently drift.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness import load_grant_table
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ROLE_DIR = _REPO_ROOT / "agents" / "engineering-agent" / "security-engineer"
+
+
+def _json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class RoleContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = _json(_ROLE_DIR / "manifest.json")
+
+    def test_role_files_exist(self) -> None:
+        self.assertTrue((_ROLE_DIR / "manifest.json").is_file())
+        self.assertTrue((_ROLE_DIR / "CLAUDE.md").is_file())
+
+    def test_is_cross_cutting_reviewer(self) -> None:
+        self.assertEqual(self.manifest["role_class"], "cross_cutting_reviewer")
+        self.assertTrue(self.manifest["reviews_other_roles"])
+        self.assertFalse(self.manifest["is_technical_approval_owner"])
+
+    def test_covers_four_review_domains(self) -> None:
+        domains = self.manifest["review_domains"]
+        for key in ("backend", "frontend", "devops", "ai_agent"):
+            self.assertIn(key, domains)
+            self.assertTrue(domains[key], f"{key} domain must list checks")
+
+    def test_backend_domain_specifics(self) -> None:
+        backend = self.manifest["review_domains"]["backend"]
+        for needle in (
+            "authentication",
+            "authorization",
+            "idor_object_level_permission",
+            "input_validation",
+            "secret_exposure",
+            "audit_logging",
+        ):
+            self.assertIn(needle, backend, needle)
+
+    def test_frontend_treats_client_as_hostile(self) -> None:
+        frontend = self.manifest["review_domains"]["frontend"]
+        self.assertIn("treat_client_as_hostile_surface", frontend)
+        self.assertIn("postmessage_origin_validation", frontend)
+        self.assertIn("permission_ui_is_not_a_security_boundary", frontend)
+
+    def test_ai_domain_specifics(self) -> None:
+        ai = self.manifest["review_domains"]["ai_agent"]
+        for needle in ("prompt_injection", "tool_overreach", "approval_gate_bypass", "data_exfiltration"):
+            self.assertIn(needle, ai, needle)
+
+    def test_devtools_anti_goal_present(self) -> None:
+        joined = " ".join(self.manifest["anti_goals"])
+        self.assertIn("개발자 도구", joined)
+        self.assertIn("서버", joined)  # server-side enforcement is the alternative
+
+    def test_intercept_triggers_non_empty(self) -> None:
+        self.assertTrue(self.manifest["intercept_triggers"])
+
+    def test_instruction_entry_points_to_role_claude(self) -> None:
+        self.assertEqual(
+            self.manifest["instruction_entry"],
+            "agents/engineering-agent/security-engineer/CLAUDE.md",
+        )
+
+
+class WiringTests(unittest.TestCase):
+    def test_department_manifest_lists_as_cross_cutting_not_member(self) -> None:
+        dept = _json(_REPO_ROOT / "agents" / "engineering-agent" / "manifest.json")
+        self.assertIn("security-engineer", dept["cross_cutting_reviewers"])
+        # must NOT be a 7-role deliberation council seat
+        self.assertNotIn("security-engineer", dept["members"])
+
+    def test_grant_override_grants_security_review(self) -> None:
+        table = load_grant_table()
+        eff = table.effective_grants("engineering-agent/security-engineer")
+        self.assertIsNotNone(eff)
+        assert eff is not None
+        self.assertTrue(eff.grants_command("/security-review"))
+
+    def test_grant_table_still_valid(self) -> None:
+        table = load_grant_table()
+        self.assertEqual(table.validate(repo_root=_REPO_ROOT), [])
+
+
+class GovernanceDocTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.doc = (_REPO_ROOT / "docs" / "security-review.md").read_text(encoding="utf-8")
+
+    def test_doc_exists_with_core_sections(self) -> None:
+        for needle in (
+            "cross-cutting",
+            "intercept",
+            "Inputs",
+            "Outputs",
+            "Boundaries",
+            "security-engineer",
+        ):
+            self.assertIn(needle, self.doc, needle)
+
+    def test_doc_states_devtools_anti_goal(self) -> None:
+        self.assertIn("개발자 도구", self.doc)
+        self.assertIn("클라이언트는 신뢰 경계가 아니다", self.doc)
+
+    def test_entrypoints_cross_link_doc(self) -> None:
+        agents_md = (_REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        root_claude = (_REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        self.assertIn("docs/security-review.md", agents_md)
+        self.assertIn("docs/security-review.md", root_claude)
+
+    def test_doc_documents_auto_dispatch_wiring(self) -> None:
+        # the auto-dispatch seam + false-positive/negative tradeoff are documented
+        for needle in ("auto-dispatch", "assess_security_review", "false-positive", "security_status"):
+            self.assertIn(needle, self.doc, needle)
+
+    def test_slash_commands_doc_documents_hot_path(self) -> None:
+        doc = (_REPO_ROOT / "docs" / "agent-slash-commands.md").read_text(encoding="utf-8")
+        for needle in ("YULE_GRANT_ENFORCEMENT_ENABLED", "pre_dispatch_gate", "compact_boundary"):
+            self.assertIn(needle, doc, needle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_context_loader_ordering.py
+++ b/tests/core/test_context_loader_ordering.py
@@ -1,0 +1,93 @@
+"""Layered context-loading order + role tier (issue #185 follow-up, item B).
+
+Locks the canonical load order AGENTS.md → root CLAUDE.md → agent
+instruction_entry → (role) role instruction_entry → policies, and the
+role-selected-vs-not split with missing-file warnings.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_core.context_loader import (
+    LABEL_AGENT,
+    LABEL_ENTRYPOINT,
+    LABEL_POLICY,
+    LABEL_ROLE,
+    LABEL_ROOT,
+    load_agent_context,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class LoadOrderTests(unittest.TestCase):
+    def test_entrypoint_root_agent_order(self) -> None:
+        loaded = load_agent_context(repo_root=_REPO_ROOT, agent_id="engineering-agent")
+        labels = [d.label for d in loaded.documents]
+        # First three docs are entrypoint → root → agent, in that order.
+        self.assertEqual(labels[0], LABEL_ENTRYPOINT)
+        self.assertEqual(labels[1], LABEL_ROOT)
+        self.assertEqual(labels[2], LABEL_AGENT)
+        # AGENTS.md is the very first document.
+        self.assertEqual(loaded.documents[0].path.name, "AGENTS.md")
+        self.assertEqual(loaded.documents[1].path.name, "CLAUDE.md")
+
+    def test_policies_loaded_after_agent(self) -> None:
+        loaded = load_agent_context(repo_root=_REPO_ROOT, agent_id="engineering-agent")
+        policy_docs = loaded.documents_by_label(LABEL_POLICY)
+        self.assertTrue(policy_docs, "agent policies should load")
+        # every policy doc comes after the agent instruction doc
+        agent_idx = [d.label for d in loaded.documents].index(LABEL_AGENT)
+        first_policy_idx = [d.label for d in loaded.documents].index(LABEL_POLICY)
+        self.assertGreater(first_policy_idx, agent_idx)
+
+
+class RoleTierTests(unittest.TestCase):
+    def test_no_role_selected_has_no_role_doc_or_warning(self) -> None:
+        loaded = load_agent_context(repo_root=_REPO_ROOT, agent_id="engineering-agent")
+        self.assertIsNone(loaded.role_id)
+        self.assertFalse(loaded.has_role_instructions())
+        self.assertFalse(
+            any("role" in w.lower() for w in loaded.warnings),
+            "no role warning when role not selected",
+        )
+
+    def test_role_selected_loads_role_instruction_after_agent(self) -> None:
+        loaded = load_agent_context(
+            repo_root=_REPO_ROOT,
+            agent_id="engineering-agent",
+            role_id="security-engineer",
+        )
+        self.assertEqual(loaded.role_id, "security-engineer")
+        self.assertTrue(loaded.has_role_instructions())
+        labels = [d.label for d in loaded.documents]
+        self.assertIn(LABEL_ROLE, labels)
+        # role doc sits after agent doc and before the first policy
+        self.assertGreater(labels.index(LABEL_ROLE), labels.index(LABEL_AGENT))
+        self.assertLess(labels.index(LABEL_ROLE), labels.index(LABEL_POLICY))
+        self.assertIsNotNone(loaded.role_manifest)
+
+    def test_missing_role_warns_and_continues(self) -> None:
+        loaded = load_agent_context(
+            repo_root=_REPO_ROOT,
+            agent_id="engineering-agent",
+            role_id="nonexistent-role",
+        )
+        # philosophy preserved: warn + continue, do not raise, agent doc still present
+        self.assertFalse(loaded.has_role_instructions())
+        self.assertTrue(
+            any("Missing role manifest" in w for w in loaded.warnings),
+            f"expected missing-role warning, got {loaded.warnings}",
+        )
+        self.assertIn(LABEL_AGENT, [d.label for d in loaded.documents])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord/test_member_bots.py
+++ b/tests/discord/test_member_bots.py
@@ -152,6 +152,9 @@ class LoadMemberBotConfigTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
+            # AGENTS.md is the required entrypoint loaded first (context-loading
+            # policy / AGENTS.md §1), ahead of root CLAUDE.md.
+            (root / "AGENTS.md").write_text("# stub entrypoint", encoding="utf-8")
             (root / "CLAUDE.md").write_text("# stub root", encoding="utf-8")
             agent_dir = root / "agents" / "fake-agent"
             agent_dir.mkdir(parents=True)

--- a/tests/runners/test_role_runner_gate.py
+++ b/tests/runners/test_role_runner_gate.py
@@ -1,0 +1,107 @@
+"""Pre-dispatch grant gate wiring on the role-runner hot path (issue #185 follow-up A)."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.runners.role_runner import (
+    PROVIDER_DETERMINISTIC,
+    RoleRunner,
+    RoleRunnerInput,
+    RoleRunnerOutput,
+    STATUS_BLOCKED,
+    STATUS_FALLBACK,
+    STATUS_OK,
+    build_role_runner_dispatcher,
+)
+
+
+@dataclass
+class _Session:
+    session_id: str = "s1"
+    extra: dict = field(default_factory=dict)  # no active_research_roles → fallback active
+
+
+def _input(role: str = "qa-engineer") -> RoleRunnerInput:
+    return RoleRunnerInput(role=role, session_id="s1", prompt="p")
+
+
+class _CountingRunner(RoleRunner):
+    provider = "claude"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def is_available(self) -> bool:
+        return True
+
+    def generate(self, input_: RoleRunnerInput) -> RoleRunnerOutput:
+        self.calls += 1
+        return RoleRunnerOutput(provider=self.provider, status=STATUS_OK, text="take")
+
+
+class GateTests(unittest.TestCase):
+    def test_gate_blocks_before_any_provider(self) -> None:
+        runner = _CountingRunner()
+        blocked = RoleRunnerOutput(
+            provider="grant-gate", status=STATUS_BLOCKED, text="", detail="blocked: /model"
+        )
+        dispatch = build_role_runner_dispatcher(
+            candidates=[runner],
+            pre_dispatch_gate=lambda session, inp: blocked,
+        )
+        out = dispatch(_Session(), _input())
+        self.assertEqual(out.status, STATUS_BLOCKED)
+        self.assertEqual(runner.calls, 0)  # provider never contacted
+
+    def test_gate_none_proceeds(self) -> None:
+        runner = _CountingRunner()
+        dispatch = build_role_runner_dispatcher(
+            candidates=[runner],
+            pre_dispatch_gate=lambda session, inp: None,
+        )
+        out = dispatch(_Session(), _input())
+        self.assertEqual(out.status, STATUS_OK)
+        self.assertEqual(runner.calls, 1)
+
+    def test_gate_raise_degrades_to_no_block(self) -> None:
+        runner = _CountingRunner()
+
+        def _boom(session, inp):
+            raise RuntimeError("gate bug")
+
+        dispatch = build_role_runner_dispatcher(
+            candidates=[runner], pre_dispatch_gate=_boom
+        )
+        out = dispatch(_Session(), _input())
+        # a buggy gate must not wedge dispatch — take proceeds
+        self.assertEqual(out.status, STATUS_OK)
+        self.assertEqual(runner.calls, 1)
+
+    def test_blocked_take_is_audited(self) -> None:
+        records = []
+        blocked = RoleRunnerOutput(provider="grant-gate", status=STATUS_BLOCKED, text="")
+        dispatch = build_role_runner_dispatcher(
+            candidates=[_CountingRunner()],
+            pre_dispatch_gate=lambda s, i: blocked,
+            audit_writer=records.append,
+        )
+        dispatch(_Session(), _input())
+        self.assertTrue(records)
+        self.assertEqual(records[-1]["status"], STATUS_BLOCKED)
+
+    def test_no_gate_is_backward_compatible(self) -> None:
+        runner = _CountingRunner()
+        dispatch = build_role_runner_dispatcher(candidates=[runner])
+        out = dispatch(_Session(), _input())
+        self.assertEqual(out.status, STATUS_OK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runners/test_runner_bootstrap_enforcement.py
+++ b/tests/runners/test_runner_bootstrap_enforcement.py
@@ -1,0 +1,106 @@
+"""Bootstrap hot-path enforcement — gate + receipt wiring (issue #185 follow-up A)."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.harness import load_grant_table
+from yule_engineering.agents.runners.bootstrap import (
+    build_role_runner_dispatch_from_env,
+    grant_enforcement_enabled,
+)
+from yule_engineering.agents.runners.role_runner import (
+    STATUS_BLOCKED,
+    STATUS_FALLBACK,
+    RoleRunnerInput,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass
+class _Session:
+    session_id: str = "s1"
+    extra: dict = field(default_factory=dict)
+
+
+def _input(role="qa-engineer", caps=None):
+    md = {"capabilities": caps} if caps is not None else {}
+    return RoleRunnerInput(role=role, session_id="s1", prompt="p", metadata=md)
+
+
+class EnforcementFlagTests(unittest.TestCase):
+    def test_flag_default_off(self) -> None:
+        self.assertFalse(grant_enforcement_enabled({}))
+        self.assertTrue(grant_enforcement_enabled({"YULE_GRANT_ENFORCEMENT_ENABLED": "true"}))
+
+
+class BootstrapWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.table = load_grant_table()
+
+    def test_ungranted_capability_blocked_in_dispatch(self) -> None:
+        dispatch, _trace = build_role_runner_dispatch_from_env(
+            env={}, grant_table=self.table
+        )
+        out = dispatch(_Session(), _input(caps=["/model"]))  # non-grantable → BLOCK
+        self.assertEqual(out.status, STATUS_BLOCKED)
+
+    def test_no_capabilities_falls_through_to_deterministic(self) -> None:
+        dispatch, _trace = build_role_runner_dispatch_from_env(
+            env={}, grant_table=self.table
+        )
+        out = dispatch(_Session(), _input())
+        self.assertEqual(out.status, STATUS_FALLBACK)  # no provider configured
+
+    def test_receipt_sink_receives_per_run_receipt(self) -> None:
+        captured = []
+        dispatch, _trace = build_role_runner_dispatch_from_env(
+            env={},
+            grant_table=self.table,
+            receipt_sink=lambda session, receipt: captured.append(receipt),
+            repo_root=_REPO_ROOT,
+        )
+        dispatch(_Session(), _input())
+        self.assertTrue(captured, "receipt sink should fire per run")
+        receipt = captured[-1]
+        d = receipt.to_dict()
+        self.assertIn("loaded_docs", d)
+        self.assertEqual(d["selected_agent"], "engineering-agent")
+        self.assertEqual(d["selected_role"], "qa-engineer")
+
+    def test_session_receipt_bucket_persisted(self) -> None:
+        from yule_engineering.agents.runners.bootstrap import _build_session_receipt_sink
+
+        session = _Session()
+        dispatch, _trace = build_role_runner_dispatch_from_env(
+            env={},
+            grant_table=self.table,
+            receipt_sink=_build_session_receipt_sink(),
+            repo_root=_REPO_ROOT,
+        )
+        dispatch(session, _input())
+        self.assertIn("execution_receipts", session.extra)
+        self.assertEqual(len(session.extra["execution_receipts"]), 1)
+
+    def test_no_grant_table_is_backward_compatible(self) -> None:
+        captured = []
+        dispatch, _trace = build_role_runner_dispatch_from_env(
+            env={}, receipt_sink=lambda s, r: captured.append(r), repo_root=_REPO_ROOT
+        )
+        out = dispatch(_Session(), _input(caps=["/model"]))
+        # no grant_table ⇒ no gate, no receipt emission
+        self.assertEqual(out.status, STATUS_FALLBACK)
+        self.assertEqual(captured, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈

- 후속: #185 ([Feat] 에이전트 슬래시 명령어 · 스킬 · 플러그인 구조 — harness 브리지 + compact→vault)
- 본 PR 은 #185 의 foundation 위에 남아 있던 hot-path 결선 후속을 마무리한다 (이슈는 닫지 않음)

## ✨ 과제 내용

문서/grant/compact→vault 기반 위에 **실제 dispatch 결선**을 최소 변경으로 연결했다.

### 1. 목적
- root → agent → role 3계층 instruction 로딩 강제
- grant table 의 runtime enforcement(advisory/block)를 실 dispatch 에 결선
- 매 run 의 execution receipt 생성, security review cross-cutting 게이트 + auto-dispatch 판정
- live Claude 실행 + /compact 토큰 캡처(graceful fallback), cleanup 안전 용량 절감

### 2. 범위
- context loader: AGENTS.md → root CLAUDE.md → agent → role → policies 순서 로딩(role 미선택/선택 분리, 누락 warning)
- security-engineer 역할 계약 + grant override + `security_gate.assess_security_review`(6 trigger) + `docs/security-review.md`
- harness 코어: grant_enforcement / execution_receipt / compaction_protocol(+/clear 가드) / cleanup(allowlist, dry-run 우선, hardened)
- hot-path 결선: `role_runner.pre_dispatch_gate` + `STATUS_BLOCKED`, `bootstrap`(gate+receipt, `YULE_GRANT_ENFORCEMENT_ENABLED` opt-in), `hot_path` seam
- live runner: `claude_code` submit + compact_boundary 캡처(`YULE_CLAUDE_LIVE_ENABLED` opt-in)
- CLI: `yule harness {receipt,compact,cleanup,security-review}`
- 비범위: provider 별 live submit(codex/gemini), security required→job auto-insert, 변경 metadata 자동 채우는 producer 결선

### 3. 리스크
- 모든 결선은 **flag-gated 기본 off** 라 기존 dispatch 동작 무변경(미설정 시 byte-for-byte 동일)
- gate/claude live 는 예외 시 graceful degrade(가게 raise → 미차단, live 실패 → estimate/fallback + warning)
- audit traceability 보존: 원문 prompt/decision/synthesis/approval/agent_ops_audit 는 압축·삭제 제외, cleanup PRESERVE 우선(sqlite sidecar/secret/env/lock)
- vault 기록 전 `/clear`/cleanup 금지 가드 유지

### 4. 테스트
- 전체 스위트 `python3 -m unittest discover -s tests -t .` → **Ran 5570 tests, OK (skipped=4)**
- 신규/갱신 회귀: context loader 순서/role/누락, grant enforcement(advisory/block), dispatch gate + bootstrap wiring, execution receipt(+security), compaction protocol(+/clear 가드, live token override), cleanup dry-run/execute/protected 비삭제 + hardening, claude live submit/compact 파싱, security auto-dispatch, docs 동기화
- `scripts/sync_harness_skills.py --check` → drift 없음

### 5. audit block
- branch: `feature/185-harness-enforcement-and-security-review` (issue #185 anchor)
- commits(4, 논리 분할): context loader / security 역할 + gate / harness 강제 코어 + 결선 / 문서 동기화
- protected branch 직접 작업 없음, draft PR 까지만(auto-merge 금지)
- feature flags: `YULE_GRANT_ENFORCEMENT_ENABLED`(기본 off), `YULE_CLAUDE_LIVE_ENABLED`(기본 off)
- secret/자격 값 미포함, vault commit/push 없음

## 📚 레퍼런스

- `docs/security-review.md` (security 게이트 SSoT), `docs/agent-slash-commands.md` (grant 강제/receipt/cleanup/live compact)
- `agents/engineering-agent/CODE_LAYOUT.md` (harness 모듈 책임/결선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
