### PR TITLE
forgekit canonical agent identity registry (SSoT)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/identity/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/identity/__init__.py
@@ -1,0 +1,21 @@
+"""Canonical agent identity — the single SSoT for who an agent is across forgekit.
+
+Resolves manifest ids / vault-authorship abbreviations to ONE canonical identity
+(role label, department, git author, GitHub App env prefix, Obsidian css/callout/
+colour). Every surface (vault authorship, git attribution, doctor) reads from here so
+the abbreviated (`fe`) vs formal (`frontend-engineer`) drift is fixed in one place.
+"""
+
+from .models import AgentIdentity
+from .registry import (
+    all_identities,
+    git_identity_for,
+    github_app_identity_for,
+    resolve_identity,
+    vault_identity_for,
+)
+
+__all__ = (
+    "AgentIdentity", "all_identities", "resolve_identity",
+    "vault_identity_for", "git_identity_for", "github_app_identity_for",
+)

--- a/apps/forgekit-console/src/forgekit_console/identity/models.py
+++ b/apps/forgekit-console/src/forgekit_console/identity/models.py
@@ -1,0 +1,81 @@
+"""Canonical agent identity model + derivation rules. Pure / stdlib-only.
+
+One :class:`AgentIdentity` per canonical agent. Some fields are *explicit* (vault
+css/colour — not derivable from the id) and some are *derived* by fixed rule
+(GitHub App env prefix, git author) so the SSoT stays small and consistent:
+
+  * ``github_app_env_prefix`` = ``YULE_GITHUB_APP_<CANONICAL_UPPER_SNAKE>_``
+  * ``git_author_name``       = ``Forgekit <role_label>``
+  * ``git_author_email``      = ``<email_local>@forgekit.local``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+def github_app_env_prefix(canonical_id: str, *, shared: bool = False) -> str:
+    if shared:
+        return "YULE_GITHUB_APP_SHARED_"
+    snake = (canonical_id or "").strip().replace("-", "_").upper()
+    return f"YULE_GITHUB_APP_{snake}_"
+
+
+def git_author_name(role_label: str) -> str:
+    return f"Forgekit {role_label}".strip()
+
+
+def git_author_email(email_local: str) -> str:
+    return f"{(email_local or 'agent').strip()}@forgekit.local"
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    """A canonical agent identity — the SSoT row every surface reads."""
+
+    canonical_id: str
+    role_label: str
+    department: str
+    vault_cssclass: str          # explicit (e.g. fk-fe — not fk-frontend-engineer)
+    vault_color: str             # explicit hex token
+    identity_aliases: Tuple[str, ...] = ()   # abbreviations / manifest variants
+    email_local: str = ""        # left side of the git author email (defaults to css stem)
+    supports_github_app: bool = True
+    supports_vault_authorship: bool = True
+    manifest_path: str = ""      # set when cross-checked against an on-disk manifest
+
+    # --- derived projections ------------------------------------------------
+    @property
+    def vault_callout(self) -> str:
+        return self.vault_cssclass  # callout type mirrors the css class
+
+    @property
+    def github_app_env_prefix(self) -> str:
+        return github_app_env_prefix(self.canonical_id)
+
+    @property
+    def git_author_name(self) -> str:
+        return git_author_name(self.role_label)
+
+    @property
+    def git_author_email(self) -> str:
+        stem = self.email_local or self.vault_cssclass.replace("fk-", "") or self.canonical_id
+        return git_author_email(stem)
+
+    def to_dict(self) -> dict:
+        return {
+            "canonical_id": self.canonical_id, "role_label": self.role_label,
+            "department": self.department,
+            "github_app_env_prefix": self.github_app_env_prefix,
+            "git_author_name": self.git_author_name,
+            "git_author_email": self.git_author_email,
+            "vault_cssclass": self.vault_cssclass, "vault_callout": self.vault_callout,
+            "vault_color": self.vault_color, "identity_aliases": list(self.identity_aliases),
+            "supports_github_app": self.supports_github_app,
+            "supports_vault_authorship": self.supports_vault_authorship,
+            "manifest_path": self.manifest_path,
+        }
+
+
+__all__ = ("AgentIdentity", "github_app_env_prefix", "git_author_name", "git_author_email")

--- a/apps/forgekit-console/src/forgekit_console/identity/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/identity/registry.py
@@ -1,0 +1,153 @@
+"""Canonical agent identity registry — the single SSoT (pure / stdlib-only).
+
+Canonical id = the FORMAL agent id (``frontend-engineer``), never the abbreviation.
+Abbreviations (``fe``) and manifest variants are accepted as *aliases* and normalise
+to the canonical identity here — so the abbreviation→formal mapping lives in exactly
+ONE place (this module), not scattered across vault/authorship, manifests and docs.
+
+Seed rows carry the *explicit* fields (role label, department, vault css/colour,
+aliases); GitHub App prefix + git author are *derived* by rule in :mod:`models`.
+``scan_manifests`` cross-checks the on-disk manifests and reports drift rather than
+silently diverging.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+
+from .models import AgentIdentity
+
+# (canonical_id, role_label, department, cssclass, color, email_local, aliases)
+_SEED: Tuple[tuple, ...] = (
+    ("product-manager", "Product (PM)", "product", "fk-pm", "#f23ccf", "pm", ("product-agent", "pm")),
+    ("gateway", "Engineering Gateway", "engineering", "fk-gateway", "#8b90a0", "gateway", ()),
+    ("tech-lead", "Tech Lead", "engineering", "fk-techlead", "#00d8f0", "techlead", ()),
+    ("frontend-engineer", "Frontend", "engineering", "fk-fe", "#3ddc97", "fe", ("fe",)),
+    ("backend-engineer", "Backend", "engineering", "fk-be", "#e0b020", "be", ("be",)),
+    ("devops-engineer", "DevOps", "engineering", "fk-devops", "#ff5c7a", "devops", ("devops",)),
+    ("qa-engineer", "QA", "engineering", "fk-qa", "#9b8cf0", "qa", ("qa",)),
+    ("security-engineer", "Security", "engineering", "fk-security", "#ff8c42", "security", ("security",)),
+    ("ai-engineer", "AI Engineer", "engineering", "fk-ai", "#38bdf8", "ai", ()),
+    ("platform-runtime-engineer", "Platform Runtime", "engineering", "fk-platform", "#14b8a6", "platform", ()),
+    ("knowledge-engineer", "Knowledge Engineer", "engineering", "fk-knowledge", "#f59e0b", "knowledge", ()),
+    ("ops-observer", "Ops Observer", "ops", "fk-ops", "#2f6f7a", "ops", ()),
+    ("ux-ui-designer", "UX/UI Designer", "design", "fk-ux", "#7dd3fc", "uxui", ("ux",)),
+    ("design-systems-designer", "Design Systems", "design", "fk-dsys", "#a78bfa", "dsys", ()),
+    ("illustration-brand-designer", "Illustration/Brand", "design", "fk-illus", "#fb7185", "brandart", ()),
+    ("design-lead", "Design Lead", "design", "fk-design-lead", "#22d3ee", "designlead", ()),
+    ("user-researcher", "User Researcher", "product", "fk-user-research", "#c084fc", "user-research", ()),
+    ("growth-marketer", "Growth", "marketing", "fk-growth", "#34d399", "growth", ()),
+    ("growth-analyst", "Growth Analyst", "marketing", "fk-growth-analyst", "#10b981", "growth-analyst", ()),
+    ("content-strategist", "Content", "marketing", "fk-content", "#f59e0b", "content", ()),
+    ("brand-manager", "Brand Manager", "marketing", "fk-brand", "#ec4899", "brand", ()),
+    ("seo-specialist", "SEO", "marketing", "fk-seo", "#84cc16", "seo", ()),
+    ("budget-analyst", "Budget Analyst", "finance", "fk-budget", "#fbbf24", "budget", ()),
+    ("recruiter", "Recruiter", "people", "fk-recruiter", "#60a5fa", "recruiter", ()),
+    ("people-ops", "People Ops", "people", "fk-peopleops", "#f472b6", "peopleops", ()),
+    ("culture-coach", "Culture Coach", "people", "fk-culture", "#a78bfa", "culture", ()),
+    ("contract-reviewer", "Contract Reviewer", "legal", "fk-contract", "#f97316", "contract", ()),
+    ("privacy-officer", "Privacy Officer", "legal", "fk-privacy", "#fb7185", "privacy", ()),
+    ("sales-rep", "Sales", "sales", "fk-sales", "#22c55e", "sales", ()),
+    ("customer-success", "Customer Success", "sales", "fk-cs", "#06b6d4", "cs", ()),
+)
+
+_FALLBACK = AgentIdentity("forgekit", "forgekit", "core", "fk-agent", "#8b90a0", (), "agent")
+
+
+def _build() -> Tuple[Dict[str, AgentIdentity], Dict[str, str]]:
+    by_id: Dict[str, AgentIdentity] = {}
+    alias_to_id: Dict[str, str] = {}
+    for cid, label, dept, css, color, email, aliases in _SEED:
+        ident = AgentIdentity(cid, label, dept, css, color, tuple(aliases), email)
+        by_id[cid] = ident
+        alias_to_id[cid] = cid
+        for a in aliases:
+            alias_to_id[a] = cid
+    return by_id, alias_to_id
+
+
+_BY_ID, _ALIAS = _build()
+
+
+def all_identities() -> Tuple[AgentIdentity, ...]:
+    return tuple(_BY_ID.values())
+
+
+def canonical_id(agent_id: str) -> str:
+    """Normalise any id/alias to its canonical id ("" if unknown)."""
+
+    return _ALIAS.get((agent_id or "").strip(), "")
+
+
+def resolve_identity(agent_id: str) -> AgentIdentity:
+    """Resolve a formal id OR an alias to the canonical identity (fallback if unknown)."""
+
+    cid = canonical_id(agent_id)
+    return _BY_ID.get(cid, _FALLBACK)
+
+
+def is_known(agent_id: str) -> bool:
+    return bool(canonical_id(agent_id))
+
+
+# --- projections (the seams vault / git / github surfaces will read) --------
+def vault_identity_for(agent_id: str) -> dict:
+    ident = resolve_identity(agent_id)
+    return {"agent_author": ident.canonical_id, "agent_role": ident.role_label,
+            "cssclass": ident.vault_cssclass, "callout": ident.vault_callout,
+            "agent_color": ident.vault_color}
+
+
+def git_identity_for(agent_id: str) -> dict:
+    ident = resolve_identity(agent_id)
+    return {"name": ident.git_author_name, "email": ident.git_author_email,
+            "canonical_id": ident.canonical_id, "role": ident.role_label}
+
+
+def github_app_identity_for(agent_id: str) -> dict:
+    ident = resolve_identity(agent_id)
+    return {"env_prefix": ident.github_app_env_prefix, "shared_prefix": "YULE_GITHUB_APP_SHARED_",
+            "supports_github_app": ident.supports_github_app, "canonical_id": ident.canonical_id}
+
+
+def to_dict() -> dict:
+    return {"identities": [i.to_dict() for i in all_identities()],
+            "aliases": dict(_ALIAS)}
+
+
+# --- manifest cross-check (drift detection, not a second SSoT) ---------------
+def scan_manifests(agents_root: Path) -> Dict[str, list]:
+    """Cross-check on-disk manifests against the registry. Returns structured drift.
+
+    ``unknown`` = manifest id not in the registry (alias or canonical); ``prefix_drift``
+    = manifest github_app_env_prefix differs from the derived one. Never raises."""
+
+    out = {"matched": [], "unknown": [], "prefix_drift": []}
+    try:
+        manifests = sorted(Path(agents_root).rglob("manifest.json"))
+    except OSError:
+        return out
+    for mf in manifests:
+        try:
+            data = json.loads(mf.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        mid = str(data.get("id", "") or data.get("role", "")).strip()
+        cid = canonical_id(mid) or canonical_id(str(data.get("role", "")).strip())
+        if not cid:
+            out["unknown"].append(mid)
+            continue
+        out["matched"].append(cid)
+        declared = str(data.get("github_app_env_prefix", "") or "").strip()
+        if declared and declared != _BY_ID[cid].github_app_env_prefix:
+            out["prefix_drift"].append((mid, declared, _BY_ID[cid].github_app_env_prefix))
+    return out
+
+
+__all__ = (
+    "all_identities", "canonical_id", "resolve_identity", "is_known",
+    "vault_identity_for", "git_identity_for", "github_app_identity_for",
+    "to_dict", "scan_manifests",
+)

--- a/docs/forgekit-console.md
+++ b/docs/forgekit-console.md
@@ -819,6 +819,24 @@ text), `/help` 를 **단일 패널 뷰 전환**(모달 아님, transcript 누적
 **범위 밖(후속):** brain/setup/provider 코어, 실제 live chat loop, Agent Town, macOS 알림,
 Discord push, approval inbox 조작, multi-provider session persistence.
 
+## 6b. agent identity registry (canonical SSoT)
+
+agent 의 정체성(role label / department / git author / GitHub App env prefix / Obsidian
+css·callout·color)은 **단일 canonical registry** 가 SSoT —
+[`identity/registry.py`](../apps/forgekit-console/src/forgekit_console/identity/registry.py).
+
+- **canonical id = 정식 id**(`frontend-engineer`), 축약(`fe`)·manifest 변형은 **alias** 로
+  registry 에서만 canonical 로 정규화(축약→정식 매핑이 vault/manifest/docs 에 흩어지지 않음).
+- 파생 규칙: `github_app_env_prefix = YULE_GITHUB_APP_<CANONICAL_UPPER_SNAKE>_`,
+  git author = `Forgekit <Role> <local@forgekit.local>`. vault css/callout/color 는 explicit.
+- projection seam: `vault_identity_for` / `git_identity_for` / `github_app_identity_for`
+  — vault/authorship·git attribution·doctor 가 이걸 읽도록 후속 통합(현재 `vault/authorship.py`
+  하드코딩 맵은 다음 단계에서 이 registry 기반 thin wrapper 로 교체 예정).
+- `scan_manifests(agents_root)` 가 on-disk manifest 와 registry drift(unknown / prefix_drift)를
+  **fail-loud 아닌 structured 결과**로 surface(실측: 25 matched / prefix-drift 0).
+- 정직: 실제 GitHub App 생성/설치는 org admin 작업 — registry 는 env contract + identity 까지,
+  live 생성은 runbook(후속).
+
 ## 7. 관련
 - [`runtime-operator-surfaces.md`](runtime-operator-surfaces.md) (재사용하는 surface) ·
   [`operations.md`](operations.md) · [`monorepo-structure.md`](monorepo-structure.md)

--- a/tests/forgekit/test_identity_registry.py
+++ b/tests/forgekit/test_identity_registry.py
@@ -1,0 +1,79 @@
+"""Canonical agent identity registry — the single SSoT (pure).
+
+Proves formal-id and alias resolution both reach the canonical identity, the
+abbreviation→formal mapping lives only here, derivation rules (github prefix / git
+author) are deterministic, projections are stable, and unknown ids fall back honestly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.identity import registry as reg
+from forgekit_console.identity.models import AgentIdentity, github_app_env_prefix
+
+
+class ResolveTests(unittest.TestCase):
+    def test_formal_id_resolves(self) -> None:
+        ident = reg.resolve_identity("frontend-engineer")
+        self.assertEqual(ident.canonical_id, "frontend-engineer")
+        self.assertEqual(ident.vault_cssclass, "fk-fe")
+
+    def test_alias_resolves_to_canonical(self) -> None:
+        # the abbreviation maps to the FORMAL canonical id (single source)
+        self.assertEqual(reg.canonical_id("fe"), "frontend-engineer")
+        self.assertEqual(reg.resolve_identity("be").canonical_id, "backend-engineer")
+        self.assertEqual(reg.resolve_identity("product-agent").canonical_id, "product-manager")
+
+    def test_unknown_is_fallback(self) -> None:
+        self.assertFalse(reg.is_known("nope"))
+        self.assertEqual(reg.resolve_identity("nope").canonical_id, "forgekit")
+
+    def test_no_duplicate_canonical_or_alias_collision(self) -> None:
+        ids = [i.canonical_id for i in reg.all_identities()]
+        self.assertEqual(len(ids), len(set(ids)))           # canonical ids unique
+        # an alias never collides with a different canonical id
+        for ident in reg.all_identities():
+            for alias in ident.identity_aliases:
+                self.assertEqual(reg.canonical_id(alias), ident.canonical_id)
+
+
+class DerivationTests(unittest.TestCase):
+    def test_github_prefix_rule(self) -> None:
+        self.assertEqual(reg.resolve_identity("tech-lead").github_app_env_prefix,
+                         "YULE_GITHUB_APP_TECH_LEAD_")
+        self.assertEqual(reg.resolve_identity("design-systems-designer").github_app_env_prefix,
+                         "YULE_GITHUB_APP_DESIGN_SYSTEMS_DESIGNER_")
+        self.assertEqual(github_app_env_prefix("x", shared=True), "YULE_GITHUB_APP_SHARED_")
+
+    def test_git_author_rule(self) -> None:
+        gid = reg.git_identity_for("backend-engineer")
+        self.assertEqual(gid["name"], "Forgekit Backend")
+        self.assertEqual(gid["email"], "be@forgekit.local")
+
+    def test_alias_input_projects_canonical(self) -> None:
+        # an alias input must still project canonical metadata (not the abbreviation)
+        v = reg.vault_identity_for("fe")
+        self.assertEqual(v["agent_author"], "frontend-engineer")
+        self.assertEqual(v["cssclass"], "fk-fe")
+        g = reg.git_identity_for("fe")
+        self.assertEqual(g["canonical_id"], "frontend-engineer")
+
+
+class ExportTests(unittest.TestCase):
+    def test_to_dict_machine_readable(self) -> None:
+        d = reg.to_dict()
+        self.assertIn("identities", d)
+        self.assertIn("aliases", d)
+        self.assertEqual(d["aliases"]["fe"], "frontend-engineer")
+        # every identity row has the required fields
+        for row in d["identities"]:
+            for key in ("canonical_id", "github_app_env_prefix", "git_author_name",
+                        "vault_cssclass", "vault_color"):
+                self.assertTrue(row.get(key), f"missing {key} in {row['canonical_id']}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> base `main` · canonical agent identity registry (SSoT)

## 목적
manifest(`frontend-engineer`)와 vault/authorship(`fe`)의 agent id 어긋남을 단일 canonical registry 로 통일.

## 범위
- `identity/{models,registry}.py` — canonical(정식 id) SSoT + alias(fe→frontend-engineer) 단일 정규화, 파생 규칙(github prefix/git author), explicit vault css/callout/color, projection seam(vault/git/github identity_for), `scan_manifests` drift 탐지.
- 제외: manifest 일괄 backfill, vault/authorship 하드코딩 교체 — **다음 단계**(seam 준비까지).

## 테스트/검증
- `test_identity_registry.py`(8). forgekit suite OK ×2 venv. 실측 scan: 25 matched / prefix-drift 0.

## 경계 (정직)
- canonical id = 정식 id, 축약은 alias 허용(registry 한 곳에서만 해석). 실제 GitHub App 생성/설치는 org admin 작업 — registry 는 identity/env contract 까지, live 생성은 runbook(후속).

## 관련
- multi-provider foundation·control-plane(merged) 위. agent-identity 프로그램 1단계.
