### PR TITLE
forgekit #240 source safe-class mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 !.gemini/commands/
 runs/*
 !runs/.gitkeep
+# forgekit-console runtime output: the daemon/autopilot mutator writes safe-class
+# notes under <repo_root>/runs/ when repo_root resolves to the app dir (#241/#240).
+# That is runtime churn — never commit it (committed evidence lives in examples/).
+apps/forgekit-console/runs/
 
 # Secrets
 .env

--- a/apps/forgekit-console/examples/autopilot/source-mutation/README.md
+++ b/apps/forgekit-console/examples/autopilot/source-mutation/README.md
@@ -1,0 +1,32 @@
+# source-code safe-class mutation — evidence (#240, WT3)
+
+note/docs/examples 를 넘어 **실제 소스 파일(.py)** 에 대한 safe-class mutation 이 가능해졌다.
+단 하나의 action — `source-format`(공백 전용 정규화) — 만 열렸고, 강한 hard rail 아래에서만 동작한다.
+
+| 파일 | 무엇 |
+| --- | --- |
+| `before-snippet.txt` / `after-snippet.txt` | 실 `runner.py` 사본에 trailing whitespace 를 넣고 정규화한 전/후 |
+| `outcome.json` | ExecOutcome — executed/verified/lines_changed/before·after hash |
+
+## 실측 (재현)
+```
+BoundedMutator(repo, source_prefixes=("apps/forgekit-console/src/",)).execute(
+    ExecTask("source-format", "apps/forgekit-console/src/.../runner.py"))
+```
+- 실 source 파일 사본의 trailing-whitespace 33줄 → **0줄**, `executed=True/verified=True`, **여전히 파싱됨**.
+- **semantics preserved**: 비공백 문자 시퀀스가 전/후 동일(공백만 이동).
+
+## hard rails (실제 강제 — 테스트로 고정: `tests/forgekit/test_source_mutation.py`)
+- **기본 OFF**: `source_prefixes` 미설정이면 source 수정 거부(소스 트리 기본 불가침).
+- **allowlist + 확장자**: 활성 prefix 아래 `.py` 만. traversal/절대경로/그 외 경로 거부.
+- **공백 전용 guard**: 비공백이 바뀌면 safe-class 아님 → **write 전에 거부**(approval 경로로).
+- **diff/line cap**: 한도 초과 → 거부, write 안 함.
+- **이미 깨진 파일 skip**: 파싱 불가 파일은 손대지 않음.
+- **verify + rollback**: write 후 re-read 일치 + 파싱 통과 검증. 실패 시 **원본 정확 복원(rollback)**, executed=False.
+- **no-op 정직**: 이미 깨끗하면 executed=False(가짜 성공 아님).
+
+## 아직 닫지 않은 경계 (정직)
+- `source-format` 는 **공백 전용**(semantics-preserving). import 정렬/타입·린트 자동수정 같은
+  **의미 보존이 아닌** safe-class 는 아직 열지 않음 — 그건 별도 verify(테스트 실행 등)와 함께 후속.
+- daemon 자동 tick 은 기본적으로 note 만 — **source-format 자동화는 opt-in**(source_prefixes 주입)이며
+  현재 always-on 기본 경로에는 연결하지 않음(자율 범위 확대는 승인 사안).

--- a/apps/forgekit-console/examples/autopilot/source-mutation/after-snippet.txt
+++ b/apps/forgekit-console/examples/autopilot/source-mutation/after-snippet.txt
@@ -1,0 +1,12 @@
+"""Bounded execution runner (WT3) — REAL safe-class mutation, hard-capped + verified.
+
+This is the teeth: autopilot's "execute" actually changes a file (it is NOT a no-op).
+But it is bounded by construction:
+
+* only **safe-class** actions (note / docs-stub / trailing-whitespace format),
+* only paths under an **allowed write prefix** (``runs/`` / ``docs/`` / ``examples/``) —
+  source trees and anything with ``..`` / absolute paths are rejected,
+* **file + diff caps** enforced before the write,
+* every write is **verified** (re-read) — verify fail → halt, do NOT report success.
+
+It never auto-commits, never touches deploy/secret/infra, never writes outside the

--- a/apps/forgekit-console/examples/autopilot/source-mutation/before-snippet.txt
+++ b/apps/forgekit-console/examples/autopilot/source-mutation/before-snippet.txt
@@ -1,0 +1,12 @@
+"""Bounded execution runner (WT3) — REAL safe-class mutation, hard-capped + verified.   
+
+This is the teeth: autopilot's "execute" actually changes a file (it is NOT a no-op).
+But it is bounded by construction:
+
+* only **safe-class** actions (note / docs-stub / trailing-whitespace format),
+* only paths under an **allowed write prefix** (``runs/`` / ``docs/`` / ``examples/``) —
+  source trees and anything with ``..`` / absolute paths are rejected,   
+* **file + diff caps** enforced before the write,
+* every write is **verified** (re-read) — verify fail → halt, do NOT report success.
+
+It never auto-commits, never touches deploy/secret/infra, never writes outside the

--- a/apps/forgekit-console/examples/autopilot/source-mutation/outcome.json
+++ b/apps/forgekit-console/examples/autopilot/source-mutation/outcome.json
@@ -1,0 +1,10 @@
+{
+  "executed": true,
+  "action": "source-format",
+  "path": "apps/forgekit-console/src/forgekit_console/autopilot/runner.py",
+  "lines_changed": 36,
+  "verified": true,
+  "refused_reason": "",
+  "before_hash": "f76b753cc539",
+  "after_hash": "5f8ce8b56eb5"
+}

--- a/apps/forgekit-console/src/forgekit_console/autopilot/runner.py
+++ b/apps/forgekit-console/src/forgekit_console/autopilot/runner.py
@@ -23,10 +23,16 @@ from typing import Optional, Tuple
 ACTION_NOTE = "note"            # write a managed note/runbook (md)
 ACTION_DOCS_STUB = "docs-stub"  # append a docs stub
 ACTION_FORMAT = "format"        # strip trailing whitespace on a target (bounded)
-SAFE_ACTIONS: Tuple[str, ...] = (ACTION_NOTE, ACTION_DOCS_STUB, ACTION_FORMAT)
+ACTION_SOURCE_FORMAT = "source-format"  # whitespace-only normalize ONE source file (#240)
+SAFE_ACTIONS: Tuple[str, ...] = (ACTION_NOTE, ACTION_DOCS_STUB, ACTION_FORMAT, ACTION_SOURCE_FORMAT)
 
 # writes are confined to these repo-relative prefixes (never source trees blindly)
 ALLOWED_WRITE_PREFIXES: Tuple[str, ...] = ("runs/", "docs/", "examples/")
+
+# source-format may touch ONLY these extensions, and only under an explicitly enabled
+# source prefix (off by default). The transform is whitespace-only + semantics-preserving
+# + parse-verified, with rollback — never a semantic edit.
+SOURCE_EXTENSIONS: Tuple[str, ...] = (".py",)
 
 
 @dataclass(frozen=True)
@@ -69,13 +75,57 @@ def _path_ok(rel_path: str) -> bool:
     return any(norm.startswith(pre) for pre in ALLOWED_WRITE_PREFIXES)
 
 
+def _source_path_ok(rel_path: str, prefixes: Tuple[str, ...]) -> bool:
+    """A source-format target must be a real file under an enabled source prefix,
+    with an allowed extension, no traversal / absolute path."""
+
+    rp = (rel_path or "").strip()
+    if not rp or rp.startswith("/") or ".." in Path(rp).parts:
+        return False
+    norm = rp.replace("\\", "/")
+    if not any(norm.endswith(ext) for ext in SOURCE_EXTENSIONS):
+        return False
+    return bool(prefixes) and any(norm.startswith(pre) for pre in prefixes)
+
+
+def _whitespace_normalize(text: str) -> str:
+    """Strip trailing whitespace per line + ensure exactly one final newline.
+    Semantics-preserving for python (only insignificant trailing whitespace)."""
+
+    body = "\n".join(line.rstrip() for line in text.split("\n"))
+    return body.rstrip("\n") + "\n" if body.strip() else body
+
+
+def _nonspace(text: str) -> str:
+    """Every non-whitespace char, in order — equal before/after ⇒ only whitespace moved."""
+
+    return "".join(text.split())
+
+
+def _py_parses(text: str, path: str) -> bool:
+    try:
+        compile(text, path or "<source>", "exec")
+        return True
+    except (SyntaxError, ValueError):
+        return False
+
+
 @dataclass
 class BoundedMutator:
-    """Performs a REAL safe-class file mutation under hard caps. Verifies every write."""
+    """Performs a REAL safe-class file mutation under hard caps. Verifies every write.
+
+    ``source_prefixes`` opts in to ``source-format`` on real source files (#240) — a
+    whitespace-only, semantics-preserving, parse-verified edit with rollback. It is OFF
+    by default (empty): without an explicit source prefix, source trees stay untouched.
+    ``source_verifier`` is the post-write gate (default: the file still parses); injectable
+    so the rollback path is testable.
+    """
 
     repo_root: Path
     max_files: int = 1
     max_diff_lines: int = 200
+    source_prefixes: Tuple[str, ...] = ()
+    source_verifier: Optional[object] = None   # (after_text, path) -> bool
 
     def __post_init__(self) -> None:
         self.repo_root = Path(self.repo_root)
@@ -83,6 +133,13 @@ class BoundedMutator:
     def validate(self, task: ExecTask) -> Tuple[bool, str]:
         if task.action not in SAFE_ACTIONS:
             return False, f"non-safe action: {task.action} (자동 실행 금지)"
+        if task.action == ACTION_SOURCE_FORMAT:
+            if not self.source_prefixes:
+                return False, "source-format 비활성 (source_prefixes 미설정 — 소스 수정 기본 OFF)"
+            if not _source_path_ok(task.rel_path, self.source_prefixes):
+                return False, (f"source 경로 불허: {task.rel_path} "
+                               f"(허용: {', '.join(self.source_prefixes) or '-'} · {', '.join(SOURCE_EXTENSIONS)})")
+            return True, ""
         if not _path_ok(task.rel_path):
             return False, f"write 경로 불허: {task.rel_path} (허용 prefix: {', '.join(ALLOWED_WRITE_PREFIXES)})"
         approx = task.content.count("\n") + 1 if task.content else 1
@@ -90,10 +147,70 @@ class BoundedMutator:
             return False, f"diff {approx} > 한도 {self.max_diff_lines}"
         return True, ""
 
+    def _execute_source_format(self, task: ExecTask) -> "ExecOutcome":
+        """Whitespace-only normalize one source file — semantics-preserving + verified +
+        rollback. NEVER changes non-whitespace content; if the result would, it refuses."""
+
+        target = self.repo_root / task.rel_path
+        if not target.exists():
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason="대상 source 파일 없음")
+        try:
+            before = target.read_text(encoding="utf-8")
+        except OSError as exc:
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason=f"read 실패: {exc}")
+        # only operate on a file that currently parses — never touch already-broken source.
+        if not _py_parses(before, str(target)):
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason="대상이 이미 파싱 불가 — skip (건드리지 않음)")
+        after = _whitespace_normalize(before)
+        # HARD GUARD: the edit must move only whitespace. If any non-whitespace char would
+        # change, this is NOT safe-class → refuse (escalates to approval, no write).
+        if _nonspace(after) != _nonspace(before):
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason="non-whitespace 변경 감지 — safe-class 아님 (approval 필요)")
+        if after == before:
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason="변경 없음 (no-op)",
+                               before_hash=_sha(before), after_hash=_sha(before))
+        lines_changed = sum(1 for a, b in zip(after.split("\n"), before.split("\n")) if a != b) \
+            + abs(after.count("\n") - before.count("\n"))
+        if lines_changed > self.max_diff_lines:
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason=f"diff {lines_changed} > 한도 {self.max_diff_lines}")
+        try:
+            target.write_text(after, encoding="utf-8")   # REAL source mutation
+        except OSError as exc:
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               refused_reason=f"write 실패: {exc}")
+        # VERIFY: re-read matches AND the post-write gate passes (default: still parses).
+        verify = self.source_verifier or (lambda txt, p: _py_parses(txt, p))
+        try:
+            reread = target.read_text(encoding="utf-8")
+            ok = (reread == after) and bool(verify(after, str(target)))
+        except OSError:
+            ok = False
+        if not ok:
+            # ROLLBACK — restore the exact original; report discarded (never fake success).
+            try:
+                target.write_text(before, encoding="utf-8")
+            except OSError:
+                pass
+            return ExecOutcome(False, action=task.action, path=task.rel_path,
+                               lines_changed=lines_changed, verified=False,
+                               before_hash=_sha(before), after_hash=_sha(after),
+                               refused_reason="verify 실패 — rollback (원본 복원, 커밋 안 함)")
+        return ExecOutcome(executed=True, action=task.action, path=task.rel_path,
+                           lines_changed=lines_changed, verified=True,
+                           before_hash=_sha(before), after_hash=_sha(after))
+
     def execute(self, task: ExecTask) -> ExecOutcome:
         ok, reason = self.validate(task)
         if not ok:
             return ExecOutcome(False, action=task.action, path=task.rel_path, refused_reason=reason)
+        if task.action == ACTION_SOURCE_FORMAT:
+            return self._execute_source_format(task)
         target = self.repo_root / task.rel_path
         try:
             before = target.read_text(encoding="utf-8") if target.exists() else ""
@@ -133,6 +250,7 @@ class BoundedMutator:
 
 
 __all__ = (
-    "ACTION_NOTE", "ACTION_DOCS_STUB", "ACTION_FORMAT", "SAFE_ACTIONS",
-    "ALLOWED_WRITE_PREFIXES", "ExecTask", "ExecOutcome", "BoundedMutator",
+    "ACTION_NOTE", "ACTION_DOCS_STUB", "ACTION_FORMAT", "ACTION_SOURCE_FORMAT",
+    "SAFE_ACTIONS", "ALLOWED_WRITE_PREFIXES", "SOURCE_EXTENSIONS",
+    "ExecTask", "ExecOutcome", "BoundedMutator",
 )

--- a/docs/forgekit-console.md
+++ b/docs/forgekit-console.md
@@ -542,6 +542,21 @@ authored vault note(WT5). 모든 mutation/active 는 gated, planned/blocked 는 
 - **operator digest**(`/digest`): 발견/자동실행(내부승인)/승인필요/차단 — "내 승인 없이 가능"=safe뿐 명시.
 - **vault trace**: 누가/왜/무엇/어느 승인 체계로(authorship frontmatter 재사용).
 
+### safe-class mutation taxonomy (`BoundedMutator`, #240)
+
+실제 파일을 바꾸는 자동 실행은 아래 action 으로 **한정**된다 — 코드 SSoT `autopilot/runner.py`.
+
+| action | 대상 경로 | 무엇 | 경계 |
+| --- | --- | --- | --- |
+| `note` / `docs-stub` | `runs/`·`docs/`·`examples/` | 관리형 note/문서 stub write·append | diff/line cap, write+verify |
+| `format` | `runs/`·`docs/`·`examples/` | trailing whitespace 정리 | 〃 |
+| `source-format` (#240) | **활성 source prefix 아래 `.py` 만** (기본 OFF) | **소스 파일 공백 전용 정규화** | semantics-preserving guard + 파싱 verify + **rollback**, cap |
+
+- `source-format` 는 **공백만** 이동(비공백 변경 감지 시 거부 → approval). 파싱 안 되는 파일 skip,
+  verify 실패 시 원본 정확 복원. **기본 OFF**(`source_prefixes` 주입해야 활성) — 소스 트리 기본 불가침.
+- 아직 **열지 않은 것**: import 정렬/타입·린트 자동수정 등 *의미 보존이 아닌* safe-class(테스트 verify 동반 후속),
+  daemon always-on 기본 경로에서의 source-format 자동화(자율 확대는 승인 사안). 실측: `examples/autopilot/source-mutation/`.
+
 관계: `auto` 가 상황을 repo-autopilot 로 추천 → autopilot 이 관측·패킷화·내부승인·safe 실행 →
 risky/restricted 는 approval-wait/runbook + operator 알림(WT4). `always-on` 은 더 일반적 bounded
 루프, `repo-autopilot` 은 레포-한정 팀형 실행 버전.

--- a/tests/forgekit/test_source_mutation.py
+++ b/tests/forgekit/test_source_mutation.py
@@ -1,0 +1,108 @@
+"""Source-code safe-class mutation (WT3 #240) — real edit under hard rails.
+
+source-format is the ONLY source action: whitespace-only, semantics-preserving,
+parse-verified, with rollback. These tests prove the rails actually bite — off by
+default, allowlist + ext enforced, cap enforced, broken/already-clean files skipped,
+a verify failure rolls back to the exact original, and the non-whitespace guard holds.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.autopilot import runner as R
+from forgekit_console.autopilot.runner import ACTION_SOURCE_FORMAT, BoundedMutator, ExecTask
+
+SRC_PREFIX = "apps/forgekit-console/src/"
+
+
+class SourceFormatTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.rel = SRC_PREFIX + "pkg/mod.py"
+        self.target = self.tmp / self.rel
+        self.target.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write(self, text: str) -> None:
+        self.target.write_text(text, encoding="utf-8")
+
+    def _mutator(self, **kw):
+        return BoundedMutator(self.tmp, source_prefixes=(SRC_PREFIX,), **kw)
+
+    def test_off_by_default(self) -> None:
+        # no source_prefixes → source mutation refused (safe default)
+        self._write("x = 1   \n")
+        out = BoundedMutator(self.tmp).execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertFalse(out.executed)
+        self.assertIn("비활성", out.refused_reason)
+
+    def test_real_whitespace_fix_executes_and_parses(self) -> None:
+        self._write("def f():   \n    return 1   \n\n\n")   # trailing ws + extra blank lines
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertTrue(out.executed)
+        self.assertTrue(out.verified)
+        after = self.target.read_text(encoding="utf-8")
+        self.assertEqual(after, "def f():\n    return 1\n")     # real change, no trailing ws
+        compile(after, "mod.py", "exec")                        # still valid python
+
+    def test_semantics_preserved_invariant(self) -> None:
+        # the transform may only move whitespace — non-whitespace content is identical
+        before = "a=1  \nb = 2\t\n"
+        self._write(before)
+        self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        after = self.target.read_text(encoding="utf-8")
+        self.assertEqual("".join(after.split()), "".join(before.split()))
+
+    def test_forbidden_path_blocked(self) -> None:
+        # a path outside the enabled source prefix is refused
+        self._write("x = 1  \n")
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, "other/place/mod.py"))
+        self.assertFalse(out.executed)
+        self.assertIn("경로 불허", out.refused_reason)
+
+    def test_non_py_extension_blocked(self) -> None:
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, SRC_PREFIX + "pkg/data.txt"))
+        self.assertFalse(out.executed)
+        self.assertIn("경로 불허", out.refused_reason)
+
+    def test_traversal_blocked(self) -> None:
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, SRC_PREFIX + "../../etc/x.py"))
+        self.assertFalse(out.executed)
+
+    def test_already_clean_is_noop(self) -> None:
+        self._write("x = 1\n")
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertFalse(out.executed)
+        self.assertIn("no-op", out.refused_reason)
+
+    def test_unparseable_file_skipped(self) -> None:
+        self._write("def f(:  \n")          # syntax error → never touched
+        out = self._mutator().execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertFalse(out.executed)
+        self.assertIn("파싱 불가", out.refused_reason)
+
+    def test_over_cap_blocked(self) -> None:
+        # many trailing-whitespace lines → diff exceeds the cap → refused, no write
+        self._write("".join(f"x{i} = {i}   \n" for i in range(20)))
+        out = self._mutator(max_diff_lines=5).execute(ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertFalse(out.executed)
+        self.assertIn("한도", out.refused_reason)
+
+    def test_failed_verify_rolls_back(self) -> None:
+        before = "y = 2   \n"
+        self._write(before)
+        # inject a verifier that fails → the write must be rolled back to the exact original
+        out = self._mutator(source_verifier=lambda txt, p: False).execute(
+            ExecTask(ACTION_SOURCE_FORMAT, self.rel))
+        self.assertFalse(out.executed)
+        self.assertIn("rollback", out.refused_reason)
+        self.assertEqual(self.target.read_text(encoding="utf-8"), before)   # original restored
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR (3/3) · branch `feature/forgekit-source-mutation-safeclass` · base `feature/forgekit-daemon-autopilot-wiring` · 4 commits

## 목적
note/docs/examples 수준이던 safe-class mutation 을 **실제 소스 파일(.py)** 까지, 강한 hard rail 아래에서 연다(#240).

## 범위
- `autopilot/runner.py` — `BoundedMutator` 에 `source-format` action(활성 source prefix 아래 `.py` **공백 전용 정규화**). semantics-preserving guard + 파싱 verify + 실패 시 **rollback** + diff cap. `source_prefixes` 기본 OFF.
- 회귀 `tests/forgekit/test_source_mutation.py`(10), evidence, taxonomy 문서.
- **hygiene 커밋 `78b701c`**: `apps/forgekit-console/runs/` gitignore — #241 데몬이 그 경로에 실행 churn 을 써서 commit 위험이라 차단(이 PR 범위에 포함).
- 제외: unrelated cleanup.

## 테스트 / 검증
- `test_source_mutation.py`(off-default/실 공백수정/semantics 불변/경로·확장자·traversal 거부/no-op/파싱불가 skip/over-cap/**verify 실패 rollback**).
- forgekit 518 OK ×2 venv, root 6323 OK.
- **실측**: 실 `runner.py` 사본 trailing-ws 33줄→0, executed+verified, 파싱 유지, 비공백 시퀀스 불변.

## evidence
- `apps/forgekit-console/examples/autopilot/source-mutation/`(before/after, outcome.json). taxonomy: `docs/forgekit-console.md`.

## 남은 리스크 / 경계 (정직)
- **현재 경계 = 공백 전용 safe-class**(semantics-preserving). import 정렬 / 타입·린트 자동수정 등 *의미 보존이 아닌* safe-class 는 **아직 미오픈**(테스트-verify 동반 전제, 후속).
- daemon always-on 기본 경로에서 source-format 자동화는 opt-in(자율 확대=승인 사안). 기본 OFF — 소스 트리 기본 불가침.

## 관련 이슈
- 구현: #240 (이미 CLOSED — 구체 acceptance[1 source path real+capped+verified+rollback] 충족분. "확대"의 넓은 의미는 deferred). umbrella #238. (base = #241 PR)
