### PR TITLE
docs: consolidate ForgeKit README, concepts, and evidence map

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,182 +4,138 @@
 
 # ForgeKit
 
-> **ForgeKit = 에이전트·워크플로·내부 도구를 직접 벼려 쓰는 개인 자동화 툴킷.**.  
-> *forge*(만들다 / 단조 — 쇠를 달궈 두드려 형태를 잡는 대장간) + *kit*(도구 묶음).  
-> 즉 "내 작업을 자동화할 에이전트와 도구를 직접 벼리는 도구 일습".  
+> **ForgeKit is a personal agent-operations forge** — you wire up AI providers, equip
+> agents with the right skills for a job, run them under operator-gated runtime policy,
+> and keep every result in a durable memory. It is **not another chatbot**: it orchestrates
+> *multiple* providers, agents and tools to carry a real task to a bounded finish.
 
-이 레포는 문서 저장소가 아니라 **개인 자동화 플랫폼**입니다.   
-역할별 AI 에이전트, 워크플로, always-on 런타임, 운영 도구가 한곳에서 한 팀처럼 돌아가는게 목표입니다.  
-모든 산출물은 SQLite + Obsidian vault 에 결정적으로 적재돼 다음 작업이 같은 컨텍스트를 다시 사용할 수 있는  
-구조를 만들어 나가고 있습니다.
+*forge* (a smithy — heat metal, hammer it to shape) + *kit* (a set of tools).
 
-## 지금 상태
+## What ForgeKit is
 
-- **운영자 콘솔 `forgekit`** — 터미널 한 줄이면 열리는 Claude-Code 스타일 TUI 콘솔.
-  런타임/harness/doctor surface 를 읽어 표시한다(cyan/magenta-on-black 브랜드 테마).
-- **provider / 런타임** — always-on engineering 런타임, 역할 멤버 봇, 자료 수집기.
-- **memory / vault** — SQLite 인덱스 + Obsidian 미러로 컨텍스트를 누적.
-- **agent 시스템** — Planning / Engineering 등 좁은 책임의 역할별 에이전트.
+A monorepo with two cooperating apps:
+- **`forgekit-console`** — the operator TUI (Claude-Code-style). You configure the brain,
+  switch runtime modes, resolve work, and read honest status.
+- **`engineering-agent`** (`yule`) — an always-on, role-based engineering runtime (Discord
+  gateway + member bots, SQLite job queue, Obsidian vault mirror).
 
-## 설치 / 진입
+Everything is provider-neutral (Claude / Codex / Gemini / Ollama and any openai-compatible
+or enterprise endpoint sit behind one contract) and operator-gated (approval / budget /
+safe-class boundaries are real, not decorative).
 
-```bash
-pip install -e '.[console]'   # 콘솔 extra (textual + 이미지 렌더)
-forgekit                      # 운영자 콘솔 TUI 열기
-yule --help                   # 기존 engineering CLI (runtime/harness/engineer/…)
-```
+## Core concepts
 
-콘솔 안에서:
+| Concept | One line | Code |
+| --- | --- | --- |
+| **ForgeKit** | the whole platform / execution environment | this repo |
+| **Hephaistos** | the *skill-forging core* — turns a request into an equip plan (agent + skills + loadout + weapons + work packet) | `forgekit_console/hephaistos/` |
+| **Nexus** | the external knowledge source (areas / patterns / snippets / troubleshooting) Hephaistos *reads* (never copies) | read path: `hephaistos/nexus_read.py` |
+| **Armory** | the catalog of Skills / Loadouts / Weapons Hephaistos forges from | `hephaistos/armory.py` |
+| **Work Packet** | a structured, executable unit (goal / scope / forbidden / commands / verify / approval / evidence) | `hephaistos/models.py` |
+| **Runtime Mode** | the operator posture (Shift+Tab) that actually changes routing / budget / approval | `policy/runtime_mode.py` |
 
