### PR TITLE
forgekit Hephaistos: resolver-core MVP (skill forge)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/hephaistos/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/__init__.py
@@ -1,0 +1,11 @@
+"""Hephaistos — ForgeKit's skill-forging core.
+
+Reads the request, forges an equip plan (agent + skills + loadout + weapons + Nexus
+source refs + Work Packet draft) from the Armory, and verifies the local loadout. Pure
+core; the console is a projection layer. Nexus is a planned read seam (not_connected).
+"""
+
+from .resolver import explain_lines, resolve
+from .verifier import readiness_lines, verify_loadout
+
+__all__ = ("resolve", "explain_lines", "verify_loadout", "readiness_lines")

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/armory.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/armory.py
@@ -1,0 +1,145 @@
+"""Armory — the MVP skill / loadout / weapon catalog Hephaistos forges from.
+
+First-cut catalog seeded in Python (a JSON/YAML manifest loader is a planned seam —
+``armory/skills/...`` files can override/extend later). Scope is intentionally the
+``backend-java-local`` loadout + java-spring family, per the MVP. Nexus source refs are
+declared here as references (status resolved at read time — not_connected today).
+Pure / stdlib-only.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from .models import (
+    NEXUS_AREA,
+    NEXUS_PATTERN,
+    NEXUS_SNIPPET,
+    NEXUS_TROUBLESHOOTING,
+    LoadoutSpec,
+    NexusSourceRef,
+    SkillSpec,
+    WeaponSpec,
+)
+
+_WEAPONS = (
+    WeaponSpec("openjdk", "OpenJDK", "runtime", "java -version", "brew install openjdk@21"),
+    WeaponSpec("gradle", "Gradle", "tool", "gradle -v", "brew install gradle"),
+    WeaponSpec("mysql", "MySQL", "service", "mysql --version", "brew install mysql"),
+    WeaponSpec("redis", "Redis", "service", "redis-cli --version", "brew install redis"),
+    WeaponSpec("docker", "Docker", "service", "docker --version", "https://docker.com"),
+    WeaponSpec("intellij", "IntelliJ IDEA", "ide", "", "jetbrains toolbox"),
+    WeaponSpec("vscode", "VS Code", "ide", "code --version", "https://code.visualstudio.com"),
+    WeaponSpec("gh", "GitHub CLI", "cli", "gh --version", "brew install gh"),
+)
+
+_SKILLS = (
+    SkillSpec(
+        "java-spring", "Java / Spring Boot",
+        domains=("backend",), languages=("java",), frameworks=("spring-boot", "spring"),
+        topics=("rest", "service-layer", "transaction"),
+        rules=("controller 에 비즈니스 로직 금지 (service 계층 분리)",
+               "트랜잭션 경계는 service 메서드에 명시"),
+        commands=("./gradlew build", "./gradlew test"),
+        verification=("./gradlew test", "./gradlew bootRun --dry-run"),
+        related_weapons=("openjdk", "gradle"), related_loadouts=("backend-java-local",),
+        related_roles=("backend-engineer",),
+        nexus_refs=(NexusSourceRef(NEXUS_AREA, "20-areas/backend/java-spring"),
+                    NexusSourceRef(NEXUS_PATTERN, "40-patterns/backend/transaction-boundary.md")),
+    ),
+    SkillSpec(
+        "auth-jwt", "Auth / JWT",
+        domains=("backend", "security"), languages=("java",), frameworks=("spring-boot",),
+        topics=("auth-jwt", "auth", "jwt", "refresh-token", "security"),
+        rules=("refresh token 저장/만료 정책 명시", "security filter chain 순서 주의",
+               "access/refresh 분리, refresh 회전(rotation) 고려"),
+        verification=("./gradlew test --tests '*Jwt*'",),
+        related_weapons=("openjdk",), related_loadouts=("backend-java-local",),
+        related_roles=("backend-engineer", "security-engineer"),
+        nexus_refs=(NexusSourceRef(NEXUS_SNIPPET, "50-snippets/java/spring-security-jwt.md"),
+                    NexusSourceRef(NEXUS_TROUBLESHOOTING, "60-troubleshooting/spring/bean-cycle-error.md")),
+    ),
+    SkillSpec(
+        "mysql", "MySQL",
+        domains=("backend", "database"), topics=("mysql", "sql", "persistence", "transaction"),
+        rules=("스키마 변경은 migration 으로", "N+1 쿼리 주의"),
+        commands=("mysql -u root -e 'SELECT 1'",),
+        verification=("mysql --version", "mysql -u root -e 'SELECT 1'"),
+        forbidden=("승인 없는 schema migration", "운영 DB 직접 변경"),
+        related_weapons=("mysql",), related_loadouts=("backend-java-local",),
+        related_roles=("backend-engineer",),
+        nexus_refs=(NexusSourceRef(NEXUS_AREA, "20-areas/backend/database/mysql"),),
+    ),
+    SkillSpec(
+        "redis", "Redis",
+        domains=("backend", "database"), topics=("redis", "cache", "session", "refresh-token"),
+        rules=("TTL 명시", "캐시 무효화 전략 정의"),
+        commands=("redis-cli ping",),
+        verification=("redis-cli ping",),
+        forbidden=("운영 redis FLUSHALL 금지",),
+        related_weapons=("redis",), related_loadouts=("backend-java-local",),
+        related_roles=("backend-engineer",),
+        nexus_refs=(NexusSourceRef(NEXUS_AREA, "20-areas/backend/database/redis"),),
+    ),
+    SkillSpec(
+        "docker", "Docker",
+        domains=("backend", "devops"), topics=("docker", "container", "local-env"),
+        rules=("local 의존(mysql/redis)은 compose 로",),
+        commands=("docker compose up -d",),
+        verification=("docker --version", "docker compose config"),
+        forbidden=("운영 container/registry 변경 금지",),
+        related_weapons=("docker",), related_loadouts=("backend-java-local",),
+        related_roles=("backend-engineer", "devops-engineer"),
+    ),
+    SkillSpec(
+        "security-review", "Security Review",
+        domains=("security",), topics=("security", "auth-jwt", "review"),
+        rules=("secret 하드코딩 금지", "입력 검증/권한 체크 누락 점검"),
+        verification=("git grep -nE '(password|secret|api[_-]?key)\\s*=' || true",),
+        forbidden=("실제 exploit/active attack 금지(plan-first)",),
+        related_roles=("security-engineer",),
+        nexus_refs=(NexusSourceRef(NEXUS_PATTERN, "40-patterns/security/authz-checklist.md"),),
+    ),
+)
+
+_LOADOUTS = (
+    LoadoutSpec(
+        "backend-java-local", "Backend Java (local)",
+        intended_roles=("backend-engineer",),
+        required_weapons=("openjdk", "gradle", "docker"),
+        optional_weapons=("mysql", "redis", "intellij", "vscode", "gh"),
+        environment_assumptions=("local JDK 21", "docker for mysql/redis"),
+        verify_commands=("java -version", "gradle -v", "docker --version"),
+    ),
+)
+
+_WEAPON_BY_ID: Dict[str, WeaponSpec] = {w.id: w for w in _WEAPONS}
+_SKILL_BY_ID: Dict[str, SkillSpec] = {s.id: s for s in _SKILLS}
+_LOADOUT_BY_ID: Dict[str, LoadoutSpec] = {l.id: l for l in _LOADOUTS}
+
+
+def all_skills() -> Tuple[SkillSpec, ...]:
+    return _SKILLS
+
+
+def all_loadouts() -> Tuple[LoadoutSpec, ...]:
+    return _LOADOUTS
+
+
+def all_weapons() -> Tuple[WeaponSpec, ...]:
+    return _WEAPONS
+
+
+def skill(skill_id: str) -> Optional[SkillSpec]:
+    return _SKILL_BY_ID.get(skill_id)
+
+
+def loadout(loadout_id: str) -> Optional[LoadoutSpec]:
+    return _LOADOUT_BY_ID.get(loadout_id)
+
+
+def weapon(weapon_id: str) -> Optional[WeaponSpec]:
+    return _WEAPON_BY_ID.get(weapon_id)
+
+
+__all__ = ("all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon")

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/models.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/models.py
@@ -1,0 +1,186 @@
+"""Hephaistos core contract — the skill-forging models. Pure / stdlib-only.
+
+ForgeKit = the whole forge (platform). Nexus = the knowledge mine/library. **Hephaistos
+= the smith**: it reads Nexus knowledge and forges it into the Skills / Loadout / Weapons
+/ Runes / Work Packet an agent equips to finish a job. These dataclasses are that
+contract — no app/UI logic here (console is a projection layer over this core).
+
+Honesty: a :class:`NexusSourceRef` carries a ``status`` — Nexus is NOT live-connected
+in this work tree, so refs resolve as ``not_connected`` (a planned seam), never faked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+# nexus source kinds + connection status
+NEXUS_AREA = "area"
+NEXUS_PATTERN = "pattern"
+NEXUS_SNIPPET = "snippet"
+NEXUS_TROUBLESHOOTING = "troubleshooting"
+NEXUS_DECISION = "decision"
+
+SRC_AVAILABLE = "available"
+SRC_NOT_CONNECTED = "not_connected"   # Nexus mount/config absent (planned seam)
+SRC_PLANNED = "planned"
+
+# weapon safety class
+WEAPON_SAFE = "safe"
+WEAPON_RISKY = "risky"
+
+
+@dataclass(frozen=True)
+class NexusSourceRef:
+    kind: str            # NEXUS_*
+    ref: str             # e.g. "20-areas/backend/java-spring"
+    status: str = SRC_NOT_CONNECTED
+    note: str = ""
+
+    def to_dict(self) -> dict:
+        return {"kind": self.kind, "ref": self.ref, "status": self.status, "note": self.note}
+
+
+@dataclass(frozen=True)
+class WeaponSpec:
+    id: str
+    display_name: str
+    kind: str = "tool"           # tool / runtime / service / cli / ide
+    verify_command: str = ""     # how to check presence (e.g. "java -version")
+    install_hint: str = ""
+    safety: str = WEAPON_SAFE
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "display_name": self.display_name, "kind": self.kind,
+                "verify_command": self.verify_command, "install_hint": self.install_hint,
+                "safety": self.safety}
+
+
+@dataclass(frozen=True)
+class SkillSpec:
+    id: str
+    name: str
+    domains: Tuple[str, ...] = ()
+    languages: Tuple[str, ...] = ()
+    frameworks: Tuple[str, ...] = ()
+    topics: Tuple[str, ...] = ()
+    rules: Tuple[str, ...] = ()
+    commands: Tuple[str, ...] = ()
+    verification: Tuple[str, ...] = ()
+    forbidden: Tuple[str, ...] = ()
+    related_weapons: Tuple[str, ...] = ()
+    related_loadouts: Tuple[str, ...] = ()
+    related_roles: Tuple[str, ...] = ()
+    nexus_refs: Tuple[NexusSourceRef, ...] = ()
+
+    def matches(self, *, domain="", language="", framework="", topic="") -> int:
+        """Heuristic relevance score for a resolve query (deterministic)."""
+
+        score = 0
+        if domain and domain in self.domains:
+            score += 2
+        if language and language in self.languages:
+            score += 2
+        if framework and framework in self.frameworks:
+            score += 3
+        if topic and topic in self.topics:
+            score += 4
+        return score
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "name": self.name, "domains": list(self.domains),
+                "languages": list(self.languages), "frameworks": list(self.frameworks),
+                "topics": list(self.topics), "rules": list(self.rules),
+                "commands": list(self.commands), "verification": list(self.verification),
+                "forbidden": list(self.forbidden), "related_weapons": list(self.related_weapons),
+                "related_loadouts": list(self.related_loadouts),
+                "related_roles": list(self.related_roles),
+                "nexus_refs": [r.to_dict() for r in self.nexus_refs]}
+
+
+@dataclass(frozen=True)
+class LoadoutSpec:
+    id: str
+    name: str
+    intended_roles: Tuple[str, ...] = ()
+    required_weapons: Tuple[str, ...] = ()
+    optional_weapons: Tuple[str, ...] = ()
+    environment_assumptions: Tuple[str, ...] = ()
+    verify_commands: Tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "name": self.name, "intended_roles": list(self.intended_roles),
+                "required_weapons": list(self.required_weapons),
+                "optional_weapons": list(self.optional_weapons),
+                "environment_assumptions": list(self.environment_assumptions),
+                "verify_commands": list(self.verify_commands)}
+
+
+@dataclass(frozen=True)
+class RuneSpec:
+    id: str
+    name: str
+    kind: str = "preset"         # env / config / alias / template
+    template_ref: str = ""
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "name": self.name, "kind": self.kind, "template_ref": self.template_ref}
+
+
+@dataclass(frozen=True)
+class WorkPacketDraft:
+    goal: str
+    scope: Tuple[str, ...] = ()
+    forbidden_scope: Tuple[str, ...] = ()
+    required_areas: Tuple[str, ...] = ()
+    commands: Tuple[str, ...] = ()
+    verification: Tuple[str, ...] = ()
+    acceptance: Tuple[str, ...] = ()
+    approval_level: str = "L2_internal_approve"
+    evidence_path: str = ""
+    nexus_refs: Tuple[NexusSourceRef, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"goal": self.goal, "scope": list(self.scope),
+                "forbidden_scope": list(self.forbidden_scope),
+                "required_areas": list(self.required_areas), "commands": list(self.commands),
+                "verification": list(self.verification), "acceptance": list(self.acceptance),
+                "approval_level": self.approval_level, "evidence_path": self.evidence_path,
+                "nexus_refs": [r.to_dict() for r in self.nexus_refs]}
+
+
+@dataclass(frozen=True)
+class ResolvedForgePlan:
+    """What Hephaistos forged for one request — the equip plan (no install performed)."""
+
+    request: str
+    domain: str = ""
+    language: str = ""
+    framework: str = ""
+    topic: str = ""
+    candidate_agents: Tuple[str, ...] = ()
+    selected_agent: str = ""
+    selected_skills: Tuple[str, ...] = ()
+    selected_loadout: str = ""
+    required_weapons: Tuple[str, ...] = ()
+    nexus_refs: Tuple[NexusSourceRef, ...] = ()
+    verification_commands: Tuple[str, ...] = ()
+    packet_draft: WorkPacketDraft = None  # type: ignore[assignment]
+
+    def to_dict(self) -> dict:
+        return {"request": self.request, "domain": self.domain, "language": self.language,
+                "framework": self.framework, "topic": self.topic,
+                "candidate_agents": list(self.candidate_agents), "selected_agent": self.selected_agent,
+                "selected_skills": list(self.selected_skills), "selected_loadout": self.selected_loadout,
+                "required_weapons": list(self.required_weapons),
+                "nexus_refs": [r.to_dict() for r in self.nexus_refs],
+                "verification_commands": list(self.verification_commands),
+                "packet_draft": self.packet_draft.to_dict() if self.packet_draft else None}
+
+
+__all__ = (
+    "NEXUS_AREA", "NEXUS_PATTERN", "NEXUS_SNIPPET", "NEXUS_TROUBLESHOOTING", "NEXUS_DECISION",
+    "SRC_AVAILABLE", "SRC_NOT_CONNECTED", "SRC_PLANNED", "WEAPON_SAFE", "WEAPON_RISKY",
+    "NexusSourceRef", "WeaponSpec", "SkillSpec", "LoadoutSpec", "RuneSpec",
+    "WorkPacketDraft", "ResolvedForgePlan",
+)

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/resolver.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/resolver.py
@@ -1,0 +1,167 @@
+"""Hephaistos resolver — request → equip plan. Rule-first, deterministic, explainable.
+
+Reads the request, infers domain/language/framework/topic, then selects the agent +
+skills + loadout + weapons from the armory and drafts a Work Packet. Nexus source refs
+are attached from the selected skills but carry their honest ``status`` — Nexus is not
+live-connected here, so they stay ``not_connected`` (never faked as read).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from . import armory
+from .models import (
+    SRC_NOT_CONNECTED,
+    NexusSourceRef,
+    ResolvedForgePlan,
+    WorkPacketDraft,
+)
+
+# keyword → inferred facet (first match wins; deterministic ordering).
+_LANGUAGE = (("kotlin", "kotlin"), ("java", "java"), ("python", "python"),
+             ("typescript", "typescript"), ("javascript", "typescript"))
+_FRAMEWORK = (("spring boot", "spring-boot"), ("springboot", "spring-boot"), ("spring", "spring-boot"),
+              ("fastapi", "fastapi"), ("nestjs", "nestjs"), ("next.js", "nextjs"), ("nextjs", "nextjs"),
+              ("react", "react"))
+_DOMAIN = (("frontend", "frontend"), ("ui", "frontend"), ("devops", "devops"), ("terraform", "devops"),
+           ("kubernetes", "devops"), ("security", "security"), ("database", "database"),
+           ("sql", "database"), ("backend", "backend"), ("api", "backend"))
+_TOPIC = (("refresh token", "auth-jwt"), ("jwt", "auth-jwt"), ("oauth", "auth-jwt"),
+          ("auth", "auth-jwt"), ("redis", "redis"), ("cache", "cache"), ("mysql", "mysql"),
+          ("docker", "docker"), ("transaction", "transaction"))
+
+_DOMAIN_AGENT = {"backend": "backend-engineer", "frontend": "frontend-engineer",
+                 "devops": "devops-engineer", "security": "security-engineer",
+                 "database": "backend-engineer", "ai": "ai-engineer"}
+
+
+def _first(pairs, blob: str) -> str:
+    for needle, value in pairs:
+        if needle in blob:
+            return value
+    return ""
+
+
+def _infer(request: str):
+    blob = (request or "").lower()
+    language = _first(_LANGUAGE, blob)
+    framework = _first(_FRAMEWORK, blob)
+    domain = _first(_DOMAIN, blob)
+    topic = _first(_TOPIC, blob)
+    # framework implies language/domain when not explicit.
+    if framework in ("spring-boot",) and not language:
+        language = "java"
+    if framework in ("spring-boot", "fastapi", "nestjs") and not domain:
+        domain = "backend"
+    if framework in ("nextjs", "react") and not domain:
+        domain = "frontend"
+    if topic in ("auth-jwt",) and not domain:
+        domain = "backend"
+    return domain, language, framework, topic, blob
+
+
+def resolve(request: str, *, preferred_role: str = "") -> ResolvedForgePlan:
+    """Forge an equip plan for *request* (suggestion-only; no install performed)."""
+
+    domain, language, framework, topic, blob = _infer(request)
+
+    # score skills by facet match + a keyword hit on the skill's own topics.
+    scored = []
+    for sk in armory.all_skills():
+        score = sk.matches(domain=domain, language=language, framework=framework, topic=topic)
+        score += sum(1 for t in sk.topics if t in blob)
+        if score > 0:
+            scored.append((score, sk))
+    scored.sort(key=lambda x: (-x[0], x[1].id))
+    selected = tuple(sk for _, sk in scored)
+
+    # candidate agents from the selected skills' roles; pick by preference/domain.
+    roles = [r for sk in selected for r in sk.related_roles]
+    candidates = tuple(dict.fromkeys(roles))
+    selected_agent = (preferred_role if preferred_role in candidates else "") \
+        or _DOMAIN_AGENT.get(domain, "") or (candidates[0] if candidates else "")
+
+    # loadout: the one whose intended roles include the agent.
+    chosen_loadout = ""
+    for lo in armory.all_loadouts():
+        if selected_agent in lo.intended_roles:
+            chosen_loadout = lo.id
+            break
+    lo_spec = armory.loadout(chosen_loadout) if chosen_loadout else None
+
+    # weapons = loadout required + selected skills' related weapons (dedup, order-stable).
+    weapons = list(lo_spec.required_weapons) if lo_spec else []
+    for sk in selected:
+        for w in sk.related_weapons:
+            if w not in weapons:
+                weapons.append(w)
+
+    # nexus refs from selected skills — honest status (not_connected: Nexus not wired).
+    refs = []
+    for sk in selected:
+        for ref in sk.nexus_refs:
+            refs.append(NexusSourceRef(ref.kind, ref.ref, SRC_NOT_CONNECTED,
+                                       note=f"for skill {sk.id}"))
+
+    verif = []
+    if lo_spec:
+        verif += list(lo_spec.verify_commands)
+    for sk in selected:
+        for v in sk.verification:
+            if v not in verif:
+                verif.append(v)
+
+    packet = _packet(request, selected, lo_spec, refs, verif)
+    return ResolvedForgePlan(
+        request=request, domain=domain, language=language, framework=framework, topic=topic,
+        candidate_agents=candidates, selected_agent=selected_agent,
+        selected_skills=tuple(sk.id for sk in selected), selected_loadout=chosen_loadout,
+        required_weapons=tuple(weapons), nexus_refs=tuple(refs),
+        verification_commands=tuple(verif), packet_draft=packet,
+    )
+
+
+def _packet(request, selected, lo_spec, refs, verif) -> WorkPacketDraft:
+    rules = [r for sk in selected for r in sk.rules]
+    forbidden = [f for sk in selected for f in sk.forbidden] or \
+        ["승인 없는 schema/auth/deploy 변경 금지"]
+    commands = []
+    for sk in selected:
+        for c in sk.commands:
+            if c not in commands:
+                commands.append(c)
+    return WorkPacketDraft(
+        goal=request or "(요청 없음)",
+        scope=tuple(rules) or ("선택 skill 의 규칙을 따른다",),
+        forbidden_scope=tuple(forbidden),
+        required_areas=tuple(r.ref for r in refs),
+        commands=tuple(commands), verification=tuple(verif),
+        acceptance=("선택 skill 의 verification 통과", "unsafe 영역 미변경(승인 필요)"),
+        approval_level="L2_internal_approve",
+        evidence_path="runs/forgekit/hephaistos/",
+        nexus_refs=tuple(refs),
+    )
+
+
+def explain_lines(plan: ResolvedForgePlan) -> Tuple[str, ...]:
+    """Operator-facing `/resolve` summary — what was equipped and why."""
+
+    lines = [f"hephaistos resolve — {plan.request[:60]}",
+             f"  domain/lang/fw/topic: {plan.domain or '-'}/{plan.language or '-'}/"
+             f"{plan.framework or '-'}/{plan.topic or '-'}",
+             f"  agent  : {plan.selected_agent or '(미정)'}  (후보: {', '.join(plan.candidate_agents) or '-'})",
+             f"  skills : {', '.join(plan.selected_skills) or '(매칭 없음 — armory 얕음)'}",
+             f"  loadout: {plan.selected_loadout or '-'}",
+             f"  weapons: {', '.join(plan.required_weapons) or '-'}",
+             f"  nexus  : {len(plan.nexus_refs)} ref ("
+             + (", ".join(sorted({r.status for r in plan.nexus_refs})) or "none")
+             + ") — Nexus 미연결이면 not_connected (읽은 척 안 함)"]
+    if plan.packet_draft:
+        lines.append(f"  packet : goal+{len(plan.packet_draft.scope)} scope / "
+                     f"{len(plan.packet_draft.verification)} verify / "
+                     f"approval={plan.packet_draft.approval_level}")
+    return tuple(lines)
+
+
+__all__ = ("resolve", "explain_lines")

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/verifier.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/verifier.py
@@ -1,0 +1,74 @@
+"""Loadout / weapon readiness verifier — checks the local env, no install. Pure-ish.
+
+``verify_loadout`` looks up the loadout's required weapons and probes each with an
+injected ``which`` (defaults to :func:`shutil.which` on the weapon's verify binary),
+returning a structured readiness verdict (ready / partial / missing / blocked) with
+next steps. It never installs anything — install is an explicit, planned seam.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Tuple
+
+from . import armory
+
+READY = "ready"
+PARTIAL = "partial"
+MISSING = "missing"
+BLOCKED = "blocked"        # unknown loadout
+
+
+@dataclass(frozen=True)
+class LoadoutReadiness:
+    loadout: str
+    status: str
+    present: Tuple[str, ...] = ()
+    missing: Tuple[str, ...] = ()
+    next_steps: Tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"loadout": self.loadout, "status": self.status, "present": list(self.present),
+                "missing": list(self.missing), "next_steps": list(self.next_steps)}
+
+
+def _binary(verify_command: str) -> str:
+    return (verify_command or "").strip().split(" ")[0]
+
+
+def verify_loadout(loadout_id: str, *, which: Optional[Callable[[str], Optional[str]]] = None
+                   ) -> LoadoutReadiness:
+    which = which or shutil.which
+    lo = armory.loadout(loadout_id)
+    if lo is None:
+        return LoadoutReadiness(loadout_id, BLOCKED, next_steps=(f"알 수 없는 loadout: {loadout_id}",))
+    present, missing, steps = [], [], []
+    for wid in lo.required_weapons:
+        w = armory.weapon(wid)
+        binary = _binary(w.verify_command) if w else wid
+        if binary and which(binary):
+            present.append(wid)
+        else:
+            missing.append(wid)
+            if w and w.install_hint:
+                steps.append(f"{w.display_name} 설치: {w.install_hint}")
+    if not missing:
+        status = READY
+    elif present:
+        status = PARTIAL
+    else:
+        status = MISSING
+    return LoadoutReadiness(loadout_id, status, tuple(present), tuple(missing), tuple(steps))
+
+
+def readiness_lines(r: LoadoutReadiness) -> Tuple[str, ...]:
+    lines = [f"loadout {r.loadout}: {r.status}",
+             f"  present: {', '.join(r.present) or '-'}",
+             f"  missing: {', '.join(r.missing) or '-'}"]
+    lines += [f"  → {s}" for s in r.next_steps]
+    return tuple(lines)
+
+
+__all__ = ("READY", "PARTIAL", "MISSING", "BLOCKED", "LoadoutReadiness",
+           "verify_loadout", "readiness_lines")

