### PR TITLE
forgekit provider control-plane core — config 편집/영속/review

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/policy/provider_ops.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/provider_ops.py
@@ -1,0 +1,167 @@
+"""Provider control-plane operations — edit + persist the brain config (operator UX).
+
+Pure config transforms (a raw dict → a new raw dict) so `/provider use|link|unlink|route`
+and the setup flow are unit-testable without IO, plus a thin persist/load pair that
+writes ``~/.forgekit/config.json`` (the only IO, path-injectable). Also a ``brain_map``
+operator view (declared routing + live-capable vs unsupported providers) and a
+``setup_review`` that distinguishes incomplete / misconfigured / missing-auth honestly.
+
+No fake state: a provider with no console transport is shown ``unsupported_in_console``,
+not hidden; an invalid config surfaces its errors rather than silently "working".
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Tuple
+
+from ..providers import builtins
+from ..runtime_paths import config_path
+from . import provider_config as pc
+from . import routing as rt
+
+# setup review verdicts
+REVIEW_READY = "ready"
+REVIEW_INCOMPLETE = "incomplete"          # no primary / no linked
+REVIEW_MISCONFIGURED = "misconfigured"    # invalid slot target / unknown provider
+REVIEW_NO_LIVE = "no_live_submit"         # configured but nothing console-live
+
+
+# --- pure config transforms (raw dict → new raw dict) -----------------------
+def _clone(cfg: Optional[Mapping]) -> dict:
+    return json.loads(json.dumps(dict(cfg or {})))
+
+
+def set_primary(cfg: Optional[Mapping], pid: str) -> dict:
+    out = _clone(cfg)
+    out["primary_provider"] = pid
+    linked = list(out.get("linked_providers") or [])
+    if pid and pid not in linked:
+        linked.insert(0, pid)
+    out["linked_providers"] = linked
+    return out
+
+
+def link_provider(cfg: Optional[Mapping], pid: str) -> dict:
+    out = _clone(cfg)
+    linked = list(out.get("linked_providers") or [])
+    if pid and pid not in linked:
+        linked.append(pid)
+    out["linked_providers"] = linked
+    return out
+
+
+def unlink_provider(cfg: Optional[Mapping], pid: str) -> dict:
+    out = _clone(cfg)
+    linked = [p for p in (out.get("linked_providers") or []) if p != pid]
+    out["linked_providers"] = linked
+    # drop slot routes that pointed at the removed provider (no dangling targets).
+    routes = {s: t for s, t in (out.get("slot_routing") or {}).items() if t != pid}
+    out["slot_routing"] = routes
+    return out
+
+
+def route_slot(cfg: Optional[Mapping], slot: str, pid: str) -> dict:
+    out = _clone(cfg)
+    routes = dict(out.get("slot_routing") or {})
+    routes[slot] = pid
+    out["slot_routing"] = routes
+    return out
+
+
+def set_implicit_fallback(cfg: Optional[Mapping], enabled: bool) -> dict:
+    out = _clone(cfg)
+    fb = dict(out.get("fallback_policy") or {})
+    fb["implicit_local_fallback"] = bool(enabled)
+    out["fallback_policy"] = fb
+    return out
+
+
+# --- persistence (the only IO; path-injectable) -----------------------------
+def load_raw_config(*, env: Optional[Mapping[str, str]] = None, path: Optional[Path] = None) -> dict:
+    p = path or config_path(env)
+    try:
+        data = json.loads(Path(p).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def persist_config(cfg: Mapping, *, env: Optional[Mapping[str, str]] = None,
+                   path: Optional[Path] = None) -> Tuple[bool, str]:
+    """Validate then write the config. Refuses to persist an invalid brain config."""
+
+    parsed = pc.load_provider_config(cfg)
+    errors = pc.validate_provider_config(parsed, config=cfg)
+    if errors:
+        return False, "; ".join(errors)
+    p = path or config_path(env)
+    try:
+        Path(p).parent.mkdir(parents=True, exist_ok=True)
+        Path(p).write_text(json.dumps(dict(cfg), ensure_ascii=False, indent=2), encoding="utf-8")
+        return True, str(p)
+    except OSError as exc:
+        return False, f"write 실패: {exc}"
+
+
+# --- operator views ---------------------------------------------------------
+@dataclass(frozen=True)
+class BrainMap:
+    primary: str
+    linked: Tuple[str, ...]
+    slot_targets: Mapping[str, str]
+    live_capable: Tuple[str, ...]        # linked providers with a console transport
+    unsupported: Tuple[str, ...]         # linked but routable-only (no console submit)
+
+    def to_dict(self) -> dict:
+        return {"primary": self.primary, "linked": list(self.linked),
+                "slot_targets": dict(self.slot_targets),
+                "live_capable": list(self.live_capable), "unsupported": list(self.unsupported)}
+
+
+def brain_map(parsed: pc.ProviderConfig) -> BrainMap:
+    """The declared brain — slot targets + which linked providers are console-live."""
+
+    live, unsup = [], []
+    for pid in parsed.linked_providers:
+        spec = builtins.builtin(pid)
+        (live if rt.submit_supported(spec) else unsup).append(pid)
+    targets = {slot: parsed.slot_target(slot) for slot in pc.ROUTING_SLOTS}
+    return BrainMap(parsed.primary_provider, parsed.linked_providers, targets,
+                    tuple(live), tuple(unsup))
+
+
+@dataclass(frozen=True)
+class SetupReview:
+    verdict: str
+    issues: Tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def ready(self) -> bool:
+        return self.verdict == REVIEW_READY
+
+
+def setup_review(cfg: Optional[Mapping]) -> SetupReview:
+    """Distinguish incomplete / misconfigured / no-live / ready (honest, no fake-ready)."""
+
+    if not pc.has_brain_config(cfg):
+        return SetupReview(REVIEW_INCOMPLETE, ("primary provider 미설정 — `/setup` 으로 브레인을 구성하세요",))
+    parsed = pc.load_provider_config(cfg)
+    errors = pc.validate_provider_config(parsed, config=cfg)
+    if errors:
+        return SetupReview(REVIEW_MISCONFIGURED, errors)
+    bmap = brain_map(parsed)
+    if not bmap.live_capable:
+        return SetupReview(REVIEW_NO_LIVE, (
+            f"linked provider 가 모두 console live-submit 미지원: {', '.join(bmap.unsupported) or '-'} "
+            "— openai-compatible(ollama/gemini)를 link 하거나 fallback 을 설정하세요",))
+    return SetupReview(REVIEW_READY, ())
+
+
+__all__ = (
+    "REVIEW_READY", "REVIEW_INCOMPLETE", "REVIEW_MISCONFIGURED", "REVIEW_NO_LIVE",
+    "set_primary", "link_provider", "unlink_provider", "route_slot", "set_implicit_fallback",
+    "load_raw_config", "persist_config", "BrainMap", "brain_map", "SetupReview", "setup_review",
+)

--- a/tests/forgekit/test_provider_ops.py
+++ b/tests/forgekit/test_provider_ops.py
@@ -1,0 +1,100 @@
+"""Provider control-plane ops — config edit/persist + brain map + setup review.
+
+Proves the operator can actually build a valid brain config (use/link/unlink/route),
+that persistence refuses invalid configs (no fake-ready), and that brain_map /
+setup_review surface live-capable vs unsupported providers honestly.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.policy import provider_config as pc
+from forgekit_console.policy import provider_ops as ops
+
+
+class TransformTests(unittest.TestCase):
+    def test_set_primary_adds_to_linked(self) -> None:
+        cfg = ops.set_primary({}, "claude")
+        self.assertEqual(cfg["primary_provider"], "claude")
+        self.assertIn("claude", cfg["linked_providers"])
+
+    def test_link_unlink(self) -> None:
+        cfg = ops.link_provider(ops.set_primary({}, "claude"), "gemini")
+        self.assertIn("gemini", cfg["linked_providers"])
+        cfg = ops.unlink_provider(cfg, "gemini")
+        self.assertNotIn("gemini", cfg["linked_providers"])
+
+    def test_unlink_drops_dangling_routes(self) -> None:
+        cfg = ops.route_slot(ops.link_provider(ops.set_primary({}, "claude"), "gemini"),
+                             "research", "gemini")
+        cfg = ops.unlink_provider(cfg, "gemini")
+        self.assertNotIn("research", cfg["slot_routing"])  # route to removed provider dropped
+
+    def test_route_and_implicit_fallback(self) -> None:
+        cfg = ops.route_slot(ops.set_primary({}, "ollama"), "research", "ollama")
+        self.assertEqual(cfg["slot_routing"]["research"], "ollama")
+        cfg = ops.set_implicit_fallback(cfg, True)
+        self.assertTrue(cfg["fallback_policy"]["implicit_local_fallback"])
+
+
+class PersistTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.path = self.tmp / "config.json"
+
+    def test_persist_valid_then_load(self) -> None:
+        cfg = ops.route_slot(ops.link_provider(ops.set_primary({}, "ollama"), "gemini"),
+                             "research", "gemini")
+        ok, where = ops.persist_config(cfg, path=self.path)
+        self.assertTrue(ok, where)
+        self.assertTrue(self.path.exists())
+        loaded = ops.load_raw_config(path=self.path)
+        self.assertEqual(loaded["primary_provider"], "ollama")
+
+    def test_persist_refuses_invalid(self) -> None:
+        # research routed to gemini but gemini not linked → invalid → not written
+        bad = {"primary_provider": "ollama", "linked_providers": ["ollama"],
+               "slot_routing": {"research": "gemini"}}
+        ok, msg = ops.persist_config(bad, path=self.path)
+        self.assertFalse(ok)
+        self.assertFalse(self.path.exists())          # nothing persisted
+        self.assertIn("research", msg)
+
+
+class ViewTests(unittest.TestCase):
+    def test_brain_map_live_vs_unsupported(self) -> None:
+        cfg = pc.load_provider_config({"primary_provider": "claude",
+                                       "linked_providers": ["claude", "ollama", "gemini"]})
+        bmap = ops.brain_map(cfg)
+        self.assertIn("ollama", bmap.live_capable)
+        self.assertIn("gemini", bmap.live_capable)
+        self.assertIn("claude", bmap.unsupported)      # CLI provider → routable, not live
+
+    def test_review_incomplete(self) -> None:
+        self.assertEqual(ops.setup_review({}).verdict, ops.REVIEW_INCOMPLETE)
+
+    def test_review_misconfigured(self) -> None:
+        rev = ops.setup_review({"primary_provider": "ollama", "linked_providers": ["ollama"],
+                                "slot_routing": {"research": "gemini"}})
+        self.assertEqual(rev.verdict, ops.REVIEW_MISCONFIGURED)
+        self.assertTrue(rev.issues)
+
+    def test_review_no_live(self) -> None:
+        # claude-only brain → routable but no console live-submit
+        rev = ops.setup_review({"primary_provider": "claude", "linked_providers": ["claude"]})
+        self.assertEqual(rev.verdict, ops.REVIEW_NO_LIVE)
+
+    def test_review_ready(self) -> None:
+        rev = ops.setup_review({"primary_provider": "ollama", "linked_providers": ["ollama"]})
+        self.assertTrue(rev.ready)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> base `main` · provider control-plane 로직 코어

## 목적
operator 가 forgekit brain(primary/linked/slot_routing/fallback)을 명시 구성하고 **검증 후 저장**할 수 있는 control-plane 로직.

## 범위
- `policy/provider_ops.py` — 순수 config transform(set_primary/link/unlink/route/set_implicit_fallback), persist_config(invalid 면 미저장), brain_map(live-capable vs unsupported 분리), setup_review(incomplete/misconfigured/no_live/ready).

## 테스트/검증
- `test_provider_ops.py`(11). forgekit suite OK ×2 venv.

## 경계 (정직 / 후속)
- 이번은 **로직 코어**. 콘솔 `/provider`·`/setup` command 표면 wiring(use/link/route 인터랙션)은 후속.
- CLI provider(claude/codex)는 brain_map 에서 unsupported 로 정직 표면(fake-live 없음).

## 관련
- multi-provider 라우팅 foundation(merged) 위. umbrella #238 계열.