-- **provider** — `~/.forgekit/config.json` 의 `main_provider` (없으면 `setup-required`).
-- **mode** — **Shift+Tab** 으로 7 런타임 모드 순환(실제 routing/budget/approval 변경), `/mode` 로 확인.
-- **always-on** — `/always-on` bounded 사이클(관측→분류→패킷→handoff→대기, 무한 자율 아님).
-- **PM intake** — `/pm-agent` 진입 후 제품 요청 → tech-lead handoff(역할 split + 권한 없는 영역 BLOCKED).
-- **알림** — 승인/결정 필요 시 operator inbox + (opt-in `FORGEKIT_NOTIFY`) macOS/Windows desktop.
-- **운영 절차(runbook)** — [docs/forgekit-console.md §2g](docs/forgekit-console.md) · end-to-end 예시
-  [`apps/forgekit-console/examples/e2e/bkurs/`](apps/forgekit-console/examples/e2e/bkurs/).
-- **discovery/보안 모드** — `/auto`(상황 분류·안전 전환) · `/sources`(무료 우선 수집원, YouTube/IG/Google은 planned) ·
-  `idea-discovery`(아이디어 브리프) · `video-watch`(저비용 transcript ingest) · `/self-improve`(repo gap→risk 패킷) ·
-  `/red-blue`(내 자산 한정 plan-only 보안 드릴). 관계: [docs/forgekit-console.md §2l](docs/forgekit-console.md).
+Mine → library → smith: **Nexus is the mine/library, ForgeKit is the forge, Hephaistos is the smith.**
 
-### 터미널별 이미지 렌더 (true raster vs fallback)
+## Current reality (honest)
 
-forgekit 의 대표 이미지는 터미널 graphics 지원에 따라 다르게 그려진다.
+Status is one of **working** / **partial** / **planned** / **blocked** — see the matrices
+in [`docs/operator-surfaces.md`](docs/operator-surfaces.md) and [`docs/evidence-map.md`](docs/evidence-map.md).
 
-- **VS Code 통합 터미널 = fallback-first 경로.** sixel/TGP 무응답이라 진짜 픽셀
-  이미지가 안 되고, forgekit 는 **깔끔한 브랜드 배지 / 워드마크**(managed fallback)로
-  표시한다 — 도트로 깨지는 portrait 를 강행하지 않는다. 기본 운영 환경으로 문제없다.
-- **iTerm2 / WezTerm / Kitty = true-raster 권장 경로.** 진짜 인라인 픽셀 이미지를
-  그린다. 단 `textual-image` 는 **Python 3.10+** 가 필요하므로 별도 console env
-  (`python3.13 -m venv .venv-console` + `pip install -e 'apps/forgekit-console[image]'`)를 쓴다.
-- **지금 내 환경 확인:** 콘솔에서 `/render` (readiness + 권장 터미널) 또는
-  `FORGEKIT_DEBUG_RENDERERS=1 forgekit` (intro 아래 `avatar=<backend> (<policy>)` 한 줄).
+| Capability | Status | Surface | Evidence |
+| --- | --- | --- | --- |
+| Multi-provider config + routing (no implicit ollama) | **working** | submit path, `/mode` | `examples/runtime-teeth/` |
+| Vendor-native usage ledger (live vs estimate) | **working** | `/usage` | `examples/usage/` |
+| Hephaistos resolve (request → equip plan) | **working** | `/resolve` `/hephaistos` `/skills` `/loadout` | `examples/hephaistos/` |
+| Armory breadth (7 categories, 25 skills, 8 loadouts) | **working** | `/resolve` | `test_armory_breadth` |
+| Nexus read path (bounded, restricted-aware) | **partial** | `/resolve` nexus line | `examples/hephaistos/nexus-read-foundation/` |
+| Always-on bounded daemon + safe-class autopilot | **working** | `forgekit runtime serve` | `examples/runtime/`, `examples/autopilot/` |
+| Provider `/provider`·`/setup` console config | **planned** | — (engine merged; command not wired) | — |
+| Nexus live repo connection | **planned** (`not_connected` until `FORGEKIT_NEXUS_ROOT` set) | — | — |
+| Live Figma / YouTube / Google / Instagram | **planned seam** (never live in this tree) | `/sources` shows planned | — |
 
-자세한 콘솔 가이드 / 정책 매트릭스는 [docs/forgekit-console.md](docs/forgekit-console.md).
+**No fake-live.** Anything not wired is shown as `planned` / `not_connected` / `blocked` /
+`restricted` / `unsupported_in_console`, never as if it works.
 
