### PR TITLE
forgekit identity: manifest backfill + vault authorship registry 통합

### DIFF
--- a/agents/engineering-agent/ai-engineer/manifest.json
+++ b/agents/engineering-agent/ai-engineer/manifest.json
@@ -15,11 +15,24 @@
     "cost_latency_management"
   ],
   "council_role": {
-    "default_seats": ["owner", "challenger", "reviewer"],
+    "default_seats": [
+      "owner",
+      "challenger",
+      "reviewer"
+    ],
     "owner_focus": "LLM runner / RAG / memory / prompt 정책 1차 draft + ResearchPack 품질",
     "challenger_focus": "hallucination / source grounding 누락 / cost·latency 폭증 / evaluation 미정의 / single-provider lock-in",
-    "reviewer_decision_inputs": ["owner_draft", "challenger_draft", "research_pack", "backend_handoff"],
-    "produces": ["RoleDraft", "PeerReviewNote", "RoleCouncilResult"],
+    "reviewer_decision_inputs": [
+      "owner_draft",
+      "challenger_draft",
+      "research_pack",
+      "backend_handoff"
+    ],
+    "produces": [
+      "RoleDraft",
+      "PeerReviewNote",
+      "RoleCouncilResult"
+    ],
     "design_doc": "../../../docs/engineering-role-council-runtime.md"
   },
   "plugins_required": [
@@ -438,5 +451,12 @@
       "AI 응답 톤/disclaimer 문구 결정 필요",
       "AI 실패 시 사용자 안내 흐름 결정 필요"
     ]
-  }
+  },
+  "git_author_name": "Forgekit AI Engineer",
+  "git_author_email": "ai@forgekit.local",
+  "vault_agent_id": "ai-engineer",
+  "vault_css_class": "fk-ai",
+  "vault_callout": "fk-ai",
+  "vault_color_token": "#38bdf8",
+  "identity_aliases": []
 }

--- a/agents/engineering-agent/backend-engineer/manifest.json
+++ b/agents/engineering-agent/backend-engineer/manifest.json
@@ -13,11 +13,24 @@
     "security_review"
   ],
   "council_role": {
-    "default_seats": ["owner", "challenger", "reviewer"],
+    "default_seats": [
+      "owner",
+      "challenger",
+      "reviewer"
+    ],
     "owner_focus": "domain_model / api_contract / data_contract / transaction / security 의 1차 draft",
     "challenger_focus": "happy-path 가정 / migration rollback 누락 / 권한 우회 / idempotency 회피 / 외부 의존 timeout",
-    "reviewer_decision_inputs": ["owner_draft", "challenger_draft", "research_pack", "tech_lead_brief"],
-    "produces": ["RoleDraft", "PeerReviewNote", "RoleCouncilResult"],
+    "reviewer_decision_inputs": [
+      "owner_draft",
+      "challenger_draft",
+      "research_pack",
+      "tech_lead_brief"
+    ],
+    "produces": [
+      "RoleDraft",
+      "PeerReviewNote",
+      "RoleCouncilResult"
+    ],
     "design_doc": "../../../docs/engineering-role-council-runtime.md"
   },
   "plugins_required": [
@@ -574,5 +587,14 @@
       "정상 케이스만으로 ship 동의하지 않는다",
       "권한별 분기/동시 요청/외부 의존 실패는 누락하지 않는다"
     ]
-  }
+  },
+  "git_author_name": "Forgekit Backend",
+  "git_author_email": "be@forgekit.local",
+  "vault_agent_id": "backend-engineer",
+  "vault_css_class": "fk-be",
+  "vault_callout": "fk-be",
+  "vault_color_token": "#e0b020",
+  "identity_aliases": [
+    "be"
+  ]
 }

--- a/agents/engineering-agent/devops-engineer/manifest.json
+++ b/agents/engineering-agent/devops-engineer/manifest.json
@@ -13,11 +13,24 @@
     "runtime_topology_planning"
   ],
   "council_role": {
-    "default_seats": ["owner", "challenger", "reviewer"],
+    "default_seats": [
+      "owner",
+      "challenger",
+      "reviewer"
+    ],
     "owner_focus": "CI/CD / 배포 / env / secret / 관측성 / rollback 1차 draft",
     "challenger_focus": "deploy 직후 30분 모니터 누락 / secret rotation 사각 / rollback window 부재 / capacity·DLQ 미정의 / supply-chain",
-    "reviewer_decision_inputs": ["owner_draft", "challenger_draft", "research_pack", "backend_handoff"],
-    "produces": ["RoleDraft", "PeerReviewNote", "RoleCouncilResult"],
+    "reviewer_decision_inputs": [
+      "owner_draft",
+      "challenger_draft",
+      "research_pack",
+      "backend_handoff"
+    ],
+    "produces": [
+      "RoleDraft",
+      "PeerReviewNote",
+      "RoleCouncilResult"
+    ],
     "secret_and_deploy_actions_stay_operator_approval": true,
     "design_doc": "../../../docs/engineering-role-council-runtime.md"
   },
