### PR TITLE
🔌 agent 계약 런타임 결선 — vault frontmatter/memory + PM gate→discussion turn

### DIFF
--- a/apps/discord-gateway/src/yule_discord/engineering/discussion_turn.py
+++ b/apps/discord-gateway/src/yule_discord/engineering/discussion_turn.py
@@ -64,6 +64,8 @@ from yule_engineering.agents.discussion import (
     synthesize_discussion,
 )
 
+from .product_intake_seam import ProductIntakeResult, run_product_intake
+
 
 # ---------------------------------------------------------------------------
 # Operator-facing escalation states — gateway surface 가 그대로 라우팅 키
@@ -95,15 +97,26 @@ class DiscussionTurnResponse:
     ``operator_status``는 운영자 surface가 사용자/운영자/tech-lead 중
     누가 다음 행동을 해야 하는지 한 dict 로 라우팅할 수 있도록 정렬된
     상태 묶음이다. 필드 의미는 모듈 docstring 참고.
+
+    ``product_intake``는 PM intake pre-step 이 켜졌을 때만 채워진다
+    (그 외엔 None). PM gate 가 제품/기능 요청을 가로채면 그 결과가
+    여기 담긴다 — PM clarification(short-circuit) 이면 ``operator_status``
+    도 PM 상태(``pm_*`` / ``layer="product"``)로 정렬되고, handoff-ready
+    면 product packet 요약이 ``rendered_text`` 앞에 carry 된 뒤 engineering
+    flow 가 그대로 이어진다. PM clarification 은 engineering 의 기술
+    clarification 과 라벨·state 가 분리되어 있다.
     """
 
     rendered_text: str
-    classification: DiscussionModeMatch
-    synthesis: DiscussionSynthesis
-    context_pack: ContextPack
+    # engineering 분류/합성/pack — PM clarification short-circuit 일 때는 None
+    # (engineering 단계를 돌지 않았다는 의미). 그 외 모든 turn 에서는 채워진다.
+    classification: Optional[DiscussionModeMatch] = None
+    synthesis: Optional[DiscussionSynthesis] = None
+    context_pack: Optional[ContextPack] = None
     handoff: Optional[DiscussionHandoff] = None
     blockers: Sequence[str] = field(default_factory=tuple)
     operator_status: Mapping[str, Any] = field(default_factory=dict)
+    product_intake: Optional[ProductIntakeResult] = None
 
 
 def build_discussion_turn_response(
@@ -118,6 +131,7 @@ def build_discussion_turn_response(
     llm_synthesizer: Optional[Any] = None,
     department_dir: Optional[Path] = None,
     role_profile_loader: Optional[Mapping[str, Mapping[str, object]]] = None,
+    product_intake_gate: bool = False,
 ) -> DiscussionTurnResponse:
     """One-shot tech-lead discussion turn.
 