-## 명령(지침) 구조
-
-읽기 순서는 한 줄로 정리된다: **[`AGENTS.md`](AGENTS.md)(진입점) → root
-[`CLAUDE.md`](CLAUDE.md)(전역 규칙 SSoT) → 작업 맥락별 `docs/<topic>.md` / scoped
-`agents/<agent>/CLAUDE.md`**. provider(Claude·Codex·Gemini)가 무엇이든 같은 경로다.
-
-## 구성 요소
-
-- **Planning Agent** — 캘린더 + GitHub 이슈 + reminder 를 모아 매일의 daily plan 과 시간 블록 브리핑을 만든다.
-- **Engineering Agent** — `#업무-접수` 채널에서 자유 대화로 작업을 받고, 7 개 역할 멤버 봇이 협업으로 리서치·합의·결과를 정리한다.
-- **Memory / Obsidian** — 모든 산출물을 SQLite + Obsidian vault 에 결정적으로 적재해 다음 작업이 같은 컨텍스트를 다시 쓸 수 있게 한다.
-
-## 주요 기능
-
-- Naver CalDAV / GitHub / Discord 통합
-- Discord 게이트웨이 + 7 개 역할 멤버 봇 (engineering-agent)
-- 자율 리서치 수집기 (Tavily / Brave 멀티 프로바이더)
-- 역할 가중 deliberation + work_report / Obsidian export
-- SQLite 기반 작업 세션 / 메모리 인덱스 / 활동 로그
-
-## 빠른 시작
+## Quick start
 
 ```bash
-# 1. 의존성 설치 (macOS + Homebrew 가정)
-./scripts/bootstrap
-
-# 2. 환경 설정
-cp .env.example .env.local
-# 자세한 키 설명은 docs/configuration.md
-
-# 3. 헬스 체크
-yule doctor
+pip install -e '.[console]'   # console extra (textual + image render)
+forgekit                      # open the operator console TUI
+yule --help                   # the engineering runtime CLI (runtime/harness/doctor/…)
 ```
 
-자세한 설치 / 토큰 / 채널 설정은 [docs/getting-started.md](docs/getting-started.md) 와 [docs/configuration.md](docs/configuration.md) 를 본다.
+First run with **no provider configured** → the console reports `setup-required` and free-text
+submit is held. **You choose the brain** — ForgeKit does **not** silently use a reachable
+local Ollama (implicit local fallback is OFF by default).
 
-## 핵심 명령
+## Provider / setup / doctor / mode
 
-운영 (always-on engineering runtime):
+- **You set the primary provider.** `~/.forgekit/config.json` carries `primary_provider` +
+  `linked_providers` + `slot_routing` + `fallback_policy` (legacy `main_provider` is migrated).
+  See [`docs/forgekit-provider-policy.md`](docs/forgekit-provider-policy.md).
+- **No implicit Ollama.** With no config, submit is `setup-required` — a reachable Ollama is
+  only used if you explicitly set `fallback_policy.implicit_local_fallback: true`.
+- **`/doctor`** checks environment readiness (render backend, runtime, provider posture).
+- **`/mode`** (Shift+Tab) cycles runtime modes — each changes real routing / budget / approval
+  (not just a label). `approval-wait` truly holds submits; `cost-save` biases cheap routing.
+- **usage `live` vs `estimate`** — `/usage` records native provider usage as `live` when the
+  response carries a usage block (ollama openai-compat does), else an honest length `estimate`.
+  The two are never summed.
 