@@ -448,5 +461,14 @@
       "rollback이 비가역이거나 데이터 손실 가능성이 있으면 사용자 승인 필요",
       "rollback 검증 없이 incident close하지 않는다"
     ]
-  }
+  },
+  "git_author_name": "Forgekit DevOps",
+  "git_author_email": "devops@forgekit.local",
+  "vault_agent_id": "devops-engineer",
+  "vault_css_class": "fk-devops",
+  "vault_callout": "fk-devops",
+  "vault_color_token": "#ff5c7a",
+  "identity_aliases": [
+    "devops"
+  ]
 }

--- a/agents/engineering-agent/frontend-engineer/manifest.json
+++ b/agents/engineering-agent/frontend-engineer/manifest.json
@@ -13,11 +13,24 @@
     "ui_test_planning"
   ],
   "council_role": {
-    "default_seats": ["owner", "challenger", "reviewer"],
+    "default_seats": [
+      "owner",
+      "challenger",
+      "reviewer"
+    ],
     "owner_focus": "component / state / api integration / loading-error-empty 상태 1차 draft",
     "challenger_focus": "디자인 토큰 우회 / 접근성 회귀 / 권한별 화면 누락 / hydration·번들 비용 / API 가정 오류",
-    "reviewer_decision_inputs": ["owner_draft", "challenger_draft", "research_pack", "design_handoff"],
-    "produces": ["RoleDraft", "PeerReviewNote", "RoleCouncilResult"],
+    "reviewer_decision_inputs": [
+      "owner_draft",
+      "challenger_draft",
+      "research_pack",
+      "design_handoff"
+    ],
+    "produces": [
+      "RoleDraft",
+      "PeerReviewNote",
+      "RoleCouncilResult"
+    ],
     "design_doc": "../../../docs/engineering-role-council-runtime.md"
   },
   "plugins_required": [
@@ -434,5 +447,14 @@
       "주요 컴포넌트 변경에는 단위 테스트를 함께 갱신한다",
       "Storybook/시각 회귀 가능 영역은 함께 업데이트한다"
     ]
-  }
+  },
+  "git_author_name": "Forgekit Frontend",
+  "git_author_email": "fe@forgekit.local",
+  "vault_agent_id": "frontend-engineer",
+  "vault_css_class": "fk-fe",
+  "vault_callout": "fk-fe",
+  "vault_color_token": "#3ddc97",
+  "identity_aliases": [
+    "fe"
+  ]
 }

--- a/agents/engineering-agent/knowledge-engineer/manifest.json
+++ b/agents/engineering-agent/knowledge-engineer/manifest.json
@@ -21,7 +21,9 @@
   "can_write_vault": true,
   "obsidian_write_target": "30-engineering/knowledge-engineer",
   "color_token": "eng-knowledge-engineer",
-  "alias_roles": ["memory-curator"],
+  "alias_roles": [
+    "memory-curator"
+  ],
   "capabilities": [
     "vault_schema_and_metadata",
     "brain_pack_build",
@@ -34,12 +36,27 @@
     "canonical / reusable 승격",
     "brain pack build / retrieval eval"
   ],
-  "inputs": ["raw notes / sources / vault state", "retrieval eval fixture"],
-  "outputs": ["canonical/reusable notes + index", "brain pack", "retrieval/color policy"],
+  "inputs": [
+    "raw notes / sources / vault state",
+    "retrieval eval fixture"
+  ],
+  "outputs": [
+    "canonical/reusable notes + index",
+    "brain pack",
+    "retrieval/color policy"
+  ],
   "boundaries": [
     "코드 직접 수정/커밋 금지 — vault note/policy 중심.",
     "starter/shared pack 은 read-only — 쓰기는 canonical note 로만.",
     "retrieval 은 metadata 기반 — 색은 사람용 보조 신호."
   ],
-  "phase": "role-contract-v1"
+  "phase": "role-contract-v1",
+  "github_app_env_prefix": "YULE_GITHUB_APP_KNOWLEDGE_ENGINEER_",
+  "git_author_name": "Forgekit Knowledge Engineer",
+  "git_author_email": "knowledge@forgekit.local",
+  "vault_agent_id": "knowledge-engineer",
+  "vault_css_class": "fk-knowledge",
+  "vault_callout": "fk-knowledge",
+  "vault_color_token": "#f59e0b",
+  "identity_aliases": []
 }

