### PR TITLE
📝 instruction 아키텍처 vendor-neutral 정리 — AGENTS=navigation, CLAUDE=공통 SSoT, GEMINI=thin projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,26 +70,27 @@ docs/
 - 새 규칙을 추가할 때는 "자주 강제해야 하면 상위, 도메인 한정이면 하위" 를
   지켜 같은 규칙이 여러 문서에 흩어지지 않게 한다.
 
-## 3. 외부 에이전트별 역할 안내
+## 3. provider 별 진입 — 누가 메인이든 같은 경로
 
-### Codex (이 파일이 진입점)
-- 기본은 **advisor / reviewer / patch proposer**. executor 역할은 작업이
-  명시할 때만.
-- 코드 리뷰, 구현 위험 분석, 테스트 중심 피드백, 패치 제안을 우선한다.
-- 사용자의 명시적 승인 없이 파일 수정, 파괴적 명령 실행, secret 접근을
-  하지 않는다.
-- engineering-agent 작업 시 `agents/engineering-agent/agent.json` 과
-  관련 정책 파일이 존재하면 이를 따른다.
-- `.codex/` 는 로컬 실행 설정이며 공유 정책으로 다루지 않는다.
+**규칙 본문은 어느 provider 문서에도 복제하지 않는다.** 메인 provider 가
+무엇이든 읽기 순서는 동일하다: **이 파일(`AGENTS.md`) → root `CLAUDE.md`(공통 규칙
+SSoT) → 작업 맥락 문서(§2)**. provider 문서는 "진입 + 기본 역할"만 얇게 둔다.
 
-### Claude (Claude Code / API)
-- root `CLAUDE.md` + 작업 맥락의 agent `CLAUDE.md` 가 일차 컨텍스트.
-- 작업이 코드 구조 변경을 동반하면 `agents/engineering-agent/CODE_LAYOUT.md`
-  를 함께 읽는다.
+| provider | native 진입 파일 | 역할 안내 |
+| --- | --- | --- |
+| **Codex** | `AGENTS.md` (이 파일) | 기본 advisor / reviewer / patch proposer. executor 는 작업이 명시할 때만. |
+| **Claude** | `CLAUDE.md` (= 공통 규칙 SSoT) | root `CLAUDE.md` + 작업 맥락 agent `CLAUDE.md` 가 일차 컨텍스트. |
+| **Gemini** | [`GEMINI.md`](GEMINI.md) (얇은 projection → `CLAUDE.md`) | 기본 advisor — 분석 / 긴 맥락 / 계획 보조. |
 
-### Gemini CLI
-- 기본은 **advisor**. 분석 / 요구사항 검토 / 긴 맥락 검토 / 계획 보조 우선.
-- 자세한 역할 컨텍스트는 [`GEMINI.md`](GEMINI.md) 참고.
+- 안전/승인/파괴적 명령 등 **공통 규칙은 모두 root `CLAUDE.md`** 에 있다(provider 무관).
+- skill projection: Claude `.claude/skills/` · Codex `.agents/skills/` · Gemini
+  `.gemini/commands/` — SSoT 는 `skills/<id>.md` + grants, 손편집 금지([`docs/agent-slash-commands.md`](docs/agent-slash-commands.md)).
+- `.codex/` / `.gemini/` 등은 로컬 실행 설정이며 공유 정책이 아니다.
+
+> **`CODEX.md` 를 따로 두지 않는다.** `AGENTS.md` 가 곧 Codex 의 native 진입
+> 파일이라 별도 wrapper 는 같은 역할을 중복할 뿐이다 — Codex 사용자는 이 파일에서
+> 바로 root `CLAUDE.md` 로 라우팅된다. (provider 가 늘어도 같은 패턴: native 진입
+> 파일은 얇게, 규칙은 `CLAUDE.md` 한 곳.)
 
 ## 4. 변경 시 반드시 동기화할 것
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,11 @@
 > 진입점은 [`AGENTS.md`](AGENTS.md). 본 파일은 **모든 에이전트 / 모든 작업
 > 에 적용되는 전역 공통 규칙** 만 둔다. 도메인 한정 규칙은
 > `agents/<agent>/CLAUDE.md` 또는 `docs/<topic>.md` 에 둔다.