@@ -125,7 +139,27 @@ def build_discussion_turn_response(
     경우 pack은 message + session에서 끌어낸 정보만 담고, issue/PR/note
     seam은 비어 있는 상태로 전달된다. caller가 풍부한 pack을 원하면
     seam이 채워진 builder를 주입한다.
+
+    ``product_intake_gate`` 가 True 면 engineering 분류/합성 *전에* PM intake
+    pre-step(:func:`run_product_intake`)을 한 번 돈다. 이 게이트는 **additive**
+    이고 기본값은 off — 끄면 비-제품 요청뿐 아니라 모든 입력에서 동작이
+    byte-for-byte 무변경이다. 켜진 상태에서도 PM gate 가 제품/기능 요청으로
+    보지 않으면(``should_intercept`` False) 기존 engineering flow 그대로 흐른다.
+    제품 요청일 때만:
+
+    * ``clarification_needed`` → PM 결정 질문을 그대로 응답으로 내고 turn 종료
+      (engineering 분류/합성/handoff 를 건너뜀). 이것은 engineering 의 기술
+      clarification 과 라벨·operator state 가 분리된 *PM* clarification 이다.
+    * ``spec_ready`` / ``implementation_candidate`` → product packet 요약을
+      engineering 본문 앞에 carry 한 뒤 engineering flow 를 계속한다 — tech-lead
+      가 raw 요청이 아니라 packet 위에서 움직인다.
     """
+
+    intake: Optional[ProductIntakeResult] = None
+    if product_intake_gate:
+        intake = run_product_intake(message_text)
+        if intake.intercepted and intake.short_circuit:
+            return _pm_short_circuit_response(intake)
 
     if builder is None:
         builder = ContextPackBuilder()
@@ -150,7 +184,12 @@ def build_discussion_turn_response(
     )
 
     handoff: Optional[DiscussionHandoff] = None
-    rendered_parts: list[str] = [synthesis.response_text]
+    rendered_parts: list[str] = []
+    # PM handoff-ready 면 product packet 요약을 engineering 본문 앞에 carry —
+    # tech-lead 가 raw 요청이 아니라 packet 위에서 움직이게 한다.
+    if intake is not None and intake.handoff_context:
+        rendered_parts.append(intake.handoff_context)
+    rendered_parts.append(synthesis.response_text)
     if synthesis.mode == DiscussionMode.IMPLEMENTATION_CANDIDATE and synthesis.implementation_ready:
         handoff = build_implementation_handoff(
             synthesis=synthesis,
@@ -186,6 +225,29 @@ def build_discussion_turn_response(
         handoff=handoff,
         blockers=blockers_dedup,
         operator_status=operator_status,
+        product_intake=intake,
+    )
+
+
+def _pm_short_circuit_response(intake: ProductIntakeResult) -> DiscussionTurnResponse:
+    """PM clarification 단계 — engineering 분류/합성을 건너뛴 응답.
+
+    제품 요청이 ``clarification_needed`` 면 engineering 으로 넘기지 않고
+    PM 결정 질문만 사용자에게 돌려준다. ``classification`` / ``synthesis`` /
+    ``context_pack`` 은 engineering 단계를 돌지 않았다는 의미로 None 자리표시
+    (placeholder) 를 둔다 — gateway 는 ``product_intake.short_circuit`` 또는
+    ``operator_status["layer"] == "product"`` 로 PM 단계임을 안다.
+    """
+
+    return DiscussionTurnResponse(
+        rendered_text=intake.rendered_text,
+        classification=None,  # engineering 분류를 돌지 않았음 (PM 단계)
+        synthesis=None,
+        context_pack=None,
+        handoff=None,
+        blockers=(),
+        operator_status=intake.operator_status,
+        product_intake=intake,
     )
 
 
@@ -293,6 +355,8 @@ def _state_remediation(state: str, synthesis: DiscussionSynthesis) -> str:
 __all__ = (
     "DiscussionTurnResponse",
     "build_discussion_turn_response",
+    "ProductIntakeResult",
+    "run_product_intake",
     "OPERATOR_STATE_CLARIFICATION",
     "OPERATOR_STATE_DISCUSSION",
     "OPERATOR_STATE_RESEARCH_PENDING",

--- a/apps/discord-gateway/src/yule_discord/engineering/product_intake_seam.py
+++ b/apps/discord-gateway/src/yule_discord/engineering/product_intake_seam.py
@@ -1,0 +1,250 @@
+"""Product intake pre-step seam — the PM gate the discussion turn consults.
+
+이 모듈은 **PM intake gate ↔ tech-lead discussion turn 경계** 를 코드 측에서
+얇게 잇는 어댑터다. ``build_discussion_turn_response`` 가 engineering 분류/합성
+을 시작하기 *전에* 이 seam 을 한 번 부른다.
+
+핵심 원칙 (additive, PM ≠ engineering):
+
+- **제품/기능 요청만** 가로챈다 (``gate.should_intercept``). 일정·잡담·단순
+  질문 등 비-제품 요청은 ``intercepted=False`` 로 그대로 통과 — 기존 engineering
+  clarification / research / status flow 는 무변경.
+- ``clarification_needed`` → PM 결정 질문(번호+옵션+추천)을 **PM clarification**
+  으로 surface 한다. 이것은 engineering 의 *기술* clarification 과 명확히
+  구분된 라벨/operator status 를 가진다.
+- ``spec_ready`` / ``implementation_candidate`` → product packet 요약
+  (acceptance / user decisions / implied features / non-goals)을 engineering
+  으로 carry 해서, tech-lead 가 raw request 가 아니라 **packet** 위에서 움직이게
+  한다.
+
+본 seam 은 외부 I/O 를 하지 않는다 — 순수 PM 코어
+(:mod:`yule_engineering.agents.product_intake`)를 reuse 만 한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence
+
+from yule_engineering.agents.product_intake.gate import (
+    ProductIntakeOutcome,
+    run_product_gate,
+)
+from yule_engineering.agents.product_intake.models import (
+    READINESS_CLARIFICATION,
+    READINESS_IMPLEMENTATION_CANDIDATE,
+    READINESS_RESEARCH_ONLY,
+    READINESS_SPEC_READY,
+)
+from yule_engineering.agents.product_intake.presenter import (
+    clarification_lines,
+    handoff_summary,
+    operator_status_line,
+)
+
+
+# ---------------------------------------------------------------------------
+# Operator-facing PM states — engineering 의 OPERATOR_STATE_* 와 의도적으로
+# 다른 prefix(``pm_``)를 써서 운영자 surface 가 "PM 단계" 와 "engineering
+# 단계" 를 한눈에 구분하게 한다. PM clarification ≠ engineering clarification.
+# ---------------------------------------------------------------------------
+
+PM_STATE_CLARIFICATION: str = "pm_clarification_needed"
+PM_STATE_HANDOFF_READY: str = "pm_handoff_ready"
+PM_STATE_RESEARCH_ONLY: str = "pm_research_only"
+
+# 렌더 본문 라벨 — 사용자가 "지금은 PM 이 기획을 보강하는 단계" 임을 알 수
+# 있도록 engineering 의 토의/clarification 헤더와 다른 라벨을 쓴다.
+_PM_CLARIFICATION_HEADER: str = "**PM clarification — 기획 결정 질문**"
+_PM_CLARIFICATION_INTRO: str = (
+    "_제품 요청으로 보입니다. engineering 으로 넘기기 전에 PM 이 먼저 "
+    "빠지면 안 되는 결정만 확인합니다 (engineering 의 기술 clarification 과는 "
+    "별개입니다)._"
+)
+_PM_HANDOFF_HEADER: str = "**PM product packet — engineering handoff**"
+_PM_HANDOFF_INTRO: str = (
+    "_PM 이 요청을 product packet 으로 정리했습니다. tech-lead 는 raw 요청이 "
+    "아니라 아래 packet 위에서 움직입니다._"
+)
+
+
+@dataclass(frozen=True)
+class ProductIntakeResult:
+    """discussion turn 이 소비하는 "product intake 결과".
+
+    ``intercepted=False`` 면 discussion turn 은 이 결과를 무시하고 기존
+    engineering flow 를 그대로 진행한다 (비-제품 요청 byte-for-byte 무변경).
+
+    필드:
+
+    - ``intercepted`` — PM gate 가 제품 요청으로 보고 가로챘는가.
+    - ``short_circuit`` — discussion turn 이 engineering 분류/합성을 건너뛰고
+      이 PM 결과를 그대로 응답으로 써야 하는가. ``clarification_needed`` 일 때만
+      True (사용자 결정 대기). handoff-ready 면 False — packet 을 carry 한 뒤
+      engineering 으로 계속 진행한다.
+    - ``rendered_text`` — short_circuit 일 때 사용자에게 그대로 게시할 PM
+      clarification 본문.
+    - ``handoff_context`` — handoff-ready 일 때 engineering 합성 본문 앞에 끼울
+      product packet 요약 블록 (없으면 빈 문자열).
+    - ``operator_status`` — 운영자 surface 가 그대로 라우팅할 수 있는 PM 상태
+      dict. ``state`` 는 ``pm_*`` prefix 로 engineering state 와 구분된다.
+    - ``outcome`` — 원본 :class:`ProductIntakeOutcome` (디버그/재사용).
+    """
+
+    intercepted: bool
+    short_circuit: bool = False
+    rendered_text: str = ""
+    handoff_context: str = ""
+    operator_status: Mapping[str, Any] = field(default_factory=dict)
+    outcome: Optional[ProductIntakeOutcome] = None
+
+
+def run_product_intake(
+    message_text: str,
+    *,
+    metadata: Optional[Mapping[str, object]] = None,
+) -> ProductIntakeResult:
+    """PM intake pre-step. 비-제품 요청이면 ``intercepted=False`` 로 통과.
+
+    discussion turn 은 이 함수를 호출한 뒤:
+
+    - ``intercepted=False`` → 결과 무시, 기존 engineering flow 그대로.
+    - ``short_circuit=True`` → ``rendered_text`` 를 게시하고 turn 종료
+      (PM 결정 질문 대기).
+    - 그 외(handoff-ready) → ``handoff_context`` 를 engineering 본문에 carry
+      하고 engineering flow 계속.
+    """
+
+    outcome = run_product_gate(message_text, metadata=metadata)
+    if not outcome.intercepted:
+        return ProductIntakeResult(intercepted=False, outcome=outcome)
+
+    state = outcome.state
+    if state == READINESS_CLARIFICATION:
+        return _clarification_result(outcome)
+    if state in (READINESS_SPEC_READY, READINESS_IMPLEMENTATION_CANDIDATE):
+        return _handoff_result(outcome)
+    if state == READINESS_RESEARCH_ONLY:
+        return _research_result(outcome)
+
+    # blocked / unknown — 가로채긴 했지만 short-circuit 하지 않고 engineering
+    # 으로 흘려보낸다. operator 는 PM 상태만 본다.
+    return ProductIntakeResult(
+        intercepted=True,
+        short_circuit=False,
+        operator_status=_pm_operator_status(
+            state=f"pm_{state}",
+            primary_actor="operator",
+            outcome=outcome,
+        ),
+        outcome=outcome,
+    )
+
+
+def _clarification_result(outcome: ProductIntakeOutcome) -> ProductIntakeResult:
+    """``clarification_needed`` → PM 결정 질문을 short-circuit 응답으로."""
+
+    questions = list(outcome.clarification_questions) or list(
+        clarification_lines(outcome.packet) if outcome.packet else ()
+    )
+    parts = [_PM_CLARIFICATION_HEADER, _PM_CLARIFICATION_INTRO, ""]
+    parts.extend(questions)
+    rendered = "\n".join(p for p in parts if p)
+    status = _pm_operator_status(
+        state=PM_STATE_CLARIFICATION,
+        primary_actor="user",
+        outcome=outcome,
+        remediation=(
+            "사용자가 번호로 결정을 답하면 PM 이 packet 을 완성해 engineering "
+            "으로 넘깁니다. (이 단계는 engineering 기술 clarification 이 아닙니다.)"
+        ),
+    )
+    return ProductIntakeResult(
+        intercepted=True,
+        short_circuit=True,
+        rendered_text=rendered,
+        operator_status=status,
+        outcome=outcome,
+    )
+
+
+def _handoff_result(outcome: ProductIntakeOutcome) -> ProductIntakeResult:
+    """``spec_ready`` / ``implementation_candidate`` → packet 을 carry."""
+
+    summary_lines = list(handoff_summary(outcome.packet)) if outcome.packet else []
+    context_parts = [_PM_HANDOFF_HEADER, _PM_HANDOFF_INTRO, ""]
+    context_parts.extend(summary_lines)
+    handoff_context = "\n".join(p for p in context_parts if p)
+    status = _pm_operator_status(
+        state=PM_STATE_HANDOFF_READY,
+        primary_actor="tech-lead",
+        outcome=outcome,
+        remediation=(
+            "tech-lead 가 product packet(acceptance / decisions / implied / "
+            "non-goals)을 받아 분해합니다. engineering 은 packet 기준으로 움직입니다."
+        ),
+    )
+    return ProductIntakeResult(
+        intercepted=True,
+        short_circuit=False,
+        handoff_context=handoff_context,
+        operator_status=status,
+        outcome=outcome,
+    )
+
+
+def _research_result(outcome: ProductIntakeOutcome) -> ProductIntakeResult:
+    """``research_only`` → 가로채되 engineering research flow 로 흘려보낸다."""
+
+    status = _pm_operator_status(
+        state=PM_STATE_RESEARCH_ONLY,
+        primary_actor="tech-lead",
+        outcome=outcome,
+        remediation="조사/분석 요청 — engineering research flow 로 진행합니다.",
+    )
+    return ProductIntakeResult(
+        intercepted=True,
+        short_circuit=False,
+        operator_status=status,
+        outcome=outcome,
+    )
+
+
+def _pm_operator_status(
+    *,
+    state: str,
+    primary_actor: str,
+    outcome: ProductIntakeOutcome,
+    remediation: str = "",
+) -> Mapping[str, Any]:
+    """운영자 surface 용 PM 상태 dict.
+
+    ``headline`` 은 PM presenter 의 ``operator_status_line`` 을 그대로 써서
+    "PM clarification" vs "engineering handoff ready" 를 한 줄로 구분한다.
+    ``layer="product"`` 로 engineering operator_status(layer 없음)와 명시적
+    으로 구분된다 — PM clarification ≠ engineering clarification.
+    """
+
+    headline = (
+        operator_status_line(outcome.packet)
+        if outcome.packet is not None
+        else f"product intake: {outcome.state}"
+    )
+    return {
+        "layer": "product",
+        "state": state,
+        "primary_actor": primary_actor,
+        "headline": headline,
+        "remediation": remediation,
+        "product_state": outcome.state,
+        "handoff_ready": outcome.handoff_ready,
+    }
+
+
+__all__ = (
+    "ProductIntakeResult",
+    "run_product_intake",
+    "PM_STATE_CLARIFICATION",
+    "PM_STATE_HANDOFF_READY",
+    "PM_STATE_RESEARCH_ONLY",
+)

--- a/apps/engineering-agent/src/yule_engineering/agents/obsidian/agent_note_frontmatter.py
+++ b/apps/engineering-agent/src/yule_engineering/agents/obsidian/agent_note_frontmatter.py
@@ -1,0 +1,155 @@
+"""Contract-stamped frontmatter for agent-authored vault notes.
+
+One shared vault; per-agent identity lives in **metadata**, not the note
+color. This module is the thin bridge between the agent invocation
+contract registry (``governance.agent_contract_registry``) and the
+Obsidian writer/exporter: given a role + note kind it produces the
+contract frontmatter keys (``agent / role / department / obsidian_lane /
+color_token / write_owner / retrieval_weight``) so every note an agent
+writes carries its identity for metadata-driven retrieval.
+
+It is **purely additive**: :func:`stamp_contract_frontmatter` merges the
+contract keys into a caller's existing frontmatter dict without removing
+or renaming any existing key. The exporter keeps owning the base note
+shape (``title / kind / status / topic / tags / …``); this only layers
+the agent identity on top.
+
+Where it plugs in: the exporter in :mod:`export_render` builds a base
+frontmatter dict (``_frontmatter`` / ``render_work_report_note``). A
+caller that knows the authoring role can pass that dict through
+:func:`stamp_contract_frontmatter` before :func:`write_note` so the note
+lands with its contract identity. Retrieval (``yule_memory``) then keys
+on those metadata fields; ``color_token`` rides along as a passive
+human-visual aid only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from ..governance.agent_contract_registry import AgentContract, contract_for
+from ..governance import note_frontmatter as nf
+
+# The contract-identity keys this module layers onto a note. ``title`` /
+# ``kind`` / ``status`` / ``project`` / ``topic`` / ``tags`` / ``created_at``
+# / ``related`` are owned by the exporter, so we only project identity +
+# retrieval-weight keys here (never clobbering caller values).
+CONTRACT_KEYS: tuple[str, ...] = (
+    "agent",
+    "role",
+    "department",
+    "obsidian_lane",
+    "color_token",
+    "write_owner",
+    "retrieval_weight",
+)
+
+
+def contract_frontmatter_keys(
+    role: str,
+    *,
+    kind: str,
+    retrieval_weight: float | None = None,
+) -> dict[str, Any]:
+    """Return just the contract-identity keys for *role* + note *kind*.
+
+    Thin wrapper over :func:`note_frontmatter.build_frontmatter` that
+    drops the exporter-owned keys, leaving only the agent identity +
+    retrieval-weight projection (see :data:`CONTRACT_KEYS`).
+    """
+
+    contract = _resolve_contract(role)
+    full = nf.build_frontmatter(
+        contract,
+        title="",
+        kind=kind,
+        retrieval_weight=retrieval_weight,  # type: ignore[arg-type]
+    )
+    return {key: full[key] for key in CONTRACT_KEYS}
+
+
+def stamp_contract_frontmatter(
+    base: Mapping[str, Any],
+    role: str,
+    *,
+    kind: str | None = None,
+    retrieval_weight: float | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Return *base* with the contract-identity keys merged in additively.
+
+    ``kind`` defaults to ``base['kind']`` when omitted so the exporter's
+    chosen note kind drives the retrieval weight. Existing keys in *base*
+    are preserved unless ``overwrite`` is True — by default we never
+    clobber a value the exporter already set, we only fill in the
+    contract keys that are missing/empty.
+    """
+
+    merged: dict[str, Any] = dict(base)
+    resolved_kind = kind if kind is not None else str(merged.get("kind") or "")
+    identity = contract_frontmatter_keys(
+        role, kind=resolved_kind, retrieval_weight=retrieval_weight
+    )
+    for key, value in identity.items():
+        if overwrite or _is_blank(merged.get(key)):
+            merged[key] = value
+    return merged
+
+
+def build_agent_note_frontmatter(
+    role: str,
+    *,
+    title: str,
+    kind: str,
+    status: str = "draft",
+    project: str = "",
+    topic: str = "",
+    tags: Sequence[str] = (),
+    created_at: str = "1970-01-01T00:00:00Z",
+    related: Sequence[str] = (),
+    retrieval_weight: float | None = None,
+) -> dict[str, Any]:
+    """Build a full contract-stamped frontmatter for *role*'s note.
+
+    Convenience entry point for callers that don't already have a base
+    frontmatter dict — resolves the contract and delegates to
+    :func:`note_frontmatter.build_frontmatter`.
+    """
+
+    contract = _resolve_contract(role)
+    return nf.build_frontmatter(
+        contract,
+        title=title,
+        kind=kind,
+        status=status,
+        project=project,
+        topic=topic,
+        tags=tags,
+        created_at=created_at,
+        related=related,
+        retrieval_weight=retrieval_weight,  # type: ignore[arg-type]
+    )
+
+
+def _resolve_contract(role: str | AgentContract) -> AgentContract:
+    if isinstance(role, AgentContract):
+        return role
+    return contract_for(role)
+
+
+def _is_blank(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) == 0
+    return False
+
+
+__all__ = (
+    "CONTRACT_KEYS",
+    "contract_frontmatter_keys",
+    "stamp_contract_frontmatter",
+    "build_agent_note_frontmatter",
+)

--- a/packages/memory/src/yule_memory/indexer.py
+++ b/packages/memory/src/yule_memory/indexer.py
@@ -250,16 +250,26 @@ def _document_from_markdown_file(
         or md_path.stem
     )
     note_kind = _normalize_note_kind(_frontmatter_value(frontmatter, "kind"))
+    # Prefer the legacy plural ``roles`` list; fall back to the singular
+    # ``role`` stamped by the agent invocation contract (note_frontmatter).
     role = _normalize_role(_first_role(_frontmatter_value(frontmatter, "roles")))
+    if role is None:
+        role = _normalize_role(_frontmatter_value(frontmatter, "role"))
     task_type = _frontmatter_value(frontmatter, "task_type")
     tags = tuple(_split_yaml_list(_frontmatter_value(frontmatter, "tags")))
     created_at = _parse_iso_datetime(_frontmatter_value(frontmatter, "created_at"))
     relative = _relative_path(md_path, base_dir)
     doc_id = f"{source_kind}:{relative}"
     # Project memory-policy section 4 reuse-boost markers + topic (recall-policy
-    # section 4 topic-aware recall) into extra (read-side only).
+    # section 4 topic-aware recall) into extra (read-side only). The agent
+    # invocation contract keys (agent / obsidian_lane / color_token /
+    # write_owner) are projected the same way so retrieval can filter on agent
+    # identity — color_token stays a passive field, never a ranking key.
     extra: dict = {}
-    for marker in ("canonical", "reusable", "status", "topic"):
+    for marker in (
+        "canonical", "reusable", "status", "topic",
+        "agent", "obsidian_lane", "color_token", "write_owner",
+    ):
         value = _frontmatter_value(frontmatter, marker)
         if value not in (None, ""):
             extra[marker] = str(value)

--- a/tests/discord/test_discussion_turn_product_intake.py
+++ b/tests/discord/test_discussion_turn_product_intake.py
@@ -1,0 +1,172 @@
+"""Integration tests — PM intake pre-step wired into the discussion turn.
+
+PM intake gate(``product_intake_seam``) 가 ``build_discussion_turn_response``
+앞단에 additive 하게 끼었을 때:
+
+1. vague feature request → PM clarification short-circuit (engineering 분류/합성
+   을 건너뛰고 PM 결정 질문만).
+2. fully-specified feature → product packet 이 engineering 본문 앞에 carry 되고
+   engineering flow 가 그대로 이어짐.
+3. non-feature request → 기존 engineering flow 무변경 (regression).
+4. gate OFF(기본값) → 제품 요청이어도 byte-for-byte 기존 동작.
+
+PM clarification 은 engineering 의 기술 clarification 과 라벨/operator state 가
+분리되어 있어야 한다 (PM ≠ engineering).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.discussion import DiscussionMode
+from yule_discord.engineering.discussion_turn import (
+    OPERATOR_STATE_CLARIFICATION,
+    build_discussion_turn_response,
+)
+from yule_discord.engineering.product_intake_seam import (
+    PM_STATE_CLARIFICATION,
+    PM_STATE_HANDOFF_READY,
+    run_product_intake,
+)
+
+
+class VagueFeatureClarificationTestCase(unittest.TestCase):
+    """vague feature request → PM clarification short-circuit."""
+
+    def test_vague_feature_short_circuits_to_pm_clarification(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="영상 업로드 서비스 구현해줘",
+            product_intake_gate=True,
+        )
+        # PM 단계 — engineering 분류/합성을 돌지 않았다.
+        self.assertIsNotNone(result.product_intake)
+        self.assertTrue(result.product_intake.intercepted)
+        self.assertTrue(result.product_intake.short_circuit)
+        self.assertIsNone(result.classification)
+        self.assertIsNone(result.synthesis)
+        self.assertIsNone(result.handoff)
+
+    def test_pm_clarification_label_is_distinct_from_engineering(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="영상 업로드 서비스 구현해줘",
+            product_intake_gate=True,
+        )
+        # PM 라벨이 본문에 명시되고 engineering 토의/clarification 헤더가 아님.
+        self.assertIn("PM clarification", result.rendered_text)
+        self.assertNotIn("**모드:**", result.rendered_text)
+        # 번호 옵션 + 추천 picks.
+        self.assertIn("(추천)", result.rendered_text)
+        self.assertIn("공개 정책", result.rendered_text)
+
+    def test_pm_operator_status_is_product_layer(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="영상 업로드 서비스 구현해줘",
+            product_intake_gate=True,
+        )
+        status = result.operator_status
+        # PM state 는 engineering state 와 prefix/layer 로 구분된다.
+        self.assertEqual(status["layer"], "product")
+        self.assertEqual(status["state"], PM_STATE_CLARIFICATION)
+        self.assertNotEqual(status["state"], OPERATOR_STATE_CLARIFICATION)
+        self.assertEqual(status["primary_actor"], "user")
+        self.assertIn("PM clarification", status["headline"])
+
+
+class SpecifiedFeatureHandoffTestCase(unittest.TestCase):
+    """fully-specified feature → packet carried, engineering continues."""
+
+    def test_specified_feature_carries_packet_then_proceeds(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="누구나 업로드, 즉시 공개, 최신순 노출되는 영상 업로드 기능 만들어줘",
+            product_intake_gate=True,
+        )
+        # 가로챘지만 short-circuit 하지 않음 — engineering 으로 계속.
+        self.assertTrue(result.product_intake.intercepted)
+        self.assertFalse(result.product_intake.short_circuit)
+        self.assertEqual(
+            result.product_intake.operator_status["state"], PM_STATE_HANDOFF_READY
+        )
+        # engineering 분류/합성이 정상적으로 돌았다.
+        self.assertIsNotNone(result.classification)
+        self.assertIsNotNone(result.synthesis)
+
+    def test_packet_summary_carried_into_rendered_text(self) -> None:
+        result = build_discussion_turn_response(
+            message_text="누구나 업로드, 즉시 공개, 최신순 노출되는 영상 업로드 기능 만들어줘",
+            product_intake_gate=True,
+        )
+        text = result.rendered_text
+        # product packet 요약(acceptance / implied / non-goals)이 본문에 carry.
+        self.assertIn("PM product packet", text)
+        self.assertIn("acceptance criteria", text)
+        self.assertIn("implied features", text)
+        self.assertIn("non-goals", text)
+        # engineering 응답 본문도 packet 뒤에 그대로 이어진다 (mode 헤더).
+        self.assertIn("**모드:**", text)
+
+
+class NonFeatureRegressionTestCase(unittest.TestCase):
+    """non-feature request → 기존 engineering flow 무변경."""
+
+    def test_non_feature_with_gate_on_unchanged(self) -> None:
+        # gate ON 이어도 비-제품 요청은 가로채지 않는다.
+        result = build_discussion_turn_response(
+            message_text="이 구조 맞아? devops 관점에서 어떻게 풀지",
+            product_intake_gate=True,
+        )
+        self.assertIsNotNone(result.product_intake)
+        self.assertFalse(result.product_intake.intercepted)
+        # 기존 engineering 토의 동작 그대로.
+        self.assertEqual(result.classification.mode, DiscussionMode.DISCUSSION)
+        self.assertIn("devops", result.rendered_text.lower())
+        self.assertIn("권한 제안", result.rendered_text)
+
+    def test_gate_off_is_byte_for_byte_unchanged_for_product_ask(self) -> None:
+        # gate 기본값(off) — 제품 요청이어도 PM pre-step 이 돌지 않는다.
+        off = build_discussion_turn_response(
+            message_text="영상 업로드 서비스 구현해줘",
+        )
+        explicit_off = build_discussion_turn_response(
+            message_text="영상 업로드 서비스 구현해줘",
+            product_intake_gate=False,
+        )
+        self.assertIsNone(off.product_intake)
+        self.assertIsNone(explicit_off.product_intake)
+        # 두 호출 모두 engineering flow 를 그대로 탔다.
+        self.assertEqual(off.rendered_text, explicit_off.rendered_text)
+        self.assertIsNotNone(off.classification)
+
+
+class SeamUnitTestCase(unittest.TestCase):
+    """``run_product_intake`` seam 단독 동작 (discussion turn 과 독립)."""
+
+    def test_non_product_passes_through(self) -> None:
+        res = run_product_intake("오늘 일정 알려줘")
+        self.assertFalse(res.intercepted)
+        self.assertFalse(res.short_circuit)
+        self.assertEqual(res.operator_status, {})
+
+    def test_clarification_short_circuits(self) -> None:
+        res = run_product_intake("영상 업로드 서비스 구현해줘")
+        self.assertTrue(res.intercepted)
+        self.assertTrue(res.short_circuit)
+        self.assertIn("PM clarification", res.rendered_text)
+        self.assertEqual(res.operator_status["layer"], "product")
+
+    def test_handoff_ready_carries_context_no_short_circuit(self) -> None:
+        res = run_product_intake(
+            "누구나 업로드, 즉시 공개, 최신순 노출되는 영상 업로드 기능 만들어줘"
+        )
+        self.assertTrue(res.intercepted)
+        self.assertFalse(res.short_circuit)
+        self.assertIn("PM product packet", res.handoff_context)
+        self.assertEqual(res.operator_status["state"], PM_STATE_HANDOFF_READY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/memory/test_contract_metadata_roundtrip.py
+++ b/tests/memory/test_contract_metadata_roundtrip.py
@@ -1,0 +1,104 @@
+"""Agent-contract frontmatter keys round-trip through the memory index.
+
+Task 2 wiring: a note stamped with the agent invocation contract
+(agent / role / obsidian_lane / color_token / write_owner) is indexed so
+those keys are searchable/filterable metadata. Retrieval stays
+metadata-driven; color_token is a passive field, never a ranking key.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_memory import MEMORY_DB_ENV, open_memory_index, reindex_paths
+from yule_memory.indexer import _document_from_markdown_file
+from yule_memory.models import SOURCE_OBSIDIAN
+from yule_memory.search import search
+
+from yule_engineering.agents.governance.agent_contract_registry import contract_for
+from yule_engineering.agents.governance import note_frontmatter as nf
+from yule_engineering.agents.obsidian import agent_note_frontmatter as anf
+
+
+def _contract_note(role: str, *, kind: str, body: str) -> str:
+    fm = anf.build_agent_note_frontmatter(
+        role,
+        title="Upload pipeline 결정",
+        kind=kind,
+        topic="upload",
+        tags=["backend"],
+    )
+    return nf.render_frontmatter(fm) + f"\n# Upload pipeline 결정\n\n{body}\n"
+
+
+class ContractMetadataExtractionTests(unittest.TestCase):
+    def test_contract_keys_projected_into_extra(self) -> None:
+        contract = contract_for("backend-engineer")
+        with tempfile.TemporaryDirectory() as tmp:
+            md = Path(tmp) / "n.md"
+            md.write_text(
+                _contract_note("backend-engineer", kind="decision", body="본문"),
+                encoding="utf-8",
+            )
+            doc = _document_from_markdown_file(
+                md_path=md, source_kind=SOURCE_OBSIDIAN, base_dir=Path(tmp)
+            )
+            self.assertIsNotNone(doc)
+            # role is a first-class column; sourced from the singular `role` key.
+            self.assertEqual(doc.role, contract.role_id)
+            # identity keys round-trip through extra.
+            self.assertEqual(doc.extra.get("agent"), contract.agent_id)
+            self.assertEqual(doc.extra.get("obsidian_lane"), contract.obsidian_write_target)
+            self.assertEqual(doc.extra.get("color_token"), contract.color_token)
+            self.assertEqual(doc.extra.get("write_owner"), contract.role_id)
+
+
+class ContractMetadataSearchRoundtripTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._prev = os.environ.get(MEMORY_DB_ENV)
+        os.environ[MEMORY_DB_ENV] = str(Path(self._tmp.name) / "memory.sqlite3")
+        vault = Path(self._tmp.name) / "vault"
+        path = vault / "Decisions" / "upload.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            _contract_note("backend-engineer", kind="decision", body="업로드 파이프라인"),
+            encoding="utf-8",
+        )
+        with open_memory_index() as index:
+            reindex_paths(
+                paths=[vault], source_kind=SOURCE_OBSIDIAN, index=index, base_dir=vault
+            )
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop(MEMORY_DB_ENV, None)
+        else:
+            os.environ[MEMORY_DB_ENV] = self._prev
+
+    def test_role_filterable_and_extra_survives_search(self) -> None:
+        contract = contract_for("backend-engineer")
+        hits = search("업로드 파이프라인", role=contract.role_id, limit=5)
+        self.assertTrue(hits)
+        doc = hits[0].document
+        self.assertEqual(doc.role, contract.role_id)
+        self.assertEqual(doc.extra.get("agent"), contract.agent_id)
+        self.assertEqual(doc.extra.get("color_token"), contract.color_token)
+        self.assertEqual(doc.extra.get("obsidian_lane"), contract.obsidian_write_target)
+
+    def test_wrong_role_filter_excludes(self) -> None:
+        hits = search("업로드 파이프라인", role="frontend-engineer", limit=5)
+        self.assertEqual(hits, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/obsidian/test_agent_note_frontmatter.py
+++ b/tests/obsidian/test_agent_note_frontmatter.py
@@ -1,0 +1,115 @@
+"""Contract-stamped frontmatter helper for agent-authored vault notes.
+
+Task 1 wiring: an agent writing a vault note stamps its invocation
+contract identity (agent / role / department / obsidian_lane /
+color_token / write_owner / retrieval_weight) onto the note frontmatter,
+additively, without clobbering exporter-owned keys.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import _bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    from tests import _bootstrap  # noqa: F401
+
+from yule_engineering.agents.governance.agent_contract_registry import contract_for
+from yule_engineering.agents.obsidian import agent_note_frontmatter as anf
+
+
+class ContractFrontmatterKeysTests(unittest.TestCase):
+    def test_keys_match_contract_identity(self) -> None:
+        role = "backend-engineer"
+        contract = contract_for(role)
+        keys = anf.contract_frontmatter_keys(role, kind="decision")
+
+        self.assertEqual(set(keys), set(anf.CONTRACT_KEYS))
+        self.assertEqual(keys["agent"], contract.agent_id)
+        self.assertEqual(keys["role"], contract.role_id)
+        self.assertEqual(keys["department"], contract.department_id)
+        self.assertEqual(keys["obsidian_lane"], contract.obsidian_write_target)
+        self.assertEqual(keys["color_token"], contract.color_token)
+        self.assertEqual(keys["write_owner"], contract.role_id)
+
+    def test_retrieval_weight_follows_kind(self) -> None:
+        canonical = anf.contract_frontmatter_keys("backend-engineer", kind="canonical")
+        status = anf.contract_frontmatter_keys("backend-engineer", kind="status")
+        self.assertEqual(canonical["retrieval_weight"], 2.0)
+        self.assertEqual(status["retrieval_weight"], 0.5)
+
+    def test_explicit_retrieval_weight_override(self) -> None:
+        keys = anf.contract_frontmatter_keys(
+            "backend-engineer", kind="status", retrieval_weight=9.0
+        )
+        self.assertEqual(keys["retrieval_weight"], 9.0)
+
+
+class StampContractFrontmatterTests(unittest.TestCase):
+    def test_additive_merge_preserves_exporter_keys(self) -> None:
+        base = {
+            "title": "Upload pipeline 결정",
+            "kind": "decision",
+            "status": "draft",
+            "roles": ["engineering-agent/backend-engineer"],
+            "topic": "upload",
+            "tags": ["backend"],
+        }
+        stamped = anf.stamp_contract_frontmatter(base, "backend-engineer")
+
+        # Existing exporter keys untouched.
+        for key, value in base.items():
+            self.assertEqual(stamped[key], value)
+        # Contract identity layered on top.
+        contract = contract_for("backend-engineer")
+        self.assertEqual(stamped["agent"], contract.agent_id)
+        self.assertEqual(stamped["role"], contract.role_id)
+        self.assertEqual(stamped["obsidian_lane"], contract.obsidian_write_target)
+        self.assertEqual(stamped["color_token"], contract.color_token)
+        self.assertEqual(stamped["write_owner"], contract.role_id)
+        # kind drove the retrieval weight.
+        self.assertEqual(stamped["retrieval_weight"], 1.0)
+
+    def test_does_not_mutate_input(self) -> None:
+        base = {"title": "t", "kind": "reference"}
+        anf.stamp_contract_frontmatter(base, "backend-engineer")
+        self.assertNotIn("agent", base)
+
+    def test_no_overwrite_by_default(self) -> None:
+        base = {"kind": "decision", "color_token": "preset-by-caller"}
+        stamped = anf.stamp_contract_frontmatter(base, "backend-engineer")
+        self.assertEqual(stamped["color_token"], "preset-by-caller")
+
+    def test_overwrite_flag_replaces(self) -> None:
+        base = {"kind": "decision", "color_token": "preset-by-caller"}
+        stamped = anf.stamp_contract_frontmatter(
+            base, "backend-engineer", overwrite=True
+        )
+        self.assertEqual(
+            stamped["color_token"], contract_for("backend-engineer").color_token
+        )
+
+    def test_kind_falls_back_to_base(self) -> None:
+        base = {"kind": "canonical"}
+        stamped = anf.stamp_contract_frontmatter(base, "backend-engineer")
+        self.assertEqual(stamped["retrieval_weight"], 2.0)
+
+
+class BuildAgentNoteFrontmatterTests(unittest.TestCase):
+    def test_full_frontmatter_validates(self) -> None:
+        from yule_engineering.agents.governance import note_frontmatter as nf
+
+        fm = anf.build_agent_note_frontmatter(
+            "backend-engineer",
+            title="제목",
+            kind="decision",
+            project="bkurs",
+            topic="upload",
+        )
+        self.assertEqual(nf.validate_frontmatter(fm), ())
+        self.assertEqual(fm["agent"], contract_for("backend-engineer").agent_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
머지된 agent invocation 계약 + product intake gate 를 실제 런타임 경로에 additive 로 결선한다.

## 범위
- **FU-A vault/memory**: `obsidian/agent_note_frontmatter.py`(계약 frontmatter 스탬프 헬퍼, 비파괴 merge) + memory indexer 가 신규 신원 메타데이터(agent/role/obsidian_lane/color_token/write_owner) 색인. retrieval 은 metadata 기반(색 아님).
- **FU-B PM gate→discussion turn**: `product_intake_seam.run_product_intake` + `build_discussion_turn_response(product_intake_gate=False)` opt-in. 제품 요청은 PM clarification(기획 결정 질문) 또는 packet handoff, 비제품/기존 engineering clarification·research·status 는 무변경. PM clarification 은 engineering clarification 과 별도 state/label.

## 리스크
- opt-in flag 기본 off → 기존 caller/테스트 무영향. origin/main ancestor → 충돌 없음.

## 테스트
- 전체 sweep 5894 tests, 신규 회귀 0. 잔존 5 errors 는 사전 환경(digest_crawler/discord stub) 무관.

## 이슈 linkage
- agent invocation contract / product intake gate 후속.

## Audit
- 한국어 gitmoji 3섹션, Co-Authored-By 없음, 명시 pathspec, push only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)