--- a/agents/engineering-agent/ops-observer/manifest.json
+++ b/agents/engineering-agent/ops-observer/manifest.json
@@ -33,12 +33,27 @@
     "budget/token 알림 임계 초과",
     "fallback spike / blocked queue / waiting approval 감지"
   ],
-  "inputs": ["runtime status / heartbeat / queue", "provider runtime / cost / fallback telemetry"],
-  "outputs": ["status summary + triage", "operator next-action", "alert note"],
+  "inputs": [
+    "runtime status / heartbeat / queue",
+    "provider runtime / cost / fallback telemetry"
+  ],
+  "outputs": [
+    "status summary + triage",
+    "operator next-action",
+    "alert note"
+  ],
   "boundaries": [
     "코드/커밋/배포 금지 — 관측·triage·status note 만.",
     "직접 조치 금지 — operator 에게 next-action 으로 surface.",
     "민감 값 read/write 금지."
   ],
-  "phase": "role-contract-v1"
+  "phase": "role-contract-v1",
+  "github_app_env_prefix": "YULE_GITHUB_APP_OPS_OBSERVER_",
+  "git_author_name": "Forgekit Ops Observer",
+  "git_author_email": "ops@forgekit.local",
+  "vault_agent_id": "ops-observer",
+  "vault_css_class": "fk-ops",
+  "vault_callout": "fk-ops",
+  "vault_color_token": "#2f6f7a",
+  "identity_aliases": []
 }

--- a/agents/engineering-agent/platform-runtime-engineer/manifest.json
+++ b/agents/engineering-agent/platform-runtime-engineer/manifest.json
@@ -49,5 +49,12 @@
     "secret 값을 읽거나 기록하지 않는다(키 이름/wiring 만).",
     "사용자 승인 없이 runtime restart / destructive 작업 금지."
   ],
-  "phase": "role-contract-v1"
+  "phase": "role-contract-v1",
+  "git_author_name": "Forgekit Platform Runtime",
+  "git_author_email": "platform@forgekit.local",
+  "vault_agent_id": "platform-runtime-engineer",
+  "vault_css_class": "fk-platform",
+  "vault_callout": "fk-platform",
+  "vault_color_token": "#14b8a6",
+  "identity_aliases": []
 }

--- a/agents/engineering-agent/qa-engineer/manifest.json
+++ b/agents/engineering-agent/qa-engineer/manifest.json
@@ -12,11 +12,25 @@
     "quality_bar_enforcement"
   ],
   "council_role": {
-    "default_seats": ["owner", "challenger", "reviewer"],
+    "default_seats": [
+      "owner",
+      "challenger",
+      "reviewer"
+    ],
     "owner_focus": "acceptance criteria / 회귀 시나리오 / failure-edge case 1차 draft",
     "challenger_focus": "happy path 편향 / 권한·동시성 누락 / 재현 불가 결함 / 자동화 빠진 수동 케이스",
-    "reviewer_decision_inputs": ["owner_draft", "challenger_draft", "research_pack", "backend_handoff", "frontend_handoff"],
-    "produces": ["RoleDraft", "PeerReviewNote", "RoleCouncilResult"],
+    "reviewer_decision_inputs": [
+      "owner_draft",
+      "challenger_draft",
+      "research_pack",
+      "backend_handoff",
+      "frontend_handoff"
+    ],
+    "produces": [
+      "RoleDraft",
+      "PeerReviewNote",
+      "RoleCouncilResult"
+    ],
     "verifies_approval_conditions": true,
     "design_doc": "../../../docs/engineering-role-council-runtime.md"
   },
@@ -412,5 +426,14 @@
       "flaky 가능성이 큰 시나리오는 자동화 후보에서 제외한다",
       "CI 시간이 늘어나는 변경은 devops와 합의한다"
     ]
-  }
+  },
+  "git_author_name": "Forgekit QA",
+  "git_author_email": "qa@forgekit.local",
+  "vault_agent_id": "qa-engineer",
+  "vault_css_class": "fk-qa",
+  "vault_callout": "fk-qa",
+  "vault_color_token": "#9b8cf0",
+  "identity_aliases": [
+    "qa"
+  ]
 }

--- a/agents/engineering-agent/security-engineer/manifest.json
+++ b/agents/engineering-agent/security-engineer/manifest.json
@@ -120,5 +120,14 @@
     "codex",
     "gemini"
   ],
-  "phase": "role-contract-v1"
+  "phase": "role-contract-v1",
+  "git_author_name": "Forgekit Security",
+  "git_author_email": "security@forgekit.local",
+  "vault_agent_id": "security-engineer",
+  "vault_css_class": "fk-security",
+  "vault_callout": "fk-security",
+  "vault_color_token": "#ff8c42",
+  "identity_aliases": [
+    "security"
+  ]
 }

