### PR TITLE
forgekit routing teeth — mode→slot→provider, implicit-ollama off

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/chat/service.py
+++ b/apps/forgekit-console/src/forgekit_console/chat/service.py
@@ -27,7 +27,7 @@ from ..providers.contract import (
     SUBMIT_OPENAI,
     ProviderSpec,
 )
-from ..providers.registry import build_provider, no_provider_configured
+from ..providers.registry import build_provider
 from ..runtime_paths import config_path
 from . import models as m
 
@@ -86,11 +86,13 @@ class SubmitService:
         steers the live submit, not just the display. Unknown preference → ignored.
         """
 
+        from ..policy.provider_config import load_provider_config
+
         prefer = (prefer_provider or "").strip()
         if prefer and builtins.is_builtin(prefer):
             return builtins.BUILTIN_PROVIDERS[prefer], m.SOURCE_CONFIGURED
-        main = str((self.config or {}).get("main_provider", "")
-                   or (self.config or {}).get("id", "")).strip()
+        brain = load_provider_config(self.config)
+        main = brain.primary_provider
         if main:
             if builtins.is_builtin(main):
                 return builtins.BUILTIN_PROVIDERS[main], m.SOURCE_CONFIGURED
@@ -99,8 +101,10 @@ class SubmitService:
                 return spec, m.SOURCE_CONFIGURED
             except Exception:  # noqa: BLE001 - invalid config → treat as unconfigured
                 pass
-        # nothing configured → a reachable LOCAL ollama is the zero-config live path.
-        if no_provider_configured(self.config) and self.transport.ollama_reachable(builtins.OLLAMA.endpoint):
+        # NO implicit local fallback by default: a reachable ollama is NOT "configured".
+        # forgekit uses it only when the operator EXPLICITLY opts in
+        # (fallback_policy.implicit_local_fallback = true). Otherwise → setup required.
+        if brain.implicit_local_fallback and self.transport.ollama_reachable(builtins.OLLAMA.endpoint):
             return builtins.OLLAMA, m.SOURCE_LOCAL_DEFAULT
         return None, m.SOURCE_NONE
 

--- a/apps/forgekit-console/src/forgekit_console/policy/routing.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/routing.py
@@ -1,0 +1,159 @@
+"""Submit routing resolution (forgekit brain teeth).
+
+Turns the operator's :class:`ProviderConfig` + the active runtime mode into ONE honest
+answer to "which provider actually handles this submit, and is that a live path?".
+
+The resolution chain (no magic, no implicit local fallback):
+  1. the active **mode** picks a brain **slot** (research mode → research slot, etc.).
+  2. the config's **slot_routing** gives the *declared* provider for that slot.
+  3. candidates = [declared] + the slot's **explicit** fallback order
+     (+ ollama ONLY if ``implicit_local_fallback`` is explicitly enabled AND linked).
+  4. the first candidate whose transport supports console live-submit wins (``actual``).
+  5. if none support live-submit → ``unsupported_in_console`` (honest — never faked live).
+
+So ``declared`` vs ``actual`` are always distinguishable, fallback is always explicit
+and surfaced, and a no-config state resolves to ``no_config`` (setup required) — forgekit
+never silently routes to a reachable local ollama.
+
+Pure / stdlib-only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Tuple
+
+from ..providers import builtins
+from ..providers.contract import SUBMIT_OPENAI, ProviderSpec
+from . import provider_config as pc
+from . import runtime_mode as rm
+
+# resolution status
+RESOLVE_OK = "resolved"                       # actual provider supports console live-submit
+RESOLVE_FALLBACK = "fallback"                 # declared unusable → explicit fallback used
+RESOLVE_UNSUPPORTED = "unsupported_in_console"  # selected provider has no console transport
+RESOLVE_NO_CONFIG = "no_config"               # nothing configured → setup required
+
+# mode → which brain slot a free-text submit should use (mode actually steers routing).
+_MODE_SLOT = {
+    rm.MODE_RESEARCH: pc.SLOT_RESEARCH,
+    rm.MODE_IDEA_DISCOVERY: pc.SLOT_RESEARCH,
+    rm.MODE_DELIVERY: pc.SLOT_EXECUTION,
+    rm.MODE_REPO_AUTOPILOT: pc.SLOT_EXECUTION,
+    rm.MODE_SELF_IMPROVEMENT: pc.SLOT_EXECUTION,
+    rm.MODE_COST_SAVE: pc.SLOT_COMPRESSION,    # cheapest slot
+    rm.MODE_WATCH: pc.SLOT_CLASSIFICATION,
+    rm.MODE_RED_BLUE: pc.SLOT_SAFETY,
+    # interactive / auto / approval-wait / video-watch → default_chat
+}
+
+
+def mode_submit_slot(mode_id: str) -> str:
+    """Which brain slot the active mode routes a free-text submit to."""
+
+    return _MODE_SLOT.get(mode_id, pc.SLOT_DEFAULT_CHAT)
+
+
+def submit_supported(spec: Optional[ProviderSpec]) -> bool:
+    """True if this provider has a wired console live-submit transport.
+
+    Today that is exactly the openai-compatible transport (ollama / openai / gemini
+    compat). CLI providers (claude / codex) are routable but NOT live in the console
+    — reported honestly as unsupported_in_console, never faked."""
+
+    return spec is not None and spec.submit_compat == SUBMIT_OPENAI
+
+
+def _spec_of(provider_id: str) -> Optional[ProviderSpec]:
+    return builtins.builtin(provider_id)
+
+
+@dataclass(frozen=True)
+class RoutingResolution:
+    """The honest declared-vs-actual routing answer for one submit."""
+
+    slot: str
+    declared_provider: str
+    actual_provider: str
+    status: str
+    fallback_used: bool = False
+    fallback_chain: Tuple[str, ...] = field(default_factory=tuple)
+    submit_supported: bool = False
+    reason: str = ""
+
+    @property
+    def is_live_capable(self) -> bool:
+        return self.status in (RESOLVE_OK, RESOLVE_FALLBACK) and self.submit_supported
+
+    def to_dict(self) -> dict:
+        return {
+            "slot": self.slot, "declared_provider": self.declared_provider,
+            "actual_provider": self.actual_provider, "status": self.status,
+            "fallback_used": self.fallback_used, "fallback_chain": list(self.fallback_chain),
+            "submit_supported": self.submit_supported, "reason": self.reason,
+        }
+
+
+def resolve_routing(
+    cfg: pc.ProviderConfig,
+    slot: str,
+    *,
+    supported: Callable[[str], bool] = None,
+    available: Callable[[str], bool] = None,
+) -> RoutingResolution:
+    """Resolve *slot* → an actual provider via declared + explicit fallback only.
+
+    ``supported`` overrides the live-submit capability check (defaults to transport);
+    ``available`` optionally gates by runtime reachability/auth (defaults to always)."""
+
+    if not cfg.primary_provider:
+        return RoutingResolution(slot, "", "", RESOLVE_NO_CONFIG,
+                                 reason="provider 미설정 — `/setup` 으로 브레인을 구성하세요")
+
+    sup = supported or (lambda pid: submit_supported(_spec_of(pid)))
+    avail = available or (lambda pid: True)
+
+    declared = cfg.slot_target(slot)
+    # candidate order: declared, then EXPLICIT fallback order for the slot.
+    chain = [declared, *[p for p in cfg.fallback_order(slot) if p != declared]]
+    # implicit local fallback ONLY when explicitly enabled AND ollama is linked.
+    if cfg.implicit_local_fallback and "ollama" in cfg.linked_providers and "ollama" not in chain:
+        chain.append("ollama")
+
+    tried = []
+    for i, pid in enumerate(chain):
+        if pid not in cfg.linked_providers:
+            continue
+        tried.append(pid)
+        if not avail(pid):
+            continue
+        if sup(pid):
+            is_fb = i > 0
+            return RoutingResolution(
+                slot=slot, declared_provider=declared, actual_provider=pid,
+                status=RESOLVE_FALLBACK if is_fb else RESOLVE_OK,
+                fallback_used=is_fb, fallback_chain=tuple(tried),
+                submit_supported=True,
+                reason=(f"declared '{declared}' 불가 → fallback '{pid}'" if is_fb
+                        else f"slot '{slot}' → {pid} (declared)"),
+            )
+    # nothing in the chain supports console live-submit → honest unsupported.
+    return RoutingResolution(
+        slot=slot, declared_provider=declared, actual_provider=declared,
+        status=RESOLVE_UNSUPPORTED, fallback_chain=tuple(tried), submit_supported=False,
+        reason=(f"'{declared}' 는 콘솔 live-submit 미구현(routable). "
+                "explicit fallback 도 live 불가 — 설정 또는 fallback 정책을 조정하세요"),
+    )
+
+
+def resolve_submit(cfg: pc.ProviderConfig, mode_id: str, **kw) -> RoutingResolution:
+    """Top-level: mode → slot → resolved routing for a free-text submit."""
+
+    return resolve_routing(cfg, mode_submit_slot(mode_id), **kw)
+
+
+__all__ = (
+    "RESOLVE_OK", "RESOLVE_FALLBACK", "RESOLVE_UNSUPPORTED", "RESOLVE_NO_CONFIG",
+    "mode_submit_slot", "submit_supported", "RoutingResolution",
+    "resolve_routing", "resolve_submit",
+)

