### PR TITLE
feat: add Nexus read foundation for Hephaistos

### DIFF
--- a/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/README.md
+++ b/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/README.md
@@ -1,0 +1,21 @@
+# Nexus read foundation — evidence (Hephaistos PR1)
+
+Hephaistos 가 Nexus(외부 지식 source)를 **정직하게** 읽는 read path 의 실측.
+Nexus 복사 없음, fake-read 없음.
+
+| 파일 | 상태 |
+| --- | --- |
+| `connected.json` | Nexus root 연결 — 3 요청 → 2 resolved(1 raw + 1 restricted **projection_only**) / 1 missing |
+| `connected-doc-sample.json` | 읽은 문서의 **bounded** 구조화(title/summary/key_points/rules/snippet/troubleshooting) — raw dump 아님 |
+| `not-connected.json` | Nexus 미연결 — **0 resolved**(아무것도 날조 안 함), read_mode=none |
+
+## 상태 모델 (정직)
+- **not_connected**: `FORGEKIT_NEXUS_ROOT`/config 미설정 → 메인 상태. docs 0.
+- **missing**: 연결됐으나 path 부재.
+- **blocked**: 존재하나 읽기 불가(permission/TCC/sandbox).
+- **restricted**: 존재하나 raw gating — 비허용 role 은 **projection_only**(title/why), raw 본문 미노출. 허용 role(design-lead 등)만 raw.
+- **exists**: 읽어서 bounded normalize.
+
+## 경계 (PR1 범위)
+- operator surface(`/resolve`·`/sources` 등)는 **PR2**. 여기는 read foundation + resolver seam(`read_plan_sources`)까지.
+- normalize 는 bounded(summary ≤500자, snippet ≤300자, points cap) — 전체 raw dump 금지.

--- a/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/connected-doc-sample.json
+++ b/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/connected-doc-sample.json
@@ -1,0 +1,58 @@
+[
+  {
+    "source_ref": {
+      "kind": "area",
+      "ref": "20-areas/backend/java-spring.md",
+      "status": "exists",
+      "note": "",
+      "title_hint": "",
+      "tags": [],
+      "priority": 0,
+      "restricted": false,
+      "required_for_skill": "",
+      "source_repo": "nexus"
+    },
+    "title": "Java Spring",
+    "summary": "Spring 핵심 area. 에러: bean cycle 주의",
+    "key_points": [
+      "controller 비즈니스 로직 금지",
+      "트랜잭션 경계 service 에 필수"
+    ],
+    "rules": [
+      "controller 비즈니스 로직 금지",
+      "트랜잭션 경계 service 에 필수"
+    ],
+    "snippets": [
+      "@Service\nclass S {}"
+    ],
+    "troubleshooting_signals": [
+      "에러: bean cycle 주의"
+    ],
+    "decision_notes": [],
+    "read_status": "exists",
+    "read_mode": "raw"
+  },
+  {
+    "source_ref": {
+      "kind": "pattern",
+      "ref": "70-restricted/design.md",
+      "status": "restricted",
+      "note": "",
+      "title_hint": "",
+      "tags": [],
+      "priority": 0,
+      "restricted": true,
+      "required_for_skill": "",
+      "source_repo": "nexus"
+    },
+    "title": "70-restricted/design.md",
+    "summary": "restricted source — pattern (raw 비공개, projection only)",
+    "key_points": [],
+    "rules": [],
+    "snippets": [],
+    "troubleshooting_signals": [],
+    "decision_notes": [],
+    "read_status": "restricted",
+    "read_mode": "projection_only"
+  }
+]

--- a/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/connected.json
+++ b/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/connected.json
@@ -1,0 +1,13 @@
+{
+  "requested": 3,
+  "resolved": 2,
+  "missing": 1,
+  "blocked": 0,
+  "restricted": 1,
+  "not_connected": false,
+  "read_mode": "raw",
+  "evidence_lines": [
+    "nexus root: <nexus-root>",
+    "requested 3 · read 1 · restricted 1 · missing 1 · blocked 0"
+  ]
+}