--- a/tests/forgekit/test_hephaistos.py
+++ b/tests/forgekit/test_hephaistos.py
@@ -1,0 +1,88 @@
+"""Hephaistos MVP core — resolve + verify + honest Nexus seam.
+
+Proves the resolver deterministically forges an equip plan for the MVP java-spring
+request (agent/skills/loadout/weapons/packet), that Nexus refs attach as not_connected
+(never faked-read), that a stack with no armory coverage resolves honestly shallow, and
+that loadout verify reflects the real (injected) environment.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.hephaistos import armory, models, resolver, verifier
+
+
+class ResolveTests(unittest.TestCase):
+    def test_spring_jwt_resolves_full_plan(self) -> None:
+        p = resolver.resolve("Spring Boot JWT refresh token 구조 정리해줘")
+        self.assertEqual((p.domain, p.language, p.framework, p.topic),
+                         ("backend", "java", "spring-boot", "auth-jwt"))
+        self.assertEqual(p.selected_agent, "backend-engineer")
+        for sk in ("java-spring", "auth-jwt", "mysql"):
+            self.assertIn(sk, p.selected_skills)
+        self.assertEqual(p.selected_loadout, "backend-java-local")
+        for w in ("openjdk", "gradle", "docker"):
+            self.assertIn(w, p.required_weapons)
+
+    def test_nexus_refs_attached_but_not_connected(self) -> None:
+        p = resolver.resolve("Spring Boot JWT refresh token")
+        self.assertTrue(p.nexus_refs)
+        # honest: Nexus is NOT live-connected → every ref is not_connected, none faked read
+        self.assertTrue(all(r.status == models.SRC_NOT_CONNECTED for r in p.nexus_refs))
+
+    def test_packet_draft_is_structured(self) -> None:
+        p = resolver.resolve("Spring Boot JWT refresh token")
+        pk = p.packet_draft
+        self.assertTrue(pk.goal and pk.scope and pk.forbidden_scope)
+        self.assertTrue(pk.verification)            # verify commands present
+        self.assertEqual(pk.approval_level, "L2_internal_approve")
+        self.assertTrue(pk.nexus_refs)
+
+    def test_uncovered_stack_resolves_shallow_honestly(self) -> None:
+        # armory is the java-spring MVP — a frontend request has no skills (not faked)
+        p = resolver.resolve("Next.js dashboard spacing 개선해줘")
+        self.assertEqual(p.domain, "frontend")
+        self.assertEqual(p.selected_skills, ())     # honest: no frontend skills yet
+        self.assertEqual(p.selected_loadout, "")
+
+    def test_deterministic(self) -> None:
+        a = resolver.resolve("Spring Boot JWT").to_dict()
+        b = resolver.resolve("Spring Boot JWT").to_dict()
+        self.assertEqual(a, b)
+
+
+class VerifyTests(unittest.TestCase):
+    def test_ready_when_all_present(self) -> None:
+        r = verifier.verify_loadout("backend-java-local", which=lambda b: "/usr/bin/" + b)
+        self.assertEqual(r.status, verifier.READY)
+        self.assertFalse(r.missing)
+
+    def test_partial_when_some_missing(self) -> None:
+        # gradle absent → partial, with an install next-step
+        which = lambda b: None if b == "gradle" else "/usr/bin/" + b
+        r = verifier.verify_loadout("backend-java-local", which=which)
+        self.assertEqual(r.status, verifier.PARTIAL)
+        self.assertIn("gradle", r.missing)
+        self.assertTrue(r.next_steps)
+
+    def test_missing_when_none(self) -> None:
+        r = verifier.verify_loadout("backend-java-local", which=lambda b: None)
+        self.assertEqual(r.status, verifier.MISSING)
+
+    def test_unknown_loadout_blocked(self) -> None:
+        self.assertEqual(verifier.verify_loadout("nope").status, verifier.BLOCKED)
+
+
+class ArmoryQualityTests(unittest.TestCase):
+    def test_skills_are_not_placeholders(self) -> None:
+        # every skill must carry rules + at least one of commands/verification (실전형)
+        for sk in armory.all_skills():
+            self.assertTrue(sk.rules, f"{sk.id} has no rules")
+            self.assertTrue(sk.commands or sk.verification, f"{sk.id} has no commands/verify")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> base `main` · Hephaistos resolver-core MVP (stacked PR0)

## 목적
ForgeKit(플랫폼)/Nexus(지식)/Hephaistos(skill forge) 분리를 코드 계약으로 고정하고, 요청→equip plan resolve 의 1차 핵심.

## 범위
- `hephaistos/` — models(Skill/Loadout/Weapon/Rune/WorkPacketDraft/NexusSourceRef/ResolvedForgePlan) · armory(backend-java-local MVP 실전형) · resolver(요청→agent/skills/loadout/weapons/nexus refs/packet, deterministic) · verifier(loadout readiness 실 env).

## 포함 안 한 것 (후속 stacked PR)
- Nexus read adapter, operator surface(/resolve 등), armory 확장, resolver 언어 게이팅, docs/README.

## 테스트/검증
- `test_hephaistos`(10). forgekit OK ×2 venv. 실측: "Spring Boot JWT" → backend-java full resolve.

## 경계 (정직)
- Nexus 미연결 → NexusSourceRef status=not_connected(**fake-read 없음**). armory backend-java 단일(나머지 스택 정직 shallow).

## 관련
- merge-prep audit: resolver-core 단위 READY TO MERGE.