--- a/agents/engineering-agent/tech-lead/manifest.json
+++ b/agents/engineering-agent/tech-lead/manifest.json
@@ -416,5 +416,12 @@
       "executor는 단일 role이어야 한다",
       "forbidden_scope를 빠뜨린 승인 제안은 승인 제안으로 보지 않는다"
     ]
-  }
+  },
+  "git_author_name": "Forgekit Tech Lead",
+  "git_author_email": "techlead@forgekit.local",
+  "vault_agent_id": "tech-lead",
+  "vault_css_class": "fk-techlead",
+  "vault_callout": "fk-techlead",
+  "vault_color_token": "#00d8f0",
+  "identity_aliases": []
 }

--- a/agents/finance-agent/budget-analyst/manifest.json
+++ b/agents/finance-agent/budget-analyst/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_BUDGET_ANALYST_",
   "autonomy_level": "advisory",
   "risk_class": "HIGH",
-  "module_path": "agents.finance_agent.budget_analyst.runner"
+  "module_path": "agents.finance_agent.budget_analyst.runner",
+  "git_author_name": "Forgekit Budget Analyst",
+  "git_author_email": "budget@forgekit.local",
+  "vault_agent_id": "budget-analyst",
+  "vault_css_class": "fk-budget",
+  "vault_callout": "fk-budget",
+  "vault_color_token": "#fbbf24",
+  "identity_aliases": []
 }

--- a/agents/hr-agent/culture-coach/manifest.json
+++ b/agents/hr-agent/culture-coach/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_CULTURE_COACH_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.hr_agent.culture_coach.runner"
+  "module_path": "agents.hr_agent.culture_coach.runner",
+  "git_author_name": "Forgekit Culture Coach",
+  "git_author_email": "culture@forgekit.local",
+  "vault_agent_id": "culture-coach",
+  "vault_css_class": "fk-culture",
+  "vault_callout": "fk-culture",
+  "vault_color_token": "#a78bfa",
+  "identity_aliases": []
 }

--- a/agents/hr-agent/people-ops/manifest.json
+++ b/agents/hr-agent/people-ops/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_PEOPLE_OPS_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.hr_agent.people_ops.runner"
+  "module_path": "agents.hr_agent.people_ops.runner",
+  "git_author_name": "Forgekit People Ops",
+  "git_author_email": "peopleops@forgekit.local",
+  "vault_agent_id": "people-ops",
+  "vault_css_class": "fk-peopleops",
+  "vault_callout": "fk-peopleops",
+  "vault_color_token": "#f472b6",
+  "identity_aliases": []
 }

--- a/agents/hr-agent/recruiter/manifest.json
+++ b/agents/hr-agent/recruiter/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_RECRUITER_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.hr_agent.recruiter.runner"
+  "module_path": "agents.hr_agent.recruiter.runner",
+  "git_author_name": "Forgekit Recruiter",
+  "git_author_email": "recruiter@forgekit.local",
+  "vault_agent_id": "recruiter",
+  "vault_css_class": "fk-recruiter",
+  "vault_callout": "fk-recruiter",
+  "vault_color_token": "#60a5fa",
+  "identity_aliases": []
 }

--- a/agents/legal-agent/contract-reviewer/manifest.json
+++ b/agents/legal-agent/contract-reviewer/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_CONTRACT_REVIEWER_",
   "autonomy_level": "advisory",
   "risk_class": "HIGH",
-  "module_path": "agents.legal_agent.contract_reviewer.runner"
+  "module_path": "agents.legal_agent.contract_reviewer.runner",
+  "git_author_name": "Forgekit Contract Reviewer",
+  "git_author_email": "contract@forgekit.local",
+  "vault_agent_id": "contract-reviewer",
+  "vault_css_class": "fk-contract",
+  "vault_callout": "fk-contract",
+  "vault_color_token": "#f97316",
+  "identity_aliases": []
 }

--- a/agents/legal-agent/privacy-officer/manifest.json
+++ b/agents/legal-agent/privacy-officer/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_PRIVACY_OFFICER_",
   "autonomy_level": "advisory",
   "risk_class": "HIGH",
-  "module_path": "agents.legal_agent.privacy_officer.runner"
+  "module_path": "agents.legal_agent.privacy_officer.runner",
+  "git_author_name": "Forgekit Privacy Officer",
+  "git_author_email": "privacy@forgekit.local",
+  "vault_agent_id": "privacy-officer",
+  "vault_css_class": "fk-privacy",
+  "vault_callout": "fk-privacy",
+  "vault_color_token": "#fb7185",
+  "identity_aliases": []
 }