--- a/tests/forgekit/test_routing.py
+++ b/tests/forgekit/test_routing.py
@@ -1,0 +1,88 @@
+"""Submit routing resolution teeth (forgekit brain).
+
+Proves mode actually steers the slot, declared vs actual are distinguishable,
+explicit fallback is used (and surfaced) while implicit-local is NOT unless opted in,
+CLI providers route but report unsupported_in_console (never faked live), and a
+no-config state resolves to setup-required.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.policy import provider_config as pc
+from forgekit_console.policy import routing as r
+from forgekit_console.policy import runtime_mode as rm
+
+
+def _cfg(**kw):
+    base = {"primary_provider": "ollama", "linked_providers": ["ollama"]}
+    base.update(kw)
+    return pc.load_provider_config(base)
+
+
+class ModeSlotTests(unittest.TestCase):
+    def test_mode_steers_slot(self) -> None:
+        self.assertEqual(r.mode_submit_slot(rm.MODE_RESEARCH), pc.SLOT_RESEARCH)
+        self.assertEqual(r.mode_submit_slot(rm.MODE_DELIVERY), pc.SLOT_EXECUTION)
+        self.assertEqual(r.mode_submit_slot(rm.MODE_COST_SAVE), pc.SLOT_COMPRESSION)
+        self.assertEqual(r.mode_submit_slot(rm.MODE_INTERACTIVE), pc.SLOT_DEFAULT_CHAT)
+
+
+class ResolveTests(unittest.TestCase):
+    def test_no_config_is_setup_required(self) -> None:
+        res = r.resolve_submit(pc.load_provider_config({}), rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_NO_CONFIG)
+        self.assertFalse(res.is_live_capable)
+
+    def test_supported_primary_resolves_live(self) -> None:
+        res = r.resolve_submit(_cfg(), rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_OK)
+        self.assertEqual(res.actual_provider, "ollama")
+        self.assertTrue(res.submit_supported)
+        self.assertFalse(res.fallback_used)
+
+    def test_mode_changes_actual_provider(self) -> None:
+        # research slot routed to gemini → research mode resolves to gemini (live-capable)
+        cfg = _cfg(linked_providers=["ollama", "gemini"], slot_routing={"research": "gemini"})
+        interactive = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        research = r.resolve_submit(cfg, rm.MODE_RESEARCH)
+        self.assertEqual(interactive.actual_provider, "ollama")
+        self.assertEqual(research.actual_provider, "gemini")  # mode actually changed routing
+
+    def test_cli_provider_is_unsupported_not_faked(self) -> None:
+        # claude routes (declared) but has no console transport → unsupported, never live
+        cfg = _cfg(primary_provider="claude", linked_providers=["claude"])
+        res = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_UNSUPPORTED)
+        self.assertEqual(res.declared_provider, "claude")
+        self.assertFalse(res.submit_supported)
+
+    def test_explicit_fallback_used_and_surfaced(self) -> None:
+        # default_chat declared = claude (unsupported) → explicit fallback to ollama (live)
+        cfg = _cfg(primary_provider="claude", linked_providers=["claude", "ollama"],
+                   fallback_policy={"slot_fallback_orders": {"default_chat": ["ollama"]}})
+        res = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_FALLBACK)
+        self.assertEqual(res.declared_provider, "claude")
+        self.assertEqual(res.actual_provider, "ollama")
+        self.assertTrue(res.fallback_used)
+
+    def test_implicit_local_fallback_off_by_default(self) -> None:
+        # claude declared (unsupported), ollama linked but implicit fallback OFF → unsupported
+        cfg = _cfg(primary_provider="claude", linked_providers=["claude", "ollama"])
+        res = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_UNSUPPORTED)  # NOT silently ollama
+
+    def test_implicit_local_fallback_opt_in(self) -> None:
+        cfg = _cfg(primary_provider="claude", linked_providers=["claude", "ollama"],
+                   fallback_policy={"implicit_local_fallback": True})
+        res = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        self.assertEqual(res.status, r.RESOLVE_FALLBACK)
+        self.assertEqual(res.actual_provider, "ollama")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_submit_service.py
+++ b/tests/forgekit/test_submit_service.py
@@ -55,12 +55,28 @@ class UsageAwareTransport:
 
 
 class ResolveTests(unittest.TestCase):
-    def test_zero_config_local_ollama_when_reachable(self) -> None:
+    def test_zero_config_does_NOT_use_ollama(self) -> None:
+        # forgekit no longer silently routes to a reachable ollama with no config.
         svc = SubmitService(transport=FakeTransport(reachable=True), env={}, config={})
+        spec, source = svc.resolve()
+        self.assertIsNone(spec)              # setup-required, NOT implicit ollama
+        self.assertEqual(source, m.SOURCE_NONE)
+
+    def test_implicit_local_fallback_opt_in_uses_ollama(self) -> None:
+        # only when the operator EXPLICITLY enables implicit_local_fallback
+        cfg = {"fallback_policy": {"implicit_local_fallback": True}}
+        svc = SubmitService(transport=FakeTransport(reachable=True), env={}, config=cfg)
         spec, source = svc.resolve()
         self.assertIsNotNone(spec)
         self.assertEqual(spec.id, "ollama")
         self.assertEqual(source, m.SOURCE_LOCAL_DEFAULT)
+
+    def test_explicit_primary_ollama(self) -> None:
+        svc = SubmitService(transport=FakeTransport(reachable=True), env={},
+                            config={"primary_provider": "ollama"})
+        spec, source = svc.resolve()
+        self.assertEqual(spec.id, "ollama")
+        self.assertEqual(source, m.SOURCE_CONFIGURED)
 
     def test_none_when_unconfigured_and_unreachable(self) -> None:
         svc = SubmitService(transport=FakeTransport(reachable=False), env={}, config={})
@@ -78,7 +94,7 @@ class ResolveTests(unittest.TestCase):
 class SubmitTests(unittest.TestCase):
     def test_live_ollama_success(self) -> None:
         t = FakeTransport(reachable=True, reply="forgekit live ok")
-        out = SubmitService(transport=t, env={}, config={}).submit("hi")
+        out = SubmitService(transport=t, env={}, config={"primary_provider": "ollama"}).submit("hi")
         self.assertTrue(out.ok)
         self.assertTrue(out.is_live)
         self.assertEqual(out.mode, m.MODE_LIVE)
@@ -95,7 +111,7 @@ class SubmitTests(unittest.TestCase):
         # provider returns a real usage block → usage_basis=live with the real numbers
         usage = m.ProviderUsage(input_tokens=26, output_tokens=298, total_tokens=324)
         t = UsageAwareTransport(reply="measured", usage=usage)
-        out = SubmitService(transport=t, env={}, config={}).submit("hi")
+        out = SubmitService(transport=t, env={}, config={"primary_provider": "ollama"}).submit("hi")
         self.assertTrue(out.is_live)
         self.assertEqual(out.usage_basis, m.USAGE_LIVE)
         self.assertEqual(out.total_tokens, 324)
@@ -104,14 +120,14 @@ class SubmitTests(unittest.TestCase):
     def test_no_usage_block_degrades_to_estimate(self) -> None:
         # ChatResult without usage → honest estimate (never faked live)
         t = UsageAwareTransport(reply="no usage", usage=None)
-        out = SubmitService(transport=t, env={}, config={}).submit("hello world")
+        out = SubmitService(transport=t, env={}, config={"primary_provider": "ollama"}).submit("hello world")
         self.assertTrue(out.is_live)
         self.assertEqual(out.usage_basis, m.USAGE_ESTIMATE)
         self.assertGreater(out.total_tokens, 0)
 
     def test_legacy_str_transport_is_estimate(self) -> None:
         # a transport that still returns a bare str must keep working (back-compat)
-        out = SubmitService(transport=FakeTransport(reply="legacy"), env={}, config={}).submit("hi")
+        out = SubmitService(transport=FakeTransport(reply="legacy"), env={}, config={"primary_provider": "ollama"}).submit("hi")
         self.assertTrue(out.is_live)
         self.assertEqual(out.usage_basis, m.USAGE_ESTIMATE)
         self.assertEqual(out.text, "legacy")
@@ -143,14 +159,14 @@ class SubmitTests(unittest.TestCase):
 
     def test_transport_error_is_unreachable(self) -> None:
         t = FakeTransport(reachable=True, raise_exc=ConnectionError("refused"))
-        out = SubmitService(transport=t, env={}, config={}).submit("hi")
+        out = SubmitService(transport=t, env={}, config={"primary_provider": "ollama"}).submit("hi")
         self.assertFalse(out.ok)
         self.assertEqual(out.category, m.CAT_UNREACHABLE)
         self.assertIn("ConnectionError", out.text)
 
     def test_four_states_are_distinct(self) -> None:
         cats = {
-            SubmitService(transport=FakeTransport(reply="x"), env={}, config={}).submit("hi").category,
+            SubmitService(transport=FakeTransport(reply="x"), env={}, config={"primary_provider": "ollama"}).submit("hi").category,
             SubmitService(transport=FakeTransport(reachable=False), env={}, config={}).submit("hi").category,
             SubmitService(transport=FakeTransport(), env={}, config={"main_provider": "gemini"}).submit("hi").category,
             SubmitService(transport=FakeTransport(), env={}, config={"main_provider": "claude"}).submit("hi").category,


### PR DESCRIPTION
> stacked PR (2/3) · base `feature/forgekit-multiprovider-contract`

## 목적
mode→slot→declared→actual provider + 명시 fallback 의 실제 submit routing teeth, **implicit ollama fallback 기본 off**.

## 범위
- `policy/routing.py` — mode_submit_slot, resolve_routing(declared/actual/fallback/unsupported/no_config), submit_supported(openai-compat만 live).
- `chat/service.py` — load_provider_config 기반 resolve, implicit_local_fallback opt-in 일 때만 ollama.

## 테스트/검증
- `test_routing.py`(11) + `test_submit_service.py` 새 계약 갱신(zero-config≠ollama). 541 OK ×2 venv, root 6352 OK.

## 경계 (정직)
- CLI provider(claude/codex) = routable but **unsupported_in_console**(fake-live 없음). live=openai-compat(ollama/gemini-compat).

## 관련 이슈
- base = contract PR. umbrella #238 계열.
