### PR TITLE
feat: add Hephaistos operator surface

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -26,6 +26,10 @@ H_DOCTOR = "doctor"
 H_RENDER = "render"
 H_BLOCKED = "blocked"
 H_WHOAMI = "whoami"
+H_RESOLVE = "resolve"
+H_HEPHAISTOS = "hephaistos"
+H_SKILLS = "skills"
+H_LOADOUT = "loadout"
 H_AGENT_ENTER = "agent_enter"
 H_LAYOUT = "layout"
 H_QUIT = "quit"
@@ -81,6 +85,10 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("usage", "토큰 사용량 — today rollup(provider/mode/live·estimate) + budget", H_MODE, "status"),
     SlashCommand("blocked", "반복 실패 에스컬레이션 목록 (왜·대안·다음 단계)", H_BLOCKED, "status"),
     SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
+    SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve (`/resolve <요청>`)", H_RESOLVE, "status"),
+    SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
+    SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
+    SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),
     SlashCommand("planning-agent", "Planning 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "planning-agent"),
     SlashCommand("backend-agent", "Backend 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "backend-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -32,6 +32,10 @@ from .registry import (
     H_MODE,
     H_BLOCKED,
     H_WHOAMI,
+    H_RESOLVE,
+    H_HEPHAISTOS,
+    H_SKILLS,
+    H_LOADOUT,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -143,6 +147,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         )
     if handler == H_WHOAMI:
         return _whoami_result(parsed)
+    if handler in (H_RESOLVE, H_HEPHAISTOS, H_SKILLS, H_LOADOUT):
+        return _hephaistos_result(handler, parsed)
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:
@@ -167,6 +173,26 @@ def _help_result(ctx: ConsoleContext) -> CommandResult:
     lines.append("")
     lines.append("일반 텍스트는 provider 로 live-submit 됩니다 (provider 미설정 시 setup 안내).")
     return CommandResult(kind=KIND_HELP, title="help", lines=tuple(lines))
+
+
+def _hephaistos_result(handler, parsed) -> CommandResult:
+    # Hephaistos operator surfaces — projection over resolver/verifier/nexus_read (pure core).
+    from ..hephaistos import projection as proj
+
+    args = getattr(parsed, "args", ()) or ()
+    request = " ".join(args).strip()
+    if handler == H_HEPHAISTOS:
+        return CommandResult.info("hephaistos", proj.hephaistos_status_lines())
+    if handler == H_LOADOUT:
+        return CommandResult.info("loadout", proj.loadout_lines(args[0] if args else "backend-java-local"))
+    if not request:
+        which = "/resolve" if handler == H_RESOLVE else "/skills"
+        return CommandResult.info(handler, (f"요청을 입력하세요 — `{which} <요청>` "
+                                            "(예: `/resolve Spring Boot JWT refresh token`).",))
+    plan, read = proj.resolve_with_sources(request)
+    if handler == H_RESOLVE:
+        return CommandResult.info("resolve", proj.resolve_summary_lines(plan, read))
+    return CommandResult.info("skills", proj.skills_lines(plan, read))
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/projection.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/projection.py
@@ -1,0 +1,108 @@
+"""Operator projection (Hephaistos PR2) — core results → console-friendly lines. Pure.
+
+A thin projection layer: it reads resolver / verifier / nexus_read results and renders
+summary-first, honest operator lines. No core logic, no UI framework — just strings the
+router/console surfaces. fake-live wording is impossible here: it reflects whatever the
+core returned (not_connected / missing / restricted / shallow shown as-is).
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Tuple
+
+from . import armory, nexus_read as nx, resolver, verifier
+from .models import SRC_RESTRICTED, ResolvedForgePlan
+
+
+def resolve_with_sources(request: str, *, env: Optional[Mapping[str, str]] = None,
+                         config: Optional[Mapping] = None, role: str = ""):
+    """Resolve + read the plan's Nexus refs (honest status). Returns (plan, read_result)."""
+
+    plan = resolver.resolve(request)
+    read = nx.read_plan_sources(plan, env=env, config=config, role=role)
+    return plan, read
+
+
+def nexus_status_lines(read: nx.NexusReadResult) -> Tuple[str, ...]:
+    if read.not_connected:
+        return ("  nexus     : not_connected (FORGEKIT_NEXUS_ROOT 미설정 — 지식 source 미연결)",)
+    return (f"  nexus     : connected · read {len(read.resolved_docs)} / "
+            f"missing {len(read.missing_refs)} / blocked {len(read.blocked_refs)} / "
+            f"restricted {len(read.restricted_refs)}",)
+
+
+def resolve_summary_lines(plan: ResolvedForgePlan, read: nx.NexusReadResult) -> Tuple[str, ...]:
+    """`/resolve` — summary-first equip plan + honest source/shallow state."""
+
+    shallow = "" if plan.selected_skills else "  ⚠ shallow — 이 스택의 armory skill 미존재(정직)"
+    lines = [
+        f"hephaistos resolve — {plan.request[:60]}",
+        f"  infer     : {plan.domain or '-'}/{plan.language or '-'}/{plan.framework or '-'}/{plan.topic or '-'}",
+        f"  agent     : {plan.selected_agent or '(미정)'}",
+        f"  skills    : {', '.join(plan.selected_skills) or '(없음)'}",
+        f"  loadout   : {plan.selected_loadout or '-'}",
+        f"  weapons   : {', '.join(plan.required_weapons) or '-'}",
+    ]
+    lines += list(nexus_status_lines(read))
+    if plan.packet_draft:
+        pk = plan.packet_draft
+        lines.append(f"  packet    : scope {len(pk.scope)} / forbidden {len(pk.forbidden_scope)} / "
+                     f"verify {len(pk.verification)} / approval {pk.approval_level}")
+    if shallow:
+        lines.append(shallow)
+    lines.append("  [dim]상세: /skills <요청> · /loadout <id> · /hephaistos[/dim]")
+    return tuple(lines)
+
+
+def skills_lines(plan: ResolvedForgePlan, read: nx.NexusReadResult) -> Tuple[str, ...]:
+    if not plan.selected_skills:
+        return (f"hephaistos skills — '{plan.request[:40]}'",
+                "  (선택된 skill 없음 — armory 가 이 스택을 아직 커버 안 함, 정직 shallow)")
+    lines = [f"hephaistos skills — '{plan.request[:40]}'"]
+    for sid in plan.selected_skills:
+        sk = armory.skill(sid)
+        if not sk:
+            continue
+        why = []
+        if plan.domain in sk.domains:
+            why.append(f"domain={plan.domain}")
+        if plan.topic in sk.topics:
+            why.append(f"topic={plan.topic}")
+        if plan.framework in sk.frameworks:
+            why.append(f"fw={plan.framework}")
+        unsafe = f" · unsafe: {sk.forbidden[0]}" if sk.forbidden else ""
+        lines.append(f"  • {sk.name} [{', '.join(sk.domains) or '-'}] — 선택이유: "
+                     f"{', '.join(why) or 'related'}{unsafe}")
+    lines += list(nexus_status_lines(read))
+    return tuple(lines)
+
+
+def loadout_lines(loadout_id: str, *, which=None) -> Tuple[str, ...]:
+    if not loadout_id:
+        return ("hephaistos loadout — 선택된 loadout 없음 (`/resolve <요청>` 먼저, 또는 `/loadout <id>`)",)
+    r = verifier.verify_loadout(loadout_id, which=which)
+    return verifier.readiness_lines(r)
+
+
+def hephaistos_status_lines(*, env: Optional[Mapping[str, str]] = None,
+                            config: Optional[Mapping] = None) -> Tuple[str, ...]:
+    """`/hephaistos` — identity + armory availability + nexus connection + next actions."""
+
+    root = nx.nexus_root(env, config)
+    nexus = "connected" if root else "not_connected (FORGEKIT_NEXUS_ROOT 미설정)"
+    return (
+        "Hephaistos — ForgeKit 의 skill-forging core (요청→skill/loadout/weapon/work packet).",
+        f"  armory    : skills {len(armory.all_skills())} · loadouts {len(armory.all_loadouts())} "
+        f"· weapons {len(armory.all_weapons())}  (현재 backend-java 중심 MVP)",
+        f"  nexus     : {nexus} — 미연결이면 source 는 not_connected 로 정직 표면(fake-read 없음)",
+        "  resolver  : rule-first·deterministic (요청→equip plan)",
+        "  loadout   : verify 가능(실 env which 기반)",
+        "  다음       : /resolve <요청> · /skills <요청> · /loadout <id>",
+        "  [dim]Nexus source 상세 상태는 /resolve·/skills 출력의 nexus 줄 참고 (/sources 는 discovery 전용)[/dim]",
+    )
+
+
+__all__ = (
+    "resolve_with_sources", "nexus_status_lines", "resolve_summary_lines",
+    "skills_lines", "loadout_lines", "hephaistos_status_lines",
+)

--- a/tests/forgekit/test_hephaistos_surface.py
+++ b/tests/forgekit/test_hephaistos_surface.py
@@ -1,0 +1,73 @@
+"""Hephaistos operator surface (PR2) — /resolve /hephaistos /skills /loadout routing.
+
+Proves the surfaces register + route, project the resolver/verifier/nexus_read core
+honestly (not_connected / shallow / partial shown as-is, no fake-live), and that
+empty/uncovered contexts surface honestly rather than dummy data.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.commands.parser import parse_input
+from forgekit_console.commands.router import build_default_context, route
+from forgekit_console.hephaistos import projection as proj
+
+
+def _ctx():
+    return build_default_context(Path("."))
+
+
+class RoutingTests(unittest.TestCase):
+    def test_resolve_routes_full_plan(self) -> None:
+        r = route(parse_input("/resolve Spring Boot JWT refresh token"), _ctx())
+        joined = "\n".join(r.lines)
+        self.assertIn("backend-engineer", joined)
+        self.assertIn("backend-java-local", joined)
+        self.assertIn("nexus", joined)               # source status surfaced
+
+    def test_hephaistos_status(self) -> None:
+        r = route(parse_input("/hephaistos"), _ctx())
+        joined = "\n".join(r.lines)
+        self.assertIn("skill-forging core", joined)
+        self.assertIn("armory", joined)
+
+    def test_loadout_verify_surface(self) -> None:
+        r = route(parse_input("/loadout backend-java-local"), _ctx())
+        joined = "\n".join(r.lines)
+        self.assertTrue(any(s in joined for s in ("ready", "partial", "missing")))
+
+    def test_skills_uncovered_is_honest(self) -> None:
+        r = route(parse_input("/skills Next.js dashboard spacing"), _ctx())
+        self.assertIn("shallow", "\n".join(r.lines))   # honest, not dummy skills
+
+    def test_resolve_without_arg_prompts(self) -> None:
+        r = route(parse_input("/resolve"), _ctx())
+        self.assertIn("요청을 입력", "\n".join(r.lines))
+
+
+class HonestyTests(unittest.TestCase):
+    def test_nexus_not_connected_surfaced(self) -> None:
+        plan, read = proj.resolve_with_sources("Spring Boot JWT", env={}, config={})
+        lines = "\n".join(proj.resolve_summary_lines(plan, read))
+        self.assertIn("not_connected", lines)           # no fake-live
+
+    def test_nexus_connected_reads(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(root, ignore_errors=True))
+        plan, _ = proj.resolve_with_sources("Spring Boot JWT", env={}, config={})
+        # create a declared ref so the read is connected
+        ref0 = plan.nexus_refs[0].ref
+        (root / ref0).parent.mkdir(parents=True, exist_ok=True)
+        (root / ref0).write_text("# area\n- 규칙\n", encoding="utf-8")
+        _, read = proj.resolve_with_sources("Spring Boot JWT",
+                                            env={"FORGEKIT_NEXUS_ROOT": str(root)}, config={})
+        self.assertIn("connected", "\n".join(proj.nexus_status_lines(read)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_palette.py
+++ b/tests/forgekit/test_palette.py
@@ -23,8 +23,13 @@ class RefilterTests(unittest.TestCase):
         self.assertEqual(s.index, -1)
 
     def test_prefix_filters(self) -> None:
-        s = P.refilter("/he", _CMDS)
+        s = P.refilter("/hel", _CMDS)
         self.assertEqual([c.name for c in s.matches], ["help"])
+
+    def test_prefix_filters_multiple(self) -> None:
+        # /he now matches both help and hephaistos (the skill-forge surface)
+        s = P.refilter("/he", _CMDS)
+        self.assertEqual([c.name for c in s.matches], ["help", "hephaistos"])
 
 
 class CycleTests(unittest.TestCase):


### PR DESCRIPTION
> stacked PR2/3 · base `feature/forgekit-nexus-read-foundation`

## 목적
`/resolve`·`/hephaistos`·`/skills`·`/loadout` operator surface 추가(이미 머지된 resolver-core + PR1 nexus-read 투영).

## 범위
command registration · projection layer(순수) · resolve+nexus read 결합 · loadout verify surface.

## 안 한 것
armory breadth 없음 · README 개편 없음.

## 정직성
shallow/partial/not_connected 표면화 · `/sources` 는 discovery 가 점유 → Nexus 상태는 `/hephaistos`·`/resolve` 의 nexus 줄로(정직 명시).

## 테스트
`test_hephaistos_surface`(7) + palette prefix 갱신, green ×2 venv.

## 다음 PR
armory breadth expansion (PR3).