--- a/agents/marketing-agent/brand-manager/manifest.json
+++ b/agents/marketing-agent/brand-manager/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_BRAND_MANAGER_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.marketing_agent.brand_manager.runner"
+  "module_path": "agents.marketing_agent.brand_manager.runner",
+  "git_author_name": "Forgekit Brand Manager",
+  "git_author_email": "brand@forgekit.local",
+  "vault_agent_id": "brand-manager",
+  "vault_css_class": "fk-brand",
+  "vault_callout": "fk-brand",
+  "vault_color_token": "#ec4899",
+  "identity_aliases": []
 }

--- a/agents/marketing-agent/content-strategist/manifest.json
+++ b/agents/marketing-agent/content-strategist/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_CONTENT_STRATEGIST_",
   "autonomy_level": "advisory",
   "risk_class": "LOW",
-  "module_path": "agents.marketing_agent.content_strategist.runner"
+  "module_path": "agents.marketing_agent.content_strategist.runner",
+  "git_author_name": "Forgekit Content",
+  "git_author_email": "content@forgekit.local",
+  "vault_agent_id": "content-strategist",
+  "vault_css_class": "fk-content",
+  "vault_callout": "fk-content",
+  "vault_color_token": "#f59e0b",
+  "identity_aliases": []
 }

--- a/agents/marketing-agent/growth-marketer/manifest.json
+++ b/agents/marketing-agent/growth-marketer/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_GROWTH_MARKETER_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.marketing_agent.growth_marketer.runner"
+  "module_path": "agents.marketing_agent.growth_marketer.runner",
+  "git_author_name": "Forgekit Growth",
+  "git_author_email": "growth@forgekit.local",
+  "vault_agent_id": "growth-marketer",
+  "vault_css_class": "fk-growth",
+  "vault_callout": "fk-growth",
+  "vault_color_token": "#34d399",
+  "identity_aliases": []
 }

--- a/agents/marketing-agent/seo-specialist/manifest.json
+++ b/agents/marketing-agent/seo-specialist/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_SEO_SPECIALIST_",
   "autonomy_level": "advisory",
   "risk_class": "LOW",
-  "module_path": "agents.marketing_agent.seo_specialist.runner"
+  "module_path": "agents.marketing_agent.seo_specialist.runner",
+  "git_author_name": "Forgekit SEO",
+  "git_author_email": "seo@forgekit.local",
+  "vault_agent_id": "seo-specialist",
+  "vault_css_class": "fk-seo",
+  "vault_callout": "fk-seo",
+  "vault_color_token": "#84cc16",
+  "identity_aliases": []
 }

--- a/agents/product-agent/growth-analyst/manifest.json
+++ b/agents/product-agent/growth-analyst/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_GROWTH_ANALYST_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.product_agent.growth_analyst.runner"
+  "module_path": "agents.product_agent.growth_analyst.runner",
+  "git_author_name": "Forgekit Growth Analyst",
+  "git_author_email": "growth-analyst@forgekit.local",
+  "vault_agent_id": "growth-analyst",
+  "vault_css_class": "fk-growth-analyst",
+  "vault_callout": "fk-growth-analyst",
+  "vault_color_token": "#10b981",
+  "identity_aliases": []
 }

--- a/agents/product-agent/product-manager/manifest.json
+++ b/agents/product-agent/product-manager/manifest.json
@@ -19,5 +19,15 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_PRODUCT_MANAGER_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.product_agent.product_manager.runner"
+  "module_path": "agents.product_agent.product_manager.runner",
+  "git_author_name": "Forgekit Product (PM)",
+  "git_author_email": "pm@forgekit.local",
+  "vault_agent_id": "product-manager",
+  "vault_css_class": "fk-pm",
+  "vault_callout": "fk-pm",
+  "vault_color_token": "#f23ccf",
+  "identity_aliases": [
+    "product-agent",
+    "pm"
+  ]
 }

--- a/agents/product-agent/user-researcher/manifest.json
+++ b/agents/product-agent/user-researcher/manifest.json
@@ -18,5 +18,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_USER_RESEARCHER_",
   "autonomy_level": "advisory",
   "risk_class": "LOW",
-  "module_path": "agents.product_agent.user_researcher.runner"
+  "module_path": "agents.product_agent.user_researcher.runner",
+  "git_author_name": "Forgekit User Researcher",
+  "git_author_email": "user-research@forgekit.local",
+  "vault_agent_id": "user-researcher",
+  "vault_css_class": "fk-user-research",
+  "vault_callout": "fk-user-research",
+  "vault_color_token": "#c084fc",
+  "identity_aliases": []
 }

