### PR TITLE
forgekit #241 daemon autopilot execution wiring

### DIFF
--- a/apps/forgekit-console/examples/runtime/README.md
+++ b/apps/forgekit-console/examples/runtime/README.md
@@ -12,8 +12,12 @@ forgekit runtime stop                                                     # kill
 ```
 
 ## 무엇이 bounded autonomy 인가 (정직)
-- 각 tick = **관측(repo-local) → 분류 → 패킷 → handoff → 대기**(runtime/loop BoundedRuntimeLoop, execute phase 없음).
-- privileged(deploy/secret/infra)는 **runbook + approval-wait** — 데몬이 자동 실행 안 함.
+- 각 tick = **관측(repo-local) → 내부 승인 chain(PM→gateway→tech-lead) → safe-class 실제 실행
+  (BoundedMutator, write+verify) → 기록**(#241, `runtime/autopilot_tick.py`). 관측-only 가 아니다 —
+  실측: `daemon-execution/`.
+- 실행 클래스 = note/docs-stub/format + `runs/`·`docs/`·`examples/` prefix **만**(소스 코드 수정은 #240).
+  cross-tick **dedupe**(no-op churn 방지) + 반복 verify 실패 시 **cooldown**.
+- privileged(deploy/secret/infra) / risky / restricted 는 **runbook + approval-wait** — 데몬이 자동 실행 안 함, surface 만.
 - 매 tick **heartbeat** 기록(`$FORGEKIT_HOME/state/runtime-heartbeat.json`), approval-needed → **operator 알림**
   (inbox 항상 + desktop `FORGEKIT_NOTIFY` opt-in, 2 surface).
 - 종료: kill switch 파일 / SIGTERM·SIGINT / `--max-ticks`.

--- a/apps/forgekit-console/examples/runtime/daemon-execution/README.md
+++ b/apps/forgekit-console/examples/runtime/daemon-execution/README.md
@@ -1,0 +1,26 @@
+# daemon ↔ autopilot execution — evidence (#241, WT2)
+
+always-on 데몬이 **관측만** 하던 것을 넘어, 매 tick 에서 **bounded safe-class 실행**을
+실제로 수행한다는 실측 증거.
+
+| 파일 | 무엇 |
+| --- | --- |
+| `serve-log.txt` | 실 `forgekit runtime serve --max-ticks 2` 출력 — exec 3 / waits 2 |
+| `sample-executed-note.md` | tick 이 **실제로 쓴** safe-class note 1개(실 finding 기반) |
+| `heartbeat-after-serve.json` | 종료 후 heartbeat 스냅샷 |
+
+## 무엇이 일어났나 (정직)
+- tick = 관측(repo-local) → 내부 승인 chain(PM→gateway→tech-lead) → **safe-class 만** 실제 mutation
+  (`BoundedMutator`, write+verify) → 기록.
+- tick 1: **exec 3**(실 파일 3개 write+verify) + propose 1 — "운영/배포 준비 점검"(L4 restricted)은
+  실행하지 않고 **surface 만**(waiting → operator 알림).
+- tick 2: 같은 finding 은 **dedupe** → exec 0 (idempotent note 의 no-op churn 방지).
+
+## 경계 (intentionally bounded / 정직)
+- 실행 클래스 = note/docs-stub/format **만**, 경로 = `runs/`/`docs/`/`examples/` prefix **만**(`BoundedMutator`).
+  **소스 코드 수정은 #240 범위**(이 데몬도 그 한도를 따른다).
+- risky/restricted/blocked = 자동 실행 **안 함** → inbox+console+desktop(≥2 surface) 알림.
+- **single executor invariant**: 한 tick 안에서 ExecutorArbiter 단일 슬롯(serial).
+- **dedupe 는 in-session**: 프로세스 재시작 후 같은 note 는 이미 존재 → no-op → 정직히 propose/halt 로 surface
+  (fake success 아님). 영속 dedupe 는 후속.
+- macOS sleep 시 프로세스 suspend(상시 가동은 homeserver/systemd 1급, #243).

--- a/apps/forgekit-console/examples/runtime/daemon-execution/heartbeat-after-serve.json
+++ b/apps/forgekit-console/examples/runtime/daemon-execution/heartbeat-after-serve.json
@@ -1,0 +1,7 @@
+{
+  "status": "stopped",
+  "tick": 2,
+  "ts": "2026-06-18T11:48:42",
+  "pid": 22401,
+  "note": "max_ticks(2)"
+}

--- a/apps/forgekit-console/examples/runtime/daemon-execution/sample-executed-note.md
+++ b/apps/forgekit-console/examples/runtime/daemon-execution/sample-executed-note.md
@@ -1,0 +1,6 @@
+# autopilot note — forgekit
+
+- finding: src/forgekit_console/selfimprove/loop.py: 5 TODO/FIXME 누적
+- kind: docs
+- class: safe (internal-approved: PM→gateway→tech-lead)
+- action: 안전 클래스 note 기록 (실제 코드 mutation 은 후속 단계)

--- a/apps/forgekit-console/examples/runtime/daemon-execution/serve-log.txt
+++ b/apps/forgekit-console/examples/runtime/daemon-execution/serve-log.txt
@@ -1,0 +1,12 @@
+$ forgekit runtime serve --interval 0 --max-ticks 2 --repo-root <forgekit-console>
+forgekit runtime serve — interval 0.0s, max_ticks 2 (Ctrl-C 또는 `forgekit runtime stop` 으로 종료)
+stopped: max_ticks(2) · ticks 2 · executed 3 · waits 2 · notified 2
+
+$ forgekit runtime status
+forgekit runtime: stopped · tick 2 · ts 2026-06-18T... · pid ...
+  last tick: max_ticks(2)
+  kill switch: clear
+
+# tick 1 실제 실행: exec 3 / propose 1 (restricted "운영/배포 준비 점검" 은 surface 만)
+#   wrote runs/forgekit/autopilot/forgekit-src-...-selfimprove-loop-py.md  (외 2개)
+# tick 2: 같은 finding dedupe → exec 0 (no-op churn 방지)

--- a/apps/forgekit-console/src/forgekit_console/cli/runtime_cmd.py
+++ b/apps/forgekit-console/src/forgekit_console/cli/runtime_cmd.py
@@ -40,27 +40,17 @@ def _repo_root(args) -> str:
 
 
 def _build_tick_fn(repo_root: str):
-    """A bounded tick: observe repo-local → always-on loop → TickOutcome."""
+    """A bounded tick that DRIVES autopilot execution (WT2 #241).
 
-    from ..runtime.daemon import TickOutcome
-    from ..runtime.loop import AUTONOMY_BOUNDED, BoundedRuntimeLoop, CAT_INFRA, Finding
-    from ..sources import RepoLocalCollector
+    observe repo-local → internal chain → safe-class real mutation (BoundedMutator) →
+    verify → record, with cross-tick dedupe + cooldown. risky/restricted stay surfaced.
+    """
 
-    def tick(n: int) -> TickOutcome:
-        findings = []
-        try:
-            for it in RepoLocalCollector(repo_root).collect(limit=4):
-                findings.append(Finding("forgekit", it.title,
-                                        category="product", privileged=False))
-        except Exception:  # noqa: BLE001
-            pass
-        # a representative privileged finding to prove the wait/notify path is bounded
-        findings.append(Finding("forgekit", "운영/배포 준비 점검", category=CAT_INFRA, privileged=True))
-        result = BoundedRuntimeLoop(autonomy=AUTONOMY_BOUNDED, max_iterations=8).run(findings)
-        return TickOutcome(summary=f"tick {n}: {len(findings)} findings, {result.blocked_count} blocked",
-                           waiting=result.waiting, blocked_count=result.blocked_count)
+    from pathlib import Path
 
-    return tick
+    from ..runtime.autopilot_tick import AutopilotTicker
+
+    return AutopilotTicker(repo_root=Path(repo_root)).tick_fn()
 
 
 def handle(args: argparse.Namespace) -> int:
@@ -74,6 +64,8 @@ def handle(args: argparse.Namespace) -> int:
     if cmd == "status":
         hb = HB.read_heartbeat()
         print(f"forgekit runtime: {hb.status} · tick {hb.tick} · ts {hb.ts or '-'} · pid {hb.pid}")
+        if hb.note:  # last tick: exec/propose/skip + written paths (WT2 #241)
+            print(f"  last tick: {hb.note}")
         print(f"  kill switch: {'SET' if HB.is_killed() else 'clear'}")
         return EXIT_OK
 
@@ -92,7 +84,9 @@ def handle(args: argparse.Namespace) -> int:
 
     if cmd == "once":
         out = daemon.once(tick_fn)
-        print(f"runtime once: {out.summary} · waiting={out.waiting}")
+        print(f"runtime once: {out.summary} · executed={out.executed} · waiting={out.waiting}")
+        if out.executed_paths:
+            print("  wrote: " + ", ".join(out.executed_paths))
         return EXIT_OK
 
     if cmd == "serve":
@@ -100,7 +94,8 @@ def handle(args: argparse.Namespace) -> int:
         print(f"forgekit runtime serve — interval {daemon.poll_interval}s, "
               f"max_ticks {daemon.max_ticks or '∞'} (Ctrl-C 또는 `forgekit runtime stop` 으로 종료)")
         res = daemon.serve(tick_fn)
-        print(f"stopped: {res.stopped_reason} · ticks {res.ticks} · waits {res.waits} · notified {res.notified}")
+        print(f"stopped: {res.stopped_reason} · ticks {res.ticks} · executed {res.executed} "
+              f"· waits {res.waits} · notified {res.notified}")
         return EXIT_OK
 
     return EXIT_ERROR

--- a/apps/forgekit-console/src/forgekit_console/runtime/autopilot_tick.py
+++ b/apps/forgekit-console/src/forgekit_console/runtime/autopilot_tick.py
@@ -1,0 +1,129 @@
+"""Daemon ↔ autopilot execution wiring (WT2 #241).
+
+The always-on daemon used to only *observe and classify* each tick. This module makes
+a tick actually DRIVE bounded autopilot execution: observe repo-local signals →
+internal approval chain (PM → gateway → tech-lead) → **safe-class only** real mutation
+via :class:`BoundedMutator` → verify → record. Everything risky/restricted/blocked is
+surfaced (``waiting``) and never executed.
+
+Cross-tick rails the daemon itself does not own:
+- **dedupe** — a finding already executed this session is not re-run (avoids no-op churn
+  that would otherwise trip the failure threshold).
+- **cooldown** — after the orchestrator halts (repeated verify failures), execution is
+  paused for ``cooldown_ticks`` and the next eligible tick is surfaced.
+
+The orchestrator keeps the single-executor invariant and the safe-class boundary; this
+ticker adds the time dimension. Pure except for the injected collector/mutator, so it is
+deterministic in tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..autopilot.artifacts import RepoFinding
+from ..autopilot.orchestrator import AutopilotOrchestrator
+from ..autopilot.runner import BoundedMutator
+from .daemon import TickOutcome
+
+# a standing restricted finding proves the bounded wait/notify path keeps surfacing
+# (it contains "배포"/deploy → L4 restricted → never auto-executed).
+_RESTRICTED_PROBE = "운영/배포 준비 점검"
+
+
+def _sig(finding: RepoFinding) -> str:
+    return f"{finding.repo}:{finding.finding}"
+
+
+@dataclass
+class AutopilotTicker:
+    """Builds a daemon tick_fn that performs bounded autopilot execution (#241)."""
+
+    repo_root: Path
+    repo_name: str = "forgekit"
+    mutator: Optional[object] = None
+    orchestrator: Optional[AutopilotOrchestrator] = None
+    collector: Optional[object] = None       # RepoLocalCollector (injectable for tests)
+    max_findings: int = 4
+    cooldown_ticks: int = 3
+    _executed_sigs: Dict[str, int] = field(default_factory=dict)
+    _cooldown_until: int = 0
+
+    def __post_init__(self) -> None:
+        self.repo_root = Path(self.repo_root)
+        if self.mutator is None:
+            self.mutator = BoundedMutator(self.repo_root)
+        if self.orchestrator is None:
+            self.orchestrator = AutopilotOrchestrator(mutator=self.mutator)
+
+    # --- observation -------------------------------------------------------
+    def _observe(self) -> List[RepoFinding]:
+        findings: List[RepoFinding] = []
+        try:
+            collector = self.collector
+            if collector is None:
+                from ..sources import RepoLocalCollector
+
+                collector = RepoLocalCollector(self.repo_root)
+            for it in collector.collect(limit=self.max_findings):
+                title = getattr(it, "title", "") or str(it)
+                findings.append(RepoFinding(self.repo_name, title, kind="docs"))
+        except Exception:  # noqa: BLE001 - observation must never crash the loop
+            pass
+        findings.append(RepoFinding(self.repo_name, _RESTRICTED_PROBE, kind="ops"))
+        return findings
+
+    @staticmethod
+    def _risk_of(finding: RepoFinding) -> str:
+        # let approval.classify_level read the wording; no forced override here.
+        return ""
+
+    # --- one tick ----------------------------------------------------------
+    def tick(self, n: int) -> TickOutcome:
+        if n < self._cooldown_until:
+            return TickOutcome(
+                summary=f"tick {n}: cooldown (실행 재개 tick {self._cooldown_until})",
+                waiting=True, skipped_reason="cooldown", next_eligible_tick=self._cooldown_until,
+            )
+        observed = self._observe()
+        # dedupe: drop findings already executed this session (avoid no-op churn).
+        fresh = [f for f in observed if _sig(f) not in self._executed_sigs]
+        deduped = len(observed) - len(fresh)
+
+        result = self.orchestrator.run_cycle(self.repo_name, fresh, risk_of=self._risk_of)
+
+        executed_paths = tuple(str(e.get("path", "")) for e in result.executed if e.get("path"))
+        for e in result.executed:
+            self._executed_sigs[f"{self.repo_name}:{e.get('finding', '')}"] = n
+
+        next_eligible = 0
+        if result.halted:
+            self._cooldown_until = n + self.cooldown_ticks
+            next_eligible = self._cooldown_until
+
+        waiting = bool(result.proposed) or result.blocked_repo or result.halted
+        skipped = ""
+        if deduped:
+            skipped = f"{deduped} dupes skipped"
+        if result.halted:
+            skipped = (skipped + "; " if skipped else "") + (result.halt_reason or "halt")
+
+        summary = (f"tick {n}: exec {len(result.executed)} / propose {len(result.proposed)}"
+                   + (f" / {skipped}" if skipped else ""))
+        if executed_paths:
+            summary += " · " + ", ".join(executed_paths[:2])
+        return TickOutcome(
+            summary=summary, waiting=waiting, blocked_count=len(result.proposed),
+            executed=len(result.executed), executed_paths=executed_paths,
+            skipped_reason=skipped, next_eligible_tick=next_eligible,
+        )
+
+    def tick_fn(self):
+        """Return a ``tick_fn(n) -> TickOutcome`` bound to this ticker (for the daemon)."""
+
+        return self.tick
+
+
+__all__ = ("AutopilotTicker",)

--- a/apps/forgekit-console/src/forgekit_console/runtime/daemon.py
+++ b/apps/forgekit-console/src/forgekit_console/runtime/daemon.py
@@ -22,11 +22,19 @@ from . import heartbeat as HB
 
 @dataclass(frozen=True)
 class TickOutcome:
-    """What one tick produced — the daemon only needs to know if an operator is needed."""
+    """What one tick produced — the daemon only needs to know if an operator is needed.
+
+    The execution fields (WT2 #241) let ``forgekit runtime status`` surface what the
+    last tick actually DID: how many safe-class mutations executed, where, why a tick
+    skipped, and the next tick eligible to act (cooldown)."""
 
     summary: str = ""
     waiting: bool = False          # an approval-needed / blocked condition this tick
     blocked_count: int = 0
+    executed: int = 0              # safe-class mutations this tick actually performed+verified
+    executed_paths: tuple = ()     # repo-relative paths really written this tick
+    skipped_reason: str = ""       # why nothing executed (cooldown / dupes / halt)
+    next_eligible_tick: int = 0    # tick at which execution resumes (0 = no cooldown)
 
 
 @dataclass
@@ -36,10 +44,12 @@ class DaemonResult:
     waits: int = 0
     notified: int = 0
     heartbeats: int = 0
+    executed: int = 0              # total safe-class mutations across the run (WT2 #241)
 
     def to_dict(self) -> dict:
         return {"ticks": self.ticks, "stopped_reason": self.stopped_reason,
-                "waits": self.waits, "notified": self.notified, "heartbeats": self.heartbeats}
+                "waits": self.waits, "notified": self.notified,
+                "heartbeats": self.heartbeats, "executed": self.executed}
 
 
 @dataclass
@@ -111,6 +121,7 @@ class BoundedDaemon:
             tick += 1
             outcome = tick_fn(tick)
             res.ticks = tick
+            res.executed += outcome.executed
             if self._heartbeat(HB.STATUS_RUNNING, tick, outcome.summary):
                 res.heartbeats += 1
             if outcome.waiting:

--- a/tests/forgekit/test_autopilot_tick.py
+++ b/tests/forgekit/test_autopilot_tick.py
@@ -1,0 +1,114 @@
+"""Daemon ↔ autopilot execution wiring (WT2 #241).
+
+Proves the always-on tick actually EXECUTES bounded safe-class mutations (not observe-
+only): a safe finding writes a real file once, dedupe stops re-running it, risky/
+restricted findings stay surfaced (never executed), and repeated verify failures trip
+a cooldown. Also drives the real BoundedDaemon to show execution metadata flows out.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.autopilot.runner import BoundedMutator, ExecOutcome
+from forgekit_console.runtime.autopilot_tick import AutopilotTicker
+from forgekit_console.runtime.daemon import BoundedDaemon
+
+
+class _Item:
+    def __init__(self, title):
+        self.title = title
+
+
+class FakeCollector:
+    def __init__(self, titles):
+        self.titles = list(titles)
+
+    def collect(self, limit=4):
+        return [_Item(t) for t in self.titles[:limit]]
+
+
+class FailingMutator:
+    """Always fails verify → drives the failure-threshold / cooldown path."""
+
+    def execute(self, task):
+        return ExecOutcome(False, action=task.action, path=task.rel_path,
+                           refused_reason="verify fail (test)")
+
+
+class TickerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+
+    def _ticker(self, titles, **kw):
+        return AutopilotTicker(repo_root=self.tmp, collector=FakeCollector(titles), **kw)
+
+    def test_safe_class_executes_real_file_once(self) -> None:
+        t = self._ticker(["문서 보강 필요"])  # clean wording → safe (L2)
+        out = t.tick(1)
+        self.assertGreaterEqual(out.executed, 1)
+        self.assertTrue(out.executed_paths)
+        # the mutation is REAL — the file exists under runs/ and has content
+        written = self.tmp / out.executed_paths[0]
+        self.assertTrue(written.exists())
+        self.assertIn("autopilot note", written.read_text(encoding="utf-8"))
+
+    def test_dedupe_stops_reexecution(self) -> None:
+        t = self._ticker(["문서 보강 필요"])
+        first = t.tick(1)
+        self.assertGreaterEqual(first.executed, 1)
+        second = t.tick(2)              # same finding → deduped, not re-run (no churn)
+        self.assertEqual(second.executed, 0)
+        self.assertIn("dupes", second.skipped_reason)
+
+    def test_restricted_probe_surfaces_never_executes(self) -> None:
+        # the standing "운영/배포 준비 점검" finding is L4 → proposed, waiting, never executed
+        t = self._ticker([])           # only the restricted probe remains
+        out = t.tick(1)
+        self.assertEqual(out.executed, 0)
+        self.assertTrue(out.waiting)
+        self.assertGreaterEqual(out.blocked_count, 1)
+
+    def test_repeated_failure_trips_cooldown(self) -> None:
+        t = self._ticker(["alpha 수정", "beta 수정", "gamma 수정"],
+                         mutator=FailingMutator(), cooldown_ticks=2)
+        first = t.tick(1)              # 3 safe findings all fail verify → halt
+        self.assertEqual(first.executed, 0)
+        self.assertTrue(first.waiting)
+        self.assertEqual(first.next_eligible_tick, 3)
+        cooled = t.tick(2)            # within cooldown → skipped, no execution attempt
+        self.assertEqual(cooled.skipped_reason, "cooldown")
+        self.assertTrue(cooled.waiting)
+
+    def test_serve_flows_execution_metadata(self) -> None:
+        hb = self.tmp / "hb.json"
+        kill = self.tmp / "kill"
+        ticker = AutopilotTicker(repo_root=self.tmp, collector=FakeCollector(["리포트 정리"]),
+                                 mutator=BoundedMutator(self.tmp))
+        daemon = BoundedDaemon(poll_interval=0.0, max_ticks=2, heartbeat_path=hb,
+                               kill_switch_path=kill, sleep_fn=lambda s: None, pid=7)
+        res = daemon.serve(ticker.tick_fn())
+        self.assertEqual(res.ticks, 2)
+        self.assertGreaterEqual(res.executed, 1)        # tick1 executes, tick2 dedupes
+
+    def test_once_heartbeat_surfaces_tick_summary(self) -> None:
+        from forgekit_console.runtime import heartbeat as HB
+
+        hb = self.tmp / "hb.json"
+        ticker = AutopilotTicker(repo_root=self.tmp, collector=FakeCollector(["리포트 정리"]),
+                                 mutator=BoundedMutator(self.tmp))
+        daemon = BoundedDaemon(heartbeat_path=hb, kill_switch_path=self.tmp / "k",
+                               sleep_fn=lambda s: None, pid=7)
+        out = daemon.once(ticker.tick_fn())
+        self.assertGreaterEqual(out.executed, 1)
+        # `forgekit runtime status` reads this heartbeat note → surfaces what the tick did
+        self.assertIn("exec", HB.read_heartbeat(path=hb).note)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR (2/3) · branch `feature/forgekit-daemon-autopilot-wiring` · base `feature/forgekit-vendor-usage-live` · 3 commits

## 목적
always-on 데몬이 관측-only 이던 것을, tick 마다 **실제 safe-class 실행**을 구동하게 wiring 한다(#241).

## 범위
- `runtime/autopilot_tick.py` — tick = 관측→내부 chain(PM→gateway→tech-lead)→safe-class 실 mutation(`BoundedMutator`, write+verify)→기록. cross-tick **dedupe** + 반복 실패 **cooldown**.
- `runtime/daemon.py` — TickOutcome/DaemonResult 에 executed/executed_paths/skipped/next_eligible(하위호환 기본값).
- `cli/runtime_cmd.py` — `_build_tick_fn` 이 ticker 구동, once/serve 출력 + `status` last-tick 표면.
- 제외: source mutation 확대(#240). (실행 자체는 기존 BoundedMutator note 경로 사용 — 필수 의존 최소 범위.)

## 테스트 / 검증
- `tests/forgekit/test_autopilot_tick.py`(6: safe 실행/dedupe/restricted surface/cooldown/daemon 통합) + 기존 `test_runtime_daemon`.
- forgekit 518 OK ×2 venv, root 6323 OK.
- **실 CLI**: `runtime serve --max-ticks 2` → **executed 3**(실파일 write+verify) + waits 2(restricted surface). once/status/stop 동작.

## evidence
- `apps/forgekit-console/examples/runtime/daemon-execution/`(serve log, 실 executed note, heartbeat).

## 남은 리스크 / 경계 (정직)
- **dedupe 는 in-session**: 프로세스 재시작 후 idempotent note 는 no-op → propose/halt 로 정직 surface(fake success 아님). 영속 dedupe 는 후속.
- **`stop` 시맨틱**: kill switch 는 *실행 중* serve 를 다음 tick 에 종료. fresh `serve` 는 시작 시 stale kill 을 clear(fresh-start).
- source-format 자동 tick 은 opt-in(기본 note). macOS sleep 시 suspend(상시가동=homeserver, #243).
- risky/restricted/blocked 는 실행 안 함 → surface 만(inbox+console+desktop ≥2 + heartbeat).

## 관련 이슈
- 구현: #241 (이미 CLOSED). umbrella #238. (base = #239 PR)
