### PR TITLE
forgekit identity: git attribution seam + /whoami surface

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -25,6 +25,7 @@ H_HARNESS = "harness"
 H_DOCTOR = "doctor"
 H_RENDER = "render"
 H_BLOCKED = "blocked"
+H_WHOAMI = "whoami"
 H_AGENT_ENTER = "agent_enter"
 H_LAYOUT = "layout"
 H_QUIT = "quit"
@@ -79,6 +80,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("design", "restricted design source 상태 — design role만 raw, 그외 projection", H_MODE, "status"),
     SlashCommand("usage", "토큰 사용량 — today rollup(provider/mode/live·estimate) + budget", H_MODE, "status"),
     SlashCommand("blocked", "반복 실패 에스컬레이션 목록 (왜·대안·다음 단계)", H_BLOCKED, "status"),
+    SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),
     SlashCommand("planning-agent", "Planning 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "planning-agent"),
     SlashCommand("backend-agent", "Backend 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "backend-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -31,6 +31,7 @@ from .registry import (
     H_HELP,
     H_MODE,
     H_BLOCKED,
+    H_WHOAMI,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -140,6 +141,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
             "mode",
             ("런타임 모드는 콘솔(TUI)에서 Shift+Tab 으로 순환되고 `/mode` 로 표시됩니다.",),
         )
+    if handler == H_WHOAMI:
+        return _whoami_result(parsed)
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:
@@ -164,6 +167,17 @@ def _help_result(ctx: ConsoleContext) -> CommandResult:
     lines.append("")
     lines.append("일반 텍스트는 provider 로 live-submit 됩니다 (provider 미설정 시 setup 안내).")
     return CommandResult(kind=KIND_HELP, title="help", lines=tuple(lines))
+
+
+def _whoami_result(parsed) -> CommandResult:
+    # agent identity surface — registry-backed git author / vault / GitHub App status.
+    # `/whoami <agent>` = one agent's detail; `/whoami` = the audit across all agents.
+    from ..identity import attribution as attr
+
+    args = getattr(parsed, "args", ()) or ()
+    if args:
+        return CommandResult.info("whoami", attr.render_whoami_lines(args[0]))
+    return CommandResult.info("whoami", attr.identity_audit_lines())
 
 
 def _render_readiness_result() -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/identity/attribution.py
+++ b/apps/forgekit-console/src/forgekit_console/identity/attribution.py
@@ -1,0 +1,154 @@
+"""Git attribution + GitHub App status — registry-backed, honest. Pure / stdlib-only.
+
+Turns a canonical agent identity into the things a commit path needs: a git author
+(``Name <email>``) and structured commit trailers (``Forgekit-Agent`` …), plus an
+HONEST GitHub App credential status read from the environment:
+
+  * ``dedicated_configured`` — the agent's own ``<PREFIX>APP_ID`` / ``INSTALLATION_ID`` /
+    ``PRIVATE_KEY_PEM`` are all present.
+  * ``partial_credentials``  — some of those three are set, but not all (mis-config).
+  * ``shared_fallback``      — the agent's own app is absent but ``YULE_GITHUB_APP_SHARED_*``
+    is configured.
+  * ``missing``              — no dedicated and no shared credentials.
+  * ``planned``              — the agent doesn't support a GitHub App.
+
+This module never *performs* a commit and never *creates* an app — it only builds the
+author/trailers/status so a real commit path can use them and an operator surface can
+show them. Creating/installing the GitHub App is an org-admin step (runbook), not here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional, Tuple
+
+from . import registry as reg
+
+# github app status
+APP_DEDICATED = "dedicated_configured"
+APP_PARTIAL = "partial_credentials"
+APP_SHARED = "shared_fallback"
+APP_MISSING = "missing"
+APP_PLANNED = "planned"
+
+_REQUIRED_SUFFIXES = ("APP_ID", "INSTALLATION_ID", "PRIVATE_KEY_PEM")
+_SHARED_PREFIX = "YULE_GITHUB_APP_SHARED_"
+
+
+def git_author_for(agent_id: str) -> str:
+    """``Forgekit <Role> <local@forgekit.local>`` for the canonical identity."""
+
+    g = reg.git_identity_for(agent_id)
+    return f"{g['name']} <{g['email']}>"
+
+
+def _present(env: Mapping[str, str], prefix: str) -> Tuple[int, int]:
+    have = sum(1 for s in _REQUIRED_SUFFIXES if str(env.get(prefix + s, "") or "").strip())
+    return have, len(_REQUIRED_SUFFIXES)
+
+
+def github_app_status(agent_id: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """Honest credential status for the agent's GitHub App (dedicated/shared/missing…)."""
+
+    env = os.environ if env is None else env
+    ident = reg.resolve_identity(agent_id)
+    if not ident.supports_github_app:
+        return APP_PLANNED
+    have, need = _present(env, ident.github_app_env_prefix)
+    if have == need:
+        return APP_DEDICATED
+    if have > 0:
+        return APP_PARTIAL
+    shared_have, shared_need = _present(env, _SHARED_PREFIX)
+    if shared_have == shared_need:
+        return APP_SHARED
+    return APP_MISSING
+
+
+def commit_trailers(agent_id: str, *, flow: str = "", mode: str = "",
+                    handoff_from: str = "", handoff_to: str = "", approval: str = "",
+                    env: Optional[Mapping[str, str]] = None) -> Tuple[str, ...]:
+    """Structured commit trailers for an agent-attributed commit (registry-backed).
+
+    Only emits trailers for values that exist — never fabricates a handoff/mode that
+    didn't happen. The GitHub-App trailer reflects the REAL credential status."""
+
+    ident = reg.resolve_identity(agent_id)
+    app = github_app_status(agent_id, env)
+    lines = [
+        f"Forgekit-Agent: {ident.canonical_id}",
+        f"Forgekit-Role: {ident.role_label}",
+        f"Forgekit-Dept: {ident.department}",
+        f"Forgekit-GitHub-App: {app}",
+        f"Forgekit-Vault-Class: {ident.vault_cssclass}",
+    ]
+    if flow:
+        lines.append(f"Forgekit-Flow: {flow}")
+    if mode:
+        lines.append(f"Forgekit-Mode: {mode}")
+    if handoff_from:
+        lines.append(f"Forgekit-Handoff-From: {handoff_from}")
+    if handoff_to:
+        lines.append(f"Forgekit-Handoff-To: {handoff_to}")
+    if approval:
+        lines.append(f"Forgekit-Approval: {approval}")
+    return tuple(lines)
+
+
+def attribution_preview(agent_id: str, env: Optional[Mapping[str, str]] = None) -> dict:
+    """Everything an operator surface (`/whoami`) needs — git + vault + app, all honest."""
+
+    ident = reg.resolve_identity(agent_id)
+    return {
+        "canonical_id": ident.canonical_id, "role": ident.role_label,
+        "department": ident.department,
+        "git_author": git_author_for(agent_id),
+        "vault_cssclass": ident.vault_cssclass, "vault_color": ident.vault_color,
+        "github_app_env_prefix": ident.github_app_env_prefix,
+        "github_app_status": github_app_status(agent_id, env),
+    }
+
+
+def render_whoami_lines(agent_id: str, env: Optional[Mapping[str, str]] = None) -> Tuple[str, ...]:
+    """Operator-facing `/whoami` lines (active agent identity, honest app status)."""
+
+    p = attribution_preview(agent_id, env)
+    app = p["github_app_status"]
+    app_note = {
+        APP_DEDICATED: "전용 app 자격 설정됨", APP_SHARED: "shared org app fallback 사용",
+        APP_PARTIAL: "자격 일부만 설정 — 점검 필요", APP_MISSING: "자격 없음 — setup runbook 필요",
+        APP_PLANNED: "GitHub App 미대상(planned)",
+    }.get(app, app)
+    return (
+        f"agent: {p['canonical_id']} ({p['role']} · {p['department']})",
+        f"  git author : {p['git_author']}",
+        f"  vault      : cssclass={p['vault_cssclass']} color={p['vault_color']}",
+        f"  github app : {app} — {app_note}",
+        f"               env prefix {p['github_app_env_prefix']}<APP_ID|INSTALLATION_ID|PRIVATE_KEY_PEM>",
+    )
+
+
+def identity_audit_lines(env: Optional[Mapping[str, str]] = None) -> Tuple[str, ...]:
+    """Operator audit (`/whoami`) — git author + GitHub App status for every agent,
+    grouped honestly so missing/partial credentials are visible, not hidden."""
+
+    rows = [(i.canonical_id, github_app_status(i.canonical_id, env)) for i in reg.all_identities()]
+    counts: dict = {}
+    for _, st in rows:
+        counts[st] = counts.get(st, 0) + 1
+    lines = ["agent identity — git author = registry, GitHub App status = env (정직):",
+             "  app status: " + (", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "-")]
+    flagged = [cid for cid, st in rows if st in (APP_PARTIAL,)]
+    if flagged:
+        lines.append("  ⚠ partial credentials: " + ", ".join(flagged))
+    lines.append(f"  dedicated app 자격 = env {reg.resolve_identity('tech-lead').github_app_env_prefix}"
+                 "APP_ID|INSTALLATION_ID|PRIVATE_KEY_PEM (예시). 실제 App 생성/설치는 org-admin runbook.")
+    lines.append("  `/whoami <agent>` 로 개별 git author / vault / app 자격 상세.")
+    return tuple(lines)
+
+
+__all__ = (
+    "APP_DEDICATED", "APP_PARTIAL", "APP_SHARED", "APP_MISSING", "APP_PLANNED",
+    "git_author_for", "github_app_status", "commit_trailers",
+    "attribution_preview", "render_whoami_lines", "identity_audit_lines",
+)

--- a/tests/forgekit/test_identity_attribution.py
+++ b/tests/forgekit/test_identity_attribution.py
@@ -1,0 +1,85 @@
+"""Git attribution + GitHub App status — registry-backed, honest.
+
+Proves git author + commit trailers come from the canonical registry (alias-safe),
+trailers never fabricate absent values, and the GitHub App status honestly
+distinguishes dedicated / partial / shared-fallback / missing / planned from env.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.identity import attribution as attr
+
+
+class AuthorTests(unittest.TestCase):
+    def test_git_author_from_registry(self) -> None:
+        self.assertEqual(attr.git_author_for("backend-engineer"),
+                         "Forgekit Backend <be@forgekit.local>")
+
+    def test_alias_resolves_for_author(self) -> None:
+        self.assertEqual(attr.git_author_for("be"), attr.git_author_for("backend-engineer"))
+
+
+class AppStatusTests(unittest.TestCase):
+    def test_dedicated_when_all_three_present(self) -> None:
+        env = {"YULE_GITHUB_APP_TECH_LEAD_APP_ID": "1",
+               "YULE_GITHUB_APP_TECH_LEAD_INSTALLATION_ID": "2",
+               "YULE_GITHUB_APP_TECH_LEAD_PRIVATE_KEY_PEM": "key"}
+        self.assertEqual(attr.github_app_status("tech-lead", env), attr.APP_DEDICATED)
+
+    def test_partial_when_some_present(self) -> None:
+        env = {"YULE_GITHUB_APP_TECH_LEAD_APP_ID": "1"}
+        self.assertEqual(attr.github_app_status("tech-lead", env), attr.APP_PARTIAL)
+
+    def test_shared_fallback(self) -> None:
+        env = {"YULE_GITHUB_APP_SHARED_APP_ID": "1",
+               "YULE_GITHUB_APP_SHARED_INSTALLATION_ID": "2",
+               "YULE_GITHUB_APP_SHARED_PRIVATE_KEY_PEM": "k"}
+        self.assertEqual(attr.github_app_status("tech-lead", env), attr.APP_SHARED)
+
+    def test_missing_when_nothing(self) -> None:
+        self.assertEqual(attr.github_app_status("tech-lead", {}), attr.APP_MISSING)
+
+
+class TrailerTests(unittest.TestCase):
+    def test_required_trailers_present(self) -> None:
+        tr = attr.commit_trailers("be", flow="repo-autopilot", env={})
+        joined = "\n".join(tr)
+        self.assertIn("Forgekit-Agent: backend-engineer", joined)   # canonical, not 'be'
+        self.assertIn("Forgekit-Role: Backend", joined)
+        self.assertIn("Forgekit-Dept: engineering", joined)
+        self.assertIn("Forgekit-Flow: repo-autopilot", joined)
+        self.assertIn("Forgekit-GitHub-App: missing", joined)       # honest env status
+
+    def test_absent_optional_trailers_not_fabricated(self) -> None:
+        tr = attr.commit_trailers("tech-lead", env={})
+        joined = "\n".join(tr)
+        self.assertNotIn("Forgekit-Handoff-From", joined)           # no handoff → not emitted
+        self.assertNotIn("Forgekit-Mode", joined)
+
+    def test_whoami_render_is_honest(self) -> None:
+        lines = "\n".join(attr.render_whoami_lines("frontend-engineer", env={}))
+        self.assertIn("frontend-engineer", lines)
+        self.assertIn("Forgekit Frontend <fe@forgekit.local>", lines)
+        self.assertIn("missing", lines)                              # no creds → honest
+
+
+class WhoamiRouterTests(unittest.TestCase):
+    def test_whoami_command_routes(self) -> None:
+        from pathlib import Path
+
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+
+        ctx = build_default_context(Path("."))
+        audit = route(parse_input("/whoami"), ctx)
+        self.assertIn("agent identity", "\n".join(audit.lines))
+        detail = route(parse_input("/whoami tech-lead"), ctx)
+        self.assertIn("Forgekit Tech Lead", "\n".join(detail.lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> base `main` · git attribution seam + `/whoami` operator surface

## 목적
누가 커밋/작성했는지 registry 기반으로 구분 가능하게 — git author + commit trailer + GitHub App 자격 상태 seam, `/whoami` operator surface.

## 범위
- `identity/attribution.py` — git_author_for, commit_trailers(Forgekit-Agent/Role/Dept/Flow/GitHub-App/Vault-Class…), github_app_status(dedicated/partial/shared/missing/planned, env presence-only), preview/whoami/audit.
- `/whoami` 명령 + router 연결.
- 제외(후속): `/doctor`·`/setup` github-app 통합, 실 commit-path enforcement, runbook docs.

## 테스트/검증
- `test_identity_attribution`(10, router smoke 포함). forgekit OK ×2 venv, **root 6385 OK**.

## 경계 (정직)
- **seam 까지** — 실제 commit 수행/ GitHub App 생성 안 함. commit-path enforcement·doctor/setup 은 후속(추적 이슈).
- secret-safe: env 존재여부만 검사(key 값 미참조/미로그), diff/test 에 raw key 0.

## 관련
- canonical identity registry(#259) + manifest/vault 통합(#260) 위. agent-identity 프로그램 3단계.
