### PR TITLE
forgekit multi-provider brain config 계약 + migration

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/policy/provider_config.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/provider_config.py
@@ -1,0 +1,231 @@
+"""Multi-provider config contract (forgekit brain orchestration).
+
+forgekit itself is the brain; providers (claude/codex/gemini/ollama) are capability
+suppliers wired into it. This module is the typed, validated SSoT for the operator's
+brain configuration — parsed once from the on-disk config dict so policy / routing /
+setup all reason over the SAME shape.
+
+The schema (field names chosen to match the repo's snake_case style)::
+
+    {
+      "primary_provider": "claude",
+      "linked_providers": ["claude", "codex", "gemini", "ollama"],
+      "model_overrides": {"claude": "opus-4.1", "ollama": "gemma3:latest"},
+      "slot_routing": {"default_chat": "claude", "research": "gemini",
+                        "execution": "codex", "compression": "ollama",
+                        "classification": "ollama", "safety": "claude",
+                        "synthesis": "claude"},
+      "fallback_policy": {
+        "implicit_local_fallback": false,
+        "slot_fallback_orders": {"default_chat": ["claude", "gemini"],
+                                  "execution": ["codex"]}
+      },
+      "budget_policy": {"primary_monthly_limit": "...",
+                         "per_provider": {"claude": "...", "ollama": "local"}}
+    }
+
+Honesty rails baked in here:
+  * ``implicit_local_fallback`` defaults to **False** — forgekit never silently
+    routes to a reachable local ollama just because no config exists.
+  * a legacy ``{"main_provider": X}`` (or ``{"id": X}``) config is **migrated** to
+    ``primary_provider=X`` / ``linked_providers=[X]`` so existing setups don't break.
+
+Pure / stdlib-only → unit-testable in a bare CI install.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional, Tuple
+
+from ..providers import builtins
+from ..providers.registry import build_provider
+
+# The canonical brain slots forgekit routes over (superset of the legacy 5).
+SLOT_DEFAULT_CHAT = "default_chat"
+SLOT_SYNTHESIS = "synthesis"
+SLOT_RESEARCH = "research"
+SLOT_EXECUTION = "execution"
+SLOT_COMPRESSION = "compression"
+SLOT_CLASSIFICATION = "classification"
+SLOT_SAFETY = "safety"
+ROUTING_SLOTS: Tuple[str, ...] = (
+    SLOT_DEFAULT_CHAT, SLOT_SYNTHESIS, SLOT_RESEARCH, SLOT_EXECUTION,
+    SLOT_COMPRESSION, SLOT_CLASSIFICATION, SLOT_SAFETY,
+)
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    """The operator's brain configuration — typed + validated."""
+
+    primary_provider: str
+    linked_providers: Tuple[str, ...]
+    model_overrides: Mapping[str, str] = field(default_factory=dict)
+    slot_routing: Mapping[str, str] = field(default_factory=dict)
+    implicit_local_fallback: bool = False
+    slot_fallback_orders: Mapping[str, Tuple[str, ...]] = field(default_factory=dict)
+    budget_policy: Mapping[str, object] = field(default_factory=dict)
+    migrated_from_legacy: bool = False
+
+    @property
+    def is_multi(self) -> bool:
+        return len(self.linked_providers) >= 2
+
+    def slot_target(self, slot: str) -> str:
+        """The declared provider for *slot* — explicit routing, else primary."""
+
+        return str(self.slot_routing.get(slot) or self.primary_provider)
+
+    def fallback_order(self, slot: str) -> Tuple[str, ...]:
+        """Explicit fallback order for *slot* (empty = no fallback declared)."""
+
+        return tuple(self.slot_fallback_orders.get(slot, ()))
+
+    def model_for(self, provider_id: str) -> str:
+        return str(self.model_overrides.get(provider_id, ""))
+
+    def to_dict(self) -> dict:
+        return {
+            "primary_provider": self.primary_provider,
+            "linked_providers": list(self.linked_providers),
+            "model_overrides": dict(self.model_overrides),
+            "slot_routing": dict(self.slot_routing),
+            "fallback_policy": {
+                "implicit_local_fallback": self.implicit_local_fallback,
+                "slot_fallback_orders": {k: list(v) for k, v in self.slot_fallback_orders.items()},
+            },
+            "budget_policy": dict(self.budget_policy),
+            "migrated_from_legacy": self.migrated_from_legacy,
+        }
+
+
+def has_brain_config(config: Optional[Mapping]) -> bool:
+    """True when SOME provider config exists (new or legacy). Mirrors the setup gate.
+
+    NOTE: a reachable local ollama is intentionally NOT a config — forgekit never
+    treats "ollama happens to be up" as being configured (implicit-fallback off)."""
+
+    if not config:
+        return False
+    primary = str(config.get("primary_provider", "") or "").strip()
+    legacy = str(config.get("main_provider", "") or config.get("id", "") or "").strip()
+    linked = config.get("linked_providers") or config.get("providers") or ()
+    return bool(primary or legacy or linked)
+
+
+def _coerce_str_map(value) -> Dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(k): str(v) for k, v in value.items() if str(k) and str(v)}
+
+
+def _coerce_order_map(value) -> Dict[str, Tuple[str, ...]]:
+    if not isinstance(value, Mapping):
+        return {}
+    out: Dict[str, Tuple[str, ...]] = {}
+    for k, v in value.items():
+        if isinstance(v, (list, tuple)):
+            out[str(k)] = tuple(str(x) for x in v if str(x))
+    return out
+
+
+def load_provider_config(config: Optional[Mapping]) -> ProviderConfig:
+    """Parse the on-disk config dict into a typed :class:`ProviderConfig`.
+
+    Migrates a legacy ``main_provider`` / ``id`` config to the new shape (primary +
+    single linked provider, implicit fallback OFF) so old setups keep working.
+    """
+
+    config = config or {}
+    primary = str(config.get("primary_provider", "") or "").strip()
+    linked_raw = config.get("linked_providers")
+    migrated = False
+
+    if not primary:
+        # legacy migration: main_provider / id → primary + single linked provider.
+        legacy = str(config.get("main_provider", "") or config.get("id", "") or "").strip()
+        if legacy:
+            primary = legacy
+            migrated = True
+
+    linked = tuple(str(p) for p in (linked_raw or ()) if str(p))
+    if not linked and primary:
+        linked = (primary,)
+        if linked_raw is None:
+            migrated = migrated or True
+    # primary must be in linked (self-link).
+    if primary and primary not in linked:
+        linked = (primary, *linked)
+
+    fb = config.get("fallback_policy") or {}
+    implicit = bool(fb.get("implicit_local_fallback", False)) if isinstance(fb, Mapping) else False
+
+    return ProviderConfig(
+        primary_provider=primary,
+        linked_providers=linked,
+        model_overrides=_coerce_str_map(config.get("model_overrides")),
+        slot_routing=_coerce_str_map(config.get("slot_routing")),
+        implicit_local_fallback=implicit,
+        slot_fallback_orders=_coerce_order_map(
+            fb.get("slot_fallback_orders") if isinstance(fb, Mapping) else {}),
+        budget_policy=dict(config.get("budget_policy") or {})
+        if isinstance(config.get("budget_policy"), Mapping) else {},
+        migrated_from_legacy=migrated,
+    )
+
+
+def _known_provider(pid: str) -> bool:
+    if builtins.is_builtin(pid):
+        return True
+    return False  # custom providers validated separately via registry/config
+
+
+def validate_provider_config(cfg: ProviderConfig, *, config: Optional[Mapping] = None
+                             ) -> Tuple[str, ...]:
+    """Human-readable errors (empty == valid). Enforces the multi-provider invariants."""
+
+    errors = []
+    if not cfg.primary_provider:
+        errors.append("primary_provider 가 비어 있습니다 — 메인 브레인 provider 를 정하세요")
+    if not cfg.linked_providers:
+        errors.append("linked_providers 가 비어 있습니다 — 최소 1개 provider 를 연결하세요")
+    if cfg.primary_provider and cfg.primary_provider not in cfg.linked_providers:
+        errors.append(f"primary_provider({cfg.primary_provider}) 가 linked_providers 에 없습니다")
+
+    # custom providers may be declared in config['providers']; collect their ids.
+    custom_ids = set()
+    for entry in (config or {}).get("providers", ()) or ():
+        if isinstance(entry, Mapping) and entry.get("id"):
+            custom_ids.add(str(entry["id"]))
+        elif isinstance(entry, str):
+            custom_ids.add(entry)
+
+    def known(pid: str) -> bool:
+        return _known_provider(pid) or pid in custom_ids
+
+    for pid in cfg.linked_providers:
+        if not known(pid):
+            errors.append(f"알 수 없는 linked provider: {pid} (built-in 또는 config.providers 에 정의 필요)")
+
+    # slot routing targets must be linked + a known slot.
+    for slot, target in cfg.slot_routing.items():
+        if slot not in ROUTING_SLOTS:
+            errors.append(f"알 수 없는 slot: {slot} (허용: {', '.join(ROUTING_SLOTS)})")
+        if target not in cfg.linked_providers:
+            errors.append(f"slot '{slot}' 의 target '{target}' 가 linked_providers 에 없습니다")
+
+    # fallback order entries must be linked.
+    for slot, order in cfg.slot_fallback_orders.items():
+        for pid in order:
+            if pid not in cfg.linked_providers:
+                errors.append(f"slot '{slot}' fallback 의 '{pid}' 가 linked_providers 에 없습니다")
+
+    return tuple(errors)
+
+
+__all__ = (
+    "SLOT_DEFAULT_CHAT", "SLOT_SYNTHESIS", "SLOT_RESEARCH", "SLOT_EXECUTION",
+    "SLOT_COMPRESSION", "SLOT_CLASSIFICATION", "SLOT_SAFETY", "ROUTING_SLOTS",
+    "ProviderConfig", "has_brain_config", "load_provider_config", "validate_provider_config",
+)

