### PR TITLE
💄 forgekit — session-following inline composer + 실제 대표 이미지 3-tier

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -1,15 +1,19 @@
 """Forgekit operator console — Claude-Code-style chat-first layout.
 
-Top→bottom: a small real-image avatar + brand/meta intro · one quiet issue line ·
-the main panel (a transcript XOR help-view state machine) · a **fixed bottom
-composer** (mode pill + input + inline palette) that is ALWAYS visible · a
-one-line hint. The user reads straight down and types at the bottom, exactly like
-Claude Code.
+Top→bottom, TOP-ALIGNED: a small real-image avatar + brand/meta intro (fixed
+banner) · then a single session flow of one quiet issue line · the main panel (a
+transcript XOR help-view state machine, ``height: auto``) · a **session-following
+inline composer** (mode pill + input + inline palette) that renders IMMEDIATELY
+AFTER the active content · a one-line hint. When the session is short the composer
+sits near the top with empty space below; as the transcript grows the content
+pushes the composer down and the :class:`tui.session_flow.SessionFlow` scroll
+keeps it in view. The user reads + types "at the end of the current session",
+exactly like Claude Code — the composer is NOT docked to the viewport bottom.
 
 ``/help`` (and F1) does NOT append into the transcript — it switches the whole
-main area to a dedicated help VIEW (transcript hidden). Esc switches back to the
-transcript exactly as it was. The view switch lives in
-:class:`tui.main_panel.MainPanel`; the composer never disappears across it.
+main area to a dedicated help VIEW (transcript hidden). The composer still sits
+right BELOW the help view (active content). Esc switches back to the transcript
+exactly as it was. The view switch lives in :class:`tui.main_panel.MainPanel`.
 
 Pure logic (parse/route/palette-state/intro/help strings + image-renderer
 selection) lives in the core/helpers; this module owns the live widget state
@@ -42,6 +46,7 @@ from .composer import Composer
 from .header import IntroHeader
 from .main_panel import MainPanel
 from .palette import CommandPalette
+from .session_flow import SessionFlow
 from .styles import SCREEN_CSS
 from .transcript import Transcript
 
@@ -75,21 +80,27 @@ class ForgekitConsoleApp(App):
     # --- layout -------------------------------------------------------------
 
     def compose(self) -> ComposeResult:
-        # top: small real-image avatar + brand/version/provider/profile/repo
+        # top (fixed banner): small real-image avatar + brand/version/provider/...
         yield IntroHeader(
             repo=str(self.repo_root),
             version=__version__,
             profile=self.context.profile,
             id="intro",
         )
-        # one quiet issue line under the intro
-        yield Static(id="issue")
-        # main area — a transcript XOR help-view state machine (mutually exclusive)
-        yield MainPanel(id="main")
-        # one-line hint just above the fixed composer
-        yield Static(id="hint")
-        # fixed bottom composer (always visible — palette inline, mode pill, input)
-        yield Composer(id="composer")
+        # the live session is a single TOP-ALIGNED vertical flow that scrolls:
+        #   issue line → active content (transcript XOR help) → inline composer → hint.
+        # The composer renders right after the content (height: auto), so a short
+        # session leaves it near the top with empty space below; as content grows
+        # the flow scrolls to keep the composer in view.
+        with SessionFlow(id="flow"):
+            # one quiet issue line under the intro
+            yield Static(id="issue")
+            # main area — a transcript XOR help-view state machine (mutually exclusive)
+            yield MainPanel(id="main")
+            # session-following inline composer (palette inline, mode pill, input)
+            yield Composer(id="composer")
+            # one-line hint follows the composer
+            yield Static(id="hint")
 
     def on_mount(self) -> None:
         self.title = render.BRAND
@@ -100,6 +111,7 @@ class ForgekitConsoleApp(App):
         self._refresh_issue()
         self._refresh_chrome()
         self.query_one("#prompt", Input).focus()
+        self._follow_tail()
 
     # --- input / palette ----------------------------------------------------
 
@@ -202,6 +214,8 @@ class ForgekitConsoleApp(App):
             self._refresh_chrome()
         if parsed.name in _STATUS_COMMANDS:
             self._refresh_issue()
+        # keep the inline composer in view as the session grows (Claude-style tail)
+        self._follow_tail()
 
     # --- help (a VIEW SWITCH, not a transcript append; composer stays visible) --
 
@@ -223,6 +237,16 @@ class ForgekitConsoleApp(App):
         # Switch back to the transcript exactly as it was (nothing left behind).
         self._main.show_transcript()
         self._refresh_chrome()
+
+    @property
+    def _flow(self) -> SessionFlow:
+        return self.query_one("#flow", SessionFlow)
+
+    def _follow_tail(self) -> None:
+        """Scroll the session flow so the inline composer stays in view."""
+
+        # call_after_refresh so the layout (new content height) is settled first.
+        self.call_after_refresh(self._flow.follow_tail)
 
     @property
     def _main(self) -> MainPanel:

--- a/apps/forgekit-console/src/forgekit_console/tui/composer.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/composer.py
@@ -1,11 +1,17 @@
-"""Composer — the fixed bottom chat input (mode pill + input + inline palette).
+"""Composer — the SESSION-FOLLOWING inline chat input (mode pill + input + palette).
 
-This is the key Claude-Code fix: the composer is **always visible**, docked to
-the bottom of the screen, and never hidden — not even when ``/help`` switches the
-main area to the help view. A prominent top border/rule above the input makes the
-chat bar read as a distinct, separate bar (like Claude Code's input box). The
-slash palette opens inline just above the input (still inside the composer), so
-it reads as part of the input flow rather than a floating dialog.
+This is the key Claude-Code fix. The composer is **part of the top-aligned
+session flow**, not a footer docked to the viewport bottom. It renders IMMEDIATELY
+AFTER the active content (transcript OR help view) and follows it: a short session
+leaves it near the top with empty space below; as the transcript grows it is
+pushed down (the enclosing :class:`tui.session_flow.SessionFlow` scroll keeps it
+in view). It is ``height: auto`` and carries NO ``dock`` — that is what makes it
+flow inline instead of pinning to the bottom.
+
+A prominent top border/rule above the input still makes the chat bar read as a
+distinct, bordered bar (like Claude Code's input box) — it is just inline, not
+docked. The slash palette opens inline just above the input (still inside the
+composer), so it reads as part of the input flow rather than a floating dialog.
 
 The widget owns no command logic; the app drives it (focus, value, palette
 show/hide, mode pill). Pure render strings come from :mod:`tui.render`.
@@ -20,11 +26,11 @@ from .palette import CommandPalette
 
 
 class Composer(Vertical):
-    """Fixed bottom composer: inline palette (top) + mode pill + input (bottom)."""
+    """Inline session-following composer: palette (top) + mode pill + input (bottom)."""
 
     DEFAULT_CSS = """
     Composer {
-        dock: bottom;
+        /* NO dock — the composer flows inline right after the active content. */
         height: auto;
         background: $background;
         /* prominent rule above the input so the chat bar reads as a distinct bar */

--- a/apps/forgekit-console/src/forgekit_console/tui/halfblock.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/halfblock.py
@@ -1,0 +1,92 @@
+"""Tier-2 avatar fallback — a small image-DERIVED half-block render of the PNG.
+
+This is the middle tier of the image-first priority (see
+:mod:`tui.image_renderer`):
+
+1. real inline raster (``textual-image``) in a graphics-capable terminal,
+2. **this** — a tiny, clean half-block render *derived from the baked PNG* for
+   terminals without inline graphics (so SOMETHING image-based still shows),
+3. a plain text/logo mark only as the last resort.
+
+Why a half-block render and not ASCII art or a text mark? Each terminal cell can
+show two vertical pixels by drawing the Unicode upper-half block ``▀`` with a
+foreground colour (the top pixel) over a background colour (the bottom pixel). So
+N rows of cells encode 2N image rows at full colour. Downscaled to ~12-16 cells
+wide it stays small and crisp — it is a real *image* of the source portrait, not
+typed characters approximating one.
+
+The render is built with Pillow (downscale + read pixels) and returned as a Rich
+:class:`~rich.text.Text` so a textual ``Static`` can mount it directly. Pillow is
+the ``console`` extra; if it (or the asset) is missing this module returns
+``None`` and the caller drops to the text mark.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+# Upper-half block: its FG colour paints the top sub-pixel, its BG the bottom.
+_UPPER_HALF = "▀"  # ▀
+
+# Small, Claude-icon scale. Two source rows per text row, so 14 cols × 14 rows of
+# cells encode a 14×28 image — tiny but recognisably the portrait.
+_DEFAULT_COLS = 14
+
+
+def render_halfblock(
+    image_path: Path,
+    *,
+    cols: int = _DEFAULT_COLS,
+):
+    """Return a Rich ``Text`` half-block render of *image_path*, or ``None``.
+
+    ``None`` means Pillow or the asset is unavailable — the caller then falls
+    through to the plain text mark (tier 3). Pure given the file: no terminal IO.
+    """
+
+    try:
+        from PIL import Image  # noqa: WPS433 - optional console extra
+        from rich.text import Text  # noqa: WPS433
+    except Exception:  # noqa: BLE001 - Pillow/rich missing → caller uses text mark
+        return None
+
+    try:
+        img = Image.open(image_path).convert("RGB")
+    except Exception:  # noqa: BLE001 - unreadable asset → caller uses text mark
+        return None
+
+    cols = max(4, int(cols))
+    src_w, src_h = img.size
+    # Keep aspect; two image rows map to one text row (the half-block trick), so
+    # the row count is half the scaled pixel height.
+    rows = max(2, round(cols * (src_h / src_w) / 2))
+    img = img.resize((cols, rows * 2), Image.LANCZOS)
+    px = img.load()
+
+    text = Text(no_wrap=True, end="")
+    for row in range(rows):
+        for col in range(cols):
+            top = px[col, row * 2]
+            bottom = px[col, row * 2 + 1]
+            fg = f"#{top[0]:02x}{top[1]:02x}{top[2]:02x}"
+            bg = f"#{bottom[0]:02x}{bottom[1]:02x}{bottom[2]:02x}"
+            text.append(_UPPER_HALF, style=f"{fg} on {bg}")
+        if row != rows - 1:
+            text.append("\n")
+    return text
+
+
+def halfblock_available(image_path: Optional[Path]) -> bool:
+    """True if a half-block render can be produced (Pillow present + asset readable)."""
+
+    if image_path is None or not Path(image_path).is_file():
+        return False
+    try:
+        import PIL  # noqa: F401,WPS433
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+__all__ = ("render_halfblock", "halfblock_available")

--- a/apps/forgekit-console/src/forgekit_console/tui/help_panel.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/help_panel.py
@@ -28,7 +28,8 @@ class HelpPanel(Static):
     DEFAULT_CSS = """
     HelpPanel {
         width: 1fr;
-        height: 1fr;
+        height: auto;
+        max-height: 80vh;
         padding: 1 2;
         overflow-y: auto;
     }

--- a/apps/forgekit-console/src/forgekit_console/tui/image_renderer.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/image_renderer.py
@@ -1,10 +1,19 @@
-"""Avatar image rendering — real inline image FIRST, text mark SECOND.
+"""Avatar image rendering — image FIRST, with an explicit 3-tier priority.
 
-The forgekit intro shows a small avatar like Claude Code's brand icon. The
-**primary** path is a real inline image of the baked portrait PNG, rendered with
-a terminal graphics protocol (Kitty / iTerm2 / Sixel) via the ``textual-image``
-package. Only when the terminal can't do that do we fall back to a small, clean
-text/symbol mark — never a big pixelated half-block raster.
+The forgekit intro shows a small avatar like Claude Code's brand icon. The render
+is **image-first**: we always try to show the actual baked portrait, dropping to
+a plain text mark only as a last resort. The priority, top→down, is:
+
+1. **REAL inline raster** — the baked PNG drawn pixel-for-pixel with a terminal
+   graphics protocol (Kitty / iTerm2 / Sixel, incl. the VS Code integrated
+   terminal's iTerm2 inline-image support) via ``textual-image``. Used when
+   :func:`detect_image_capability` says the terminal is graphics-capable.
+2. **IMAGE-DERIVED half-block** — when inline graphics aren't available we still
+   show an *image*: a tiny (~12-16 col) Unicode half-block render derived from
+   the **same baked PNG** with Pillow (:mod:`tui.halfblock`). Clean and small,
+   genuinely the portrait's pixels — NOT typed text approximating it.
+3. **TEXT/logo mark** — only if even Pillow / the asset is missing do we fall to
+   the two-line brand mark.
 
 Design for testability
 -----------------------
@@ -14,11 +23,12 @@ terminal:
 * :func:`detect_image_capability` reads the environment/terminal and returns a
   pure :class:`ImageCapability` decision (injectable ``env`` / overrides).
 * :func:`select_renderer` takes that decision (or any bool) and returns which
-  renderer to use — no IO, fully pure.
-* :class:`RealImageRenderer` / :class:`TextMarkRenderer` are the two concrete
-  renderers; the real one degrades to the fallback if ``textual-image`` is
-  missing at *render* time (import guarded), so the priority is "real first,
-  fall back if truly unsupported".
+  renderer to use — no IO, fully pure. Capable → real raster; not-capable → the
+  image-derived half-block (tier 2), which itself degrades to text only when
+  Pillow/the asset is missing.
+* :class:`RealImageRenderer` / :class:`HalfBlockRenderer` / :class:`TextMarkRenderer`
+  are the three concrete renderers; each degrades down a tier at *render* time
+  (import/asset guarded), so the image-first priority holds wherever it can.
 
 Nothing here imports textual's App; the widget wiring lives in
 :mod:`tui.avatar_panel`.
@@ -37,8 +47,9 @@ _DISPLAY_PNG = "forgekit-avatar.png"
 _SOURCE_JPG = "profile_hermes_source.jpg"
 
 # Renderer identifiers (returned by select_renderer; stable for tests).
-RENDERER_REAL = "real-image"
-RENDERER_TEXT = "text-mark"
+RENDERER_REAL = "real-image"  # tier 1 — inline raster
+RENDERER_HALFBLOCK = "half-block"  # tier 2 — image-derived unicode half-block
+RENDERER_TEXT = "text-mark"  # tier 3 — last-resort text/logo mark
 
 # Env var to force a path regardless of detection (operator/testing override).
 #   FORGEKIT_AVATAR=image  → force real image
@@ -48,6 +59,10 @@ _FORCE_ENV = "FORGEKIT_AVATAR"
 # Terminals/protocols known to support inline graphics. Detection is heuristic
 # (textual-image does the real protocol probing at render time); this gates the
 # *attempt* so a plain terminal never even tries.
+#   iterm.app  — iTerm2 inline image protocol
+#   wezterm    — Kitty + iTerm2 protocols
+#   vscode     — VS Code integrated terminal (recent versions speak the iTerm2
+#                inline-image protocol, so TERM_PROGRAM=vscode is worth attempting)
 _GRAPHICS_TERM_PROGRAMS = ("iterm.app", "wezterm", "vscode")
 _GRAPHICS_TERMS = ("xterm-kitty", "wezterm")
 
@@ -118,6 +133,9 @@ def detect_image_capability(
         return ImageCapability(True, reason="iterm2 inline images")
     if "sixel" in term or environ.get("FORGEKIT_SIXEL"):
         return ImageCapability(True, reason="sixel")
+    # VS Code integrated terminal: recent versions support the iTerm2 inline-image
+    # protocol, so TERM_PROGRAM=vscode is worth the real-raster attempt (textual-
+    # image probes for real at render time; this only gates the attempt).
     if term_program in _GRAPHICS_TERM_PROGRAMS:
         return ImageCapability(True, reason=f"term_program={term_program}")
     if term in _GRAPHICS_TERMS:
@@ -129,12 +147,15 @@ def detect_image_capability(
 def select_renderer(capability) -> str:
     """Pure selection: capability (truthy/ImageCapability) → renderer id.
 
-    Real image FIRST when capable, else the text mark. Accepts a bool or an
-    :class:`ImageCapability` so callers and tests can inject either.
+    Image-first priority: capable terminal → the REAL inline raster (tier 1);
+    otherwise the IMAGE-DERIVED half-block (tier 2). The half-block renderer
+    itself degrades to the text mark (tier 3) at render time when Pillow / the
+    asset is missing, so "show an image whenever possible" holds. Accepts a bool
+    or an :class:`ImageCapability` so callers and tests can inject either.
     """
 
     capable = capability.capable if isinstance(capability, ImageCapability) else bool(capability)
-    return RENDERER_REAL if capable else RENDERER_TEXT
+    return RENDERER_REAL if capable else RENDERER_HALFBLOCK
 
 
 # --- text/symbol fallback mark (SECONDARY) ---------------------------------
@@ -165,7 +186,7 @@ class AvatarRenderer(Protocol):
 
 @dataclass(frozen=True)
 class TextMarkRenderer:
-    """SECONDARY renderer — a small clean text/symbol mark (no image lib)."""
+    """TIER 3 (last resort) — a small clean text/symbol mark (no image at all)."""
 
     renderer_id: str = RENDERER_TEXT
 
@@ -174,11 +195,35 @@ class TextMarkRenderer:
 
 
 @dataclass(frozen=True)
-class RealImageRenderer:
-    """PRIMARY renderer — a real inline image via ``textual-image``.
+class HalfBlockRenderer:
+    """TIER 2 — an image-DERIVED half-block render of the baked PNG (Pillow).
 
-    Falls back to the text mark only if the image lib is missing or the asset is
-    unreadable at render time, so "real image first" holds wherever it can.
+    Shown when inline graphics aren't available: still a real *image* of the
+    portrait (downscaled half-block raster, ~12-16 cols), not typed text. Degrades
+    to the text mark (tier 3) only when Pillow / the asset is missing.
+    """
+
+    renderer_id: str = RENDERER_HALFBLOCK
+    cols: int = 14  # cells wide; small & clean
+
+    def renderable(self):
+        from . import halfblock  # local import keeps Pillow optional at import time
+
+        path = best_image_path()
+        rendered = halfblock.render_halfblock(path, cols=self.cols) if path else None
+        if rendered is None:
+            return TextMarkRenderer().renderable()
+        return rendered
+
+
+@dataclass(frozen=True)
+class RealImageRenderer:
+    """TIER 1 (primary) — a real inline image raster via ``textual-image``.
+
+    Falls back DOWN the tiers if the image lib is missing or the asset is
+    unreadable at render time: first to the image-derived half-block (tier 2),
+    then to the text mark (tier 3). So "show the real image first, else still an
+    image" holds wherever it can.
     """
 
     renderer_id: str = RENDERER_REAL
@@ -190,12 +235,12 @@ class RealImageRenderer:
             return TextMarkRenderer().renderable()
         try:
             from textual_image.renderable import Image as _InlineImage  # noqa: WPS433
-        except Exception:  # noqa: BLE001 - textual-image not installed → fallback
-            return TextMarkRenderer().renderable()
+        except Exception:  # noqa: BLE001 - textual-image absent → image-derived tier 2
+            return HalfBlockRenderer().renderable()
         try:
             return _InlineImage(str(path), width=self.width)
-        except Exception:  # noqa: BLE001 - any render construction failure
-            return TextMarkRenderer().renderable()
+        except Exception:  # noqa: BLE001 - raster construction failed → tier 2
+            return HalfBlockRenderer().renderable()
 
 
 def make_renderer(
@@ -204,22 +249,30 @@ def make_renderer(
     width: int = 12,
     env: Optional[Mapping[str, str]] = None,
 ) -> AvatarRenderer:
-    """Build the renderer chosen by *capability* (detected from *env* if None)."""
+    """Build the renderer chosen by *capability* (detected from *env* if None).
+
+    Image-first: capable → real raster (tier 1), not-capable → image-derived
+    half-block (tier 2). Both degrade to the text mark (tier 3) at render time.
+    """
 
     if capability is None:
         capability = detect_image_capability(env)
     renderer_id = select_renderer(capability)
     if renderer_id == RENDERER_REAL:
         return RealImageRenderer(width=width)
+    if renderer_id == RENDERER_HALFBLOCK:
+        return HalfBlockRenderer()
     return TextMarkRenderer()
 
 
 __all__ = (
     "RENDERER_REAL",
+    "RENDERER_HALFBLOCK",
     "RENDERER_TEXT",
     "ImageCapability",
     "AvatarRenderer",
     "RealImageRenderer",
+    "HalfBlockRenderer",
     "TextMarkRenderer",
     "detect_image_capability",
     "select_renderer",

--- a/apps/forgekit-console/src/forgekit_console/tui/main_panel.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/main_panel.py
@@ -13,7 +13,14 @@ This replaces the old "append help into the transcript" behaviour:
   about help is left behind in the transcript — help lives in its own widget.
 
 It is an in-app panel, not a modal: no new screen is pushed, so the composer
-stays docked at the bottom and the screen stack length stays 1.
+stays in the inline session flow right below it and the screen stack length
+stays 1.
+
+Layout note: the panel is ``height: auto`` (it sizes to its active child's
+content), NOT ``1fr``. That is what lets the composer render IMMEDIATELY AFTER the
+content instead of being shoved to the viewport bottom by a flex-filled main
+area. The enclosing :class:`tui.session_flow.SessionFlow` scroll provides the
+overflow handling as the transcript grows.
 """
 
 from __future__ import annotations
@@ -28,12 +35,16 @@ _HELP_ID = "help"
 
 
 class MainPanel(ContentSwitcher):
-    """Switches the main area between the transcript and the help view (XOR)."""
+    """Switches the main area between the transcript and the help view (XOR).
+
+    ``height: auto`` — sizes to the active child so the composer follows the
+    content inline (see module docstring).
+    """
 
     DEFAULT_CSS = """
     MainPanel {
         width: 1fr;
-        height: 1fr;
+        height: auto;
     }
     """
 

--- a/apps/forgekit-console/src/forgekit_console/tui/session_flow.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/session_flow.py
@@ -1,0 +1,51 @@
+"""Session flow — the top-aligned vertical scroll that holds the live session.
+
+This is the container that makes the console read like Claude Code: a single
+TOP-ALIGNED vertical flow of
+
+    issue line → active content (transcript XOR help view) → inline composer → hint
+
+where the active content is ``height: auto`` and the composer renders IMMEDIATELY
+AFTER it. When the session is short the composer sits near the top with EMPTY
+space below (exactly the Claude screenshot); as the transcript grows, the content
+pushes the composer down and this :class:`~textual.containers.VerticalScroll`
+provides the overflow, auto-scrolling so the newest output + the composer stay in
+view.
+
+The intro header is intentionally kept OUTSIDE this scroll (in the app's
+``compose``) as a fixed top banner; only the live session (issue/content/composer/
+hint) scrolls. :meth:`follow_tail` is called by the app after new input/output so
+the composer is kept visible.
+"""
+
+from __future__ import annotations
+
+from textual.containers import VerticalScroll
+
+
+class SessionFlow(VerticalScroll):
+    """Top-aligned scroll holding issue → content → composer → hint inline."""
+
+    DEFAULT_CSS = """
+    SessionFlow {
+        width: 1fr;
+        height: 1fr;
+        /* top-aligned: children stack from the top, NOT pinned to the bottom */
+        align-vertical: top;
+        scrollbar-size-vertical: 1;
+    }
+    """
+
+    def follow_tail(self) -> None:
+        """Scroll so the tail of the flow (newest content + composer) stays in view.
+
+        Called after a new transcript entry / command output so the inline
+        composer is kept visible as the session grows — the "typing at the end of
+        the current session" feel.
+        """
+
+        # animate=False keeps it snappy + deterministic for pilot tests.
+        self.scroll_end(animate=False)
+
+
+__all__ = ("SessionFlow",)

--- a/apps/forgekit-console/src/forgekit_console/tui/styles.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/styles.py
@@ -1,9 +1,12 @@
 """Screen CSS — Claude-Code-style chat-first layout. Kept out of app.py.
 
-Top→bottom: intro (small avatar + brand/meta) · one quiet issue line · the
-transcript (chat-first main area, ``1fr``) · a one-line hint · a **fixed bottom
-composer** docked to the bottom (always visible — even when ``/help`` fills the
-transcript). Per-widget CSS lives on each widget (IntroHeader / Composer /
+Top→bottom, TOP-ALIGNED: intro (small avatar + brand/meta, a fixed banner) · then
+the session flow (:class:`tui.session_flow.SessionFlow`, ``1fr`` scroll) holding
+one quiet issue line · the main area (transcript XOR help, ``height: auto``) · the
+**session-following inline composer** (renders right after the content, NOT
+docked) · a one-line hint. A short session leaves the composer near the top with
+empty space below; as content grows the flow scrolls to keep it in view.
+Per-widget CSS lives on each widget (IntroHeader / SessionFlow / Composer /
 Transcript / CommandPalette); this holds only the Screen-level frame.
 """
 

--- a/apps/forgekit-console/src/forgekit_console/tui/transcript.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/transcript.py
@@ -1,10 +1,17 @@
 """Transcript — the chat-first main area where command output stacks.
 
 Like Claude Code's transcript: command echoes, results, and agent output stack
-top→down in one scrolling area. ``/help`` is NOT rendered here — it is a separate
-view (:class:`tui.help_panel.HelpPanel`) that the :class:`tui.main_panel.MainPanel`
-switches to, so opening or switching help never appends anything to this log.
-The composer stays docked at the bottom the whole time.
+top→down. ``/help`` is NOT rendered here — it is a separate view
+(:class:`tui.help_panel.HelpPanel`) that the :class:`tui.main_panel.MainPanel`
+switches to, so opening or switching help never appends anything to this log. The
+inline composer follows this content the whole time.
+
+Layout note: the log is ``height: auto`` (it grows with its content) so a short
+session leaves the composer near the top with empty space below — the
+session-following inline feel. It is capped by a ``max-height`` so a very long
+session scrolls instead of unbounded growth; the enclosing
+:class:`tui.session_flow.SessionFlow` scroll keeps the newest line + the composer
+in view.
 
 This is a thin :class:`RichLog` wrapper; it owns no help/view state anymore.
 """
@@ -19,12 +26,13 @@ from . import render
 
 
 class Transcript(RichLog):
-    """Scrolling chat-first log. Help is a separate view, not appended here."""
+    """Auto-height chat-first log. Help is a separate view, not appended here."""
 
     DEFAULT_CSS = """
     Transcript {
         width: 1fr;
-        height: 1fr;
+        height: auto;
+        max-height: 80vh;
         padding: 0 1;
     }
     """
@@ -33,6 +41,7 @@ class Transcript(RichLog):
         kwargs.setdefault("markup", True)
         kwargs.setdefault("wrap", True)
         kwargs.setdefault("highlight", False)
+        kwargs.setdefault("auto_scroll", True)
         super().__init__(**kwargs)
 
     def write_lines(self, lines: Sequence[str]) -> None:

--- a/docs/forgekit-console.md
+++ b/docs/forgekit-console.md
@@ -2,10 +2,14 @@
 
 > `forgekit` 는 이 레포(사용자-facing 이름 **forgekit**)의 운영자 콘솔이다. 터미널에서
 > `forgekit` 한 줄이면 전체화면 TUI 콘솔이 열린다. UI 는 **Claude Code CLI 처럼 chat-first**:
-> 상단 작은 실-이미지 아바타 intro → 조용한 issue line → 본문(transcript) → **항상 보이는
-> 하단 고정 composer(채팅 입력)** → hint 한 줄. `/help` 는 modal 도 아니고 transcript 에
-> 쌓이는 것도 아니다 — 본문 영역을 **help 뷰로 통째로 전환**(transcript 숨김)한다. Esc 로
-> transcript 로 돌아온다.
+> 상단 작은 실-이미지 아바타 intro(고정 배너) → 조용한 issue line → 본문(transcript) →
+> **세션을 따라가는 inline composer(채팅 입력)** → hint 한 줄. composer 는 viewport
+> 하단에 고정된 footer 가 아니라 **본문 바로 아래에 inline 으로** 렌더된다 — 세션이 짧으면
+> 상단 가까이에 있고 아래는 비어 있다가, transcript 가 늘면 content 가 composer 를 아래로
+> 밀고 flow scroll 이 composer 를 화면에 유지한다. `/help` 는 modal 도 아니고 transcript
+> 에 쌓이는 것도 아니다 — 본문 영역을 **help 뷰로 통째로 전환**(transcript 숨김)하고
+> composer 는 그 help 뷰 **바로 아래**에 그대로 inline 으로 보인다. Esc 로 transcript 로
+> 돌아온다.
 
 ## 1. forgekit 와 yule 의 관계
 
@@ -36,56 +40,77 @@ forgekit console --repo-root /path/to/repo   # status 기준 경로 지정
   콘솔 실행 시 **친절한 설치 안내(exit 3)** 를 출력한다(트레이스백 아님).
 - 기본 repo root 해석 우선순위: `--repo-root` > `YULE_REPO_ROOT` > 현재 디렉터리.
 
-### 아바타 — 실 이미지가 1순위 (real-image FIRST)
+### 아바타 — 이미지가 1순위, 3-tier 우선순위 (image FIRST)
 
-- **기본 표시 경로는 진짜 인라인 이미지다 — ASCII/half-block 텍스트가 아니다.** 원본
-  헤드폰 portrait(`assets/avatar/profile_hermes_source.jpg`, 고해상 master)를 얼굴 중심으로
-  crop → 작은 square PNG(`assets/avatar/forgekit-avatar.png`, ≈96px, Claude 아이콘 스케일)
-  로 **사전-베이크**(`python -m forgekit_console.assets.avatar.bake`, Pillow 필요)해 커밋한다.
-  콘솔은 큰 master 를 직접 렌더하지 않고 이 작은 PNG 만 렌더한다.
-- **이미지-capable 터미널** (Kitty graphics / iTerm2 inline / Sixel) 이면 `textual-image`
-  패키지로 그 PNG 를 **진짜 인라인 이미지**로 그린다 (1순위, primary).
-- **그렇지 않은 터미널** 이면 작고 선명한 **텍스트/심볼 마크** 로 fallback 한다 (2순위,
-  secondary). fallback 은 절대 큰 픽셀 덩어리(half-block 래스터)가 아니라 두 줄짜리
-  깔끔한 브랜드 마크다.
+대표 이미지는 **헤드폰 girl 라인아트 portrait** 다. 원본
+`assets/avatar/profile_hermes_source.jpg`(고해상 master)를 얼굴 중심으로 crop → 작은
+square PNG(`assets/avatar/forgekit-avatar.png`, ≈96px, Claude 아이콘 스케일)로
+**사전-베이크**(`python -m forgekit_console.assets.avatar.bake`, Pillow 필요)해 커밋한다.
+콘솔은 큰 master 를 직접 렌더하지 않고 이 작은 PNG 만 렌더한다.
+
+표시는 **image-first** — 항상 실제 portrait 를 보여주려 하고, 텍스트 마크는 정말 마지막
+수단일 때만 쓴다. 코드(`tui/image_renderer.py`)의 우선순위는 위→아래로:
+
+1. **REAL 인라인 래스터** — image-capable 터미널(Kitty graphics / iTerm2 inline / Sixel,
+   그리고 **VS Code 통합 터미널** — 최근 버전은 iTerm2 inline-image 프로토콜을 지원하므로
+   `TERM_PROGRAM=vscode` 도 시도)이면 `textual-image` 로 그 PNG 를 **진짜 인라인 이미지**로
+   그린다. **full real raster 는 `pip install -e '.[console]'`(textual-image) + graphics-capable
+   터미널이 있어야 보인다.**
+2. **IMAGE-DERIVED half-block** — 인라인 그래픽이 안 되는 터미널이면 그래도 **이미지**를
+   보여준다: 같은 베이크 PNG 를 Pillow 로 downscale 해 만든 작고 깔끔한(~12-16 cols) Unicode
+   half-block(`▀`) 래스터(`tui/halfblock.py`). 타이핑한 텍스트로 흉내 낸 게 아니라 실제
+   포트레이트의 픽셀에서 유도된 이미지다.
+3. **TEXT/로고 마크** — Pillow / 에셋마저 없을 때만 두 줄짜리 깔끔한 브랜드 마크로 떨어진다.
+
 - capability 판정과 renderer 선택은 **순수·주입가능** (env / `force` 인자) — `tui/image_renderer.py`
-  의 `detect_image_capability` / `select_renderer`. 그래서 실제 터미널 없이 테스트된다.
-  `FORGEKIT_AVATAR=image|text` 로 강제할 수 있다.
-- 현실 주의: headless / 이미지-비지원 터미널에서는 실 이미지 렌더를 눈으로 확인할 수 없다.
-  코드/테스트는 **추상화 + capability 검출 + fallback 로직 + 레이아웃 구조** 를 보장하고,
-  우선순위(real-image FIRST, fallback SECOND)를 명시한다.
+  의 `detect_image_capability` / `select_renderer`. capable → real(tier1), not-capable →
+  image-derived half-block(tier2), 둘 다 render 시점에 text(tier3)로 단계적 degrade. 그래서
+  실제 터미널 없이 테스트된다. `FORGEKIT_AVATAR=image|text` 로 강제할 수 있다.
+- 현실 주의: headless / 이미지-비지원 터미널에서는 tier-1 실 이미지 렌더를 눈으로 확인할 수
+  없다. 그 경우 tier-2 image-derived half-block 이 대신 보인다. 코드/테스트는
+  **추상화 + capability 검출 + 3-tier fallback 로직 + 레이아웃 구조** 를 보장하고,
+  우선순위(real → image-derived half-block → text)를 명시한다.
 
 ## 3. 화면 구성 (Claude Code chat-first 위→아래 흐름)
 
-Claude Code 터미널 UI 처럼 **intro → issue line → 본문(main panel) → 고정 composer → hint**
-의 세로 흐름이다. 핵심은 **하단 composer(채팅 입력)가 항상 보인다**는 점 — `/help` 뷰가
-열려도 약해지거나 사라지지 않는다.
+Claude Code 터미널 UI 처럼 **intro → issue line → 본문(main panel) → inline composer → hint**
+의 **TOP-ALIGNED** 세로 흐름이다. 핵심은 **composer 가 본문 바로 아래에 inline 으로 따라간다**
+는 점 — viewport 하단에 고정된 footer 가 아니다. 세션이 짧으면 composer 가 상단 가까이에
+있고 아래는 비어 있다(Claude 스크린샷과 동일).
 
 ```
-🜲  forgekit v0.1.0                     ← intro: 작은 실-이미지 아바타(좌) + 브랜드/버전/provider/profile/repo(우)
+🜲  forgekit v0.1.0                     ← intro: 작은 실-이미지 아바타(좌) + 브랜드/버전/provider/profile/repo(우) — 고정 배너
     operator console
     provider —   profile operator
     /repo/path
 ready · /status                        ← issue line (텍스트 1줄, 조용)
-─ main panel(본문, 1fr): transcript XOR help 뷰 — 둘 중 하나만 보인다(상호 배타) ─
-   …                                      (transcript: welcome → 명령 결과; /help → help 뷰로 통째 전환)
-/help · / palette · Tab 완성 · ^C quit  ← 1줄 hint
+› /help                                ← 본문(transcript) — content 만큼만(height: auto)
+  └ …
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ← (composer 상단 강조 rule)
   palette …            (slash 입력 시 입력 바로 위 inline)
-● operator  > 명령 입력 …               ← 고정 composer(mode pill + input) — dock: bottom, 항상 보임
+● operator  > 명령 입력 …               ← inline composer — content 바로 아래(NOT dock: bottom)
+▶▶ /help · / palette · Tab 완성 · ^C quit  ← composer 를 따르는 1줄 hint
+(아래는 비어 있음 — composer 는 viewport 하단이 아니다)
 ```
 
 - **intro(IntroHeader)**: 작은 **실-이미지** 아바타(좌, image-capable 시) + `forgekit` 이름/버전,
-  provider/profile, repo(우). 비지원 터미널이면 아바타 자리에 작은 텍스트 마크.
+  provider/profile, repo(우). 비지원 터미널이면 아바타 자리에 tier-2 image-derived half-block.
+  intro 는 flow 밖 **고정 배너**.
 - **issue line(1줄)**: 텍스트 중심 한 줄 — 기본 `ready · /status`, 이슈 있으면 `N issues: … · /doctor`. 긴 operator 상태 행은 첫 화면에서 약화(자세히는 `/status`).
-- **main panel(1fr, 본문)**: `transcript` 와 `help 뷰` 의 **상호 배타 state machine**(textual
-  `ContentSwitcher`, `tui/main_panel.py`). 평소엔 transcript(명령 echo·결과가 위→아래로 쌓이는
-  chat-first 영역)만 보인다. `/help`(또는 F1)이면 본문 전체가 **help 뷰로 전환**되고 transcript
-  는 숨는다 — transcript 에 아무것도 append 되지 않는다. Esc 로 transcript 가 그대로 복원된다.
-- **composer(고정, 하단)**: `dock: bottom` + 입력 위 **강조 rule(border-top heavy)** 로 채팅 바가
-  뚜렷한 별도 바로 읽힌다. **항상 보이는** 채팅 입력 — inline palette(slash 입력 시 입력 바로 위)
-  + mode pill(`● operator` / `● palette` / `● <agent>`) + 입력창. help 뷰가 열려 있는 동안에도
-  그대로 보이고(하단 고정 유지) 입력 가능하다.
+- **session flow(`tui/session_flow.py`)**: issue line · 본문 · composer · hint 를 담는 하나의
+  **top-aligned `VerticalScroll`**. 본문이 `height: auto` 라 composer 가 바로 아래에 inline 으로
+  붙고, transcript 가 늘면 content 가 composer 를 아래로 밀며 flow 가 `scroll_end` 로 composer
+  를 화면에 유지한다(새 입력/출력마다 `follow_tail`).
+- **main panel(본문, `height: auto`)**: `transcript` 와 `help 뷰` 의 **상호 배타 state machine**
+  (textual `ContentSwitcher`, `tui/main_panel.py`). 평소엔 transcript(명령 echo·결과가 위→아래로
+  쌓이는 chat-first 영역)만 보인다. `/help`(또는 F1)이면 본문 전체가 **help 뷰로 전환**되고
+  transcript 는 숨는다 — transcript 에 아무것도 append 되지 않는다. Esc 로 transcript 가 그대로
+  복원된다.
+- **composer(inline, 세션 추종)**: `dock` **없음** — content 바로 아래에 inline 으로 렌더된다.
+  입력 위 **강조 rule(border-top heavy)** 로 채팅 바가 뚜렷한 별도 바로 읽힌다. inline
+  palette(slash 입력 시 입력 바로 위) + mode pill(`● operator` / `● palette` / `● <agent>`) +
+  입력창. help 뷰가 열려 있는 동안에는 그 **help 뷰 바로 아래**에 그대로 inline 으로 보이고
+  입력 가능하다.
 
 ## 3b. 키 바인딩 / 상호작용
 
@@ -99,13 +124,13 @@ ready · /status                        ← issue line (텍스트 1줄, 조용)
 | `F1` | help 뷰 토글 |
 | `^L` / `^R` / `^C` | 로그 지우기 / issue line 새로고침 / 종료 |
 
-- **slash palette**: 평소 숨김, `/` 입력 시 (고정 composer 안의) 입력 바로 위 얇은 inline 메뉴로 필터·하이라이트.
+- **slash palette**: 평소 숨김, `/` 입력 시 (inline composer 안의) 입력 바로 위 얇은 inline 메뉴로 필터·하이라이트.
 - **`/help`**: 모달/사이드패널/아코디언 아님, **transcript 누적도 아님** → 본문 영역을 **help 뷰로
   통째로 전환**한다(transcript 숨김, `tui/help_panel.py` + `tui/main_panel.py`). 사용자는 "지금 help
   화면을 보고 있다" 고 느낀다. 상단 탭 strip `Help · General · Commands · Agents`, **기본 General**,
   한 번에 활성 탭만 표시(Tab 으로 **제자리** 전환 — 같은 위젯 re-render, append 없음). modal 이 아니라
-  in-app 패널이므로 `screen_stack` 길이는 1 그대로다. **composer 는 그 동안에도 하단 고정으로 보인다.**
-  Esc 로 transcript 가 그대로 복원된다(help 흔적 없음).
+  in-app 패널이므로 `screen_stack` 길이는 1 그대로다. **composer 는 그 동안에도 help 뷰 바로 아래에
+  inline 으로 보인다.** Esc 로 transcript 가 그대로 복원된다(help 흔적 없음).
 
 ## 4. slash 명령
 
@@ -139,20 +164,22 @@ apps/forgekit-console/src/forgekit_console/
     router.py          ParsedInput → CommandResult (순수, 로더 주입)
   data/status_loader.py  기존 surface 재사용 + 순수 shaper
   tui/render.py        문자열 렌더(welcome/intro-meta/issue-line/hint/mode-pill/help-panel-document/palette) — 순수
-  tui/image_renderer.py 아바타 렌더 추상화 — capability 검출(순수) + real-image/text 두 renderer
+  tui/image_renderer.py 아바타 렌더 추상화 — capability 검출(순수) + real/half-block/text 3-tier renderer
+  tui/halfblock.py     tier-2 image-derived half-block 렌더(베이크 PNG → Pillow downscale → ▀ 래스터)
   tui/avatar_panel.py  아바타 위젯(선택된 renderer 의 renderable 을 mount, textual)
   tui/header.py        IntroHeader 위젯 — 아바타(좌) + 브랜드/버전/provider/profile/repo(우)
-  tui/main_panel.py    MainPanel(ContentSwitcher) — transcript XOR help 뷰 상호배타 전환
-  tui/transcript.py    Transcript 위젯 — chat-first 본문(명령 echo·결과만; help 누적 안 함)
+  tui/session_flow.py  SessionFlow(VerticalScroll) — issue·본문·composer·hint 의 top-aligned inline flow + follow_tail
+  tui/main_panel.py    MainPanel(ContentSwitcher) — transcript XOR help 뷰 상호배타 전환(height: auto)
+  tui/transcript.py    Transcript 위젯 — chat-first 본문(명령 echo·결과만; help 누적 안 함; height: auto)
   tui/help_panel.py    HelpPanel 위젯 — help 뷰(탭 strip + 활성 탭 본문, Tab 제자리 re-render)
-  tui/composer.py      Composer 위젯 — 고정 하단 채팅 입력(강조 rule + palette + mode pill + input)
+  tui/composer.py      Composer 위젯 — 세션 추종 inline 채팅 입력(NOT dock; 강조 rule + palette + mode pill + input)
   tui/keymap.py        키 바인딩 + 힌트 (순수 데이터)
   tui/styles.py        Screen CSS 상수(app.py 분리, 위젯별 CSS 는 각 위젯에)
   tui/palette.py       inline command palette 위젯 (textual, composer 안)
-  tui/app.py           Textual App — Claude-Code chat-first compose + 상태(mode/palette) + help 뷰 전환 wiring
+  tui/app.py           Textual App — Claude-Code chat-first compose(session flow) + 상태(mode/palette) + help 뷰 전환 wiring
   app/main.py          `forgekit` 엔트리 (textual 부재 시 graceful degrade)
-  assets/avatar/profile_hermes_source.jpg  고해상 master(crop 원본)
-  assets/avatar/forgekit-avatar.png        작은 베이크 PNG(실-이미지 1순위 표시 에셋)
+  assets/avatar/profile_hermes_source.jpg  고해상 master(헤드폰 라인아트 portrait, crop 원본)
+  assets/avatar/forgekit-avatar.png        작은 베이크 PNG(image-first 표시 에셋: tier1 real / tier2 half-block 소스)
   assets/avatar/bake.py                    master → 작은 PNG 베이크 build-time 도구(Pillow)
 ```
 
@@ -165,11 +192,11 @@ apps/forgekit-console/src/forgekit_console/
 
 ## 6. 이번 범위 / 범위 밖
 
-**범위(Claude Code clone 디자인):** chat-first 세로 흐름(작은 **실-이미지** 아바타 intro →
-issue line → 본문(transcript XOR help 뷰) → **항상 보이는 고정 하단 composer** → hint), 아바타
-real-image FIRST + capability 검출 + text fallback SECOND, `/help` 를 **단일 패널 뷰 전환**(모달
-아님, transcript 누적 아님), `/exit`(=`/quit` alias), 상단 정보 밀도 완화(operator 상세는
-`/status`), 테스트/문서. brain/setup/provider 는 미포함.
+**범위(Claude Code clone 디자인):** chat-first **top-aligned** 세로 흐름(작은 **실-이미지** 아바타
+intro → issue line → 본문(transcript XOR help 뷰) → **세션 추종 inline composer(NOT dock:bottom,
+본문 바로 아래)** → hint), 아바타 **image-first 3-tier**(real raster → image-derived half-block →
+text), `/help` 를 **단일 패널 뷰 전환**(모달 아님, transcript 누적 아님), `/exit`(=`/quit` alias),
+상단 정보 밀도 완화(operator 상세는 `/status`), 테스트/문서. brain/setup/provider 는 미포함.
 
 **범위 밖(후속):** brain/setup/provider 코어, 실제 live chat loop, Agent Town, macOS 알림,
 Discord push, approval inbox 조작, multi-provider session persistence.

--- a/tests/forgekit/test_image_renderer.py
+++ b/tests/forgekit/test_image_renderer.py
@@ -1,9 +1,13 @@
-"""Avatar image renderer — capability detection + renderer selection + fallback.
+"""Avatar image renderer — capability detection + 3-tier renderer priority.
 
-Real-image-FIRST is the contract: when the terminal is capable we select the
-real-image renderer; otherwise the text-mark fallback. The capability decision
-and the selection are pure (injectable env / force), so these tests need no real
-terminal and no graphics protocol.
+Image-FIRST is the contract, with an explicit 3-tier priority:
+
+1. capable terminal → REAL inline raster,
+2. not-capable terminal → IMAGE-DERIVED half-block (still an image, NOT text),
+3. only when Pillow / the asset is missing → text/logo mark.
+
+The capability decision and the selection are pure (injectable env / force), so
+these tests need no real terminal and no graphics protocol.
 """
 
 from __future__ import annotations
@@ -48,28 +52,43 @@ class CapabilityDetectionTests(unittest.TestCase):
         self.assertIn("no known", cap.reason)
 
 
+class CapabilityVscodeTests(unittest.TestCase):
+    def test_vscode_integrated_terminal_attempts_real(self) -> None:
+        # recent VS Code terminals speak the iTerm2 inline-image protocol → attempt
+        cap = ir.detect_image_capability({"TERM_PROGRAM": "vscode"})
+        self.assertTrue(cap.capable)
+        self.assertIn("vscode", cap.reason)
+
+    def test_wezterm_detected(self) -> None:
+        self.assertTrue(ir.detect_image_capability({"TERM_PROGRAM": "WezTerm"}).capable)
+        self.assertTrue(ir.detect_image_capability({"TERM": "wezterm"}).capable)
+
+
 class RendererSelectionTests(unittest.TestCase):
     def test_capable_selects_real(self) -> None:
         cap = ir.ImageCapability(True)
         self.assertEqual(ir.select_renderer(cap), ir.RENDERER_REAL)
 
-    def test_not_capable_selects_text(self) -> None:
+    def test_not_capable_selects_image_derived_halfblock_not_text(self) -> None:
+        # tier 2: not-capable → image-derived half-block, NOT the text mark
         cap = ir.ImageCapability(False)
-        self.assertEqual(ir.select_renderer(cap), ir.RENDERER_TEXT)
+        self.assertEqual(ir.select_renderer(cap), ir.RENDERER_HALFBLOCK)
+        self.assertNotEqual(ir.select_renderer(cap), ir.RENDERER_TEXT)
 
     def test_accepts_bare_bool(self) -> None:
         self.assertEqual(ir.select_renderer(True), ir.RENDERER_REAL)
-        self.assertEqual(ir.select_renderer(False), ir.RENDERER_TEXT)
+        self.assertEqual(ir.select_renderer(False), ir.RENDERER_HALFBLOCK)
 
     def test_make_renderer_capable_is_real(self) -> None:
         r = ir.make_renderer(ir.ImageCapability(True))
         self.assertEqual(r.renderer_id, ir.RENDERER_REAL)
         self.assertIsInstance(r, ir.RealImageRenderer)
 
-    def test_make_renderer_incapable_is_text(self) -> None:
+    def test_make_renderer_incapable_is_halfblock(self) -> None:
+        # incapable terminal still gets an IMAGE (tier 2), not the text mark
         r = ir.make_renderer(ir.ImageCapability(False))
-        self.assertEqual(r.renderer_id, ir.RENDERER_TEXT)
-        self.assertIsInstance(r, ir.TextMarkRenderer)
+        self.assertEqual(r.renderer_id, ir.RENDERER_HALFBLOCK)
+        self.assertIsInstance(r, ir.HalfBlockRenderer)
 
 
 class AssetTests(unittest.TestCase):
@@ -87,9 +106,34 @@ class AssetTests(unittest.TestCase):
         self.assertEqual(ir.best_image_path(), ir.display_png_path())
 
 
+class HalfBlockTier2Tests(unittest.TestCase):
+    """Tier 2 — an IMAGE-DERIVED half-block render of the baked PNG (Pillow)."""
+
+    def test_halfblock_renderer_produces_image_derived_render_not_text(self) -> None:
+        # With Pillow + the baked asset present, tier 2 is a Rich Text half-block
+        # render of the actual image — NOT the plain text mark.
+        from rich.text import Text
+
+        out = ir.HalfBlockRenderer().renderable()
+        self.assertIsInstance(out, Text)
+        plain = out.plain
+        # the half-block raster is made of upper-half block glyphs (image-derived)
+        self.assertIn("▀", plain)
+        # and it is NOT the brand text mark
+        self.assertNotIn("forge", plain)
+
+    def test_make_renderer_incapable_renders_halfblock_image(self) -> None:
+        from rich.text import Text
+
+        r = ir.make_renderer(ir.ImageCapability(False))
+        out = r.renderable()
+        self.assertIsInstance(out, Text)
+        self.assertIn("▀", out.plain)
+
+
 class FallbackTests(unittest.TestCase):
     def test_text_mark_is_small_and_crisp(self) -> None:
-        # fallback must be a small text mark, NOT a per-pixel raster block
+        # last-resort text mark must be small, NOT a per-pixel raster block
         mark = ir.text_mark_lines()
         self.assertLessEqual(len(mark), 3)
         self.assertIn("forge", "\n".join(mark))
@@ -99,24 +143,29 @@ class FallbackTests(unittest.TestCase):
         out = ir.TextMarkRenderer().renderable()
         self.assertIn("forge", out)
 
-    def test_real_renderer_falls_back_when_lib_missing(self) -> None:
-        # textual-image isn't installed in the test env → real renderer degrades
-        # to the text mark renderable (string), proving the fallback path.
+    def test_real_renderer_degrades_to_halfblock_when_lib_missing(self) -> None:
+        # textual-image isn't installed in the test env → the real renderer drops
+        # to the IMAGE-DERIVED half-block (tier 2), not straight to text.
+        from rich.text import Text
+
         out = ir.RealImageRenderer().renderable()
-        if isinstance(out, str):
+        if isinstance(out, Text):  # tier 2 half-block (expected without textual-image)
+            self.assertIn("▀", out.plain)
+        elif isinstance(out, str):  # only if Pillow/asset somehow gone → text mark
             self.assertIn("forge", out)
-        else:  # textual-image present → an Image renderable; just assert non-None
+        else:  # textual-image present → a real Image renderable
             self.assertIsNotNone(out)
 
-    def test_real_renderer_with_missing_asset_uses_text(self) -> None:
+    def test_halfblock_with_missing_asset_uses_text(self) -> None:
+        # ONLY when the image asset is missing does tier 2 fall through to text.
         orig = ir.best_image_path
-        ir_module = ir
-        ir_module.best_image_path = lambda: None  # type: ignore[assignment]
+        ir.best_image_path = lambda: None  # type: ignore[assignment]
         try:
-            out = ir.RealImageRenderer().renderable()
+            out = ir.HalfBlockRenderer().renderable()
+            self.assertIsInstance(out, str)
             self.assertIn("forge", out)
         finally:
-            ir_module.best_image_path = orig  # type: ignore[assignment]
+            ir.best_image_path = orig  # type: ignore[assignment]
 
 
 if __name__ == "__main__":

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -1,11 +1,14 @@
 """forgekit console TUI smoke — driven headlessly via Textual's pilot.
 
-Exercises the Claude-Code-style chat-first layout: small-avatar intro · quiet
-issue line · main panel (transcript XOR help view) · **fixed bottom composer
-(always visible)** · hint line. Verifies the composer stays present before AND
-after ``/help`` (the key fix), that ``/help`` is a single-panel VIEW SWITCH
-(transcript hidden, NOT appended, screen-stack length stays 1 → a panel not a
-modal), that Esc restores the transcript unchanged, that ``/exit`` quits, and
+Exercises the Claude-Code-style chat-first layout: small-avatar intro · then a
+top-aligned session flow of quiet issue line · main panel (transcript XOR help
+view) · **session-following inline composer (NOT docked to the viewport bottom)** ·
+hint line. Verifies the composer renders within/after the content flow (short
+session → composer near the top with empty space below; grown transcript →
+composer pushed down following the content), that it stays right below the help
+view when ``/help`` is open (the key fix), that ``/help`` is a single-panel VIEW
+SWITCH (transcript hidden, NOT appended, screen-stack length stays 1 → a panel not
+a modal), that Esc restores the transcript unchanged, that ``/exit`` quits, and
 palette open/Tab-complete/cycle/close. Skipped without textual.
 """
 
@@ -66,8 +69,12 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(app.query_one("#prompt", Input))
             self.assertIn("operator", str(app.query_one("#modepill", Static).render()))
 
-    async def test_composer_fixed_before_and_after_help(self) -> None:
-        """The composer (chat input) is ALWAYS visible + docked at the bottom — even with help open."""
+    async def test_composer_is_inline_not_docked_bottom(self) -> None:
+        """Composer is NOT dock:bottom — it flows inline right after the content.
+
+        On a short session it sits in the UPPER area with EMPTY space below (not
+        pinned to the viewport bottom, unlike the old footer).
+        """
         from textual.widgets import Input
         from forgekit_console.tui.composer import Composer
 
@@ -75,24 +82,56 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             composer = app.query_one("#composer", Composer)
-            # before help: visible + docked at the very bottom
+            # the composer carries NO dock (it is part of the inline session flow)
+            self.assertNotEqual(str(composer.styles.dock or "none").lower(), "bottom")
             self.assertTrue(composer.display)
             self.assertTrue(app.query_one("#prompt", Input).display)
-            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
-            # open help (switches the main area to the help VIEW)
+            # short session → composer near the TOP, empty space below (not pinned)
+            self.assertLess(composer.region.bottom, app.size.height - 2)
+            self.assertLess(composer.region.y, app.size.height // 2)
+
+    async def test_composer_follows_content_as_transcript_grows(self) -> None:
+        """As the transcript grows, the inline composer is pushed DOWN (follows content)."""
+        from forgekit_console.tui.composer import Composer
+
+        app = self._app()
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            composer = app.query_one("#composer", Composer)
+            short_y = composer.region.y
+            # write several transcript entries
+            for _ in range(30):
+                app._execute("/status")
+            await pilot.pause()
+            await pilot.pause()
+            # the composer moved down (content pushed it), still visible
+            self.assertGreater(composer.region.y, short_y)
+            self.assertTrue(composer.display)
+
+    async def test_composer_below_help_panel_when_help_open(self) -> None:
+        """When help is open the composer still sits right BELOW the help view."""
+        from textual.widgets import Input
+        from forgekit_console.tui.composer import Composer
+        from forgekit_console.tui.main_panel import MainPanel
+
+        app = self._app()
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            composer = app.query_one("#composer", Composer)
             app._execute("/help")
             await pilot.pause()
+            await pilot.pause()
             self.assertTrue(app._main.help_open)
-            # composer STILL visible + still docked at the bottom after help opened
             self.assertTrue(composer.display)
             self.assertTrue(app.query_one("#prompt", Input).display)
-            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
-            # and after closing help
+            # composer is below the help content (active content), not at viewport bottom
+            main = app.query_one("#main", MainPanel)
+            self.assertGreaterEqual(composer.region.y, main.region.bottom)
+            # close help → transcript restored, composer still visible below it
             await pilot.press("escape")
             await pilot.pause()
             self.assertFalse(app._main.help_open)
             self.assertTrue(composer.display)
-            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
 
     async def test_help_is_view_switch_not_transcript_append(self) -> None:
         """/help switches the main area to the help view; the transcript is hidden,
@@ -218,11 +257,13 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             self.assertEqual(app.mode, "operator")
 
-    async def test_topdown_order_intro_issue_transcript_hint_composer(self) -> None:
-        """Geometry smoke: widgets stack top→down with the composer at the bottom.
+    async def test_topdown_order_intro_issue_content_composer_hint(self) -> None:
+        """Geometry smoke: TOP-ALIGNED inline flow intro → issue → main → composer → hint.
 
         Stands in for an SVG snapshot (the CI sweep runs unittest, not the
         textual-snapshot pytest plugin): it asserts the y-order of the regions.
+        The composer renders right after the content (inline), NOT docked at the
+        viewport bottom — so on a short session it leaves empty space below.
         """
         from textual.widgets import Static
         from forgekit_console.tui.composer import Composer
@@ -235,15 +276,15 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             intro = app.query_one("#intro", IntroHeader).region
             issue = app.query_one("#issue", Static).region
             log = app.query_one("#main", MainPanel).region
-            hint = app.query_one("#hint", Static).region
             composer = app.query_one("#composer", Composer).region
-            # top → down: intro above issue above transcript; composer is last
+            hint = app.query_one("#hint", Static).region
+            # top → down: intro · issue · content · composer · hint (composer inline)
             self.assertLessEqual(intro.y, issue.y)
             self.assertLessEqual(issue.y, log.y)
-            self.assertLess(log.y, composer.y)
-            self.assertLessEqual(hint.y, composer.y)
-            # composer is docked at the very bottom of the screen
-            self.assertGreaterEqual(composer.bottom, app.size.height - 1)
+            self.assertLessEqual(log.bottom, composer.y)
+            self.assertLessEqual(composer.bottom, hint.y)
+            # composer is NOT pinned to the viewport bottom on a short session
+            self.assertLess(composer.bottom, app.size.height - 2)
 
     async def test_intro_avatar_renderer_selected(self) -> None:
         from forgekit_console.tui.header import IntroHeader
@@ -253,8 +294,11 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
         async with app.run_test() as pilot:
             await pilot.pause()
             intro = app.query_one("#intro", IntroHeader)
-            # whichever the headless terminal selected, it is one of the two
-            self.assertIn(intro.avatar_renderer_id, (ir.RENDERER_REAL, ir.RENDERER_TEXT))
+            # whichever the headless terminal selected, it is one of the three tiers
+            self.assertIn(
+                intro.avatar_renderer_id,
+                (ir.RENDERER_REAL, ir.RENDERER_HALFBLOCK, ir.RENDERER_TEXT),
+            )
 
     async def test_intro_block_renders_avatar_and_meta(self) -> None:
         """The compact intro block mounts: avatar column (left) + brand/version/


### PR DESCRIPTION
## 목적
forgekit 콘솔 2가지 교정: (1) 채팅바를 viewport 하단 고정 footer → Claude식 session-following inline composer, (2) intro 에 실제 대표 이미지(헤드폰 line-art) image-first 렌더.

## 범위
- **composer**: `dock:bottom` 제거 → `tui/session_flow.py`(top-aligned VerticalScroll: issue → main panel → composer → hint, content height auto). composer 가 active content 바로 아래. 짧은 세션이면 상단 근처(아래 빈 공간), 길어지면 따라 내려가며 follow_tail 자동 스크롤. help 열려도 help panel 아래.
- **image**: 3-tier 우선순위 — (1) textual-image 실 raster(graphics 터미널), (2) NEW `tui/halfblock.py` 베이크 PNG→half-block image-derived 렌더(텍스트 아님), (3) text mark 최후. capability 검출에 VS Code(TERM_PROGRAM=vscode)/iTerm2/Kitty/Sixel 포함.
- help panel 구조 유지, /exit 유지.

## 리스크
- 실 raster 는 graphics-capable 터미널 + `[console]` extra 필요(미지원 시 tier-2 half-block). headless 검증은 geometry pilot + 단위 테스트.

## 테스트
- forgekit 164 tests, 전체 sweep 5969 tests, 신규 회귀 0(사전 환경 5 errors 무관). pilot: 짧은 세션 composer 상단·긴 세션 따라 내려감 확인. governance·파일크기 OK, yule/forgekit 무손상.

## Audit
- 한국어 gitmoji 3섹션, Co-Authored-By 없음, 명시 pathspec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)