--- a/agents/sales-cs-agent/customer-success/manifest.json
+++ b/agents/sales-cs-agent/customer-success/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_CUSTOMER_SUCCESS_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.sales_cs_agent.customer_success.runner"
+  "module_path": "agents.sales_cs_agent.customer_success.runner",
+  "git_author_name": "Forgekit Customer Success",
+  "git_author_email": "cs@forgekit.local",
+  "vault_agent_id": "customer-success",
+  "vault_css_class": "fk-cs",
+  "vault_callout": "fk-cs",
+  "vault_color_token": "#06b6d4",
+  "identity_aliases": []
 }

--- a/agents/sales-cs-agent/sales-rep/manifest.json
+++ b/agents/sales-cs-agent/sales-rep/manifest.json
@@ -19,5 +19,12 @@
   "github_app_env_prefix": "YULE_GITHUB_APP_SALES_REP_",
   "autonomy_level": "advisory",
   "risk_class": "MEDIUM",
-  "module_path": "agents.sales_cs_agent.sales_rep.runner"
+  "module_path": "agents.sales_cs_agent.sales_rep.runner",
+  "git_author_name": "Forgekit Sales",
+  "git_author_email": "sales@forgekit.local",
+  "vault_agent_id": "sales-rep",
+  "vault_css_class": "fk-sales",
+  "vault_callout": "fk-sales",
+  "vault_color_token": "#22c55e",
+  "identity_aliases": []
 }

--- a/apps/forgekit-console/src/forgekit_console/vault/authorship.py
+++ b/apps/forgekit-console/src/forgekit_console/vault/authorship.py
@@ -21,10 +21,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Mapping, Tuple
 
+from ..identity import registry as _idreg
+
 
 @dataclass(frozen=True)
 class AgentIdentity:
-    """An agent's stable vault identity — author id, role label, css class, colour."""
+    """An agent's stable vault identity — author id, role label, css class, colour.
+
+    This is a thin view over the canonical identity registry (the SSoT). ``agent_id``
+    here is always the CANONICAL id, so an abbreviation (``fe``) and the formal id
+    (``frontend-engineer``) both yield the same vault identity."""
 
     agent_id: str
     role_label: str
@@ -33,31 +39,22 @@ class AgentIdentity:
     callout: str        # callout type for the `> [!type]` marker
 
 
-# Brand-aligned per-agent identities (PM / gateway / tech-lead / engineers / ops).
-AGENT_IDENTITIES: Mapping[str, AgentIdentity] = {
-    "product-agent": AgentIdentity("product-agent", "Product (PM)", "fk-pm", "#f23ccf", "fk-pm"),
-    "gateway": AgentIdentity("gateway", "Engineering Gateway", "fk-gateway", "#8b90a0", "fk-gateway"),
-    "tech-lead": AgentIdentity("tech-lead", "Tech Lead", "fk-techlead", "#00d8f0", "fk-techlead"),
-    "fe": AgentIdentity("fe", "Frontend", "fk-fe", "#3ddc97", "fk-fe"),
-    "be": AgentIdentity("be", "Backend", "fk-be", "#e0b020", "fk-be"),
-    "devops": AgentIdentity("devops", "DevOps", "fk-devops", "#ff5c7a", "fk-devops"),
-    "qa": AgentIdentity("qa", "QA", "fk-qa", "#9b8cf0", "fk-qa"),
-    "security": AgentIdentity("security", "Security", "fk-security", "#ff8c42", "fk-security"),
-    "ops-observer": AgentIdentity("ops-observer", "Ops Observer", "fk-ops", "#2f6f7a", "fk-ops"),
-    # design-family roles (design source/role split program)
-    "ux-ui-designer": AgentIdentity("ux-ui-designer", "UX/UI Designer", "fk-ux", "#7dd3fc", "fk-ux"),
-    "design-systems-designer": AgentIdentity("design-systems-designer", "Design Systems",
-                                             "fk-dsys", "#a78bfa", "fk-dsys"),
-    "illustration-brand-designer": AgentIdentity("illustration-brand-designer", "Illustration/Brand",
-                                                 "fk-illus", "#fb7185", "fk-illus"),
-    "design-lead": AgentIdentity("design-lead", "Design Lead", "fk-design-lead", "#22d3ee", "fk-design-lead"),
-}
+def _from_registry(ident) -> AgentIdentity:
+    return AgentIdentity(ident.canonical_id, ident.role_label, ident.vault_cssclass,
+                         ident.vault_color, ident.vault_callout)
 
-_FALLBACK = AgentIdentity("forgekit", "forgekit", "fk-agent", "#8b90a0", "fk-agent")
+
+# Derived from the canonical registry (NOT a second hardcoded SSoT) — keyed by
+# canonical id. The abbreviation→canonical mapping lives only in identity.registry.
+AGENT_IDENTITIES: Mapping[str, AgentIdentity] = {
+    ident.canonical_id: _from_registry(ident) for ident in _idreg.all_identities()
+}
 
 
 def identity_for(agent_id: str) -> AgentIdentity:
