### PR TITLE
🔍 forgekit 아바타/브랜드 렌더 경로 진단 (FORGEKIT_DEBUG_RENDERERS)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/tui/header.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/header.py
@@ -43,6 +43,11 @@ class IntroHeader(Vertical):
         height: auto;
         padding: 0 0 0 1;
     }
+    IntroHeader #intro-renderers {
+        height: auto;
+        padding: 0 0 0 1;
+        color: $text-muted;
+    }
     """
 
     def __init__(
@@ -89,6 +94,11 @@ class IntroHeader(Vertical):
                 ),
                 id="intro-meta",
             )
+        # opt-in diagnostic: SELECTED→REALIZED renderer ids (FORGEKIT_DEBUG_RENDERERS).
+        # Off by default — no chrome unless explicitly enabled.
+        if image_renderer.debug_renderers_enabled():
+            diag = image_renderer.diagnose_renderers()
+            yield Static(render.renderer_debug_line(diag), id="intro-renderers")
 
 
 __all__ = ("IntroHeader",)

--- a/apps/forgekit-console/src/forgekit_console/tui/image_renderer.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/image_renderer.py
@@ -59,6 +59,12 @@ RENDERER_TEXT = "text-mark"  # tier 3 — last-resort text/logo mark
 #   FORGEKIT_AVATAR=text   → force text mark
 _FORCE_ENV = "FORGEKIT_AVATAR"
 
+# Diagnostic flag: when set, the intro shows the SELECTED→REALIZED renderer ids so
+# an operator can tell at a glance whether the real inline image actually rendered
+# or silently degraded. Off by default (no chrome).
+#   FORGEKIT_DEBUG_RENDERERS=1
+_DEBUG_ENV = "FORGEKIT_DEBUG_RENDERERS"
+
 # Terminals/protocols known to support inline graphics. Detection is heuristic
 # (textual-image does the real protocol probing at render time); this gates the
 # *attempt* so a plain terminal never even tries.
@@ -372,6 +378,93 @@ def make_renderer(
     return TextMarkRenderer()
 
 
+# --- diagnostics (FORGEKIT_DEBUG_RENDERERS) --------------------------------
+#
+# Why selected≠realized matters: detection/selection can pick ``real-image`` while
+# the actual ``renderable()`` silently degrades a tier (textual-image missing/
+# incompatible, asset unreadable, raster construction fails). The selected id alone
+# would mislead — these helpers expose what is REALLY on screen vs what was chosen,
+# so an operator can split "asset problem" from "renderer/terminal path problem".
+
+
+def debug_renderers_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """True when ``FORGEKIT_DEBUG_RENDERERS`` is set truthy. Pure given *env*."""
+
+    environ = os.environ if env is None else env
+    return (environ.get(_DEBUG_ENV) or "").strip().lower() in ("1", "true", "on", "yes")
+
+
+def real_image_support() -> Tuple[bool, str]:
+    """Probe whether ``textual-image`` can actually import its inline raster.
+
+    Returns ``(ok, reason)``. This is the import that the real renderers attempt at
+    render time; when it fails (e.g. textual-image needs Python ≥3.10 for
+    ``types.NoneType``) EVERY terminal degrades regardless of its graphics support.
+    """
+
+    try:
+        from textual_image.renderable import Image as _Probe  # noqa: F401,WPS433
+    except Exception as exc:  # noqa: BLE001 - any import failure → no real raster
+        return False, f"{type(exc).__name__}: {exc}"
+    return True, "textual-image import ok"
+
+
+def realized_avatar_id(renderable) -> str:
+    """Classify an avatar ``renderable()`` result back into its actual tier."""
+
+    from rich.text import Text  # noqa: WPS433 - rich is a textual dep, always present
+
+    if isinstance(renderable, str):
+        return RENDERER_TEXT  # tier 3 text mark
+    if isinstance(renderable, Text):
+        return RENDERER_HALFBLOCK  # tier 2 image-derived half-block
+    return RENDERER_REAL  # a textual-image Image renderable (tier 1)
+
+
+def realized_brand_id(renderable) -> str:
+    """Classify a brand ``renderable()`` result back into its actual tier."""
+
+    # brand has no half-block tier: a str is the text wordmark, anything else is
+    # the real inline banner image.
+    return RENDERER_BRAND_TEXT if isinstance(renderable, str) else RENDERER_BRAND_IMAGE
+
+
+@dataclass(frozen=True)
+class RendererDiagnostics:
+    """What was selected vs what actually rendered, for the debug line."""
+
+    avatar_selected: str
+    avatar_realized: str
+    brand_selected: str
+    brand_realized: str
+    capability_reason: str
+    raster_ok: bool
+    raster_reason: str
+
+
+def diagnose_renderers(env: Optional[Mapping[str, str]] = None) -> RendererDiagnostics:
+    """Build the renderer diagnostics for *env* (defaults to the live environment).
+
+    Mirrors exactly what the intro panels do (same ``make_renderer`` /
+    ``make_brand_renderer`` selection), then renders once more to capture the
+    REALIZED tier — so the debug line reflects the real screen, not just intent.
+    """
+
+    cap = detect_image_capability(env)
+    avatar = make_renderer(env=env)
+    brand = make_brand_renderer(env=env)
+    raster_ok, raster_reason = real_image_support()
+    return RendererDiagnostics(
+        avatar_selected=avatar.renderer_id,
+        avatar_realized=realized_avatar_id(avatar.renderable()),
+        brand_selected=brand.renderer_id,
+        brand_realized=realized_brand_id(brand.renderable()),
+        capability_reason=cap.reason,
+        raster_ok=raster_ok,
+        raster_reason=raster_reason,
+    )
+
+
 __all__ = (
     "RENDERER_REAL",
     "RENDERER_HALFBLOCK",
@@ -389,6 +482,12 @@ __all__ = (
     "select_renderer",
     "make_renderer",
     "make_brand_renderer",
+    "debug_renderers_enabled",
+    "real_image_support",
+    "realized_avatar_id",
+    "realized_brand_id",
+    "RendererDiagnostics",
+    "diagnose_renderers",
     "text_mark_lines",
     "brand_wordmark_lines",
     "assets_dir",

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -57,6 +57,34 @@ def intro_meta_lines(
     )
 
 
+def renderer_debug_line(diag) -> str:
+    """A small dim diagnostic line: SELECTED→REALIZED avatar/brand renderers.
+
+    Only shown when ``FORGEKIT_DEBUG_RENDERERS`` is set. When the realized tier
+    differs from the selected one (a silent degrade) it is shown as
+    ``selected→realized`` so the operator immediately sees the real image did NOT
+    render. The terminal's capability reason and (if the real raster is
+    unavailable) the import failure are appended — that splits "asset problem"
+    from "renderer/terminal path problem" at a glance. Pure: takes a
+    :class:`tui.image_renderer.RendererDiagnostics`-shaped object, returns markup.
+    """
+
+    def tier(selected: str, realized: str) -> str:
+        return realized if selected == realized else f"{selected}→{realized}"
+
+    parts = [
+        f"avatar={tier(diag.avatar_selected, diag.avatar_realized)}",
+        f"brand={tier(diag.brand_selected, diag.brand_realized)}",
+        f"cap={diag.capability_reason}",
+    ]
+    if not diag.raster_ok:
+        reason = diag.raster_reason
+        if len(reason) > 56:
+            reason = reason[:55] + "…"
+        parts.append(f"raster✗ {reason}")
+    return f"[dim]renderers · {' · '.join(parts)}[/dim]"
+
+
 def issue_line(summary: StatusSummary) -> str:
     """The compact setup/status line under the intro — text-first, one line.
 
