### PR TITLE
✨ forgekit 설치형 코어 — brain(WT1) + provider 계약/정책/adaptive usage(WT2)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/app/main.py
+++ b/apps/forgekit-console/src/forgekit_console/app/main.py
@@ -34,15 +34,25 @@ def resolve_repo_root(explicit: Optional[str] = None) -> Path:
     return Path.cwd().resolve()
 
 
+# CLI subcommand modules — each exposes add_parser(subparsers) + handle(args).
+# Registered here so `app.main` stays a thin dispatcher.
+def _cli_modules() -> dict:
+    from ..cli import brain_cmd
+
+    return {"brain": brain_cmd}
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="forgekit",
-        description="Forgekit operator console (TUI over the yule runtime/harness surfaces).",
+        description="Forgekit provider-agnostic operator console + setup.",
     )
     parser.add_argument("--version", action="store_true", help="버전 출력 후 종료")
     sub = parser.add_subparsers(dest="command")
     console = sub.add_parser("console", help="운영자 콘솔 TUI 열기 (기본)")
     console.add_argument("--repo-root", help="status surface 의 기준 repo 경로")
+    for module in _cli_modules().values():
+        module.add_parser(sub)
     return parser
 
 
@@ -74,9 +84,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return EXIT_OK
 
     # bare `forgekit` or `forgekit console` → open the console
-    repo_root = resolve_repo_root(getattr(args, "repo_root", None))
     if args.command in (None, "console"):
+        repo_root = resolve_repo_root(getattr(args, "repo_root", None))
         return launch_console(repo_root=repo_root)
+
+    modules = _cli_modules()
+    if args.command in modules:
+        return modules[args.command].handle(args)
 
     parser.print_help()
     return EXIT_USAGE

--- a/apps/forgekit-console/src/forgekit_console/app/main.py
+++ b/apps/forgekit-console/src/forgekit_console/app/main.py
@@ -37,9 +37,9 @@ def resolve_repo_root(explicit: Optional[str] = None) -> Path:
 # CLI subcommand modules — each exposes add_parser(subparsers) + handle(args).
 # Registered here so `app.main` stays a thin dispatcher.
 def _cli_modules() -> dict:
-    from ..cli import brain_cmd
+    from ..cli import brain_cmd, provider_cmd
 
-    return {"brain": brain_cmd}
+    return {"brain": brain_cmd, "provider": provider_cmd}
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/apps/forgekit-console/src/forgekit_console/brain/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/__init__.py
@@ -1,0 +1,6 @@
+"""Forgekit brain — personal (RW) / starter pack (RO) / source vault / working set.
+
+Pure models + policy live in ``models`` / ``policy``; disk-backed personal brain
+in ``personal``; read-only starter pack build in ``pack``; env-aware orchestration
+in ``service``.
+"""