--- a/tests/forgekit/test_provider_config.py
+++ b/tests/forgekit/test_provider_config.py
@@ -1,0 +1,104 @@
+"""Multi-provider config contract + migration (forgekit brain).
+
+Proves the new schema parses, the legacy single-provider config migrates without
+breaking, and the multi-provider invariants are actually enforced (primary linked,
+slot targets linked, fallback entries linked, implicit-local-fallback off by default).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.policy import provider_config as pc
+
+
+class LoadTests(unittest.TestCase):
+    def test_full_schema_parses(self) -> None:
+        cfg = pc.load_provider_config({
+            "primary_provider": "claude",
+            "linked_providers": ["claude", "codex", "gemini", "ollama"],
+            "model_overrides": {"ollama": "gemma3:latest"},
+            "slot_routing": {"research": "gemini", "execution": "codex"},
+            "fallback_policy": {"implicit_local_fallback": True,
+                                 "slot_fallback_orders": {"default_chat": ["claude", "gemini"]}},
+            "budget_policy": {"per_provider": {"ollama": "local"}},
+        })
+        self.assertEqual(cfg.primary_provider, "claude")
+        self.assertTrue(cfg.is_multi)
+        self.assertEqual(cfg.slot_target("research"), "gemini")
+        self.assertEqual(cfg.slot_target("synthesis"), "claude")  # unset → primary
+        self.assertEqual(cfg.fallback_order("default_chat"), ("claude", "gemini"))
+        self.assertTrue(cfg.implicit_local_fallback)
+        self.assertEqual(cfg.model_for("ollama"), "gemma3:latest")
+        self.assertFalse(cfg.migrated_from_legacy)
+
+    def test_implicit_local_fallback_off_by_default(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude", "linked_providers": ["claude"]})
+        self.assertFalse(cfg.implicit_local_fallback)  # OFF unless explicitly enabled
+
+    def test_legacy_main_provider_migrates(self) -> None:
+        cfg = pc.load_provider_config({"main_provider": "ollama", "model": "gemma3:latest"})
+        self.assertEqual(cfg.primary_provider, "ollama")
+        self.assertEqual(cfg.linked_providers, ("ollama",))
+        self.assertTrue(cfg.migrated_from_legacy)
+        self.assertFalse(cfg.implicit_local_fallback)  # migration never enables implicit
+
+    def test_legacy_id_field_migrates(self) -> None:
+        cfg = pc.load_provider_config({"id": "claude"})
+        self.assertEqual(cfg.primary_provider, "claude")
+        self.assertTrue(cfg.migrated_from_legacy)
+
+    def test_primary_forced_into_linked(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude", "linked_providers": ["gemini"]})
+        self.assertIn("claude", cfg.linked_providers)
+
+
+class HasConfigTests(unittest.TestCase):
+    def test_empty_is_not_configured(self) -> None:
+        self.assertFalse(pc.has_brain_config(None))
+        self.assertFalse(pc.has_brain_config({}))
+
+    def test_new_and_legacy_are_configured(self) -> None:
+        self.assertTrue(pc.has_brain_config({"primary_provider": "claude"}))
+        self.assertTrue(pc.has_brain_config({"main_provider": "ollama"}))
+        self.assertTrue(pc.has_brain_config({"linked_providers": ["gemini"]}))
+
+
+class ValidateTests(unittest.TestCase):
+    def test_valid_config(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude",
+                                       "linked_providers": ["claude", "gemini"],
+                                       "slot_routing": {"research": "gemini"}})
+        self.assertEqual(pc.validate_provider_config(cfg), ())
+
+    def test_missing_primary(self) -> None:
+        cfg = pc.load_provider_config({"linked_providers": []})
+        errs = pc.validate_provider_config(cfg)
+        self.assertTrue(any("primary_provider" in e for e in errs))
+
+    def test_slot_target_must_be_linked(self) -> None:
+        # research routed to gemini but gemini not linked → error
+        cfg = pc.load_provider_config({"primary_provider": "claude", "linked_providers": ["claude"],
+                                       "slot_routing": {"research": "gemini"}})
+        errs = pc.validate_provider_config(cfg)
+        self.assertTrue(any("research" in e and "gemini" in e for e in errs))
+
+    def test_unknown_slot_rejected(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude", "linked_providers": ["claude"],
+                                       "slot_routing": {"nonsense": "claude"}})
+        self.assertTrue(any("nonsense" in e for e in pc.validate_provider_config(cfg)))
+
+    def test_fallback_entry_must_be_linked(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude", "linked_providers": ["claude"],
+                                       "fallback_policy": {"slot_fallback_orders": {"default_chat": ["gemini"]}}})
+        self.assertTrue(any("fallback" in e and "gemini" in e for e in pc.validate_provider_config(cfg)))
+
+    def test_unknown_linked_provider_rejected(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "mystery", "linked_providers": ["mystery"]})
+        self.assertTrue(any("mystery" in e for e in pc.validate_provider_config(cfg)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR (1/3) · base `main` · multi-provider brain 기반

## 목적
single main_provider 구조를 forgekit-as-brain + multi-provider 계약으로 전환하는 데이터 토대.

## 범위
- `policy/provider_config.py` — primary_provider + linked_providers + slot_routing(7 slot) + fallback_policy(implicit_local_fallback 기본 OFF) + budget_policy 타입 계약, 레거시 main_provider/id migration, invariant 검증.

## 테스트/검증
- `test_provider_config.py`(13). forgekit 541 OK ×2 venv, root 6352 OK.

## evidence / 경계
- 순수 계약(IO 없음). implicit_local_fallback 기본 False = 무설정 자동 ollama 금지의 토대.

## 관련 이슈
- 후속 routing/control-plane PR 의 base. umbrella #238 계열.