@@ -295,7 +323,7 @@ def result_block(title: str, lines: Sequence[str]) -> Tuple[str, ...]:
 
 __all__ = (
     "BRAND", "TAGLINE",
-    "welcome_banner", "intro_meta_lines", "issue_line", "agent_pane_lines",
+    "welcome_banner", "intro_meta_lines", "renderer_debug_line", "issue_line", "agent_pane_lines",
     "status_pane_lines",
     "palette_lines", "palette_panel_lines", "mode_badge", "mode_pill",
     "status_pill", "hint_line", "help_sections",

--- a/docs/forgekit-console.md
+++ b/docs/forgekit-console.md
@@ -104,6 +104,58 @@ crop+보정을 거친 display asset 을 따로 두는 것이다.
   **추상화 + capability 검출 + 3-tier fallback 로직 + 레이아웃 구조** 를 보장하고,
   우선순위(real → image-derived half-block → text)를 명시한다.
 
+### 렌더 경로 진단 — `FORGEKIT_DEBUG_RENDERERS`
+
+아바타/브랜드가 "깨져 보일" 때 원인이 **에셋**인지 **렌더 경로(터미널/라이브러리)**인지
+가르려면, 선택(selected)과 실제 렌더(realized)를 동시에 봐야 한다. selected 는 capability
+검출이 고른 tier 이고, realized 는 `renderable()` 이 실제로 만든 tier 다. 둘이 다르면
+**조용한 degrade** 가 일어난 것이다(real 로 골랐지만 화면엔 half-block).
+
+```bash
+# 평상시(진단 off): 아무 chrome 없음
+.venv/bin/forgekit
+
+# 진단 on: intro 아래 작은 dim 한 줄로 selected→realized 노출
+FORGEKIT_DEBUG_RENDERERS=1 .venv/bin/forgekit
+```
+
+표시 형태(예):
+
+```
+renderers · avatar=real-image→half-block · brand=brand-image→brand-text · cap=term_program=vscode · raster✗ ImportError: cannot import name 'NoneType' …
+```
+
+- `avatar=real-image→half-block` : real 로 선택됐지만 실제론 half-block 으로 떨어짐(조용한 degrade).
+  화살표가 없으면(`avatar=real-image`) selected==realized — 정상.
+- `cap=…` : capability 검출 사유(예 `term_program=vscode`, `no known graphics protocol`).
+- `raster✗ …` : `textual-image` 의 inline-raster import 가 실패한 이유. 이게 떠 있으면
+  **터미널이 무엇이든** tier-1 real 이미지는 안 나오고 전부 half-block/text 로 degrade 한다.
+
+구현: `image_renderer.diagnose_renderers()`(selected/realized/capability/raster 진단 묶음) +
+`render.renderer_debug_line()`(순수 문자열 빌더) + `IntroHeader` 가 flag on 일 때만 한 줄을
+mount. 코드는 `image_renderer.realized_avatar_id` / `realized_brand_id` 로 `renderable()`
+결과를 tier 로 역분류한다.
+
+#### 터미널별 확인 절차 (cross-terminal)
+
+같은 빌드를 서로 다른 터미널에서 돌려 `realized` 가 바뀌는지 비교한다.
+
+- **VS Code 통합 터미널**: `TERM_PROGRAM=vscode` 라 capability 는 `real-image` 를 고른다.
+  `FORGEKIT_DEBUG_RENDERERS=1 .venv/bin/forgekit` 로 `avatar=` 가 `real-image` 그대로인지,
+  아니면 `real-image→half-block` 인지 본다. `raster✗` 가 떠 있으면 터미널과 무관하게
+  `textual-image` 가 import 안 되는 것이다(아래 Python 버전 주의 참고).
+- **iTerm2 / WezTerm**: 같은 명령을 그 터미널에서 실행한다. capability 는 각각
+  `iterm2 inline images` / `term_program=wezterm` 로 잡힌다. `textual-image` 가 정상 import
+  되는 인터프리터라면 여기서 `avatar=real-image`(화살표 없음)로 바뀌어야 한다 — 즉
+  **VS Code 에서 half-block 이던 게 여기선 real 이미지로 바뀌면** 원인은 에셋이 아니라
+  터미널/라이브러리 경로다.
+
+> **Python 버전 주의(이 레포 `.venv` 의 현 상태):** `textual-image` 는 Python ≥3.10
+> 을 요구한다(`types.NoneType`). 현재 `.venv` 가 3.9 면 어느 터미널이든 inline-raster
+> import 가 실패해 `raster✗` 가 뜨고 전부 half-block/text 로 degrade 한다. 이때는
+> **에셋 문제가 아니라** Python/의존성 호환 문제다 — `.[console]` extra 를 3.10+
+> 인터프리터에 설치해야 tier-1 real 이미지가 산다.
+
 ## 3. 화면 구성 (Claude Code chat-first 위→아래 흐름)
 
 Claude Code 터미널 UI 처럼 **intro → issue line → 본문(main panel) → inline composer → hint**

--- a/tests/forgekit/test_image_renderer.py
+++ b/tests/forgekit/test_image_renderer.py
@@ -203,6 +203,51 @@ class FallbackTests(unittest.TestCase):
             ir.best_image_path = orig  # type: ignore[assignment]
 
 
+class DiagnosticsTests(unittest.TestCase):
+    """FORGEKIT_DEBUG_RENDERERS — selected vs realized renderer ids."""
+
+    def test_debug_flag_reads_env(self) -> None:
+        self.assertFalse(ir.debug_renderers_enabled({}))
+        self.assertFalse(ir.debug_renderers_enabled({"FORGEKIT_DEBUG_RENDERERS": "0"}))
+        for on in ("1", "true", "on", "yes", "TRUE"):
+            self.assertTrue(ir.debug_renderers_enabled({"FORGEKIT_DEBUG_RENDERERS": on}), on)
+
+    def test_realized_avatar_classifies_each_tier(self) -> None:
+        from rich.text import Text
+
+        self.assertEqual(ir.realized_avatar_id("forge\nkit"), ir.RENDERER_TEXT)
+        self.assertEqual(ir.realized_avatar_id(Text("▀▀")), ir.RENDERER_HALFBLOCK)
+        # any non-str/non-Text object is treated as the real inline raster
+        self.assertEqual(ir.realized_avatar_id(object()), ir.RENDERER_REAL)
+
+    def test_realized_brand_classifies_text_vs_image(self) -> None:
+        self.assertEqual(ir.realized_brand_id("forgekit"), ir.RENDERER_BRAND_TEXT)
+        self.assertEqual(ir.realized_brand_id(object()), ir.RENDERER_BRAND_IMAGE)
+
+    def test_real_image_support_returns_reason(self) -> None:
+        ok, reason = ir.real_image_support()
+        self.assertIsInstance(ok, bool)
+        self.assertTrue(reason)  # always explains, pass or fail
+
+    def test_diagnose_renderers_fields_are_known_ids(self) -> None:
+        # env-portable: don't assert raster_ok (python-version dependent), only that
+        # the structure is coherent and ids are from the known vocabulary.
+        diag = ir.diagnose_renderers({"TERM_PROGRAM": "iterm.app"})
+        self.assertIn(diag.avatar_selected, (ir.RENDERER_REAL, ir.RENDERER_HALFBLOCK, ir.RENDERER_TEXT))
+        self.assertIn(diag.avatar_realized, (ir.RENDERER_REAL, ir.RENDERER_HALFBLOCK, ir.RENDERER_TEXT))
+        self.assertIn(diag.brand_selected, (ir.RENDERER_BRAND_IMAGE, ir.RENDERER_BRAND_TEXT))
+        self.assertIn(diag.brand_realized, (ir.RENDERER_BRAND_IMAGE, ir.RENDERER_BRAND_TEXT))
+        self.assertTrue(diag.capability_reason)
+
+    def test_diagnose_reflects_forced_text_selection(self) -> None:
+        diag = ir.diagnose_renderers({"FORGEKIT_AVATAR": "text"})
+        # forced text → selection is the half-block tier (the not-capable branch),
+        # and it realizes as half-block (asset present) — never the real raster.
+        self.assertEqual(diag.avatar_selected, ir.RENDERER_HALFBLOCK)
+        self.assertEqual(diag.brand_selected, ir.RENDERER_BRAND_TEXT)
+        self.assertNotEqual(diag.avatar_realized, ir.RENDERER_REAL)
+
+
 class BrandBannerTests(unittest.TestCase):
     """The intro brand mark: REAL inline banner image first, else text wordmark."""
 

--- a/tests/forgekit/test_render.py
+++ b/tests/forgekit/test_render.py
@@ -190,6 +190,52 @@ class IntroMetaTests(unittest.TestCase):
         self.assertIn("forge", "\n".join(lines))
 
 
+class _Diag:
+    """Minimal RendererDiagnostics-shaped stub for the debug-line builder."""
+
+    def __init__(self, av_sel, av_real, br_sel, br_real, cap, raster_ok, raster_reason=""):
+        self.avatar_selected = av_sel
+        self.avatar_realized = av_real
+        self.brand_selected = br_sel
+        self.brand_realized = br_real
+        self.capability_reason = cap
+        self.raster_ok = raster_ok
+        self.raster_reason = raster_reason
+
+
+class RendererDebugLineTests(unittest.TestCase):
+    def test_healthy_shows_plain_realized_ids_no_arrow(self) -> None:
+        # selected == realized → no arrow, no raster failure tail
+        line = render.renderer_debug_line(
+            _Diag("real-image", "real-image", "brand-image", "brand-image",
+                  "kitty graphics protocol", True, "textual-image import ok")
+        )
+        self.assertIn("avatar=real-image", line)
+        self.assertIn("brand=brand-image", line)
+        self.assertNotIn("→", line)
+        self.assertNotIn("raster", line)
+        self.assertIn("cap=kitty graphics protocol", line)
+
+    def test_silent_degrade_shows_arrow_and_raster_failure(self) -> None:
+        # selected real but realized fallback → arrow exposes the silent degrade
+        line = render.renderer_debug_line(
+            _Diag("real-image", "half-block", "brand-image", "brand-text",
+                  "term_program=vscode", False, "ImportError: cannot import name 'NoneType'")
+        )
+        self.assertIn("avatar=real-image→half-block", line)
+        self.assertIn("brand=brand-image→brand-text", line)
+        self.assertIn("cap=term_program=vscode", line)
+        self.assertIn("raster✗", line)
+
+    def test_long_raster_reason_truncated(self) -> None:
+        line = render.renderer_debug_line(
+            _Diag("real-image", "half-block", "brand-image", "brand-text",
+                  "term_program=vscode", False, "X" * 200)
+        )
+        self.assertIn("…", line)
+        self.assertLess(len(line), 200)
+
+
 class IssueLineTests(unittest.TestCase):
     def _summary(self, **over):
         base = dict(title="op", sections=(StatusSection("provider", ("ok",)),), alerts=())

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -358,6 +358,35 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
         # text fallback is the clean cyan→magenta wordmark on its own
         self.assertIn("forge", plain.renderable())
 
+    async def test_renderer_debug_line_hidden_by_default(self) -> None:
+        """No diagnostic chrome unless FORGEKIT_DEBUG_RENDERERS is set."""
+        import os
+        from unittest import mock
+        from textual.css.query import NoMatches
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FORGEKIT_DEBUG_RENDERERS", None)
+            app = self._app()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                with self.assertRaises(NoMatches):
+                    app.query_one("#intro-renderers")
+
+    async def test_renderer_debug_line_shown_when_flag_set(self) -> None:
+        """With the flag on, the intro shows a SELECTED→REALIZED renderer line."""
+        import os
+        from unittest import mock
+        from textual.widgets import Static
+
+        with mock.patch.dict(os.environ, {"FORGEKIT_DEBUG_RENDERERS": "1"}):
+            app = self._app()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                line = str(app.query_one("#intro-renderers", Static).render())
+                self.assertIn("renderers", line)
+                self.assertIn("avatar=", line)
+                self.assertIn("brand=", line)
+
     async def test_intro_block_renders_avatar_and_meta(self) -> None:
         """The compact intro block mounts: avatar column (left) + brand/version/
         provider/profile/repo meta (right)."""


### PR DESCRIPTION
## 목적
forgekit 아바타/브랜드 이미지가 왜 깨져 보이는지 **렌더 경로만 진단**한다. UI
리디자인/composer 수정 아님. flag 로 selected→realized 렌더러 id 를 노출해 원인을
asset vs renderer/terminal path 로 가른다.

## 범위
- `image_renderer`: `debug_renderers_enabled` · `real_image_support`(textual-image
  import probe) · `realized_avatar_id`/`realized_brand_id`(renderable→tier 역분류) ·
  `RendererDiagnostics`/`diagnose_renderers`.
- `render.renderer_debug_line`(순수) + `IntroHeader` 가 flag on 일 때만 한 줄 mount.
- 테스트 + 문서(터미널별 확인 절차).

## 진단 결과 (핵심)
현재 `.venv`(Python 3.9) + VS Code 통합 터미널에서:
```
renderers · avatar=real-image→half-block · brand=brand-image→brand-text · cap=term_program=vscode · raster✗ ImportError: cannot import name 'NoneType' …
```
- capability 검출은 vscode 를 **capable** 로 보고 `real-image` 를 고른다(정상).
- 그러나 `textual-image` 의 inline-raster import 가 **Python ≥3.10**(`types.NoneType`)
  을 요구 → 3.9 venv 에서 import 실패 → **모든 터미널이** half-block/text 로 조용히 degrade.
- 즉 핵심 원인은 **asset 도 capability 검출도 아니고, 의존성/Python 버전 호환(렌더 경로)**.

## 리스크
- 매우 낮음. 진단 표시 추가만 — 렌더 선택 로직/asset/composer 불변. 기본 off.

## 테스트
- forgekit 196 그린(1 skip=TUI). 신규 회귀: debug flag·realized 역분류·degrade
  화살표·pilot 로 flag on/off 시 #intro-renderers 유무.
- 전체 sweep 6001: 기존 환경 의존 실패 5건만(digest_crawler ×4 / gateway_shutdown ×1).

## 이슈 linkage
- 후속(별도): terminal capability 대응 — `.[console]` extra 를 3.10+ 인터프리터에 설치해
  tier-1 real 이미지 검증. asset 재수정은 불필요.

## audit
- 명시 pathspec 만 stage, broad add 없음. 3 commit 논리 분할(진단 core·표시 wiring·테스트/문서).
- 가장 가능성 높은 경로 = terminal/library path(Python 3.9 ↔ textual-image 비호환), asset 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)