+>
+> **이 파일은 vendor-neutral 공통 규칙의 SSoT 다.** 파일명은 `CLAUDE.md` 지만
+> Claude 전용이 아니라 **Codex / Claude / Gemini 모두가 공유**하는 전역 규칙 본문이다.
+> 어떤 provider 를 메인으로 쓰든 `AGENTS.md` → 본 파일 → 작업 맥락 문서 순으로 읽는다.
+> 공통 규칙은 **여기 한 곳에만** 두고 provider 문서(`GEMINI.md` 등)는 본 파일을 참조만 한다.
 
 ## Purpose
 이 레포지토리는 여러 GitHub 프로젝트의 이슈, 문서, 작업 흐름을 관리하는

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,24 +3,21 @@
 This file provides Gemini CLI context for this repository.  
 (이 파일은 Gemini CLI가 이 레포지토리의 작업 맥락을 이해하기 위한 컨텍스트 파일이다)
 
-Shared project rules are defined in `CLAUDE.md`.  
-(공통 프로젝트 규칙은 `CLAUDE.md`에 정의되어 있다)
+**Entry order (any main provider is the same):** `AGENTS.md` → root `CLAUDE.md` → context docs.
+This file is a THIN projection — it adds only Gemini's default role. **All shared rules
+(safety / approval / coding / git / sync) live in `CLAUDE.md` — not duplicated here.**  
+(공통 규칙은 `CLAUDE.md` 한 곳에만 있다 — 여기 복제하지 않는다)
 
 @./CLAUDE.md
 
-## Gemini Role
+## Gemini Role (projection only)
 
-- Treat Gemini as an advisor by default unless a task explicitly assigns it as an executor.  
-  (작업에서 명시적으로 executor 역할을 부여하지 않는 한, Gemini는 기본적으로 advisor로 동작한다)
-
-- Prefer analysis, requirement review, long-context review, and planning support.  
-  (분석, 요구사항 검토, 긴 맥락 검토, 계획 보조를 우선한다)
-
-- Do not modify files, run destructive commands, or access secrets unless explicitly approved by the user.  
-  (사용자의 명시적 승인 없이 파일 수정, 파괴적 명령 실행, 민감 정보 접근을 하지 않는다)
-
-- When working on the Engineering Agent, follow `agents/engineering-agent/agent.json` and the relevant policy files if they exist.  
-  (Engineering Agent 작업 시 `agents/engineering-agent/agent.json`과 관련 정책 파일이 존재하면 이를 따른다)
+- Default **advisor** unless a task explicitly assigns executor.  
+  (명시적 executor 부여가 없으면 기본 advisor)
+- Prefer analysis, requirement review, long-context review, planning support.  
+  (분석 / 요구사항 검토 / 긴 맥락 검토 / 계획 보조 우선)
+- Everything else (file edits, destructive commands, secrets, approval gates, engineering-agent
+  policy) follows the shared rules in `CLAUDE.md` + the context docs routed by `AGENTS.md`.
 
 ## Custom commands (generated projection)
 


### PR DESCRIPTION
## 목적
instruction 계층을 vendor-neutral 하게 고정: 진입점/공통 규칙 SSoT/얇은 projection 역할을 명확히.

## 범위 (최소 수정)
- **root CLAUDE.md**(파일명 유지): "vendor-neutral 공통 규칙 SSoT — Codex/Claude/Gemini 공유" 명시. 어느 provider 메인이든 AGENTS→CLAUDE→맥락 순.
- **AGENTS.md §3**: provider별 진입 표(Codex=AGENTS native / Claude=CLAUDE / Gemini=GEMINI), 규칙은 root CLAUDE 한 곳. **CODEX.md 안 만드는 이유 명시** — AGENTS.md 가 곧 Codex native 진입이라 wrapper 는 중복.
- **GEMINI.md**: 중복 안전 규칙 제거 → CLAUDE.md 참조, projection-only.

## 결과 계층
- AGENTS.md = navigation(+Codex native 진입)
- root CLAUDE.md = vendor-neutral shared rules SSoT(+Claude native 진입)
- agents/<agent>/CLAUDE.md = scoped(root 복제 없음)
- GEMINI.md = thin projection. CODEX.md 없음(의도).

## 테스트
- 전체 sweep 5969 tests, 신규 회귀 0(사전 환경 5 errors 무관). docs-hierarchy governance OK. 파일크기 AGENTS 105/CLAUDE 125/GEMINI 31.

## Audit
- 한국어 gitmoji 3섹션, Co-Authored-By 없음, 명시 pathspec. 공통 규칙 복제 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)