--- a/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/not-connected.json
+++ b/apps/forgekit-console/examples/hephaistos/nexus-read-foundation/not-connected.json
@@ -1,0 +1,13 @@
+{
+  "requested": 3,
+  "resolved": 0,
+  "missing": 0,
+  "blocked": 0,
+  "restricted": 0,
+  "not_connected": true,
+  "read_mode": "none",
+  "evidence_lines": [
+    "nexus root: (not configured → not_connected)",
+    "requested 3 · read 0 · restricted 0 · missing 0 · blocked 0"
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/models.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/models.py
@@ -24,6 +24,12 @@ NEXUS_DECISION = "decision"
 SRC_AVAILABLE = "available"
 SRC_NOT_CONNECTED = "not_connected"   # Nexus mount/config absent (planned seam)
 SRC_PLANNED = "planned"
+# exists_status values used by the read path (PR1):
+SRC_UNKNOWN = "unknown"               # not yet resolved
+SRC_EXISTS = "exists"                 # the file is present + readable
+SRC_MISSING = "missing"              # Nexus connected but the path is absent
+SRC_BLOCKED = "blocked"              # present but unreadable (permission/TCC/sandbox)
+SRC_RESTRICTED = "restricted"        # present but raw read gated → projection only
 
 # weapon safety class
 WEAPON_SAFE = "safe"
@@ -33,12 +39,25 @@ WEAPON_RISKY = "risky"
 @dataclass(frozen=True)
 class NexusSourceRef:
     kind: str            # NEXUS_*
-    ref: str             # e.g. "20-areas/backend/java-spring"
-    status: str = SRC_NOT_CONNECTED
+    ref: str             # e.g. "20-areas/backend/java-spring"  (the path)
+    status: str = SRC_NOT_CONNECTED   # exists_status (SRC_*) — resolved by the read path
     note: str = ""
+    title_hint: str = ""
+    tags: Tuple[str, ...] = ()
+    priority: int = 0
+    restricted: bool = False
+    required_for_skill: str = ""
+    source_repo: str = "nexus"
+
+    @property
+    def path(self) -> str:           # spec alias — ``ref`` IS the path
+        return self.ref
 
     def to_dict(self) -> dict:
-        return {"kind": self.kind, "ref": self.ref, "status": self.status, "note": self.note}
+        return {"kind": self.kind, "ref": self.ref, "status": self.status, "note": self.note,
+                "title_hint": self.title_hint, "tags": list(self.tags), "priority": self.priority,
+                "restricted": self.restricted, "required_for_skill": self.required_for_skill,
+                "source_repo": self.source_repo}
 
 
 @dataclass(frozen=True)

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/nexus_read.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/nexus_read.py
@@ -1,0 +1,241 @@
+"""Nexus read foundation (Hephaistos PR1) — read source refs, honestly. Pure/stdlib.
+
+Nexus is an EXTERNAL knowledge source. Hephaistos reads its markdown (when connected)
+and forges a BOUNDED projection to attach to a plan/packet — it never copies Nexus into
+ForgeKit and never claims to have read what it couldn't:
+
+  * no Nexus root configured → every ref is ``not_connected`` (no docs fabricated).
+  * connected but path absent → ``missing``. unreadable (permission/TCC) → ``blocked``.
+  * restricted source → raw read is gated; non-allowed roles get a ``projection_only``
+    view (title/why), never the raw body.
+
+``normalize_markdown`` is bounded (capped chars/points/snippets) — it extracts the few
+points a resolver needs, never dumps the whole document. This is the foundation PR2's
+``/resolve``/``/sources`` surface projects; no UI / command registration here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from .models import (
+    SRC_BLOCKED,
+    SRC_EXISTS,
+    SRC_MISSING,
+    SRC_NOT_CONNECTED,
+    SRC_RESTRICTED,
+    NexusSourceRef,
+)
+
+ENV_NEXUS_ROOT = "FORGEKIT_NEXUS_ROOT"
+
+# read modes for a single ref
+READ_RAW = "raw"                 # the bounded normalized body was read
+READ_PROJECTION = "projection_only"   # restricted → only a title/why projection
+READ_NONE = "none"               # nothing read (missing / blocked / not_connected)
+
+# path prefixes / tokens that mark a source restricted (design/privacy/contract/secret).
+_RESTRICTED_TOKENS = ("restricted", "design-private", "privacy", "contract", "secret",
+                      "70-restricted")
+# roles allowed to read restricted raw (others get projection only).
+DEFAULT_RESTRICTED_ROLES = ("design-lead", "ux-ui-designer", "privacy-officer",
+                            "contract-reviewer", "security-engineer")
+
+
+@dataclass(frozen=True)
+class NexusDocument:
+    source_ref: NexusSourceRef
+    title: str = ""
+    summary: str = ""
+    key_points: Tuple[str, ...] = ()
+    rules: Tuple[str, ...] = ()
+    snippets: Tuple[str, ...] = ()
+    troubleshooting_signals: Tuple[str, ...] = ()
+    decision_notes: Tuple[str, ...] = ()
+    read_status: str = SRC_NOT_CONNECTED
+    read_mode: str = READ_NONE
+
+    def to_dict(self) -> dict:
+        return {"source_ref": self.source_ref.to_dict(), "title": self.title,
+                "summary": self.summary, "key_points": list(self.key_points),
+                "rules": list(self.rules), "snippets": list(self.snippets),
+                "troubleshooting_signals": list(self.troubleshooting_signals),
+                "decision_notes": list(self.decision_notes),
+                "read_status": self.read_status, "read_mode": self.read_mode}
+
+
+@dataclass(frozen=True)
+class NexusReadResult:
+    requested_refs: Tuple[NexusSourceRef, ...] = ()
+    resolved_docs: Tuple[NexusDocument, ...] = ()
+    missing_refs: Tuple[NexusSourceRef, ...] = ()
+    blocked_refs: Tuple[NexusSourceRef, ...] = ()
+    restricted_refs: Tuple[NexusSourceRef, ...] = ()
+    not_connected: bool = False
+    read_mode: str = READ_NONE
+    evidence_lines: Tuple[str, ...] = ()
+
+    @property
+    def connected(self) -> bool:
+        return not self.not_connected
+
+    def to_dict(self) -> dict:
+        return {"requested": len(self.requested_refs), "resolved": len(self.resolved_docs),
+                "missing": len(self.missing_refs), "blocked": len(self.blocked_refs),
+                "restricted": len(self.restricted_refs), "not_connected": self.not_connected,
+                "read_mode": self.read_mode, "evidence_lines": list(self.evidence_lines)}
+
+
+def nexus_root(env: Optional[Mapping[str, str]] = None,
+               config: Optional[Mapping] = None) -> Optional[Path]:
+    """The configured Nexus root (env or config). None → not connected (honest)."""
+
+    env = os.environ if env is None else env
+    raw = str(env.get(ENV_NEXUS_ROOT, "") or (config or {}).get("nexus_root", "") or "").strip()
+    return Path(raw) if raw else None
+
+
+def _is_restricted(path: str) -> bool:
+    p = (path or "").lower()
+    return any(tok in p for tok in _RESTRICTED_TOKENS)
+
+
+def resolve_ref(ref: NexusSourceRef, root: Optional[Path]) -> NexusSourceRef:
+    """Resolve a ref's exists_status against the (maybe-absent) Nexus root. No read."""
+
+    from dataclasses import replace
+
+    restricted = ref.restricted or _is_restricted(ref.ref)
+    if root is None:
+        return replace(ref, status=SRC_NOT_CONNECTED, restricted=restricted)
+    target = root / ref.ref
+    try:
+        exists = target.exists()
+    except OSError:
+        return replace(ref, status=SRC_BLOCKED, restricted=restricted)
+    if not exists:
+        return replace(ref, status=SRC_MISSING, restricted=restricted)
+    if not os.access(target, os.R_OK):
+        return replace(ref, status=SRC_BLOCKED, restricted=restricted)
+    return replace(ref, status=SRC_RESTRICTED if restricted else SRC_EXISTS, restricted=restricted)
+
+
+def _capped(items, n):
+    return tuple(items[:n])
+
+
+def normalize_markdown(text: str, *, max_chars: int = 500, max_points: int = 8,
+                       max_snippet_chars: int = 300) -> dict:
+    """Bounded extraction — title / summary / key points / snippet / signals. NOT a dump."""
+
+    lines = (text or "").splitlines()
+    title = ""
+    headings, points, signals, decisions = [], [], [], []
+    summary_parts, snippet, in_code = [], [], False
+    for ln in lines:
+        s = ln.rstrip()
+        if s.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code and len("\n".join(snippet)) < max_snippet_chars:
+            snippet.append(s)
+            continue
+        if s.startswith("# ") and not title:
+            title = s[2:].strip()
+        elif s.startswith("## "):
+            headings.append(s[3:].strip())
+        elif s.lstrip().startswith(("- ", "* ")):
+            points.append(s.lstrip()[2:].strip())
+        elif not s.startswith("#") and s.strip() and len(" ".join(summary_parts)) < max_chars:
+            summary_parts.append(s.strip())
+        low = s.lower()
+        if any(k in low for k in ("error", "issue", "주의", "troubleshoot", "fail", "exception")):
+            signals.append(s.strip()[:120])
+        if any(k in low for k in ("decision", "결정", "trade-off", "트레이드오프")):
+            decisions.append(s.strip()[:120])
+    title = title or (lines[0].strip() if lines else "")
+    return {
+        "title": title,
+        "summary": " ".join(summary_parts)[:max_chars],
+        "key_points": _capped(points, max_points),
+        "rules": _capped([p for p in points if any(k in p for k in ("금지", "필수", "must", "주의", "정책"))], max_points),
+        "snippets": (("\n".join(snippet)[:max_snippet_chars],) if snippet else ()),
+        "troubleshooting_signals": _capped(signals, 4),
+        "decision_notes": _capped(decisions, 3),
+    }
+
+
+def read_ref(ref: NexusSourceRef, root: Optional[Path], *, role: str = "",
+             restricted_roles: Tuple[str, ...] = DEFAULT_RESTRICTED_ROLES) -> NexusDocument:
+    """Read ONE ref → a bounded NexusDocument. Never fabricates content for a status
+    that isn't readable; restricted + non-allowed role → projection_only (no raw)."""
+
+    resolved = resolve_ref(ref, root)
+    st = resolved.status
+    if st in (SRC_NOT_CONNECTED, SRC_MISSING, SRC_BLOCKED):
+        # honest: no content, status preserved (no fake-read).
+        return NexusDocument(resolved, read_status=st, read_mode=READ_NONE,
+                             title=resolved.title_hint)
+    if st == SRC_RESTRICTED and role not in restricted_roles:
+        # restricted → projection only: title/why, NEVER the raw body.
+        return NexusDocument(resolved, read_status=SRC_RESTRICTED, read_mode=READ_PROJECTION,
+                             title=resolved.title_hint or resolved.ref,
+                             summary=f"restricted source — {resolved.kind} (raw 비공개, projection only)")
+    # exists (or restricted+allowed) → read + bounded normalize.
+    try:
+        text = (root / resolved.ref).read_text(encoding="utf-8")
+    except OSError:
+        return NexusDocument(resolved, read_status=SRC_BLOCKED, read_mode=READ_NONE)
+    nm = normalize_markdown(text)
+    return NexusDocument(
+        resolved, title=nm["title"] or resolved.title_hint, summary=nm["summary"],
+        key_points=nm["key_points"], rules=nm["rules"], snippets=nm["snippets"],
+        troubleshooting_signals=nm["troubleshooting_signals"], decision_notes=nm["decision_notes"],
+        read_status=st, read_mode=READ_RAW,
+    )
+
+
+def read_refs(refs, root: Optional[Path], *, role: str = "",
+              restricted_roles: Tuple[str, ...] = DEFAULT_RESTRICTED_ROLES) -> NexusReadResult:
+    """Read a batch of refs into a structured, honest NexusReadResult."""
+
+    refs = tuple(refs)
+    docs, missing, blocked, restricted = [], [], [], []
+    for ref in refs:
+        doc = read_ref(ref, root, role=role, restricted_roles=restricted_roles)
+        if doc.read_status == SRC_MISSING:
+            missing.append(doc.source_ref)
+        elif doc.read_status == SRC_BLOCKED:
+            blocked.append(doc.source_ref)
+        elif doc.read_status == SRC_RESTRICTED:
+            restricted.append(doc.source_ref)
+            docs.append(doc)         # restricted doc is included as projection_only
+        elif doc.read_status == SRC_EXISTS:
+            docs.append(doc)
+        # not_connected → neither resolved nor missing; surfaced via not_connected flag
+    not_connected = root is None
+    mode = READ_NONE if not_connected else (READ_RAW if docs else READ_NONE)
+    ev = [f"nexus root: {root if root else '(not configured → not_connected)'}",
+          f"requested {len(refs)} · read {len([d for d in docs if d.read_mode==READ_RAW])} "
+          f"· restricted {len(restricted)} · missing {len(missing)} · blocked {len(blocked)}"]
+    return NexusReadResult(
+        requested_refs=refs, resolved_docs=tuple(docs), missing_refs=tuple(missing),
+        blocked_refs=tuple(blocked), restricted_refs=tuple(restricted),
+        not_connected=not_connected, read_mode=mode, evidence_lines=tuple(ev))
+
+
+def read_plan_sources(plan, *, env: Optional[Mapping[str, str]] = None,
+                      config: Optional[Mapping] = None, role: str = "") -> NexusReadResult:
+    """Resolver seam — read the Nexus refs a ResolvedForgePlan declared (PR2 surfaces this)."""
+
+    return read_refs(getattr(plan, "nexus_refs", ()), nexus_root(env, config), role=role)
+
+
+__all__ = (
+    "ENV_NEXUS_ROOT", "READ_RAW", "READ_PROJECTION", "READ_NONE", "DEFAULT_RESTRICTED_ROLES",
+    "NexusDocument", "NexusReadResult", "nexus_root", "resolve_ref", "normalize_markdown",
+    "read_ref", "read_refs", "read_plan_sources",
+)

--- a/tests/forgekit/test_nexus_read.py
+++ b/tests/forgekit/test_nexus_read.py
@@ -1,0 +1,120 @@
+"""Nexus read foundation (Hephaistos PR1) — honest read path, no fake-read.
+
+Proves: refs resolve to connected/missing/blocked/restricted/not_connected; markdown
+normalize is bounded (not a raw dump); an unreadable status never fabricates content;
+restricted sources give projection-only to non-allowed roles; and the resolver seam
+(read_plan_sources) reads a plan's declared refs.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.hephaistos import models, nexus_read as nx, resolver
+
+
+def _ref(path, kind=models.NEXUS_AREA):
+    return models.NexusSourceRef(kind, path)
+
+
+class ResolveRefTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.root, ignore_errors=True))
+
+    def test_not_connected_when_no_root(self) -> None:
+        r = nx.resolve_ref(_ref("20-areas/x"), None)
+        self.assertEqual(r.status, models.SRC_NOT_CONNECTED)
+
+    def test_missing_when_path_absent(self) -> None:
+        r = nx.resolve_ref(_ref("20-areas/absent"), self.root)
+        self.assertEqual(r.status, models.SRC_MISSING)
+
+    def test_exists_when_present(self) -> None:
+        (self.root / "20-areas").mkdir(parents=True)
+        (self.root / "20-areas/x.md").write_text("# T\n- a\n", encoding="utf-8")
+        r = nx.resolve_ref(_ref("20-areas/x.md"), self.root)
+        self.assertEqual(r.status, models.SRC_EXISTS)
+
+    def test_restricted_detected(self) -> None:
+        (self.root / "70-restricted").mkdir(parents=True)
+        (self.root / "70-restricted/secret.md").write_text("# s\n", encoding="utf-8")
+        r = nx.resolve_ref(_ref("70-restricted/secret.md"), self.root)
+        self.assertEqual(r.status, models.SRC_RESTRICTED)
+        self.assertTrue(r.restricted)
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_bounded_extraction(self) -> None:
+        md = ("# JWT 가이드\n\n요약 문장.\n\n## 규칙\n- refresh token 필수 회전\n"
+              "- secret 하드코딩 금지\n\n```java\nString x = jwt();\n```\n"
+              "에러: bean cycle 주의\n" + ("긴내용 " * 500))
+        nm = nx.normalize_markdown(md)
+        self.assertEqual(nm["title"], "JWT 가이드")
+        self.assertTrue(nm["key_points"])
+        self.assertTrue(any("회전" in p for p in nm["rules"]))
+        self.assertTrue(nm["snippets"] and "jwt()" in nm["snippets"][0])
+        self.assertTrue(nm["troubleshooting_signals"])
+        self.assertLessEqual(len(nm["summary"]), 500)            # bounded, no raw dump
+        self.assertLessEqual(len(nm["snippets"][0]), 300)
+
+
+class NoFakeReadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.root, ignore_errors=True))
+
+    def test_not_connected_yields_no_doc_content(self) -> None:
+        res = nx.read_refs([_ref("20-areas/x")], None)
+        self.assertTrue(res.not_connected)
+        self.assertEqual(res.resolved_docs, ())             # nothing fabricated
+        self.assertEqual(res.read_mode, nx.READ_NONE)
+
+    def test_missing_is_honest(self) -> None:
+        res = nx.read_refs([_ref("20-areas/absent")], self.root)
+        self.assertEqual(len(res.missing_refs), 1)
+        self.assertEqual(res.resolved_docs, ())
+
+    def test_restricted_projection_only_for_other_role(self) -> None:
+        (self.root / "70-restricted").mkdir(parents=True)
+        (self.root / "70-restricted/d.md").write_text("# secret design\n- 비밀 내용\n", encoding="utf-8")
+        res = nx.read_refs([_ref("70-restricted/d.md")], self.root, role="backend-engineer")
+        self.assertEqual(len(res.restricted_refs), 1)
+        doc = res.resolved_docs[0]
+        self.assertEqual(doc.read_mode, nx.READ_PROJECTION)
+        self.assertNotIn("비밀 내용", doc.summary)            # raw body NOT exposed
+        self.assertEqual(doc.key_points, ())
+
+    def test_restricted_raw_for_allowed_role(self) -> None:
+        (self.root / "70-restricted").mkdir(parents=True)
+        (self.root / "70-restricted/d.md").write_text("# design\n- 핵심 포인트\n", encoding="utf-8")
+        res = nx.read_refs([_ref("70-restricted/d.md")], self.root, role="design-lead")
+        self.assertEqual(res.resolved_docs[0].read_mode, nx.READ_RAW)
+        self.assertTrue(res.resolved_docs[0].key_points)      # allowed role gets content
+
+
+class ResolverSeamTests(unittest.TestCase):
+    def test_read_plan_sources_reads_declared_refs(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(root, ignore_errors=True))
+        plan = resolver.resolve("Spring Boot JWT refresh token")
+        # not connected → honest not_connected, no docs
+        nc = nx.read_plan_sources(plan, env={}, config={})
+        self.assertTrue(nc.not_connected)
+        # create one of the plan's declared ref paths → it reads
+        ref0 = plan.nexus_refs[0].ref
+        target = root / ref0
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# area\n- 규칙 필수\n", encoding="utf-8")
+        res = nx.read_plan_sources(plan, env={"FORGEKIT_NEXUS_ROOT": str(root)}, config={})
+        self.assertFalse(res.not_connected)
+        self.assertTrue(res.resolved_docs or res.missing_refs)   # seam actually read/located
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR1/3 · base `main`

## 목적
Hephaistos resolver 가 Nexus source ref 를 **정직하게** 읽는 read foundation.

## 범위
source ref→path resolution · read adapter · bounded markdown normalize · connected/missing/blocked/restricted/not_connected 상태 · restricted projection · resolver seam(`read_plan_sources`).

## 안 한 것
operator surface 없음 · armory breadth 없음 · README 개편 없음.

## 정직성
no fake-read · restricted raw 미노출 · not_connected/missing/blocked 상태 보존.

## 테스트
`test_nexus_read`(10), forgekit green ×2 venv.

## 다음 PR
operator surface (PR2).