-```bash
-yule runtime up --dry-run                    # 띄울 service 목록 확인 (실제 spawn 없음)
-yule runtime up --profile engineering        # 단일 호스트 전체 부팅
-yule run-service eng-research-worker         # 단일 worker (CLI / systemd)
-yule runtime status                          # heartbeat / queue / circuit / failed_terminal 요약
-yule runtime status --post-discord           # #봇-상태 markdown 게시 (dedup 기반)
-yule runtime circuit reset eng-role-qa-engineer   # 운영자 circuit 해제
+## Operator console overview
+
+`/resolve <req>` (equip plan) · `/hephaistos` (forge status) · `/skills <req>` · `/loadout <id>`
+(real env verify) · `/usage` · `/mode` · `/doctor` · `/render` · `/whoami` (agent identity) ·
+`/autopilot <repo>` · `/digest` · `/sources` (discovery) · `/blocked`. Full honest matrix:
+[`docs/operator-surfaces.md`](docs/operator-surfaces.md).
+
+Example — `/resolve "Spring Boot JWT refresh token"` →
+`backend-engineer` + skills `java-spring, auth-jwt, mysql` + loadout `backend-java-local` +
+weapons + nexus refs (`not_connected` until configured) + a Work Packet draft.
+
+## Always-on runtime (honest limits)
+
+`forgekit runtime serve` is a **real** bounded daemon (observe → safe-class execute → verify →
+record), but **macOS lid-close suspends it** — **Linux / homeserver / systemd is the 1st-class
+always-on path**. See [`apps/forgekit-console/examples/runtime/`](apps/forgekit-console/examples/runtime/).
+
+The `engineering-agent` runtime (`yule runtime up`, Discord member bots, SQLite queue, Obsidian
+mirror) is the production multi-bot path — see [`docs/operations.md`](docs/operations.md).
+
+## Architecture at a glance
+
+```
+Inputs/Connectors → Hephaistos (forge: resolve → packet) → Agents (PM/gateway/tech-lead/specialists)
+                                        ↑ reads                         ↓ bounded execution
+                                      Nexus (knowledge)            Memory / Vault (SQLite + Obsidian)
 ```
 
-자료/일정/작업 흐름:
+## Docs map
 
-```bash
-yule daily warmup --json          # 오늘 plan 스냅샷 생성
-yule planning snapshot --json     # planning 데이터 갱신
-yule engineer intake --prompt "…" # CLI 로 engineering 작업 접수
-yule memory search "query"        # 로컬 지식 검색
-yule obsidian sync --session <id> # Obsidian vault 적재
-```
+| Topic | Doc |
+| --- | --- |
+| Vision / why the split | [docs/vision.md](docs/vision.md) |
+| Hephaistos runtime | [docs/hephaistos-runtime.md](docs/hephaistos-runtime.md) |
+| Nexus read path | [docs/nexus-read-path.md](docs/nexus-read-path.md) |
+| Armory (skills/loadouts) | [docs/armory.md](docs/armory.md) |
+| Work Packet | [docs/work-packet.md](docs/work-packet.md) |
+| Operator surfaces (reality matrix) | [docs/operator-surfaces.md](docs/operator-surfaces.md) |
+| Evidence map | [docs/evidence-map.md](docs/evidence-map.md) |
+| Console guide / policy | [docs/forgekit-console.md](docs/forgekit-console.md) |
+| Provider policy | [docs/forgekit-provider-policy.md](docs/forgekit-provider-policy.md) · [docs/provider-capability-matrix.md](docs/provider-capability-matrix.md) |
+| Operations (always-on) | [docs/operations.md](docs/operations.md) |
+| Config / memory / testing | [docs/configuration.md](docs/configuration.md) · [docs/memory.md](docs/memory.md) · [docs/testing.md](docs/testing.md) |
 
-개발 / 로컬 (dev launcher):
+Reading order for contributors/agents: [`AGENTS.md`](AGENTS.md) → [`CLAUDE.md`](CLAUDE.md) → topical `docs/<topic>.md`.
 
-```bash
-yule discord bot                  # planning 봇 단독 실행 (dev)
-yule discord up --dry-run         # 9-봇 인벤토리 확인 (dev)
-yule discord up                   # 9 봇 multiprocessing 일괄 기동 (dev)
-```
+## Roadmap / non-goals
 
-production 권장 경로 = `yule runtime up` 또는 systemd 기반 `yule run-service` — [docs/operations.md](docs/operations.md). `yule discord up` 은 dev / 로컬 단독 호스트 부트스트랩이며, 제거 / deprecation 되지 않는다.
+**Next:** `/provider`·`/setup` console config surface · Nexus live connection · per-provider usage
+surface · GitHub-App doctor/commit-path. **Non-goals (now):** fully-autonomous unsupervised code
+mutation (safe-class only, operator-gated), live social/Figma scraping, "complete autonomous team".
 
-## 아키텍처 한눈에 보기
+## Contributing / license
 
-> 다이어그램은 Mermaid 로 직접 그린다 — flowchart / sequence / ERD 모두. 정책: [policies/runtime/agents/engineering-agent/diagram-conventions.md](policies/runtime/agents/engineering-agent/diagram-conventions.md).
-
-### 시스템 토폴로지
-
-```mermaid
-flowchart LR
-  User[운영자]
-  Discord[Discord]
-  Planning[planning-bot]
-  Gateway[engineering-gateway]
-  Member[engineering-member × 7]
-  Runtime[yule runtime up]
-  Queue[SQLite cache + job queue]
-  Vault[Obsidian vault mirror]
-  Github[GitHub repo + Apps]
-
-  User --> Discord
-  Discord --> Planning
-  Discord --> Gateway
-  Discord --> Member
-  Gateway --> Runtime
-  Member --> Runtime
-  Planning --> Runtime
-  Runtime --> Queue
-  Runtime --> Github
-  Queue --> Vault
-  Runtime --> Vault
-```
-
-- 역할 봇은 각자 독립 프로세스로 운영된다.
-- 모든 작업 상태는 SQLite 에 저장되고, Discord 메시지는 신호일 뿐이다.
-- Engineering 런타임 lifecycle 정책: [policies/runtime/agents/engineering-agent/lifecycle-mvp.md](policies/runtime/agents/engineering-agent/lifecycle-mvp.md).
-- P0-K command-only 가드 정책: [docs/p0k-command-only-research-thread-guard.md](docs/p0k-command-only-research-thread-guard.md).
-
-## 문서 안내
-
-| 카테고리 | 위치 | 내용 |
-|---|---|---|
-| 빠른 시작 | [docs/getting-started.md](docs/getting-started.md) | 설치, 토큰, `yule doctor` |
-| 환경 설정 | [docs/configuration.md](docs/configuration.md) | env 키, `.env.local` 운영, 캐시 |
-| Discord 운영 | [docs/discord.md](docs/discord.md) | 봇 토큰, 채널, slash command |
-| Engineering Agent | [docs/engineering.md](docs/engineering.md) | intake / 7 역할 / coding authorization / Obsidian sync |
-| Planning Agent | [docs/planning.md](docs/planning.md) | daily plan / scheduled briefing |
-| Research budget | [docs/research-budget.md](docs/research-budget.md) | reference budget tier / multi-provider |
-| Memory 인덱스 | [docs/memory.md](docs/memory.md) | reindex / search / source_kind |
-| 테스트 | [docs/testing.md](docs/testing.md) | 묶음 명령 / fixture |
-| 아키텍처 | [docs/architecture.md](docs/architecture.md) | 디렉토리, 모듈 구조 |
-| 상시 운영 | [docs/operations.md](docs/operations.md) | systemd 기반 always-on 운영 |
-| 캘린더 메모 | [docs/calendar-notes.md](docs/calendar-notes.md) | CalDAV 운영 노하우 |
-| 정책 (런타임) | [policies/runtime/](policies/runtime/) | lifecycle / role weight / live regression |
-| 정책 (참조) | [policies/reference/](policies/reference/) | commit / branch / naming convention |
-
-## 기여 / 라이선스
-
-개인 프로젝트이며 외부 기여는 받기 전 단계다. 커밋 메시지 형식은 [policies/reference/COMMIT_CONVENTION.md](policies/reference/COMMIT_CONVENTION.md) 를 따른다. 운영 회고·의사결정·실험 메모는 README 가 아니라 Obsidian vault 에 적재한다.
+Personal project, pre-external-contribution. Commit format:
+[policies/reference/COMMIT_CONVENTION.md](policies/reference/COMMIT_CONVENTION.md). Retrospectives /
+decisions go in the Obsidian vault, not the README.

--- a/docs/armory.md
+++ b/docs/armory.md
@@ -1,0 +1,28 @@
+# Armory
+
+The catalog Hephaistos forges from — `forgekit_console/hephaistos/armory.py`. **Provider-neutral**:
+skills describe *capability / framework / workflow* (`capability_note` carries the capability lens),
+never a vendor name.
+
+## Coverage (7 categories, 25 skills, 8 loadouts)
+| category | skills |
+| --- | --- |
+| backend | java-spring, kotlin-spring, node-nestjs, python-fastapi |
+| frontend | react-typescript, nextjs, vite-react |
+| database | mysql, postgres, redis |
+| devops | docker, kubernetes, terraform, aws-ecs |
+| security | auth-jwt, oauth2, secrets-management, web-security-review |
+| ai | openai-api, rag-basics, eval-harness, agent-evaluation |
+| design-support | figma-read (partial — blocked when unconnected), design-system-review, ux-ui-reference-pack |
+
+Loadouts: backend-java/python/node-local, frontend-react-local, fullstack-web-local,
+devops-cloud-local, ai-agent-local, security-review-local, design-review-local.
+
+## Manifest contract (no placeholders)
+Each skill carries id/title/category/summary/when_to_use/commands/verify/**unsafe_boundary**/
+signals/capability_note/nexus_refs. Each loadout carries goal/recommended/optional/**blocked**_skills/
+selection_signals — so the resolver can *explain why* a combo was chosen. Validity is locked by
+`test_armory_breadth` (referential integrity + non-placeholder guard).
+
+Uncovered stacks (e.g. Rust embedded) resolve **shallow** — honest, never faked. Adding a stack =
+add a manifest + signals; the resolver picks it up.

--- a/docs/evidence-map.md
+++ b/docs/evidence-map.md
@@ -1,0 +1,22 @@
+# Evidence map
+
+Where each capability's evidence lives. Paths under `apps/forgekit-console/examples/` are tracked;
+`runs/` artifacts are **gitignored** (regenerate via the noted command).
+
+| capability | evidence path | tracked? | regenerate |
+| --- | --- | --- | --- |
+| Hephaistos resolve (MVP) | `examples/hephaistos/` (+ `test_hephaistos`) | yes | `pytest`-style unittest |
+| Nexus read foundation | `examples/hephaistos/nexus-read-foundation/` | yes | see its README |
+| usage ledger / live vs estimate | `examples/usage/` (+ `native-usage-live/`) | yes | `/usage` writes `runs/forgekit/usage/` |
+| runtime-teeth (submit gate) | `examples/runtime-teeth/` | yes | — |
+| always-on daemon | `examples/runtime/` (`daemon-execution/`, heartbeat) | yes | `forgekit runtime serve --max-ticks N` |
+| autopilot safe-class execution | `examples/autopilot/` (`source-mutation/`) | yes | `/autopilot <repo>` |
+| handoff (PM→gateway→tech-lead) | `examples/handoff/`, `examples/e2e/bkurs/` | yes | `/pm-agent` |
+| notifications | `examples/notify/` | yes | — |
+| discovery / sources | `examples/sources/`, `examples/discovery/` | yes | `/sources` |
+| design restricted source | `examples/design/` | yes | `/design` |
+| security red/blue | `examples/security/` | yes | `/red-blue` |
+| vault authorship | `examples/vault/` | yes | — |
+
+Runtime output written by the daemon/autopilot lands under `<repo>/runs/forgekit/…`
+(**gitignored** — `apps/forgekit-console/runs/` is ignored; committed evidence lives in `examples/`).

--- a/docs/hephaistos-runtime.md
+++ b/docs/hephaistos-runtime.md
@@ -1,0 +1,25 @@
+# Hephaistos runtime
+
+Hephaistos is ForgeKit's **skill-forging core** — pure (`forgekit_console/hephaistos/`), the
+console is a projection layer over it. Flow:
+
+```
+request → resolve (infer domain/lang/framework/topic) → score Armory skills (+ language gate)
+        → pick loadout (signals + recommended overlap) → required weapons
+        → attach Nexus refs (read path; honest status) → Work Packet draft
+```
+
+- **resolver** (`resolver.py`) — rule-first, deterministic, explainable. Language gate excludes
+  a Java skill for a Python request (FastAPI → `python-fastapi`, not `java-spring`).
+- **verifier** (`verifier.py`) — loadout readiness against the real env (`ready/partial/missing/blocked`).
+- **models** (`models.py`) — Skill/Loadout/Weapon/Rune/WorkPacketDraft/NexusSourceRef/ResolvedForgePlan.
+
+## What works / what doesn't (honest)
+- **working**: resolve for the covered stacks (backend/frontend/db/devops/security/ai/design-support),
+  loadout verify, work packet draft, operator surfaces (`/resolve`·`/hephaistos`·`/skills`·`/loadout`).
+- **partial**: Nexus read (foundation only — `not_connected` until `FORGEKIT_NEXUS_ROOT` set).
+- **planned**: per-skill install/equip automation (verify-only today), figma-read live.
+- Uncovered requests resolve **shallow** (honest, never faked).
+
+Runtime posture (mode/approval/budget) is the existing `policy/runtime_mode.py` EffectivePolicy —
+a mode change changes real routing/budget/approval. See [operator-surfaces.md](operator-surfaces.md).

--- a/docs/nexus-read-path.md
+++ b/docs/nexus-read-path.md
@@ -1,0 +1,23 @@
+# Nexus read path
+
+Hephaistos reads Nexus as an **external** knowledge source — it never copies Nexus into the
+repo. Code: `forgekit_console/hephaistos/nexus_read.py`. Flow: `source ref → resolve → read →
+bounded normalize → attach`.
+
+## Status semantics (honest, no fake-read)
+| status | meaning |
+| --- | --- |
+| `not_connected` | `FORGEKIT_NEXUS_ROOT` (env) / `nexus_root` (config) unset — the default |
+| `missing` | connected but the path is absent |
+| `blocked` | present but unreadable (permission / TCC / sandbox) |
+| `restricted` | present but raw read gated → **projection_only** for non-allowed roles |
+| `exists` | read + bounded normalize |
+
+- **bounded normalize** — title / summary (≤500 chars) / key points / one snippet (≤300 chars) /
+  troubleshooting / decision. Never a full raw dump.
+- **restricted projection** — a non-allowed role gets title/why only, never the raw body;
+  allowed roles (design-lead, privacy-officer, …) get the bounded read.
+- An unreadable status **never fabricates content**.
+
+Evidence: [`examples/hephaistos/nexus-read-foundation/`](../apps/forgekit-console/examples/hephaistos/nexus-read-foundation/)
+(connected / not_connected / restricted projection). Surfaced via the `nexus` line in `/resolve`.

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -1,0 +1,40 @@
+# Operator surfaces — reality matrix
+
+Honest status of each console surface (working / partial / planned). Code:
+`commands/registry.py` + `commands/router.py` + `tui/app.py`.
+
+## Capability reality matrix
+| capability | status | surface | evidence |
+| --- | --- | --- | --- |
+| Hephaistos resolve | working | `/resolve` `/skills` | `examples/hephaistos/`, `test_armory_breadth` |
+| forge status | working | `/hephaistos` | `test_hephaistos_surface` |
+| loadout verify (real env) | working | `/loadout <id>` | `test_hephaistos` |
+| Nexus read | partial (not_connected default) | `/resolve` nexus line | `examples/hephaistos/nexus-read-foundation/` |
+| usage ledger (live vs estimate) | working | `/usage` | `examples/usage/` |
+| runtime modes (real routing/budget/approval) | working | `/mode`, Shift+Tab | `examples/runtime-teeth/` |
+| always-on daemon + safe-class autopilot | working (bounded) | `forgekit runtime serve`, `/autopilot` | `examples/runtime/`, `examples/autopilot/` |
+| agent identity (git author / app status) | working | `/whoami` | `test_identity_attribution` |
+| discovery collectors (free-first) | working; YouTube/IG/Google planned | `/sources` | `examples/sources/` |
+| design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |
+| red/blue planning (owned assets) | working (plan-only) | `/red-blue` | `examples/security/` |
+| `/provider`·/setup console config | planned (engine merged, command not wired) | — | — |
+
+## Provider reality matrix
+| provider | connection | live submit | usage basis | mode influence |
+| --- | --- | --- | --- | --- |
+| ollama (local, openai-compat) | zero-config if running | yes | **live** (native usage) | yes |
+| openai / gemini (openai-compat) | api key | yes (when keyed) | live (when reported) else estimate | yes |
+| claude / codex (CLI) | routable | **no** (`unsupported_in_console`) | n/a | routing only |
+
+The operator **sets `primary_provider`**; no implicit local fallback (a reachable ollama is NOT used
+unless `fallback_policy.implicit_local_fallback: true`). No provider → `setup-required`.
+
+## Source reality matrix
+| source | read status | restrictions | evidence |
+| --- | --- | --- | --- |
+| repo-local docs | working | — | `examples/sources/` |
+| Nexus vault | not_connected (until `FORGEKIT_NEXUS_ROOT`) | restricted projection for some roles | `examples/hephaistos/nexus-read-foundation/` |
+| restricted design source | blocked (TCC) | design role only (else projection) | `examples/design/` |
+| Figma | planned seam | — | — |
+| YouTube / Google / Instagram | planned | — | — |
+| GitHub / HN / Reddit / RSS | working (injected fetcher; free-first) | rate/ToS | `examples/sources/` |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,22 @@
+# ForgeKit vision
+
+ForgeKit goes from "a personal automation toolkit" toward a **bounded, senior-team-like
+runtime** — many providers/agents/tools wired into one operator-gated forge that carries
+real work to a finish, with everything recorded for reuse.
+
+## Why the split (ForgeKit / Nexus / Hephaistos / Armory)
+- **Nexus** = the mine/library: where knowledge (areas/patterns/snippets/troubleshooting/
+  decisions) lives. Source of truth for *what we know*.
+- **ForgeKit** = the forge/platform: the execution environment, operator surfaces, runtime,
+  approval, memory.
+- **Hephaistos** = the smith: reads Nexus knowledge and forges it into Skills / Loadout /
+  Weapons / Work Packet an agent equips to finish a job. It is a **core inside ForgeKit**,
+  not the whole platform and not a single slash command.
+- **Armory** = the smith's catalog: the skill/loadout/weapon manifests.
+
+## Non-goals (now)
+- Fully-autonomous, unsupervised code mutation — only **safe-class**, operator-gated.
+- Live social/Figma scraping — **planned seams**, never faked live.
+- "Complete autonomous team" — agents are bounded and approval-gated by design.
+
+Related: [hephaistos-runtime.md](hephaistos-runtime.md) · [README](../README.md).

--- a/docs/work-packet.md
+++ b/docs/work-packet.md
@@ -1,0 +1,17 @@
+# Work Packet
+
+A Work Packet is the **executable unit** Hephaistos drafts from a resolve — not a text blob.
+Model: `WorkPacketDraft` in `forgekit_console/hephaistos/models.py`.
+
+Fields: `goal` · `scope` (the skill rules / why) · `forbidden_scope` (unsafe boundaries) ·
+`required_areas` (Nexus refs) · `commands` · `verification` · `acceptance` · `approval_level`
+(default `L2_internal_approve`) · `evidence_path` · `nexus_refs`.
+
+## Why packets matter (PM → gateway → tech-lead → specialist)
+A raw request is not handed straight to implementation. The packet carries the *missing decisions,
+forbidden scope, verification, and approval level* so the internal chain (PM intake → gateway route →
+tech-lead signoff → specialist) can act safely. Only **safe-class** work auto-executes; risky/
+restricted go to approval-wait + runbook. See [docs/forgekit-console.md](forgekit-console.md) §2m
+(repo-autopilot) and `examples/autopilot/` for the execution side.
+
+The Hephaistos packet draft is **proposal-only** today — it shapes the work; it does not auto-run.


### PR DESCRIPTION
> docs PR4 · base `main` (PR1–3 merged)

## 목적
PR1~PR3 으로 main 에 반영된 ForgeKit / Hephaistos / Nexus / Armory 상태를 README·문서에 **정직하게** 정리(오픈소스 입문 가능 수준).

## 범위
- README 재구성(core concept 표 + current reality working/partial/planned/blocked).
- concept docs 7종(vision/hephaistos-runtime/nexus-read-path/armory/work-packet/operator-surfaces/evidence-map).
- capability/provider/source **reality matrix 3종** + evidence map.
- setup/doctor/mode/provider 설명 명확화.

## 안 한 것
새 기능 구현 없음 · provider surface 구현 없음 · Nexus live 연결 없음 · Figma/social/live source adapter 없음.

## 정직성
implemented/partial/planned/blocked/not_connected 구분 유지 · **implicit ollama 문구 제거** · primary_provider operator 주도 명시 · always-on macOS sleep 한계 + Linux/systemd 1급.

## 테스트
governance docs-sync **209 green** · markdown **broken link 0**(검증) · 코드 변경 0.

## 다음 단계
final QA / merge-prep → provider·/setup UX 구현.