-    return AGENT_IDENTITIES.get((agent_id or "").strip(), _FALLBACK)
+    """Resolve any id/alias to its canonical vault identity (registry-backed)."""
+
+    return _from_registry(_idreg.resolve_identity(agent_id))
 
 
 def _yaml_scalar(value: str) -> str:

--- a/scripts/backfill_agent_identity.py
+++ b/scripts/backfill_agent_identity.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Backfill agent identity fields into manifests from the canonical registry.
+
+Deterministic + idempotent + non-destructive: for each ``agents/**/manifest.json``
+whose ``id``/``role`` resolves to a canonical identity, it sets the identity fields
+from the registry (preserving every other key). Manifests that don't resolve (container
+/ example agents) are left untouched and reported. Re-running changes nothing.
+
+Usage:  python3 scripts/backfill_agent_identity.py [--check] [--agents-root agents]
+  --check : report drift / missing fields, write nothing (CI-friendly).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps" / "forgekit-console" / "src"))
+
+from forgekit_console.identity import registry as reg  # noqa: E402
+
+_FIELDS = ("github_app_env_prefix", "git_author_name", "git_author_email",
+           "vault_agent_id", "vault_css_class", "vault_callout", "vault_color_token",
+           "identity_aliases")
+
+
+def identity_fields(canonical_id: str) -> dict:
+    ident = reg.resolve_identity(canonical_id)
+    return {
+        "github_app_env_prefix": ident.github_app_env_prefix,
+        "git_author_name": ident.git_author_name,
+        "git_author_email": ident.git_author_email,
+        "vault_agent_id": ident.canonical_id,
+        "vault_css_class": ident.vault_cssclass,
+        "vault_callout": ident.vault_callout,
+        "vault_color_token": ident.vault_color,
+        "identity_aliases": list(ident.identity_aliases),
+    }
+
+
+def run(agents_root: Path, *, check: bool) -> int:
+    changed, skipped, drift = [], [], []
+    for mf in sorted(Path(agents_root).rglob("manifest.json")):
+        try:
+            data = json.loads(mf.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        mid = str(data.get("id", "") or data.get("role", "")).strip()
+        cid = reg.canonical_id(mid) or reg.canonical_id(str(data.get("role", "")).strip())
+        if not cid:
+            skipped.append(mid)
+            continue
+        want = identity_fields(cid)
+        if all(data.get(k) == v for k, v in want.items()):
+            continue  # already consistent (idempotent)
+        if check:
+            drift.append(mid)
+            continue
+        data.update(want)
+        mf.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        changed.append(mid)
+    print(f"backfill: {'check' if check else 'applied'} — "
+          f"changed={len(changed)} drift={len(drift)} skipped(unknown)={len(skipped)}")
+    if skipped:
+        print("  skipped (not in registry):", ", ".join(sorted(set(skipped))))
+    if check and drift:
+        print("  drift (need backfill):", ", ".join(sorted(set(drift))))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--agents-root", default=str(ROOT / "agents"))
+    args = ap.parse_args()
+    raise SystemExit(run(Path(args.agents_root), check=args.check))

--- a/tests/forgekit/test_manifest_identity.py
+++ b/tests/forgekit/test_manifest_identity.py
@@ -1,0 +1,59 @@
+"""Manifest ↔ identity registry consistency guard (drift prevention).
+
+After backfill, every manifest that resolves to a canonical identity must carry the
+registry-derived identity fields and have NO prefix drift. This locks the manifests
+and the registry to one SSoT so they can't silently diverge.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.identity import registry as reg
+
+_REPO = Path(__file__).resolve().parents[2]
+_AGENTS = _REPO / "agents"
+
+_REQUIRED = ("github_app_env_prefix", "git_author_name", "git_author_email",
+             "vault_agent_id", "vault_css_class", "vault_color_token")
+
+
+class ManifestIdentityTests(unittest.TestCase):
+    def _matched_manifests(self):
+        out = []
+        for mf in sorted(_AGENTS.rglob("manifest.json")):
+            try:
+                data = json.loads(mf.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            cid = (reg.canonical_id(str(data.get("id", "")).strip())
+                   or reg.canonical_id(str(data.get("role", "")).strip()))
+            if cid:
+                out.append((mf, data, cid))
+        return out
+
+    def test_no_prefix_drift(self) -> None:
+        scan = reg.scan_manifests(_AGENTS)
+        self.assertEqual(scan["prefix_drift"], [], f"prefix drift: {scan['prefix_drift']}")
+        self.assertGreaterEqual(len(scan["matched"]), 20)   # the backfilled set
+
+    def test_matched_manifests_have_identity_fields(self) -> None:
+        matched = self._matched_manifests()
+        self.assertGreaterEqual(len(matched), 20)
+        for mf, data, _cid in matched:
+            for field in _REQUIRED:
+                self.assertTrue(data.get(field), f"{mf.name} missing {field}")
+
+    def test_manifest_identity_matches_registry(self) -> None:
+        for mf, data, cid in self._matched_manifests():
+            ident = reg.resolve_identity(cid)
+            self.assertEqual(data.get("git_author_name"), ident.git_author_name, mf.name)
+            self.assertEqual(data.get("vault_css_class"), ident.vault_cssclass, mf.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_vault_authorship.py
+++ b/tests/forgekit/test_vault_authorship.py
@@ -23,8 +23,16 @@ class AuthorshipMetaTests(unittest.TestCase):
         colors = {i.color for i in A.AGENT_IDENTITIES.values()}
         self.assertEqual(len(css), len(A.AGENT_IDENTITIES))      # unique css classes
         self.assertGreaterEqual(len(colors), 6)                  # visually distinct
-        for key in ("product-agent", "tech-lead", "fe", "be", "devops", "qa", "security"):
+        # AGENT_IDENTITIES is keyed by CANONICAL id (registry SSoT), not abbreviations
+        for key in ("product-manager", "tech-lead", "frontend-engineer",
+                    "backend-engineer", "devops-engineer", "qa-engineer", "security-engineer"):
             self.assertIn(key, A.AGENT_IDENTITIES)
+
+    def test_alias_input_normalizes_to_canonical(self) -> None:
+        # an abbreviation input yields the canonical identity (single SSoT via registry)
+        self.assertEqual(A.identity_for("fe").agent_id, "frontend-engineer")
+        self.assertEqual(A.identity_for("product-agent").agent_id, "product-manager")
+        self.assertEqual(A.identity_for("fe").cssclass, "fk-fe")
 
     def test_frontmatter_carries_authorship_and_handoff(self) -> None:
         note = vault.build_authored_note(
@@ -32,7 +40,7 @@ class AuthorshipMetaTests(unittest.TestCase):
             handoff_from="operator", handoff_to="gateway", phase="intake",
             source_flow="pm-intake", created_at="2026-06-17",
         )
-        for token in ("agent_author: product-agent", "agent_role: Product (PM)",
+        for token in ("agent_author: product-manager", "agent_role: Product (PM)",
                       "handoff_from: operator", "handoff_to: gateway",
                       "phase: intake", "source_flow: pm-intake",
                       "cssclasses: [fk-pm]", "created_at: 2026-06-17"):
@@ -46,7 +54,7 @@ class AuthorshipMetaTests(unittest.TestCase):
         # the colour comes from a cssclass snippet the user adds — real Obsidian
         self.assertIn(".fk-pm", snippet)
         self.assertIn("data-callout", snippet)   # callout theming too
-        self.assertIn(A.AGENT_IDENTITIES["product-agent"].color, snippet)
+        self.assertIn(A.AGENT_IDENTITIES["product-manager"].color, snippet)
 
 
 class HandoffNoteTests(unittest.TestCase):
@@ -68,7 +76,7 @@ class HandoffNoteTests(unittest.TestCase):
         path = vault.write_note(note, tmp, "10-projects/bkurs/be-note.md")
         self.assertIsNotNone(path)
         self.assertTrue(path.exists())
-        self.assertIn("agent_author: be", path.read_text(encoding="utf-8"))
+        self.assertIn("agent_author: backend-engineer", path.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> base `main` · manifest backfill + vault authorship registry integration

## 목적
agent 정체성을 manifest / vault 에서 **canonical identity registry 한 SSoT** 로 일관되게.

## 범위
- `vault/authorship.py` 의 하드코딩 identity 맵 **제거** → registry 파생. identity_for 가 alias→canonical 정규화(fe→frontend-engineer), note frontmatter/css snippet 도 canonical.
- `scripts/backfill_agent_identity.py`(deterministic·idempotent·--check) 로 manifest **25개** backfill(git author/vault css/color/alias). registry 미해소 4개는 정직 skip.
- drift 가드 테스트.

## 테스트/검증
- `test_vault_authorship`(canonical 갱신) + `test_manifest_identity`(3: prefix drift 0 / 필수 필드 / registry 일치). forgekit OK ×2 venv, **root 6375 OK**.

## 경계 (정직)
- 거동 변경: agent_author 가 canonical id. github_app_env_prefix 는 이미 일치(0 drift). 실제 GitHub App 생성/설치는 org admin(후속 runbook), 이번은 identity/env contract 까지.

## 관련
- canonical identity registry(merged #259) 위. agent-identity 프로그램 2단계.