--- a/apps/forgekit-console/src/forgekit_console/brain/models.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/models.py
@@ -1,0 +1,93 @@
+"""Brain models + the brain-layer policy constants — pure, stdlib.
+
+The brain has four layers with distinct read/write rules:
+
+  * ``personal``  — read-write. The default (and only) write target.
+  * ``starter``   — read-only. A pack *built from* a source vault, never edited.
+  * ``source``    — local-only source vault; the build input for a starter pack,
+    never read directly at runtime (we read the built pack instead).
+  * ``working``   — the per-session/project working set injected into a run;
+    a minimal projection, not a store.
+
+These are declarative so the policy + tests assert them without touching disk.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Tuple
+
+LAYER_PERSONAL = "personal"
+LAYER_STARTER = "starter"
+LAYER_SOURCE = "source"
+LAYER_WORKING = "working"
+
+ALL_LAYERS: Tuple[str, ...] = (LAYER_PERSONAL, LAYER_STARTER, LAYER_SOURCE, LAYER_WORKING)
+
+# Which layers accept writes. Only the personal brain does.
+_WRITABLE = frozenset({LAYER_PERSONAL})
+# Which layers the runtime reads from directly. NOT source (read its built pack).
+_RUNTIME_READABLE = frozenset({LAYER_PERSONAL, LAYER_STARTER, LAYER_WORKING})
+
+# Personal brain folder skeleton created on init.
+PERSONAL_SKELETON: Tuple[str, ...] = ("notes", "decisions", "inbox")
+
+
+@dataclass(frozen=True)
+class BrainNote:
+    """One markdown note (frontmatter + body) in the personal brain."""
+
+    title: str
+    body: str
+    kind: str = "note"  # note | decision | inbox
+    tags: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PackEntry:
+    """One indexed document inside a starter pack manifest."""
+
+    rel_path: str
+    title: str
+    bytes: int
+    digest_chars: int
+    tags: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PackManifest:
+    """The read-only starter pack manifest — what was built, from where."""
+
+    source_path: str
+    built_at: str
+    doc_count: int
+    total_bytes: int
+    entries: Tuple[PackEntry, ...] = ()
+    meta: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": "forgekit-starter-pack",
+            "source_path": self.source_path,
+            "built_at": self.built_at,
+            "doc_count": self.doc_count,
+            "total_bytes": self.total_bytes,
+            "entries": [
+                {
+                    "rel_path": e.rel_path,
+                    "title": e.title,
+                    "bytes": e.bytes,
+                    "digest_chars": e.digest_chars,
+                    "tags": list(e.tags),
+                }
+                for e in self.entries
+            ],
+            "meta": dict(self.meta),
+        }
+
+
+__all__ = (
+    "LAYER_PERSONAL", "LAYER_STARTER", "LAYER_SOURCE", "LAYER_WORKING", "ALL_LAYERS",
+    "PERSONAL_SKELETON",
+    "BrainNote", "PackEntry", "PackManifest",
+)

--- a/apps/forgekit-console/src/forgekit_console/brain/pack.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/pack.py
@@ -1,0 +1,162 @@
+"""Starter brain pack — build a read-only pack from a local source vault.
+
+Philosophy: the *whole* local vault may be the source, but the forgekit runtime
+never reads the raw vault — it reads this built **pack** (manifest + per-doc
+compressed digests + a lightweight index). The build is read-only on the source
+and deterministic, so the same vault always produces the same pack.
+
+This is local-only today but the manifest shape is reusable for later
+distribution. Writes never touch the source or the personal brain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .models import PackEntry, PackManifest
+
+_MD_SUFFIXES = (".md", ".markdown")
+_SKIP_DIRS = {".git", ".obsidian", ".trash", "node_modules", ".cache"}
+MANIFEST_NAME = "manifest.json"
+INDEX_NAME = "index.json"
+READONLY_MARKER = ".readonly"
+DIGEST_DIR = "digests"
+
+
+class PackBuildError(RuntimeError):
+    """Raised when a starter pack cannot be built (e.g. missing source)."""
+
+
+def _frontmatter_meta(text: str) -> Tuple[str, Tuple[str, ...]]:
+    """Extract (title, tags) from a leading ``---`` frontmatter block, if any."""
+
+    title, tags = "", ()
+    if not text.startswith("---"):
+        return title, tags
+    end = text.find("\n---", 3)
+    if end == -1:
+        return title, tags
+    for line in text[3:end].splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key, value = key.strip().lower(), value.strip()
+        if key == "title" and value:
+            title = value
+        elif key == "tags" and value:
+            tags = tuple(t.strip() for t in value.replace(",", " ").split() if t.strip())
+    return title, tags
+
+
+def _body_after_frontmatter(text: str) -> str:
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            nl = text.find("\n", end + 1)
+            return text[nl + 1:] if nl != -1 else ""
+    return text
+
+
+def _digest(text: str, limit: int) -> str:
+    body = _body_after_frontmatter(text).strip()
+    if len(body) <= limit:
+        return body
+    return body[:limit].rstrip() + " …"
+
+
+def build_starter_pack(
+    source_path: Path,
+    dest_dir: Path,
+    *,
+    built_at: str = "1970-01-01T00:00:00Z",
+    max_docs: int = 2000,
+    digest_chars: int = 800,
+) -> PackManifest:
+    """Build a read-only starter pack from *source_path* into *dest_dir*."""
+
+    source = Path(source_path)
+    if not source.exists() or not source.is_dir():
+        raise PackBuildError(f"source vault not found: {source}")
+    dest = Path(dest_dir)
+    digests = dest / DIGEST_DIR
+    digests.mkdir(parents=True, exist_ok=True)
+
+    files = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in _MD_SUFFIXES:
+            continue
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        files.append(path)
+        if len(files) >= max_docs:
+            break
+
+    entries: list[PackEntry] = []
+    total_bytes = 0
+    index: list[dict] = []
+    for i, path in enumerate(files):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        rel = str(path.relative_to(source))
+        title, tags = _frontmatter_meta(text)
+        if not title:
+            title = path.stem
+        digest = _digest(text, digest_chars)
+        size = len(text.encode("utf-8"))
+        total_bytes += size
+        (digests / f"{i:05d}.txt").write_text(digest, encoding="utf-8")
+        entries.append(PackEntry(rel_path=rel, title=title, bytes=size,
+                                 digest_chars=len(digest), tags=tags))
+        index.append({"i": i, "title": title, "rel_path": rel, "tags": list(tags)})
+
+    manifest = PackManifest(
+        source_path=str(source),
+        built_at=built_at,
+        doc_count=len(entries),
+        total_bytes=total_bytes,
+        entries=tuple(entries),
+        meta={"digest_chars": str(digest_chars), "read_only": "true"},
+    )
+    (dest / MANIFEST_NAME).write_text(
+        json.dumps(manifest.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (dest / INDEX_NAME).write_text(
+        json.dumps({"docs": index}, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (dest / READONLY_MARKER).write_text(
+        "이 디렉터리는 forgekit starter pack(read-only)입니다. 직접 수정하지 마세요.\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def pack_status(dest_dir: Path) -> Optional[dict]:
+    """Read the built pack's manifest summary, or None if not built."""
+
+    manifest = Path(dest_dir) / MANIFEST_NAME
+    if not manifest.exists():
+        return None
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return {
+        "source_path": data.get("source_path"),
+        "built_at": data.get("built_at"),
+        "doc_count": data.get("doc_count", 0),
+        "total_bytes": data.get("total_bytes", 0),
+        "read_only": True,
+    }
+
+
+__all__ = (
+    "PackBuildError",
+    "build_starter_pack",
+    "pack_status",
+    "MANIFEST_NAME",
+    "READONLY_MARKER",
+)

--- a/apps/forgekit-console/src/forgekit_console/brain/personal.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/personal.py
@@ -1,0 +1,123 @@
+"""Personal brain — the auto-created, read-write default store.
+
+No Obsidian dependency: notes are plain markdown with a tiny frontmatter block
+(``key: value`` lines between ``---`` fences), so the brain is readable/writable
+with nothing installed. Auto-init lays down a small folder skeleton; writes go
+only here (enforced via :mod:`brain.policy`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from . import policy
+from .models import LAYER_PERSONAL, PERSONAL_SKELETON, BrainNote
+
+_KIND_DIR = {"note": "notes", "decision": "decisions", "inbox": "inbox"}
+_INDEX_NAME = "index.md"
+
+
+def _slugify(title: str) -> str:
+    keep = [c.lower() if c.isalnum() else "-" for c in title.strip()]
+    slug = "".join(keep)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug.strip("-") or "untitled"
+
+
+def _frontmatter(note: BrainNote, created_at: str) -> str:
+    tags = ", ".join(note.tags)
+    return (
+        "---\n"
+        f"title: {note.title}\n"
+        f"kind: {note.kind}\n"
+        f"created_at: {created_at}\n"
+        f"tags: {tags}\n"
+        "brain_layer: personal\n"
+        "---\n"
+    )
+
+
+@dataclass(frozen=True)
+class PersonalBrain:
+    base_dir: Path
+
+    @property
+    def index_path(self) -> Path:
+        return self.base_dir / _INDEX_NAME
+
+    def is_initialized(self) -> bool:
+        return self.base_dir.is_dir() and self.index_path.exists()
+
+    def write_note(self, note: BrainNote, *, created_at: str = "1970-01-01T00:00:00Z") -> Path:
+        """Write *note* into the personal brain; returns the file path.
+
+        The layer policy is asserted first — a personal-only write target means
+        this is the single sanctioned write path in the whole brain.
+        """
+
+        policy.assert_writable(LAYER_PERSONAL)
+        subdir = self.base_dir / _KIND_DIR.get(note.kind, "notes")
+        subdir.mkdir(parents=True, exist_ok=True)
+        path = subdir / f"{_slugify(note.title)}.md"
+        path.write_text(_frontmatter(note, created_at) + "\n" + note.body.rstrip() + "\n", encoding="utf-8")
+        return path
+
+    def list_notes(self) -> Tuple[Path, ...]:
+        if not self.base_dir.is_dir():
+            return ()
+        return tuple(sorted(p for p in self.base_dir.rglob("*.md") if p.name != _INDEX_NAME))
+
+    def stats(self) -> Mapping[str, int]:
+        notes = self.list_notes()
+        by_kind = {kind: 0 for kind in _KIND_DIR}
+        for p in notes:
+            by_kind[_kind_of(p)] = by_kind.get(_kind_of(p), 0) + 1
+        return {"total": len(notes), **by_kind}
+
+
+def _kind_of(path: Path) -> str:
+    parent = path.parent.name
+    for kind, d in _KIND_DIR.items():
+        if d == parent:
+            return kind
+    return "note"
+
+
+def init_personal_brain(base_dir: Path, *, created_at: str = "1970-01-01T00:00:00Z") -> PersonalBrain:
+    """Create the personal-brain skeleton + index if missing. Idempotent."""
+
+    base = Path(base_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    for sub in PERSONAL_SKELETON:
+        (base / sub).mkdir(parents=True, exist_ok=True)
+    brain = PersonalBrain(base_dir=base)
+    if not brain.index_path.exists():
+        brain.index_path.write_text(
+            "---\n"
+            "title: personal brain\n"
+            "brain_layer: personal\n"
+            f"created_at: {created_at}\n"
+            "---\n\n"
+            "# personal brain\n\n"
+            "forgekit 의 기본 read-write 브레인입니다. 모든 write 는 여기로 갑니다.\n"
+            "starter/shared pack 은 read-only — 직접 수정하지 않습니다.\n",
+            encoding="utf-8",
+        )
+    return brain
+
+
+def open_personal_brain(base_dir: Path) -> Optional[PersonalBrain]:
+    """Return the brain if initialized, else None (no side effects)."""
+
+    brain = PersonalBrain(base_dir=Path(base_dir))
+    return brain if brain.is_initialized() else None
+
+
+__all__ = (
+    "PersonalBrain",
+    "init_personal_brain",
+    "open_personal_brain",
+)

--- a/apps/forgekit-console/src/forgekit_console/brain/policy.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/policy.py
@@ -1,0 +1,73 @@
+"""Brain layer policy — pure rules over the four layers.
+
+The single source of truth for "who can write where, what the runtime reads, and
+where a write goes by default". Disk operations (``personal``/``pack``) consult
+these so the read-only / default-write-target invariants can't be bypassed.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .models import (
+    ALL_LAYERS,
+    LAYER_PERSONAL,
+    LAYER_SOURCE,
+    LAYER_STARTER,
+    LAYER_WORKING,
+)
+
+_WRITABLE = frozenset({LAYER_PERSONAL})
+_RUNTIME_READABLE = frozenset({LAYER_PERSONAL, LAYER_STARTER, LAYER_WORKING})
+
+
+class BrainPolicyError(RuntimeError):
+    """Raised when a brain operation violates the layer policy."""
+
+
+def is_writable(layer: str) -> bool:
+    return layer in _WRITABLE
+
+
+def is_runtime_readable(layer: str) -> bool:
+    return layer in _RUNTIME_READABLE
+
+
+def default_write_target() -> str:
+    """Writes always default to the personal brain."""
+
+    return LAYER_PERSONAL
+
+
+def assert_writable(layer: str) -> None:
+    """Raise unless *layer* accepts writes (only ``personal`` does)."""
+
+    if layer not in ALL_LAYERS:
+        raise BrainPolicyError(f"unknown brain layer: {layer!r}")
+    if not is_writable(layer):
+        reason = {
+            LAYER_STARTER: "starter/shared brain is read-only (build from source instead)",
+            LAYER_SOURCE: "source vault is a build input, not a write target",
+            LAYER_WORKING: "working set is an ephemeral projection, not a store",
+        }.get(layer, "not a writable layer")
+        raise BrainPolicyError(f"refusing write to '{layer}': {reason}")
+
+
+def runtime_read_order() -> Tuple[str, ...]:
+    """Layer precedence the runtime reads (working > personal > starter).
+
+    The ``source`` vault is intentionally absent — the runtime reads the built
+    starter *pack*, never the raw vault.
+    """
+
+    return (LAYER_WORKING, LAYER_PERSONAL, LAYER_STARTER)
+
+
+__all__ = (
+    "BrainPolicyError",
+    "is_writable",
+    "is_runtime_readable",
+    "default_write_target",
+    "assert_writable",
+    "runtime_read_order",
+)

--- a/apps/forgekit-console/src/forgekit_console/brain/service.py
+++ b/apps/forgekit-console/src/forgekit_console/brain/service.py
@@ -1,0 +1,58 @@
+"""Env-aware brain orchestration — the surface CLI / console / setup call.
+
+Thin glue over :mod:`brain.personal` + :mod:`brain.pack` that resolves paths from
+:mod:`runtime_paths` (so a default install targets ``~/.forgekit`` and tests point
+``FORGEKIT_HOME`` at a tempdir). Holds no policy of its own.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional
+
+from .. import runtime_paths
+from . import pack as pack_mod
+from . import personal as personal_mod
+from .models import PackManifest
+
+
+def ensure_personal_brain(
+    env: Optional[Mapping[str, str]] = None, *, created_at: str = "1970-01-01T00:00:00Z"
+) -> personal_mod.PersonalBrain:
+    """Auto-create the personal brain under the forgekit home. Idempotent."""
+
+    return personal_mod.init_personal_brain(
+        runtime_paths.personal_brain_dir(env), created_at=created_at
+    )
+
+
+def build_pack_from(
+    source: Path,
+    env: Optional[Mapping[str, str]] = None,
+    *,
+    built_at: str = "1970-01-01T00:00:00Z",
+) -> PackManifest:
+    """Build the read-only starter pack from *source* into the forgekit home."""
+
+    return pack_mod.build_starter_pack(
+        Path(source), runtime_paths.starter_pack_dir(env), built_at=built_at
+    )
+
+
+def brain_status(env: Optional[Mapping[str, str]] = None) -> dict:
+    """A combined brain status for CLI / console / doctor."""
+
+    personal_dir = runtime_paths.personal_brain_dir(env)
+    brain = personal_mod.open_personal_brain(personal_dir)
+    starter = pack_mod.pack_status(runtime_paths.starter_pack_dir(env))
+    return {
+        "personal_path": str(personal_dir),
+        "personal_initialized": brain is not None,
+        "personal_notes": brain.stats()["total"] if brain else 0,
+        "starter_path": str(runtime_paths.starter_pack_dir(env)),
+        "starter_built": starter is not None,
+        "starter": starter,
+    }
+
+
+__all__ = ("ensure_personal_brain", "build_pack_from", "brain_status")

--- a/apps/forgekit-console/src/forgekit_console/cli/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Forgekit OS-level CLI subcommands (argparse). Distinct from the TUI slash
+``commands`` package. Each module exposes ``add_parser`` + ``handle``.
+"""

--- a/apps/forgekit-console/src/forgekit_console/cli/brain_cmd.py
+++ b/apps/forgekit-console/src/forgekit_console/cli/brain_cmd.py
@@ -1,0 +1,68 @@
+"""`forgekit brain` — init / pack build / status.
+
+Thin argparse glue over :mod:`brain.service`. Prints human output and returns an
+exit code; all logic lives in the brain package.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    brain = subparsers.add_parser("brain", help="개인 브레인 / starter pack 관리")
+    bsub = brain.add_subparsers(dest="brain_command", required=True)
+    bsub.add_parser("init", help="개인 브레인 자동 생성 (idempotent)")
+    pack = bsub.add_parser("pack", help="starter pack 관리")
+    psub = pack.add_subparsers(dest="pack_command", required=True)
+    build = psub.add_parser("build", help="source vault 로부터 read-only starter pack 빌드")
+    build.add_argument("--source", required=True, help="source vault 경로(로컬 전체 vault 가능)")
+    bsub.add_parser("status", help="브레인/팩 상태 출력")
+
+
+def handle(args: argparse.Namespace) -> int:
+    from ..brain import service
+
+    now = datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+    command = getattr(args, "brain_command", None)
+
+    if command == "init":
+        brain = service.ensure_personal_brain(created_at=now)
+        print(f"personal brain ready: {brain.base_dir}")
+        print("write target = personal (starter/shared 는 read-only)")
+        return EXIT_OK
+
+    if command == "pack":
+        if getattr(args, "pack_command", None) == "build":
+            from ..brain.pack import PackBuildError
+
+            try:
+                manifest = service.build_pack_from(args.source, built_at=now)
+            except PackBuildError as exc:
+                print(f"pack build 실패: {exc}")
+                return EXIT_ERROR
+            print(f"starter pack built (read-only): {manifest.doc_count} docs, "
+                  f"{manifest.total_bytes} bytes from {manifest.source_path}")
+            return EXIT_OK
+        return EXIT_ERROR
+
+    if command == "status":
+        st = service.brain_status()
+        print(f"personal: {st['personal_path']}")
+        print(f"  initialized={st['personal_initialized']} notes={st['personal_notes']}")
+        print(f"starter:  {st['starter_path']}")
+        if st["starter_built"]:
+            s = st["starter"]
+            print(f"  built={s['built_at']} docs={s['doc_count']} source={s['source_path']} (read-only)")
+        else:
+            print("  not built (forgekit brain pack build --source <vault>)")
+        return EXIT_OK
+
+    return EXIT_ERROR
+
+
+__all__ = ("add_parser", "handle")

--- a/apps/forgekit-console/src/forgekit_console/cli/provider_cmd.py
+++ b/apps/forgekit-console/src/forgekit_console/cli/provider_cmd.py
@@ -1,0 +1,64 @@
+"""`forgekit provider` — list built-in providers / show slot resolution.
+
+Thin argparse glue over :mod:`providers` + :mod:`policy`. Read-only: prints the
+provider contract and how a policy mode resolves slots. No live submit.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    provider = subparsers.add_parser("provider", help="provider 계약 / slot 정책 조회")
+    psub = provider.add_subparsers(dest="provider_command", required=True)
+    psub.add_parser("list", help="built-in provider 목록 출력")
+    slots = psub.add_parser("slots", help="main provider + mode 의 slot 해석 출력")
+    slots.add_argument("main", help="main provider id (claude/codex/gemini/ollama)")
+    slots.add_argument(
+        "--mode",
+        default="hybrid",
+        choices=("strict-single", "hybrid", "optimized"),
+        help="policy mode (기본: hybrid)",
+    )
+    slots.add_argument(
+        "--available",
+        default="",
+        help="콤마 구분 available provider id 목록 (optimized auto-pick 용)",
+    )
+
+
+def handle(args: argparse.Namespace) -> int:
+    from ..policy import main_profile, provider_policy
+    from ..providers import builtins
+
+    command = getattr(args, "provider_command", None)
+
+    if command == "list":
+        for pid in builtins.BUILTIN_IDS:
+            spec = builtins.BUILTIN_PROVIDERS[pid]
+            flags = ",".join(spec.capability_flags)
+            print(f"{spec.id:8} {spec.label:14} kind={spec.kind:10} "
+                  f"auth={spec.auth_kind:8} usage={spec.usage_mode:12} [{flags}]")
+        return EXIT_OK
+
+    if command == "slots":
+        main = args.main
+        available = tuple(p.strip() for p in args.available.split(",") if p.strip())
+        profile = main_profile.profile_for(main)
+        mapping = provider_policy.resolve_slots(main, args.mode, available=available)
+        print(f"main={main} mode={args.mode} lean={profile.agent_lean} "
+              f"default_usage={profile.default_usage_mode}")
+        for slot, pid in mapping.items():
+            print(f"  {slot:14} → {pid}")
+        for warning in profile.warnings:
+            print(f"  ! {warning}")
+        return EXIT_OK
+
+    return EXIT_ERROR
+
+
+__all__ = ("add_parser", "handle")

--- a/apps/forgekit-console/src/forgekit_console/policy/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/__init__.py
@@ -1,0 +1,42 @@
+"""Forgekit policy layer — provider slot resolution / main-provider defaults / usage.
+
+``provider_policy`` resolves which provider fills each agent slot under a mode
+(strict-single / hybrid / optimized); ``main_profile`` derives setup defaults from
+the chosen main provider; ``usage_policy`` is the adaptive usage/budget posture
+(modes + reserve). Pure rules over the provider contract — no live submit.
+"""
+
+from __future__ import annotations
+
+from .main_profile import MainProviderProfile, profile_for
+from .provider_policy import (
+    ALL_POLICIES,
+    ALL_SLOTS,
+    POLICY_HYBRID,
+    POLICY_OPTIMIZED,
+    POLICY_STRICT_SINGLE,
+    resolve_slots,
+)
+from .usage_policy import (
+    ALL_BILLING_MODES,
+    ALL_USAGE_MODES,
+    UsagePolicy,
+    default_usage_policy,
+    should_throttle,
+)
+
+__all__ = (
+    "resolve_slots",
+    "POLICY_STRICT_SINGLE",
+    "POLICY_HYBRID",
+    "POLICY_OPTIMIZED",
+    "ALL_POLICIES",
+    "ALL_SLOTS",
+    "MainProviderProfile",
+    "profile_for",
+    "UsagePolicy",
+    "default_usage_policy",
+    "should_throttle",
+    "ALL_USAGE_MODES",
+    "ALL_BILLING_MODES",
+)

--- a/apps/forgekit-console/src/forgekit_console/policy/main_profile.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/main_profile.py
@@ -1,0 +1,137 @@
+"""Main-provider-derived defaults.
+
+The provider you pick as *main* at setup biases forgekit's defaults: the default
+policy mode, the agent's lean (what kind of work it's tuned for), the default
+usage mode, and any capability warnings. This keeps setup to one decision —
+"which provider is yours" — and derives sensible defaults the operator can still
+override.
+
+  * claude  → synthesis-heavy lean, hybrid mode, subscription usage.
+  * codex   → execution-heavy lean, hybrid mode, api usage.
+  * gemini  → research-heavy lean, hybrid mode, api usage.
+  * ollama  → local-first lean, strict-single mode, local usage, + a "limited
+    capability" warning (a single local model can't cover every slot well).
+
+A custom/enterprise main provider falls back to a neutral profile derived from
+its capability flags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from ..providers import builtins
+from ..providers.contract import (
+    CAP_EXECUTION,
+    CAP_LOCAL,
+    CAP_RESEARCH,
+    CAP_SYNTHESIS,
+    ProviderSpec,
+)
+from .provider_policy import POLICY_HYBRID, POLICY_STRICT_SINGLE
+
+LEAN_SYNTHESIS = "synthesis-heavy"
+LEAN_EXECUTION = "execution-heavy"
+LEAN_RESEARCH = "research-heavy"
+LEAN_LOCAL_FIRST = "local-first"
+LEAN_BALANCED = "balanced"
+
+
+@dataclass(frozen=True)
+class MainProviderProfile:
+    """Defaults derived from the chosen main provider."""
+
+    main_provider: str
+    default_policy_mode: str
+    agent_lean: str
+    default_usage_mode: str
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return {
+            "main_provider": self.main_provider,
+            "default_policy_mode": self.default_policy_mode,
+            "agent_lean": self.agent_lean,
+            "default_usage_mode": self.default_usage_mode,
+            "warnings": list(self.warnings),
+        }
+
+
+# Explicit per-builtin profiles (keeps intent obvious vs. deriving everything).
+_BUILTIN_PROFILES = {
+    "claude": (POLICY_HYBRID, LEAN_SYNTHESIS),
+    "codex": (POLICY_HYBRID, LEAN_EXECUTION),
+    "gemini": (POLICY_HYBRID, LEAN_RESEARCH),
+    "ollama": (POLICY_STRICT_SINGLE, LEAN_LOCAL_FIRST),
+}
+
+
+def _lean_from_capabilities(spec: ProviderSpec) -> str:
+    """Derive a lean for a custom/enterprise provider from its flags."""
+
+    if spec.has_capability(CAP_LOCAL):
+        return LEAN_LOCAL_FIRST
+    if spec.has_capability(CAP_EXECUTION):
+        return LEAN_EXECUTION
+    if spec.has_capability(CAP_RESEARCH):
+        return LEAN_RESEARCH
+    if spec.has_capability(CAP_SYNTHESIS):
+        return LEAN_SYNTHESIS
+    return LEAN_BALANCED
+
+
+def profile_for(main_provider_id: str, spec: ProviderSpec | None = None) -> MainProviderProfile:
+    """Return the default profile for *main_provider_id*.
+
+    For a built-in, the mapping above wins. For a custom/enterprise provider, pass
+    its resolved ``spec`` so the lean/usage can be derived from its flags.
+    """
+
+    resolved = spec or builtins.builtin(main_provider_id)
+
+    if main_provider_id in _BUILTIN_PROFILES:
+        mode, lean = _BUILTIN_PROFILES[main_provider_id]
+        usage = resolved.usage_mode if resolved else "subscription"
+        warnings: Tuple[str, ...] = ()
+        if main_provider_id == "ollama":
+            warnings = (
+                "ollama 는 단일 로컬 모델이라 slot 전반 capability 가 제한적입니다 "
+                "(execution/research/synthesis 는 cloud provider 보강 권장)",
+            )
+        return MainProviderProfile(
+            main_provider=main_provider_id,
+            default_policy_mode=mode,
+            agent_lean=lean,
+            default_usage_mode=usage,
+            warnings=warnings,
+        )
+
+    # custom / enterprise — derive from flags.
+    if resolved is None:
+        return MainProviderProfile(
+            main_provider=main_provider_id,
+            default_policy_mode=POLICY_STRICT_SINGLE,
+            agent_lean=LEAN_BALANCED,
+            default_usage_mode="enterprise",
+            warnings=("미지의 provider — 보수적으로 strict-single 로 시작합니다",),
+        )
+
+    lean = _lean_from_capabilities(resolved)
+    warnings = ()
+    if lean == LEAN_LOCAL_FIRST:
+        warnings = ("local-first provider — capability 가 제한적일 수 있습니다",)
+    return MainProviderProfile(
+        main_provider=main_provider_id,
+        default_policy_mode=POLICY_HYBRID,
+        agent_lean=lean,
+        default_usage_mode=resolved.usage_mode,
+        warnings=warnings,
+    )
+
+
+__all__ = (
+    "MainProviderProfile",
+    "profile_for",
+    "LEAN_SYNTHESIS", "LEAN_EXECUTION", "LEAN_RESEARCH", "LEAN_LOCAL_FIRST", "LEAN_BALANCED",
+)

--- a/apps/forgekit-console/src/forgekit_console/policy/provider_policy.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/provider_policy.py
@@ -1,0 +1,153 @@
+"""Provider policy — resolve which provider fills each agent slot.
+
+Forgekit picks a *main provider* at setup. The policy mode then decides how the
+remaining work slots are filled:
+
+  * ``strict-single`` — every slot is the main provider. Simplest, one bill, no
+    surprises. Good default when you only have one provider configured.
+  * ``hybrid`` — main provider everywhere, but the operator may pin specific
+    slots to other *explicitly chosen* providers (no auto-magic).
+  * ``optimized`` — like hybrid, plus: for a slot whose capability another
+    available provider serves better, auto-pick that provider. Operator overrides
+    still win; the main provider is always the deterministic fallback.
+
+Slots are the coarse work types an agent does. Resolution is pure + deterministic
+so the same inputs always yield the same mapping (auditable).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Tuple
+
+from ..providers import builtins
+from ..providers.contract import (
+    CAP_CHEAP,
+    CAP_EXECUTION,
+    CAP_LONG_CONTEXT,
+    CAP_RESEARCH,
+    CAP_SYNTHESIS,
+    ProviderSpec,
+)
+
+POLICY_STRICT_SINGLE = "strict-single"
+POLICY_HYBRID = "hybrid"
+POLICY_OPTIMIZED = "optimized"
+ALL_POLICIES: Tuple[str, ...] = (POLICY_STRICT_SINGLE, POLICY_HYBRID, POLICY_OPTIMIZED)
+
+SLOT_DEFAULT_CHAT = "default_chat"
+SLOT_EXECUTION = "execution"
+SLOT_RESEARCH = "research"
+SLOT_SYNTHESIS = "synthesis"
+SLOT_FALLBACK = "fallback"
+ALL_SLOTS: Tuple[str, ...] = (
+    SLOT_DEFAULT_CHAT,
+    SLOT_EXECUTION,
+    SLOT_RESEARCH,
+    SLOT_SYNTHESIS,
+    SLOT_FALLBACK,
+)
+
+# For optimized mode: which capability flag makes a provider "better" for a slot.
+_SLOT_CAPABILITY = {
+    SLOT_EXECUTION: CAP_EXECUTION,
+    SLOT_RESEARCH: CAP_RESEARCH,
+    SLOT_SYNTHESIS: CAP_SYNTHESIS,
+    # fallback prefers the cheapest available provider when optimizing.
+    SLOT_FALLBACK: CAP_CHEAP,
+    # default_chat has no single "better" capability — stays on main.
+}
+# Secondary preference for research → long_context if no research provider.
+_SLOT_SECONDARY = {SLOT_RESEARCH: CAP_LONG_CONTEXT}
+
+
+def _resolve_available(available: Iterable) -> Dict[str, ProviderSpec]:
+    """Normalize ``available`` (ids or ProviderSpecs) → {id: ProviderSpec}."""
+
+    out: Dict[str, ProviderSpec] = {}
+    for item in available:
+        if isinstance(item, ProviderSpec):
+            out[item.id] = item
+        else:
+            spec = builtins.builtin(str(item))
+            if spec is not None:
+                out[str(item)] = spec
+            else:
+                out[str(item)] = None  # type: ignore[assignment]
+    return out
+
+
+def _auto_pick(slot: str, main_provider: str, avail: Mapping[str, ProviderSpec]) -> str:
+    """Pick the best available provider for *slot* by capability (optimized only).
+
+    Falls back to the main provider when no available provider serves the slot's
+    capability better. Deterministic: scans availability in iteration order.
+    """
+
+    wanted = _SLOT_CAPABILITY.get(slot)
+    if wanted is None:
+        return main_provider
+    for cap in (wanted, _SLOT_SECONDARY.get(slot)):
+        if cap is None:
+            continue
+        for pid, spec in avail.items():
+            if spec is not None and spec.has_capability(cap):
+                return pid
+    return main_provider
+
+
+def resolve_slots(
+    main_provider: str,
+    mode: str,
+    *,
+    overrides: Mapping[str, str] | None = None,
+    available: Iterable = (),
+) -> Dict[str, str]:
+    """Resolve every slot → provider id for *main_provider* under *mode*.
+
+    * strict-single ignores overrides; every slot is the main provider.
+    * hybrid honours explicit overrides; everything else is the main provider.
+    * optimized honours overrides, then auto-picks by capability, else main.
+
+    An override (or auto-pick) that names a provider not in *available* is
+    rejected and falls back to the main provider — deterministic, never silent
+    about an unavailable choice (the result simply holds the main id).
+    """
+
+    if mode not in ALL_POLICIES:
+        raise ValueError(f"알 수 없는 policy mode: {mode!r}")
+
+    overrides = overrides or {}
+    avail = _resolve_available(available)
+    # The main provider is always considered available to itself.
+    avail.setdefault(main_provider, builtins.builtin(main_provider))  # type: ignore[arg-type]
+
+    def usable(pid: str) -> bool:
+        return pid == main_provider or pid in avail
+
+    result: Dict[str, str] = {}
+    for slot in ALL_SLOTS:
+        if mode == POLICY_STRICT_SINGLE:
+            result[slot] = main_provider
+            continue
+
+        # hybrid + optimized: explicit override first.
+        chosen = overrides.get(slot)
+        if chosen and usable(chosen):
+            result[slot] = chosen
+            continue
+
+        if mode == POLICY_OPTIMIZED:
+            picked = _auto_pick(slot, main_provider, avail)
+            result[slot] = picked if usable(picked) else main_provider
+        else:  # hybrid, no usable override → main
+            result[slot] = main_provider
+
+    return result
+
+
+__all__ = (
+    "POLICY_STRICT_SINGLE", "POLICY_HYBRID", "POLICY_OPTIMIZED", "ALL_POLICIES",
+    "SLOT_DEFAULT_CHAT", "SLOT_EXECUTION", "SLOT_RESEARCH", "SLOT_SYNTHESIS",
+    "SLOT_FALLBACK", "ALL_SLOTS",
+    "resolve_slots",
+)

--- a/apps/forgekit-console/src/forgekit_console/policy/usage_policy.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/usage_policy.py
@@ -1,0 +1,128 @@
+"""Adaptive usage / budget policy — structure first, not billing accuracy.
+
+Forgekit doesn't bill — but it must *reason* about usage posture so it can throttle
+or defer work before an operator's budget is blown. This declares the policy
+shape; real spend numbers are fed in by callers.
+
+Usage modes (how aggressively forgekit spends):
+
+  * ``adaptive`` — spend freely until a reserve threshold, then throttle. Default.
+  * ``strict`` — hard stop at budget; no reserve grace.
+  * ``subscription_aware`` — treat a subscription as effectively flat; only the
+    reserve guards against rate-limit / fair-use cliffs.
+  * ``local_first`` — prefer the local/no-cost provider; only spill to paid when
+    a slot truly needs it.
+
+Billing modes mirror the provider usage_mode (subscription / api / local /
+enterprise) so the policy can pick a sensible default per provider.
+
+The ``reserve`` is a held-back fraction of the budget (0.0–1.0). When remaining
+budget drops into the reserve, forgekit throttles rather than spending it — the
+reserve is the safety margin that keeps a run from hard-failing mid-task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+USAGE_ADAPTIVE = "adaptive"
+USAGE_STRICT = "strict"
+USAGE_SUBSCRIPTION_AWARE = "subscription_aware"
+USAGE_LOCAL_FIRST = "local_first"
+ALL_USAGE_MODES: Tuple[str, ...] = (
+    USAGE_ADAPTIVE,
+    USAGE_STRICT,
+    USAGE_SUBSCRIPTION_AWARE,
+    USAGE_LOCAL_FIRST,
+)
+
+BILLING_SUBSCRIPTION = "subscription"
+BILLING_API = "api"
+BILLING_LOCAL = "local"
+BILLING_ENTERPRISE = "enterprise"
+ALL_BILLING_MODES: Tuple[str, ...] = (
+    BILLING_SUBSCRIPTION,
+    BILLING_API,
+    BILLING_LOCAL,
+    BILLING_ENTERPRISE,
+)
+
+# Default usage mode per billing posture.
+_BILLING_DEFAULT_USAGE = {
+    BILLING_SUBSCRIPTION: USAGE_SUBSCRIPTION_AWARE,
+    BILLING_API: USAGE_ADAPTIVE,
+    BILLING_LOCAL: USAGE_LOCAL_FIRST,
+    BILLING_ENTERPRISE: USAGE_ADAPTIVE,
+}
+
+# Default reserve fraction per usage mode.
+_USAGE_DEFAULT_RESERVE = {
+    USAGE_ADAPTIVE: 0.15,
+    USAGE_STRICT: 0.0,
+    USAGE_SUBSCRIPTION_AWARE: 0.10,
+    USAGE_LOCAL_FIRST: 0.05,
+}
+
+
+@dataclass(frozen=True)
+class UsagePolicy:
+    """A usage/budget posture: how to spend and how much to hold back."""
+
+    usage_mode: str
+    billing_mode: str
+    reserve: float = 0.15  # fraction (0.0–1.0) of budget held back as safety margin
+
+    def to_dict(self) -> dict:
+        return {
+            "usage_mode": self.usage_mode,
+            "billing_mode": self.billing_mode,
+            "reserve": self.reserve,
+        }
+
+    def reserve_floor(self, budget: float) -> float:
+        """The absolute spend level at which the reserve begins."""
+
+        return budget * (1.0 - max(0.0, min(1.0, self.reserve)))
+
+
+def default_usage_policy(main_provider: str, billing_mode: str) -> UsagePolicy:
+    """Derive a default usage policy from the main provider's billing mode.
+
+    *main_provider* is accepted for future per-provider tuning; today the billing
+    mode drives the defaults.
+    """
+
+    if billing_mode not in ALL_BILLING_MODES:
+        raise ValueError(f"알 수 없는 billing_mode: {billing_mode!r}")
+    usage_mode = _BILLING_DEFAULT_USAGE[billing_mode]
+    return UsagePolicy(
+        usage_mode=usage_mode,
+        billing_mode=billing_mode,
+        reserve=_USAGE_DEFAULT_RESERVE[usage_mode],
+    )
+
+
+def should_throttle(policy: UsagePolicy, spent: float, budget: float) -> bool:
+    """Should forgekit throttle/defer given *spent* against *budget*?
+
+    * strict mode throttles once spend meets or exceeds budget.
+    * every other mode throttles once spend crosses into the held-back reserve.
+    * a non-positive budget means "unbounded" (local_first / no-cost) → never
+      throttle unless explicitly strict.
+    """
+
+    if budget <= 0:
+        return policy.usage_mode == USAGE_STRICT and spent > 0
+    if policy.usage_mode == USAGE_STRICT:
+        return spent >= budget
+    return spent >= policy.reserve_floor(budget)
+
+
+__all__ = (
+    "USAGE_ADAPTIVE", "USAGE_STRICT", "USAGE_SUBSCRIPTION_AWARE", "USAGE_LOCAL_FIRST",
+    "ALL_USAGE_MODES",
+    "BILLING_SUBSCRIPTION", "BILLING_API", "BILLING_LOCAL", "BILLING_ENTERPRISE",
+    "ALL_BILLING_MODES",
+    "UsagePolicy", "default_usage_policy", "should_throttle",
+)

--- a/apps/forgekit-console/src/forgekit_console/providers/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/providers/__init__.py
@@ -1,0 +1,33 @@
+"""Forgekit provider layer — the vendor-neutral provider contract + registry.
+
+``contract`` holds the fixed ``ProviderSpec`` shape every provider conforms to,
+``builtins`` declares the four shipped providers, ``registry`` builds specs from
+generic config (the enterprise / internal seam). Pure data + validation; no live
+submit lives here.
+"""
+
+from __future__ import annotations
+
+from .builtins import BUILTIN_IDS, BUILTIN_PROVIDERS, builtin, is_builtin
+from .contract import ProviderSpec, validate_provider_spec
+from .registry import (
+    ALL_SHAPES,
+    ProviderConfigError,
+    build_provider,
+    no_provider_configured,
+    validate_config,
+)
+
+__all__ = (
+    "ProviderSpec",
+    "validate_provider_spec",
+    "BUILTIN_PROVIDERS",
+    "BUILTIN_IDS",
+    "builtin",
+    "is_builtin",
+    "build_provider",
+    "validate_config",
+    "no_provider_configured",
+    "ProviderConfigError",
+    "ALL_SHAPES",
+)

--- a/apps/forgekit-console/src/forgekit_console/providers/builtins.py
+++ b/apps/forgekit-console/src/forgekit_console/providers/builtins.py
@@ -1,0 +1,115 @@
+"""Built-in provider specs — the four shipped providers.
+
+Capability flags project ``docs/provider-capability-matrix.md`` onto each
+provider's strongest role:
+
+  * Claude — safety / synthesis / verification平面 → synthesis + safety primary.
+  * Codex  — execution / tool 조작 평면 → execution + tool_use primary.
+  * Gemini — research / large-context 평면 → research + long_context primary.
+  * Ollama — local inference backend → cheap + local + classification.
+
+These are declared once here so registry / policy / tests share one source.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from .contract import (
+    AUTH_API_KEY,
+    AUTH_NONE,
+    AUTH_OAUTH,
+    CAP_CHAT,
+    CAP_CHEAP,
+    CAP_CLASSIFICATION,
+    CAP_EXECUTION,
+    CAP_LOCAL,
+    CAP_LONG_CONTEXT,
+    CAP_RESEARCH,
+    CAP_SAFETY,
+    CAP_SYNTHESIS,
+    CAP_TOOL_USE,
+    HEALTH_API_KEY_SET,
+    HEALTH_CLI_PRESENT,
+    HEALTH_ENDPOINT_REACHABLE,
+    KIND_CLOUD_API,
+    KIND_CLOUD_CLI,
+    KIND_LOCAL,
+    SUBMIT_CLI,
+    SUBMIT_OPENAI,
+    USAGE_API,
+    USAGE_LOCAL,
+    USAGE_SUBSCRIPTION,
+    ProviderSpec,
+)
+
+CLAUDE = ProviderSpec(
+    id="claude",
+    label="Claude Code",
+    kind=KIND_CLOUD_CLI,
+    auth_kind=AUTH_OAUTH,
+    usage_mode=USAGE_SUBSCRIPTION,
+    submit_compat=SUBMIT_CLI,
+    health_contract=HEALTH_CLI_PRESENT,
+    capability_flags=(CAP_CHAT, CAP_SYNTHESIS, CAP_SAFETY, CAP_TOOL_USE, CAP_LONG_CONTEXT),
+)
+
+CODEX = ProviderSpec(
+    id="codex",
+    label="Codex",
+    kind=KIND_CLOUD_CLI,
+    auth_kind=AUTH_API_KEY,
+    usage_mode=USAGE_API,
+    submit_compat=SUBMIT_CLI,
+    health_contract=HEALTH_CLI_PRESENT,
+    capability_flags=(CAP_CHAT, CAP_EXECUTION, CAP_TOOL_USE),
+)
+
+GEMINI = ProviderSpec(
+    id="gemini",
+    label="Gemini",
+    kind=KIND_CLOUD_API,
+    auth_kind=AUTH_API_KEY,
+    usage_mode=USAGE_API,
+    submit_compat=SUBMIT_OPENAI,
+    health_contract=HEALTH_API_KEY_SET,
+    capability_flags=(CAP_CHAT, CAP_RESEARCH, CAP_LONG_CONTEXT, CAP_CHEAP),
+)
+
+OLLAMA = ProviderSpec(
+    id="ollama",
+    label="Ollama",
+    kind=KIND_LOCAL,
+    auth_kind=AUTH_NONE,
+    usage_mode=USAGE_LOCAL,
+    submit_compat=SUBMIT_OPENAI,
+    health_contract=HEALTH_ENDPOINT_REACHABLE,
+    capability_flags=(CAP_CHAT, CAP_CHEAP, CAP_LOCAL, CAP_CLASSIFICATION),
+    endpoint="http://localhost:11434",
+)
+
+BUILTIN_PROVIDERS: Dict[str, ProviderSpec] = {
+    CLAUDE.id: CLAUDE,
+    CODEX.id: CODEX,
+    GEMINI.id: GEMINI,
+    OLLAMA.id: OLLAMA,
+}
+
+BUILTIN_IDS: Tuple[str, ...] = tuple(BUILTIN_PROVIDERS.keys())
+
+
+def builtin(provider_id: str) -> ProviderSpec | None:
+    """Look up a built-in spec by id (None if not a built-in)."""
+
+    return BUILTIN_PROVIDERS.get(provider_id)
+
+
+def is_builtin(provider_id: str) -> bool:
+    return provider_id in BUILTIN_PROVIDERS
+
+
+__all__ = (
+    "CLAUDE", "CODEX", "GEMINI", "OLLAMA",
+    "BUILTIN_PROVIDERS", "BUILTIN_IDS",
+    "builtin", "is_builtin",
+)

--- a/apps/forgekit-console/src/forgekit_console/providers/contract.py
+++ b/apps/forgekit-console/src/forgekit_console/providers/contract.py
@@ -1,0 +1,178 @@
+"""The minimal provider contract every forgekit provider conforms to.
+
+Forgekit is provider-agnostic: Claude / Codex / Gemini / Ollama and any
+enterprise/internal endpoint are all described by the *same* fixed ``ProviderSpec``
+shape. This is the seam that lets policy (slots / usage) reason over providers
+without knowing any vendor specifics — pure data, no live submit here.
+
+Design notes (the "why" behind the fields):
+
+  * ``kind`` separates *where the inference runs* (cloud CLI / cloud API / local
+    box / enterprise gateway). It drives doctor checks and auth expectations.
+  * ``auth_kind`` is orthogonal to kind — a local provider needs no auth, a cloud
+    CLI rides an OAuth session, a cloud API needs a key, an enterprise gateway is
+    reached by an endpoint contract.
+  * ``capability_flags`` are vendor-neutral capability *hints* (the projection of
+    ``docs/provider-capability-matrix.md`` onto one provider) so the optimized
+    policy can auto-pick a better provider per slot.
+  * ``submit_compat`` says *how* you'd eventually talk to it (cli / openai-style /
+    custom http / native) — recorded now so the enterprise seam validates even
+    though live submit is intentionally not implemented in this work tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+# kind — where the inference physically runs.
+KIND_CLOUD_CLI = "cloud_cli"
+KIND_CLOUD_API = "cloud_api"
+KIND_LOCAL = "local"
+KIND_ENTERPRISE = "enterprise"
+ALL_KINDS: Tuple[str, ...] = (KIND_CLOUD_CLI, KIND_CLOUD_API, KIND_LOCAL, KIND_ENTERPRISE)
+
+# auth_kind — how a caller authenticates.
+AUTH_OAUTH = "oauth"
+AUTH_API_KEY = "api_key"
+AUTH_NONE = "none"
+AUTH_ENDPOINT = "endpoint"
+ALL_AUTH_KINDS: Tuple[str, ...] = (AUTH_OAUTH, AUTH_API_KEY, AUTH_NONE, AUTH_ENDPOINT)
+
+# submit_compat — the wire shape (recorded; live submit not implemented here).
+SUBMIT_CLI = "cli"
+SUBMIT_OPENAI = "openai_compatible"
+SUBMIT_CUSTOM_HTTP = "custom_http"
+SUBMIT_NATIVE = "native"
+ALL_SUBMIT_COMPAT: Tuple[str, ...] = (SUBMIT_CLI, SUBMIT_OPENAI, SUBMIT_CUSTOM_HTTP, SUBMIT_NATIVE)
+
+# usage_mode — billing/availability posture (paired with policy.usage_policy).
+USAGE_SUBSCRIPTION = "subscription"
+USAGE_API = "api"
+USAGE_LOCAL = "local"
+USAGE_ENTERPRISE = "enterprise"
+ALL_USAGE_MODES: Tuple[str, ...] = (USAGE_SUBSCRIPTION, USAGE_API, USAGE_LOCAL, USAGE_ENTERPRISE)
+
+# health_contract — how `forgekit doctor` would probe the provider.
+HEALTH_CLI_PRESENT = "cli_present"        # a CLI binary is on PATH / logged in
+HEALTH_API_KEY_SET = "api_key_set"        # an API key env/secret is present
+HEALTH_ENDPOINT_REACHABLE = "endpoint_reachable"  # a base URL responds
+ALL_HEALTH_CONTRACTS: Tuple[str, ...] = (
+    HEALTH_CLI_PRESENT,
+    HEALTH_API_KEY_SET,
+    HEALTH_ENDPOINT_REACHABLE,
+)
+
+# Common capability flags (vendor-neutral; a provider may carry any subset).
+CAP_CHAT = "chat"
+CAP_EXECUTION = "execution"
+CAP_RESEARCH = "research"
+CAP_SYNTHESIS = "synthesis"
+CAP_LONG_CONTEXT = "long_context"
+CAP_TOOL_USE = "tool_use"
+CAP_CHEAP = "cheap"
+CAP_SAFETY = "safety"
+CAP_CLASSIFICATION = "classification"
+CAP_LOCAL = "local"
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """The fixed minimal contract every provider conforms to."""
+
+    id: str
+    label: str
+    kind: str                      # one of ALL_KINDS
+    auth_kind: str                 # one of ALL_AUTH_KINDS
+    usage_mode: str                # one of ALL_USAGE_MODES
+    submit_compat: str             # one of ALL_SUBMIT_COMPAT
+    health_contract: str           # one of ALL_HEALTH_CONTRACTS
+    capability_flags: Tuple[str, ...] = ()
+    endpoint: str = ""             # required for local/enterprise; empty otherwise
+    enterprise: bool = False       # internal/enterprise provider (seam marker)
+
+    def has_capability(self, flag: str) -> bool:
+        return flag in self.capability_flags
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "kind": self.kind,
+            "auth_kind": self.auth_kind,
+            "usage_mode": self.usage_mode,
+            "submit_compat": self.submit_compat,
+            "health_contract": self.health_contract,
+            "capability_flags": list(self.capability_flags),
+            "endpoint": self.endpoint,
+            "enterprise": self.enterprise,
+        }
+
+
+def validate_provider_spec(spec: ProviderSpec) -> Tuple[str, ...]:
+    """Return a tuple of human-readable errors (empty == valid).
+
+    Checks the enum membership of every field plus cross-field consistency:
+    local/enterprise providers must carry an endpoint; an endpoint health
+    contract requires an endpoint; none-auth only makes sense for local; the
+    usage_mode must be coherent with the kind.
+    """
+
+    errors: list[str] = []
+
+    if not spec.id or not spec.id.strip():
+        errors.append("id 가 비어 있습니다")
+    if not spec.label or not spec.label.strip():
+        errors.append("label 이 비어 있습니다")
+    if spec.kind not in ALL_KINDS:
+        errors.append(f"알 수 없는 kind: {spec.kind!r}")
+    if spec.auth_kind not in ALL_AUTH_KINDS:
+        errors.append(f"알 수 없는 auth_kind: {spec.auth_kind!r}")
+    if spec.usage_mode not in ALL_USAGE_MODES:
+        errors.append(f"알 수 없는 usage_mode: {spec.usage_mode!r}")
+    if spec.submit_compat not in ALL_SUBMIT_COMPAT:
+        errors.append(f"알 수 없는 submit_compat: {spec.submit_compat!r}")
+    if spec.health_contract not in ALL_HEALTH_CONTRACTS:
+        errors.append(f"알 수 없는 health_contract: {spec.health_contract!r}")
+
+    needs_endpoint = spec.kind in (KIND_LOCAL, KIND_ENTERPRISE)
+    if needs_endpoint and not spec.endpoint.strip():
+        errors.append(f"{spec.kind} provider 는 endpoint 가 필요합니다")
+    if spec.health_contract == HEALTH_ENDPOINT_REACHABLE and not spec.endpoint.strip():
+        errors.append("health_contract=endpoint_reachable 는 endpoint 가 필요합니다")
+
+    if spec.auth_kind == AUTH_NONE and spec.kind not in (KIND_LOCAL,):
+        errors.append("auth_kind=none 은 local provider 에서만 허용됩니다")
+    if spec.auth_kind == AUTH_ENDPOINT and spec.kind != KIND_ENTERPRISE:
+        errors.append("auth_kind=endpoint 는 enterprise provider 에서만 허용됩니다")
+
+    # usage_mode ↔ kind coherence.
+    coherent = {
+        KIND_CLOUD_CLI: {USAGE_SUBSCRIPTION, USAGE_API},
+        KIND_CLOUD_API: {USAGE_API, USAGE_SUBSCRIPTION},
+        KIND_LOCAL: {USAGE_LOCAL},
+        KIND_ENTERPRISE: {USAGE_ENTERPRISE},
+    }
+    if spec.kind in ALL_KINDS and spec.usage_mode in ALL_USAGE_MODES:
+        if spec.usage_mode not in coherent[spec.kind]:
+            errors.append(
+                f"usage_mode={spec.usage_mode} 는 kind={spec.kind} 와 맞지 않습니다"
+            )
+
+    if spec.enterprise and spec.kind != KIND_ENTERPRISE:
+        errors.append("enterprise=True 는 kind=enterprise 와 함께여야 합니다")
+
+    return tuple(errors)
+
+
+__all__ = (
+    "ProviderSpec",
+    "validate_provider_spec",
+    "KIND_CLOUD_CLI", "KIND_CLOUD_API", "KIND_LOCAL", "KIND_ENTERPRISE", "ALL_KINDS",
+    "AUTH_OAUTH", "AUTH_API_KEY", "AUTH_NONE", "AUTH_ENDPOINT", "ALL_AUTH_KINDS",
+    "SUBMIT_CLI", "SUBMIT_OPENAI", "SUBMIT_CUSTOM_HTTP", "SUBMIT_NATIVE", "ALL_SUBMIT_COMPAT",
+    "USAGE_SUBSCRIPTION", "USAGE_API", "USAGE_LOCAL", "USAGE_ENTERPRISE", "ALL_USAGE_MODES",
+    "HEALTH_CLI_PRESENT", "HEALTH_API_KEY_SET", "HEALTH_ENDPOINT_REACHABLE", "ALL_HEALTH_CONTRACTS",
+    "CAP_CHAT", "CAP_EXECUTION", "CAP_RESEARCH", "CAP_SYNTHESIS", "CAP_LONG_CONTEXT",
+    "CAP_TOOL_USE", "CAP_CHEAP", "CAP_SAFETY", "CAP_CLASSIFICATION", "CAP_LOCAL",
+)

--- a/apps/forgekit-console/src/forgekit_console/providers/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/providers/registry.py
@@ -1,0 +1,193 @@
+"""Provider registry — build a ProviderSpec from generic config + the enterprise seam.
+
+Two ways a provider enters forgekit:
+
+  1. A built-in id (``claude`` / ``codex`` / ``gemini`` / ``ollama``) — resolved
+     straight from :mod:`builtins`, optionally with a few overridable fields.
+  2. A *generic config dict* describing a custom / enterprise / internal provider.
+     This is the **enterprise seam**: ``openai-compatible`` / ``custom-http`` /
+     ``internal-enterprise`` config shapes load through the same contract so a
+     company can point forgekit at their own gateway. Live submit is NOT
+     implemented — the registry validates the shape so setup/doctor can reason
+     about it, and a future work tree wires the actual transport.
+
+A config dict looks like::
+
+    {"id": "acme-gw", "label": "Acme Gateway", "shape": "internal-enterprise",
+     "endpoint": "https://llm.acme.internal/v1", "auth_kind": "endpoint",
+     "capability_flags": ["chat", "execution"]}
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Tuple
+
+from . import builtins
+from .contract import (
+    ALL_AUTH_KINDS,
+    AUTH_API_KEY,
+    AUTH_ENDPOINT,
+    HEALTH_API_KEY_SET,
+    HEALTH_ENDPOINT_REACHABLE,
+    KIND_CLOUD_API,
+    KIND_ENTERPRISE,
+    SUBMIT_CUSTOM_HTTP,
+    SUBMIT_OPENAI,
+    USAGE_API,
+    USAGE_ENTERPRISE,
+    ProviderSpec,
+    validate_provider_spec,
+)
+
+# Generic config shapes for the enterprise / internal seam.
+SHAPE_OPENAI_COMPATIBLE = "openai-compatible"
+SHAPE_CUSTOM_HTTP = "custom-http"
+SHAPE_INTERNAL_ENTERPRISE = "internal-enterprise"
+ALL_SHAPES: Tuple[str, ...] = (
+    SHAPE_OPENAI_COMPATIBLE,
+    SHAPE_CUSTOM_HTTP,
+    SHAPE_INTERNAL_ENTERPRISE,
+)
+
+# Per-shape defaults — chosen so a minimal config still produces a valid spec.
+_SHAPE_DEFAULTS = {
+    SHAPE_OPENAI_COMPATIBLE: {
+        "kind": KIND_CLOUD_API,
+        "auth_kind": AUTH_API_KEY,
+        "usage_mode": USAGE_API,
+        "submit_compat": SUBMIT_OPENAI,
+        "health_contract": HEALTH_API_KEY_SET,
+    },
+    SHAPE_CUSTOM_HTTP: {
+        "kind": KIND_ENTERPRISE,
+        "auth_kind": AUTH_ENDPOINT,
+        "usage_mode": USAGE_ENTERPRISE,
+        "submit_compat": SUBMIT_CUSTOM_HTTP,
+        "health_contract": HEALTH_ENDPOINT_REACHABLE,
+    },
+    SHAPE_INTERNAL_ENTERPRISE: {
+        "kind": KIND_ENTERPRISE,
+        "auth_kind": AUTH_ENDPOINT,
+        "usage_mode": USAGE_ENTERPRISE,
+        "submit_compat": SUBMIT_CUSTOM_HTTP,
+        "health_contract": HEALTH_ENDPOINT_REACHABLE,
+    },
+}
+
+
+class ProviderConfigError(ValueError):
+    """Raised when a provider config dict can't be turned into a valid spec."""
+
+
+def validate_config(config: Mapping[str, object]) -> Tuple[str, ...]:
+    """Return human-readable errors for a generic provider config (empty == ok)."""
+
+    errors: list[str] = []
+    if not isinstance(config, Mapping):
+        return ("config 는 매핑이어야 합니다",)
+
+    provider_id = str(config.get("id", "")).strip()
+    if not provider_id:
+        errors.append("config.id 가 비어 있습니다")
+
+    # A built-in reference is always valid (no shape needed).
+    if builtins.is_builtin(provider_id) and "shape" not in config:
+        return tuple(errors)
+
+    shape = config.get("shape")
+    if shape is None:
+        errors.append("config.shape (또는 built-in id) 가 필요합니다")
+    elif shape not in ALL_SHAPES:
+        errors.append(f"알 수 없는 shape: {shape!r} (허용: {', '.join(ALL_SHAPES)})")
+
+    if not str(config.get("label", "")).strip():
+        errors.append("config.label 이 비어 있습니다")
+
+    # Endpoint-bearing shapes need an endpoint.
+    if shape in (SHAPE_CUSTOM_HTTP, SHAPE_INTERNAL_ENTERPRISE, SHAPE_OPENAI_COMPATIBLE):
+        if not str(config.get("endpoint", "")).strip():
+            errors.append(f"shape={shape} 는 endpoint 가 필요합니다")
+
+    auth = config.get("auth_kind")
+    if auth is not None and auth not in ALL_AUTH_KINDS:
+        errors.append(f"알 수 없는 auth_kind: {auth!r}")
+
+    flags = config.get("capability_flags", ())
+    if flags and not isinstance(flags, (list, tuple)):
+        errors.append("capability_flags 는 리스트여야 합니다")
+
+    # If the shape resolves, surface contract-level errors too.
+    if not errors and shape in ALL_SHAPES:
+        spec = _spec_from_config(config, shape)
+        errors.extend(validate_provider_spec(spec))
+
+    return tuple(errors)
+
+
+def _spec_from_config(config: Mapping[str, object], shape: str) -> ProviderSpec:
+    defaults = dict(_SHAPE_DEFAULTS[shape])
+    flags = tuple(config.get("capability_flags") or ())
+    return ProviderSpec(
+        id=str(config["id"]),
+        label=str(config.get("label", config["id"])),
+        kind=str(config.get("kind", defaults["kind"])),
+        auth_kind=str(config.get("auth_kind", defaults["auth_kind"])),
+        usage_mode=str(config.get("usage_mode", defaults["usage_mode"])),
+        submit_compat=str(config.get("submit_compat", defaults["submit_compat"])),
+        health_contract=str(config.get("health_contract", defaults["health_contract"])),
+        capability_flags=tuple(str(f) for f in flags),
+        endpoint=str(config.get("endpoint", "")),
+        enterprise=defaults["kind"] == KIND_ENTERPRISE,
+    )
+
+
+def build_provider(config: Mapping[str, object]) -> ProviderSpec:
+    """Build a ProviderSpec from a generic config dict (built-in id or a shape).
+
+    Raises :class:`ProviderConfigError` if the config is invalid.
+    """
+
+    errors = validate_config(config)
+    if errors:
+        raise ProviderConfigError("; ".join(errors))
+
+    provider_id = str(config["id"]).strip()
+    if builtins.is_builtin(provider_id) and "shape" not in config:
+        base = builtins.BUILTIN_PROVIDERS[provider_id]
+        # Allow a couple of overridable fields (label / endpoint / extra flags).
+        if not any(k in config for k in ("label", "endpoint", "capability_flags")):
+            return base
+        from dataclasses import replace
+
+        flags = tuple(config.get("capability_flags") or base.capability_flags)
+        return replace(
+            base,
+            label=str(config.get("label", base.label)),
+            endpoint=str(config.get("endpoint", base.endpoint)),
+            capability_flags=tuple(str(f) for f in flags),
+        )
+
+    return _spec_from_config(config, str(config["shape"]))
+
+
+def no_provider_configured(config: Mapping[str, object] | None) -> bool:
+    """Setup-incomplete signal: no provider has been configured yet.
+
+    True when there is no config at all, no ``main_provider``/``id``, and no
+    ``providers`` list — i.e. forgekit setup hasn't picked a provider.
+    """
+
+    if not config:
+        return True
+    main = str(config.get("main_provider", "") or config.get("id", "")).strip()
+    providers = config.get("providers") or ()
+    return not main and not providers
+
+
+__all__ = (
+    "ProviderConfigError",
+    "build_provider",
+    "validate_config",
+    "no_provider_configured",
+    "SHAPE_OPENAI_COMPATIBLE", "SHAPE_CUSTOM_HTTP", "SHAPE_INTERNAL_ENTERPRISE", "ALL_SHAPES",
+)

--- a/apps/forgekit-console/src/forgekit_console/runtime_paths.py
+++ b/apps/forgekit-console/src/forgekit_console/runtime_paths.py
@@ -1,0 +1,57 @@
+"""Forgekit runtime paths — the installed product's data home. Pure, stdlib.
+
+Everything forgekit persists (personal brain, starter pack, setup config) lives
+under a single home dir so an install is self-contained and removable. Default is
+``~/.forgekit``; ``FORGEKIT_HOME`` overrides it. Every helper takes an optional
+``env`` mapping so tests point the whole tree at a tempdir — nothing here ever
+writes; callers create dirs explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping, Optional
+
+ENV_HOME = "FORGEKIT_HOME"
+_DEFAULT_HOME = "~/.forgekit"
+
+
+def forgekit_home(env: Optional[Mapping[str, str]] = None) -> Path:
+    """The forgekit data home (``$FORGEKIT_HOME`` or ``~/.forgekit``)."""
+
+    source = env if env is not None else os.environ
+    raw = (source.get(ENV_HOME) or "").strip() or _DEFAULT_HOME
+    return Path(os.path.expanduser(raw)).resolve()
+
+
+def brain_root(env: Optional[Mapping[str, str]] = None) -> Path:
+    return forgekit_home(env) / "brain"
+
+
+def personal_brain_dir(env: Optional[Mapping[str, str]] = None) -> Path:
+    """Read-write personal brain — the default write target."""
+
+    return brain_root(env) / "personal"
+
+
+def starter_pack_dir(env: Optional[Mapping[str, str]] = None) -> Path:
+    """Read-only starter/shared brain pack (built from a source vault)."""
+
+    return brain_root(env) / "starter"
+
+
+def config_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    """The forgekit setup config (provider/policy/brain selections)."""
+
+    return forgekit_home(env) / "config.json"
+
+
+__all__ = (
+    "ENV_HOME",
+    "forgekit_home",
+    "brain_root",
+    "personal_brain_dir",
+    "starter_pack_dir",
+    "config_path",
+)

--- a/docs/forgekit-provider-policy.md
+++ b/docs/forgekit-provider-policy.md
@@ -1,0 +1,146 @@
+# Forgekit provider policy — 계약 / slot 정책 / main-provider 기본값 / usage
+
+> Forgekit 는 **provider-agnostic** 한 설치형 제품이다. Claude / Codex / Gemini /
+> Ollama 그리고 사내(enterprise) endpoint 까지 모두 *하나의 고정 최소 계약*
+> (`ProviderSpec`) 으로 기술되고, policy 가 그 계약 위에서 slot 배치 / 기본값 /
+> usage 를 결정한다. **순수 데이터 + 검증만** — live submit 은 본 문서 범위 밖.
+>
+> 코드 SSoT:
+> - 계약/built-in/registry: `apps/forgekit-console/src/forgekit_console/providers/`
+> - slot/main-profile/usage 정책: `apps/forgekit-console/src/forgekit_console/policy/`
+> - 짝 문서: capability 배치 SSoT 는 [`provider-capability-matrix.md`](provider-capability-matrix.md).
+
+## 1. Provider 계약 (`ProviderSpec`)
+
+모든 provider 가 conform 하는 고정 최소 계약. `providers/contract.py`.
+
+| 필드 | 의미 | 허용값 |
+| --- | --- | --- |
+| `id` | provider 식별자 | non-empty |
+| `label` | 사람용 이름 | non-empty |
+| `kind` | 추론이 *어디서* 도는가 | `cloud_cli` / `cloud_api` / `local` / `enterprise` |
+| `auth_kind` | 인증 방식 (kind 와 직교) | `oauth` / `api_key` / `none` / `endpoint` |
+| `usage_mode` | 과금/가용 posture | `subscription` / `api` / `local` / `enterprise` |
+| `submit_compat` | wire 모양 (기록만, live 미구현) | `cli` / `openai_compatible` / `custom_http` / `native` |
+| `health_contract` | doctor 가 어떻게 검사하나 | `cli_present` / `api_key_set` / `endpoint_reachable` |
+| `capability_flags` | vendor-neutral capability 힌트 | `chat`/`execution`/`research`/`synthesis`/`long_context`/`tool_use`/`cheap`/`safety`/`classification`/`local` |
+| `endpoint` | local/enterprise 의 base URL | local/enterprise 는 필수 |
+| `enterprise` | 사내 provider seam marker | `kind=enterprise` 와 함께 |
+
+`validate_provider_spec(spec) -> tuple[errors]` 가 enum 멤버십 + cross-field 일관성을
+검사한다: local/enterprise 는 endpoint 필수, `endpoint_reachable` 는 endpoint 필요,
+`auth_kind=none` 은 local 에서만, `auth_kind=endpoint` 는 enterprise 에서만, usage_mode 는
+kind 와 coherent 해야 한다.
+
+### Built-in 4종 (`providers/builtins.py`)
+
+capability 매트릭스를 각 provider 의 강점 평면에 투영:
+
+| id | kind | auth | usage | capability lean |
+| --- | --- | --- | --- | --- |
+| `claude` | cloud_cli | oauth | subscription | synthesis / safety / tool_use / long_context |
+| `codex` | cloud_cli | api_key | api | execution / tool_use |
+| `gemini` | cloud_api | api_key | api | research / long_context / cheap |
+| `ollama` | local | none | local | cheap / local / classification |
+
+## 2. Policy mode × slot 해석 (`policy/provider_policy.py`)
+
+slot = 에이전트가 하는 거친 작업 종류:
+`default_chat` / `execution` / `research` / `synthesis` / `fallback`.
+
+`resolve_slots(main_provider, mode, *, overrides={}, available=()) -> {slot: provider_id}`
+는 순수·결정형이다 (같은 입력 → 같은 매핑, 감사 가능).
+
+| mode | 동작 |
+| --- | --- |
+| `strict-single` | **모든 slot 을 main provider 로** 채운다. overrides 무시. 가장 단순, 한 청구서. |
+| `hybrid` | main 이 기본, 운영자가 **명시적으로 지정한** slot 만 다른 provider 로 pin. auto-magic 없음. |
+| `optimized` | hybrid + 어떤 slot 의 capability 를 다른 *available* provider 가 더 잘하면 **auto-pick**. override 가 항상 우선, main 이 결정형 fallback. |
+
+slot → capability 매핑(optimized): execution→`execution`, research→`research`
+(보조 `long_context`), synthesis→`synthesis`, fallback→`cheap`. `default_chat` 은
+단일 "더 나은" capability 가 없어 main 에 머문다.
+
+**unavailable override/auto-pick 은 거부되고 main 으로 fallback** 한다 — 결정형이며
+없는 선택지에 대해 silent 하지 않는다(결과가 단순히 main id 를 담는다).
+
+예 (`main=claude, optimized, available=codex,gemini`):
+`execution→codex`, `research→gemini`, `synthesis→claude`, `fallback→gemini`,
+`default_chat→claude`.
+
+## 3. Main-provider 기본값 (`policy/main_profile.py`)
+
+setup 의 단 하나의 결정 — "어느 provider 가 네 것인가" — 에서 기본값을 파생한다.
+`profile_for(main_provider_id) -> MainProviderProfile`:
+`default_policy_mode` / `agent_lean` / `default_usage_mode` / `warnings`.
+
+| main | default mode | agent lean | default usage | warning |
+| --- | --- | --- | --- | --- |
+| claude | hybrid | synthesis-heavy | subscription | — |
+| codex | hybrid | execution-heavy | api | — |
+| gemini | hybrid | research-heavy | api | — |
+| ollama | **strict-single** | local-first | local | **단일 로컬 모델 → capability 제한 경고** |
+
+custom/enterprise main 은 capability flags 에서 lean 을 파생(local→local-first,
+execution→execution-heavy, …), 미지의 provider 는 보수적으로 strict-single 로 시작.
+
+## 4. Adaptive usage / billing / reserve (`policy/usage_policy.py`)
+
+forgekit 는 청구하지 않지만 budget 이 터지기 전에 throttle/defer 할 수 있어야 한다.
+구조 우선(billing 정확도 아님).
+
+**usage modes**: `adaptive`(reserve 임계까지 자유롭게, 이후 throttle — 기본) /
+`strict`(budget 에서 hard stop, reserve 없음) / `subscription_aware`(구독은 사실상
+flat, reserve 만 rate-limit/fair-use cliff 방어) / `local_first`(local/무비용 우선,
+필요한 slot 만 paid 로 spill).
+
+**billing modes**: `subscription` / `api` / `local` / `enterprise` — provider 의
+usage_mode 와 대응. `default_usage_policy(main_provider, billing_mode)` 가 매핑:
+subscription→subscription_aware, api→adaptive, local→local_first, enterprise→adaptive.
+
+**reserve** = budget 에서 held-back 한 fraction(0.0–1.0). 남은 budget 이 reserve 로
+들어오면 spend 대신 throttle — task 중간 hard-fail 을 막는 안전 margin.
+기본 reserve: adaptive 0.15 / strict 0.0 / subscription_aware 0.10 / local_first 0.05.
+
+`should_throttle(policy, spent, budget)`: strict 는 `spent >= budget`, 그 외는
+`spent >= reserve_floor(budget)`. budget<=0(unbounded/무비용)은 strict 가 아니면
+throttle 안 함.
+
+## 5. Enterprise / internal seam (`providers/registry.py`)
+
+provider 가 forgekit 에 들어오는 두 경로:
+
+1. **built-in id** — `claude`/`codex`/`gemini`/`ollama` 를 바로 해석.
+2. **generic config dict** — custom/enterprise/internal provider. 같은 계약으로
+   load 되므로 사내 gateway 를 가리킬 수 있다. live submit 은 미구현 —
+   registry 가 *shape 를 검증*해 setup/doctor 가 추론할 수 있게 하고, 실제 transport
+   결선은 후속 work tree.
+
+config shape 3종:
+
+| shape | 기본 kind | 기본 auth | 기본 submit | health |
+| --- | --- | --- | --- | --- |
+| `openai-compatible` | cloud_api | api_key | openai_compatible | api_key_set |
+| `custom-http` | enterprise | endpoint | custom_http | endpoint_reachable |
+| `internal-enterprise` | enterprise | endpoint | custom_http | endpoint_reachable |
+
+`validate_config(config) -> tuple[errors]` 와 `build_provider(config) -> ProviderSpec`
+(invalid → `ProviderConfigError`). endpoint-bearing shape 는 endpoint 필수, 미지의
+shape/빈 id/빈 label 은 거부.
+
+`no_provider_configured(config)` — **setup-incomplete signal**: config 가 없거나
+`main_provider`/`id`/`providers` 가 전혀 없으면 True(provider 가 아직 안 골라짐).
+
+## 6. CLI 읽기 표면
+
+```
+forgekit provider list                       # built-in 계약 출력
+forgekit provider slots <main> [--mode m] [--available a,b]   # slot 해석 출력
+```
+
+`cli/provider_cmd.py`. read-only, live submit 없음.
+
+## 7. 테스트
+`tests/forgekit/test_providers.py`(계약 검증 + built-in + enterprise seam),
+`tests/forgekit/test_policy.py`(slot 해석 + main-profile + usage). 실행:
+`python3 -m unittest discover -s tests/forgekit -p 'test_*.py'`.

--- a/docs/provider-capability-matrix.md
+++ b/docs/provider-capability-matrix.md
@@ -132,6 +132,18 @@ capability 는 `RoleRunnerInput.metadata['capability_class']` 또는 `task_type`
 - native 의존(computer-use/token-cache/pre-tool-hook) = **projection 유지**.
 - Ollama = **backend 분리**.
 
-## 9. 관련
-- [`plugin-taxonomy.md`](plugin-taxonomy.md) · [`agent-slash-commands.md`](agent-slash-commands.md) · `GEMINI.md`
+## 9. Forgekit provider 계약/정책으로의 투영
+
+이 매트릭스가 정의하는 capability 배치는 forgekit(설치형 제품)에서 **고정 최소
+provider 계약(`ProviderSpec`) + slot 정책**으로 투영된다 —
+[`forgekit-provider-policy.md`](forgekit-provider-policy.md). 본 문서가 "어느 provider
+가 어느 capability 를 1차로 두나"를 정하면, forgekit 쪽은 그 capability_flags 를 각
+built-in spec(claude=synthesis/safety, codex=execution/tool, gemini=research/long_context,
+ollama=cheap/local/classification)에 실어 `strict-single`/`hybrid`/`optimized` slot
+해석과 main-provider 기본값/usage 정책을 굴린다. 사내(enterprise) provider 도 같은
+계약의 generic config seam 으로 들어온다. 코드 SSoT 는
+`apps/forgekit-console/src/forgekit_console/{providers,policy}/`.
+
+## 10. 관련
+- [`forgekit-provider-policy.md`](forgekit-provider-policy.md) · [`plugin-taxonomy.md`](plugin-taxonomy.md) · [`agent-slash-commands.md`](agent-slash-commands.md) · `GEMINI.md`
 - backend/runner: `agents/runners/` · 거버넌스 회귀: `tests/governance/test_provider_capability_taxonomy.py`

--- a/tests/forgekit/test_brain.py
+++ b/tests/forgekit/test_brain.py
@@ -1,0 +1,146 @@
+"""forgekit brain — layers/policy, personal auto-init, starter pack build."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.brain import pack as pack_mod
+from forgekit_console.brain import personal as personal_mod
+from forgekit_console.brain import policy, service
+from forgekit_console.brain.models import (
+    LAYER_PERSONAL,
+    LAYER_SOURCE,
+    LAYER_STARTER,
+    LAYER_WORKING,
+    BrainNote,
+)
+
+
+class PolicyTests(unittest.TestCase):
+    def test_only_personal_writable(self) -> None:
+        self.assertTrue(policy.is_writable(LAYER_PERSONAL))
+        for layer in (LAYER_STARTER, LAYER_SOURCE, LAYER_WORKING):
+            self.assertFalse(policy.is_writable(layer))
+            with self.assertRaises(policy.BrainPolicyError):
+                policy.assert_writable(layer)
+
+    def test_default_write_target_is_personal(self) -> None:
+        self.assertEqual(policy.default_write_target(), LAYER_PERSONAL)
+
+    def test_runtime_read_order_excludes_source(self) -> None:
+        order = policy.runtime_read_order()
+        self.assertNotIn(LAYER_SOURCE, order)
+        self.assertEqual(order[0], LAYER_WORKING)
+        self.assertIn(LAYER_STARTER, order)
+
+    def test_unknown_layer_raises(self) -> None:
+        with self.assertRaises(policy.BrainPolicyError):
+            policy.assert_writable("bogus")
+
+
+class PersonalBrainTests(unittest.TestCase):
+    def test_auto_init_skeleton_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "personal"
+            brain = personal_mod.init_personal_brain(base)
+            self.assertTrue(brain.is_initialized())
+            for sub in ("notes", "decisions", "inbox"):
+                self.assertTrue((base / sub).is_dir())
+            # idempotent
+            personal_mod.init_personal_brain(base)
+            self.assertTrue(brain.index_path.exists())
+
+    def test_write_note_frontmatter_and_kind_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            brain = personal_mod.init_personal_brain(Path(tmp))
+            path = brain.write_note(BrainNote("My Decision", "we chose X", kind="decision", tags=("infra",)))
+            self.assertEqual(path.parent.name, "decisions")
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("title: My Decision", text)
+            self.assertIn("brain_layer: personal", text)
+            self.assertIn("we chose X", text)
+            self.assertEqual(brain.stats()["total"], 1)
+
+    def test_open_uninitialized_is_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(personal_mod.open_personal_brain(Path(tmp) / "missing"))
+
+
+class PackBuildTests(unittest.TestCase):
+    def _vault(self, tmp: Path) -> Path:
+        vault = tmp / "vault"
+        (vault / "notes").mkdir(parents=True)
+        (vault / "notes" / "a.md").write_text(
+            "---\ntitle: Alpha\ntags: ops infra\n---\n\n" + "x" * 2000, encoding="utf-8"
+        )
+        (vault / "b.md").write_text("# Plain\n\nhello", encoding="utf-8")
+        (vault / ".obsidian").mkdir()
+        (vault / ".obsidian" / "skip.md").write_text("should be skipped", encoding="utf-8")
+        return vault
+
+    def test_build_pack_manifest_and_readonly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            vault, dest = self._vault(tmp), tmp / "starter"
+            manifest = pack_mod.build_starter_pack(vault, dest, digest_chars=200)
+            self.assertEqual(manifest.doc_count, 2)  # .obsidian skipped
+            self.assertTrue((dest / pack_mod.MANIFEST_NAME).exists())
+            self.assertTrue((dest / pack_mod.READONLY_MARKER).exists())
+            self.assertTrue((dest / "digests" / "00000.txt").exists())
+            # digest of the long doc is truncated
+            titles = {e.title for e in manifest.entries}
+            self.assertIn("Alpha", titles)        # from frontmatter title
+            self.assertIn("b", titles)            # frontmatter-less → filename stem
+            big = next(e for e in manifest.entries if e.title == "Alpha")
+            self.assertLessEqual(big.digest_chars, 210)
+
+    def test_pack_status_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pack_mod.build_starter_pack(self._vault(tmp), tmp / "starter")
+            st = pack_mod.pack_status(tmp / "starter")
+            self.assertEqual(st["doc_count"], 2)
+            self.assertTrue(st["read_only"])
+
+    def test_missing_source_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(pack_mod.PackBuildError):
+                pack_mod.build_starter_pack(Path(tmp) / "nope", Path(tmp) / "out")
+
+    def test_pack_status_none_when_unbuilt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(pack_mod.pack_status(Path(tmp)))
+
+
+class ServiceTests(unittest.TestCase):
+    def test_env_scoped_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as vault:
+            env = {"FORGEKIT_HOME": home}
+            (Path(vault) / "x.md").write_text("# x\n\nbody", encoding="utf-8")
+            # ensure_personal_brain / build_pack_from read env via os.environ; set it
+            import os
+
+            prev = os.environ.get("FORGEKIT_HOME")
+            os.environ["FORGEKIT_HOME"] = home
+            try:
+                brain = service.ensure_personal_brain()
+                self.assertTrue(brain.is_initialized())
+                service.build_pack_from(Path(vault))
+                st = service.brain_status()
+                self.assertTrue(st["personal_initialized"])
+                self.assertTrue(st["starter_built"])
+                self.assertEqual(st["starter"]["doc_count"], 1)
+            finally:
+                if prev is None:
+                    os.environ.pop("FORGEKIT_HOME", None)
+                else:
+                    os.environ["FORGEKIT_HOME"] = prev
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_policy.py
+++ b/tests/forgekit/test_policy.py
@@ -1,0 +1,147 @@
+"""forgekit policy layer — slot resolution, main-provider defaults, usage policy."""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.policy import main_profile, provider_policy, usage_policy
+from forgekit_console.policy.provider_policy import (
+    ALL_SLOTS,
+    POLICY_HYBRID,
+    POLICY_OPTIMIZED,
+    POLICY_STRICT_SINGLE,
+    SLOT_EXECUTION,
+    SLOT_RESEARCH,
+    SLOT_SYNTHESIS,
+    resolve_slots,
+)
+
+
+class StrictSingleTests(unittest.TestCase):
+    def test_fills_every_slot_with_main(self) -> None:
+        mapping = resolve_slots("claude", POLICY_STRICT_SINGLE)
+        self.assertEqual(set(mapping), set(ALL_SLOTS))
+        self.assertTrue(all(v == "claude" for v in mapping.values()))
+
+    def test_strict_ignores_overrides(self) -> None:
+        mapping = resolve_slots(
+            "claude", POLICY_STRICT_SINGLE,
+            overrides={SLOT_EXECUTION: "codex"}, available=("codex",),
+        )
+        self.assertEqual(mapping[SLOT_EXECUTION], "claude")
+
+
+class HybridTests(unittest.TestCase):
+    def test_uses_explicit_overrides(self) -> None:
+        mapping = resolve_slots(
+            "claude", POLICY_HYBRID,
+            overrides={SLOT_EXECUTION: "codex"}, available=("codex",),
+        )
+        self.assertEqual(mapping[SLOT_EXECUTION], "codex")
+        self.assertEqual(mapping[SLOT_RESEARCH], "claude")  # no override → main
+
+    def test_hybrid_does_not_auto_pick(self) -> None:
+        # research-capable gemini is available but hybrid never auto-picks.
+        mapping = resolve_slots("claude", POLICY_HYBRID, available=("gemini",))
+        self.assertEqual(mapping[SLOT_RESEARCH], "claude")
+
+    def test_unavailable_override_falls_back_to_main(self) -> None:
+        mapping = resolve_slots(
+            "claude", POLICY_HYBRID, overrides={SLOT_EXECUTION: "codex"}, available=(),
+        )
+        self.assertEqual(mapping[SLOT_EXECUTION], "claude")
+
+
+class OptimizedTests(unittest.TestCase):
+    def test_auto_picks_by_capability(self) -> None:
+        mapping = resolve_slots(
+            "claude", POLICY_OPTIMIZED, available=("codex", "gemini"),
+        )
+        self.assertEqual(mapping[SLOT_EXECUTION], "codex")   # codex = execution
+        self.assertEqual(mapping[SLOT_RESEARCH], "gemini")   # gemini = research
+        self.assertEqual(mapping[SLOT_SYNTHESIS], "claude")  # claude = synthesis (main)
+
+    def test_override_beats_autopick(self) -> None:
+        mapping = resolve_slots(
+            "claude", POLICY_OPTIMIZED,
+            overrides={SLOT_EXECUTION: "gemini"}, available=("codex", "gemini"),
+        )
+        self.assertEqual(mapping[SLOT_EXECUTION], "gemini")
+
+    def test_no_better_provider_keeps_main(self) -> None:
+        mapping = resolve_slots("claude", POLICY_OPTIMIZED, available=())
+        self.assertTrue(all(v == "claude" for v in mapping.values()))
+
+    def test_unknown_mode_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_slots("claude", "bogus")
+
+
+class MainProfileTests(unittest.TestCase):
+    def test_builtins_differ(self) -> None:
+        claude = main_profile.profile_for("claude")
+        codex = main_profile.profile_for("codex")
+        gemini = main_profile.profile_for("gemini")
+        ollama = main_profile.profile_for("ollama")
+        self.assertEqual(claude.agent_lean, main_profile.LEAN_SYNTHESIS)
+        self.assertEqual(codex.agent_lean, main_profile.LEAN_EXECUTION)
+        self.assertEqual(gemini.agent_lean, main_profile.LEAN_RESEARCH)
+        self.assertEqual(ollama.agent_lean, main_profile.LEAN_LOCAL_FIRST)
+        # leans are distinct across the four
+        leans = {claude.agent_lean, codex.agent_lean, gemini.agent_lean, ollama.agent_lean}
+        self.assertEqual(len(leans), 4)
+
+    def test_ollama_warns_and_strict_single(self) -> None:
+        ollama = main_profile.profile_for("ollama")
+        self.assertEqual(ollama.default_policy_mode, POLICY_STRICT_SINGLE)
+        self.assertTrue(ollama.warnings)
+        self.assertEqual(ollama.default_usage_mode, "local")
+
+    def test_claude_usage_subscription(self) -> None:
+        self.assertEqual(main_profile.profile_for("claude").default_usage_mode, "subscription")
+        self.assertEqual(main_profile.profile_for("codex").default_usage_mode, "api")
+
+    def test_unknown_provider_conservative(self) -> None:
+        prof = main_profile.profile_for("mystery")
+        self.assertEqual(prof.default_policy_mode, POLICY_STRICT_SINGLE)
+        self.assertTrue(prof.warnings)
+
+
+class UsagePolicyTests(unittest.TestCase):
+    def test_default_usage_per_billing(self) -> None:
+        sub = usage_policy.default_usage_policy("claude", "subscription")
+        api = usage_policy.default_usage_policy("codex", "api")
+        local = usage_policy.default_usage_policy("ollama", "local")
+        self.assertEqual(sub.usage_mode, usage_policy.USAGE_SUBSCRIPTION_AWARE)
+        self.assertEqual(api.usage_mode, usage_policy.USAGE_ADAPTIVE)
+        self.assertEqual(local.usage_mode, usage_policy.USAGE_LOCAL_FIRST)
+
+    def test_unknown_billing_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            usage_policy.default_usage_policy("x", "bitcoin")
+
+    def test_reserve_and_throttle(self) -> None:
+        pol = usage_policy.UsagePolicy(
+            usage_mode=usage_policy.USAGE_ADAPTIVE, billing_mode="api", reserve=0.2,
+        )
+        # reserve floor = 100 * (1 - 0.2) = 80
+        self.assertEqual(pol.reserve_floor(100.0), 80.0)
+        self.assertFalse(usage_policy.should_throttle(pol, 70.0, 100.0))
+        self.assertTrue(usage_policy.should_throttle(pol, 85.0, 100.0))
+
+    def test_strict_throttles_at_budget(self) -> None:
+        pol = usage_policy.UsagePolicy(
+            usage_mode=usage_policy.USAGE_STRICT, billing_mode="api", reserve=0.0,
+        )
+        self.assertFalse(usage_policy.should_throttle(pol, 99.0, 100.0))
+        self.assertTrue(usage_policy.should_throttle(pol, 100.0, 100.0))
+
+    def test_unbounded_budget_never_throttles_unless_strict(self) -> None:
+        adaptive = usage_policy.default_usage_policy("ollama", "local")
+        self.assertFalse(usage_policy.should_throttle(adaptive, 999.0, 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_providers.py
+++ b/tests/forgekit/test_providers.py
@@ -1,0 +1,181 @@
+"""forgekit provider layer — contract validation, built-ins, enterprise seam."""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.providers import builtins, registry
+from forgekit_console.providers.contract import (
+    AUTH_API_KEY,
+    AUTH_ENDPOINT,
+    AUTH_NONE,
+    AUTH_OAUTH,
+    CAP_EXECUTION,
+    CAP_LOCAL,
+    CAP_RESEARCH,
+    CAP_SYNTHESIS,
+    HEALTH_CLI_PRESENT,
+    HEALTH_ENDPOINT_REACHABLE,
+    KIND_CLOUD_CLI,
+    KIND_ENTERPRISE,
+    KIND_LOCAL,
+    SUBMIT_CLI,
+    SUBMIT_CUSTOM_HTTP,
+    USAGE_API,
+    USAGE_ENTERPRISE,
+    USAGE_LOCAL,
+    USAGE_SUBSCRIPTION,
+    ProviderSpec,
+    validate_provider_spec,
+)
+
+
+class ContractTests(unittest.TestCase):
+    def test_good_spec_validates(self) -> None:
+        spec = ProviderSpec(
+            id="x", label="X", kind=KIND_CLOUD_CLI, auth_kind=AUTH_OAUTH,
+            usage_mode=USAGE_SUBSCRIPTION, submit_compat=SUBMIT_CLI,
+            health_contract=HEALTH_CLI_PRESENT, capability_flags=(CAP_SYNTHESIS,),
+        )
+        self.assertEqual(validate_provider_spec(spec), ())
+
+    def test_unknown_enum_fields_flagged(self) -> None:
+        spec = ProviderSpec(
+            id="x", label="X", kind="bogus", auth_kind="nope",
+            usage_mode="weird", submit_compat="??", health_contract="??",
+        )
+        errors = validate_provider_spec(spec)
+        self.assertTrue(any("kind" in e for e in errors))
+        self.assertTrue(any("auth_kind" in e for e in errors))
+        self.assertTrue(any("usage_mode" in e for e in errors))
+
+    def test_local_requires_endpoint(self) -> None:
+        spec = ProviderSpec(
+            id="loc", label="Loc", kind=KIND_LOCAL, auth_kind=AUTH_NONE,
+            usage_mode=USAGE_LOCAL, submit_compat=SUBMIT_CLI,
+            health_contract=HEALTH_ENDPOINT_REACHABLE,
+        )
+        errors = validate_provider_spec(spec)
+        self.assertTrue(any("endpoint" in e for e in errors))
+
+    def test_none_auth_only_local(self) -> None:
+        spec = ProviderSpec(
+            id="c", label="C", kind=KIND_CLOUD_CLI, auth_kind=AUTH_NONE,
+            usage_mode=USAGE_SUBSCRIPTION, submit_compat=SUBMIT_CLI,
+            health_contract=HEALTH_CLI_PRESENT,
+        )
+        errors = validate_provider_spec(spec)
+        self.assertTrue(any("none" in e for e in errors))
+
+    def test_usage_kind_coherence(self) -> None:
+        spec = ProviderSpec(
+            id="c", label="C", kind=KIND_CLOUD_CLI, auth_kind=AUTH_OAUTH,
+            usage_mode=USAGE_LOCAL, submit_compat=SUBMIT_CLI,
+            health_contract=HEALTH_CLI_PRESENT,
+        )
+        errors = validate_provider_spec(spec)
+        self.assertTrue(any("맞지 않" in e for e in errors))
+
+    def test_empty_id_label_flagged(self) -> None:
+        spec = ProviderSpec(
+            id="", label="", kind=KIND_CLOUD_CLI, auth_kind=AUTH_OAUTH,
+            usage_mode=USAGE_SUBSCRIPTION, submit_compat=SUBMIT_CLI,
+            health_contract=HEALTH_CLI_PRESENT,
+        )
+        errors = validate_provider_spec(spec)
+        self.assertTrue(any("id" in e for e in errors))
+        self.assertTrue(any("label" in e for e in errors))
+
+
+class BuiltinTests(unittest.TestCase):
+    def test_all_builtins_valid(self) -> None:
+        for pid in builtins.BUILTIN_IDS:
+            spec = builtins.BUILTIN_PROVIDERS[pid]
+            self.assertEqual(validate_provider_spec(spec), (), f"{pid} invalid")
+
+    def test_expected_four_builtins(self) -> None:
+        self.assertEqual(set(builtins.BUILTIN_IDS), {"claude", "codex", "gemini", "ollama"})
+
+    def test_capability_lean_per_provider(self) -> None:
+        self.assertTrue(builtins.CLAUDE.has_capability(CAP_SYNTHESIS))
+        self.assertTrue(builtins.CODEX.has_capability(CAP_EXECUTION))
+        self.assertTrue(builtins.GEMINI.has_capability(CAP_RESEARCH))
+        self.assertTrue(builtins.OLLAMA.has_capability(CAP_LOCAL))
+
+    def test_ollama_local_no_auth_endpoint(self) -> None:
+        self.assertEqual(builtins.OLLAMA.kind, KIND_LOCAL)
+        self.assertEqual(builtins.OLLAMA.auth_kind, AUTH_NONE)
+        self.assertEqual(builtins.OLLAMA.usage_mode, USAGE_LOCAL)
+        self.assertTrue(builtins.OLLAMA.endpoint)
+
+    def test_builtin_lookup(self) -> None:
+        self.assertIs(builtins.builtin("claude"), builtins.CLAUDE)
+        self.assertIsNone(builtins.builtin("nope"))
+
+
+class RegistrySeamTests(unittest.TestCase):
+    def test_build_from_builtin_id(self) -> None:
+        spec = registry.build_provider({"id": "codex"})
+        self.assertIs(spec, builtins.CODEX)
+
+    def test_openai_compatible_config(self) -> None:
+        cfg = {
+            "id": "vllm", "label": "Local vLLM", "shape": "openai-compatible",
+            "endpoint": "http://gpu:8000/v1", "capability_flags": ["chat", "cheap"],
+        }
+        self.assertEqual(registry.validate_config(cfg), ())
+        spec = registry.build_provider(cfg)
+        self.assertEqual(spec.submit_compat, "openai_compatible")
+        self.assertEqual(spec.auth_kind, AUTH_API_KEY)
+
+    def test_custom_http_config(self) -> None:
+        cfg = {
+            "id": "acme", "label": "Acme HTTP", "shape": "custom-http",
+            "endpoint": "https://llm.acme.internal", "capability_flags": ["chat"],
+        }
+        self.assertEqual(registry.validate_config(cfg), ())
+        spec = registry.build_provider(cfg)
+        self.assertEqual(spec.kind, KIND_ENTERPRISE)
+        self.assertEqual(spec.submit_compat, SUBMIT_CUSTOM_HTTP)
+        self.assertTrue(spec.enterprise)
+
+    def test_internal_enterprise_config(self) -> None:
+        cfg = {
+            "id": "acme-gw", "label": "Acme Gateway", "shape": "internal-enterprise",
+            "endpoint": "https://gw.acme.internal/v1", "auth_kind": "endpoint",
+            "capability_flags": ["chat", "execution"],
+        }
+        self.assertEqual(registry.validate_config(cfg), ())
+        spec = registry.build_provider(cfg)
+        self.assertEqual(spec.kind, KIND_ENTERPRISE)
+        self.assertEqual(spec.auth_kind, AUTH_ENDPOINT)
+        self.assertEqual(spec.usage_mode, USAGE_ENTERPRISE)
+
+    def test_enterprise_missing_endpoint_rejected(self) -> None:
+        cfg = {"id": "acme", "label": "Acme", "shape": "internal-enterprise"}
+        errors = registry.validate_config(cfg)
+        self.assertTrue(any("endpoint" in e for e in errors))
+        with self.assertRaises(registry.ProviderConfigError):
+            registry.build_provider(cfg)
+
+    def test_unknown_shape_rejected(self) -> None:
+        cfg = {"id": "x", "label": "X", "shape": "telepathy", "endpoint": "x"}
+        errors = registry.validate_config(cfg)
+        self.assertTrue(any("shape" in e for e in errors))
+
+    def test_missing_id_rejected(self) -> None:
+        errors = registry.validate_config({"label": "X", "shape": "custom-http", "endpoint": "x"})
+        self.assertTrue(any("id" in e for e in errors))
+
+    def test_no_provider_configured_signal(self) -> None:
+        self.assertTrue(registry.no_provider_configured(None))
+        self.assertTrue(registry.no_provider_configured({}))
+        self.assertTrue(registry.no_provider_configured({"brain": "x"}))
+        self.assertFalse(registry.no_provider_configured({"main_provider": "claude"}))
+        self.assertFalse(registry.no_provider_configured({"providers": [{"id": "codex"}]}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
forgekit 를 provider-agnostic 설치형 제품으로 만드는 코어. 미머지로 남아있던 brain WT1(개인 브레인+로컬 starter pack)을 함께 올리고, 그 위에 provider 계약/정책(WT2)을 쌓는다.

## 범위
- **brain WT1** (cherry-pick): `runtime_paths`(FORGEKIT_HOME), `brain/`(personal RW / starter RO / source / working 4계층, Obsidian-free auto-init, 로컬 vault→read-only pack), `forgekit brain init/pack build/status`.
- **provider WT2**:
  - `providers/contract.py` `ProviderSpec`(id/label/kind/auth/endpoint/capability_flags/submit_compat/usage_mode/health) + validation.
  - `providers/builtins.py` claude/codex/gemini/ollama 최소 계약(capability matrix 반영).
  - `providers/registry.py` enterprise/internal seam(openai-compatible/custom-http/internal-enterprise) + no-provider→setup incomplete.
  - `policy/provider_policy.py` slots(default_chat/execution/research/synthesis/fallback) × strict-single/hybrid/optimized 해석(optimized=capability auto-pick).
  - `policy/main_profile.py` main provider→default mode/agent lean/usage(claude synthesis / codex execution / gemini research / ollama local-first+warning).
  - `policy/usage_policy.py` adaptive/strict/subscription-aware/local-first + billing(subscription/api/local/enterprise) + reserve.
  - `forgekit provider list / slots <main>` CLI.

## 리스크
- live submit 미구현(계약/정책/검증만). origin/main ancestor → 충돌 없음. yule/forgekit 무손상.

## 테스트
- 신규 provider/policy/brain 회귀, forgekit 155 tests, 전체 sweep 5960 tests, 신규 회귀 0(사전 환경 5 errors 무관). governance·파일크기 OK.

## 이슈 linkage
- forgekit 설치형 제품 코어(brain + provider).

## Audit
- 한국어 gitmoji 3섹션, Co-Authored-By 없음, 명시 pathspec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)