### PR TITLE
feat: add provider setup operator surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ in [`docs/operator-surfaces.md`](docs/operator-surfaces.md) and [`docs/evidence-
 | Armory breadth (7 categories, 25 skills, 8 loadouts) | **working** | `/resolve` | `test_armory_breadth` |
 | Nexus read path (bounded, restricted-aware) | **partial** | `/resolve` nexus line | `examples/hephaistos/nexus-read-foundation/` |
 | Always-on bounded daemon + safe-class autopilot | **working** | `forgekit runtime serve` | `examples/runtime/`, `examples/autopilot/` |
-| Provider `/provider`·`/setup` console config | **planned** | — (engine merged; command not wired) | — |
+| Provider `/provider` console config (set primary / list / doctor) | **working** | `/provider` | `test_provider_surface` |
 | Nexus live repo connection | **planned** (`not_connected` until `FORGEKIT_NEXUS_ROOT` set) | — | — |
 | Live Figma / YouTube / Google / Instagram | **planned seam** (never live in this tree) | `/sources` shows planned | — |
 
@@ -130,7 +130,7 @@ Reading order for contributors/agents: [`AGENTS.md`](AGENTS.md) → [`CLAUDE.md`
 
 ## Roadmap / non-goals
 
-**Next:** `/provider`·`/setup` console config surface · Nexus live connection · per-provider usage
+**Next:** Nexus live connection · per-provider usage
 surface · GitHub-App doctor/commit-path. **Non-goals (now):** fully-autonomous unsupervised code
 mutation (safe-class only, operator-gated), live social/Figma scraping, "complete autonomous team".
 

--- a/apps/forgekit-console/src/forgekit_console/chat/service.py
+++ b/apps/forgekit-console/src/forgekit_console/chat/service.py
@@ -135,9 +135,9 @@ class SubmitService:
             return m.SubmitResult(
                 ok=False, mode=m.MODE_SETUP, category=m.CAT_NO_PROVIDER, source=source,
                 runtime_mode=runtime_mode,
-                text="provider 가 아직 설정되지 않았습니다 — free-text 를 보낼 대상이 없습니다.",
-                next_action="`forgekit` setup 으로 provider 를 설정하거나, 로컬 ollama 를 실행하세요 "
-                            "(http://localhost:11434).",
+                text="primary provider 가 아직 설정되지 않았습니다 — free-text 를 보낼 대상이 없습니다.",
+                next_action="콘솔에서 `/provider set <id>` (claude/codex/gemini/ollama) 로 primary provider 를 "
+                            "정하세요. ForgeKit 은 자동으로 ollama 를 쓰지 않습니다 — operator 가 정합니다.",
             )
         if spec.submit_compat == SUBMIT_OPENAI:
             return self._submit_openai(prompt, spec, source, runtime_mode=runtime_mode)

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -30,6 +30,7 @@ H_RESOLVE = "resolve"
 H_HEPHAISTOS = "hephaistos"
 H_SKILLS = "skills"
 H_LOADOUT = "loadout"
+H_PROVIDER = "provider"
 H_AGENT_ENTER = "agent_enter"
 H_LAYOUT = "layout"
 H_QUIT = "quit"
@@ -89,6 +90,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
+    SlashCommand("provider", "primary provider 설정/확인 — `/provider [set <id>|list|doctor]` (operator 주도, implicit ollama 없음)", H_PROVIDER, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),
     SlashCommand("planning-agent", "Planning 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "planning-agent"),
     SlashCommand("backend-agent", "Backend 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "backend-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -36,6 +36,7 @@ from .registry import (
     H_HEPHAISTOS,
     H_SKILLS,
     H_LOADOUT,
+    H_PROVIDER,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -149,6 +150,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _whoami_result(parsed)
     if handler in (H_RESOLVE, H_HEPHAISTOS, H_SKILLS, H_LOADOUT):
         return _hephaistos_result(handler, parsed)
+    if handler == H_PROVIDER:
+        return _provider_result(parsed)
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:
@@ -173,6 +176,24 @@ def _help_result(ctx: ConsoleContext) -> CommandResult:
     lines.append("")
     lines.append("일반 텍스트는 provider 로 live-submit 됩니다 (provider 미설정 시 setup 안내).")
     return CommandResult(kind=KIND_HELP, title="help", lines=tuple(lines))
+
+
+def _provider_result(parsed) -> CommandResult:
+    # /provider operator surface over policy.provider_surface (read) + provider_ops (persist).
+    from ..policy import provider_ops as ops
+    from ..policy import provider_surface as ps
+
+    args = list(getattr(parsed, "args", ()) or ())
+    sub = args[0].lower() if args else ""
+    cfg = ops.load_raw_config()
+    if sub == "set":
+        ok, msg = ps.apply_set_primary(args[1] if len(args) > 1 else "")
+        return (CommandResult.info if ok else CommandResult.error)("provider set", (msg,))
+    if sub == "list":
+        return CommandResult.info("provider list", ps.provider_list_lines(cfg))
+    if sub == "doctor":
+        return CommandResult.info("provider doctor", ps.provider_doctor_lines(cfg))
+    return CommandResult.info("provider", ps.provider_status_lines(cfg))
 
 
 def _hephaistos_result(handler, parsed) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/policy/provider_surface.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/provider_surface.py
@@ -1,0 +1,116 @@
+"""`/provider` operator surface — projection + apply over the provider_ops engine.
+
+Read surfaces (status / list / doctor) are pure over a config dict; ``set_primary`` is the
+one mutation (validate → set_primary → persist). This is the surface that makes the merged
+multi-provider control-plane usable: the operator sets the **primary provider** explicitly,
+so ForgeKit never looks like it "just uses Ollama" — a reachable local Ollama is only one
+available provider, and with no config the honest state is setup-required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from ..providers import builtins
+from ..providers.contract import SUBMIT_OPENAI
+from . import provider_config as pc
+from . import provider_ops as ops
+from . import routing as rt
+
+
+def _live_word(pid: str) -> str:
+    spec = builtins.builtin(pid)
+    if spec is None:
+        return "custom"
+    return "live" if spec.submit_compat == SUBMIT_OPENAI else "unsupported_in_console"
+
+
+def provider_status_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
+    """`/provider` — current brain: primary / linked / live-capable / setup verdict."""
+
+    review = ops.setup_review(cfg)
+    if not pc.has_brain_config(cfg):
+        return (
+            "provider: [setup-required] primary provider 미설정",
+            "  ForgeKit 은 operator 가 정한 primary provider 를 씁니다 — 자동 Ollama 사용 안 함.",
+            "  다음: `/provider set <id>` (claude/codex/gemini/ollama) 또는 `~/.forgekit/config.json` 의 primary_provider.",
+            "  설정 후 `/doctor` 로 점검, `/mode` 로 routing 확인.",
+        )
+    parsed = pc.load_provider_config(cfg)
+    bmap = ops.brain_map(parsed)
+    lines = [
+        f"provider: [{review.verdict}]",
+        f"  primary : {parsed.primary_provider} ({_live_word(parsed.primary_provider)})",
+        f"  linked  : {', '.join(parsed.linked_providers) or '-'}",
+        f"  live    : {', '.join(bmap.live_capable) or '(없음)'}",
+        f"  unsupported_in_console: {', '.join(bmap.unsupported) or '-'}",
+        f"  implicit local fallback: {'on' if parsed.implicit_local_fallback else 'off (기본)'}",
+    ]
+    if not review.ready:
+        lines += [f"  ⚠ {i}" for i in review.issues]
+    lines.append("  명령: /provider set <id> · /provider list · /provider doctor")
+    return tuple(lines)
+
+
+def provider_list_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
+    """`/provider list` — built-in providers + console-submit capability + configured state."""
+
+    parsed = pc.load_provider_config(cfg)
+    lines = ["provider list (built-in):"]
+    for pid, spec in builtins.BUILTIN_PROVIDERS.items():
+        marks = []
+        if pid == parsed.primary_provider:
+            marks.append("primary")
+        elif pid in parsed.linked_providers:
+            marks.append("linked")
+        marks.append(_live_word(pid))
+        if spec.auth_kind == "api_key":
+            marks.append(f"needs {pid.upper()}_API_KEY")
+        lines.append(f"  • {spec.label:<12} [{pid}] — {', '.join(marks)}")
+    lines.append("  [dim]claude/codex 는 routable 이지만 콘솔 live-submit 미구현(unsupported_in_console).[/dim]")
+    return tuple(lines)
+
+
+def provider_doctor_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
+    """`/provider doctor` — provider-focused diagnosis (subset of /doctor)."""
+
+    parsed = pc.load_provider_config(cfg)
+    review = ops.setup_review(cfg)
+    res = rt.resolve_submit(parsed, "interactive") if parsed.primary_provider else None
+    lines = [f"provider doctor: {review.verdict}"]
+    if not parsed.primary_provider:
+        lines.append("  primary 미설정 → submit setup-required (mode gate). `/provider set <id>`.")
+        return tuple(lines)
+    lines.append(f"  primary {parsed.primary_provider} · live={_live_word(parsed.primary_provider)}")
+    if res is not None:
+        lines.append(f"  default_chat 해소: {res.actual_provider or '-'} ({res.status})"
+                     + (f" · fallback {'→'.join(res.fallback_chain)}" if res.fallback_used else ""))
+    for issue in review.issues:
+        lines.append(f"  ⚠ {issue}")
+    return tuple(lines)
+
+
+def apply_set_primary(pid: str, *, env: Optional[Mapping[str, str]] = None,
+                      path: Optional[Path] = None) -> Tuple[bool, str]:
+    """`/provider set <id>` — set primary provider + persist. Honest success/failure."""
+
+    pid = (pid or "").strip()
+    if not pid:
+        return False, "provider id 가 필요합니다 — `/provider set <id>`."
+    if not builtins.is_builtin(pid):
+        return False, (f"알 수 없는 provider: {pid} (built-in: "
+                       f"{', '.join(builtins.BUILTIN_PROVIDERS)}). custom 은 config 로 추가하세요.")
+    cur = ops.load_raw_config(env=env, path=path)
+    new_cfg = ops.set_primary(cur, pid)
+    ok, where = ops.persist_config(new_cfg, env=env, path=path)
+    if not ok:
+        return False, f"저장 실패: {where}"
+    live = _live_word(pid)
+    note = "" if live == "live" else f" — 단 {live}(콘솔 live-submit 미구현, routing/usage 는 동작)"
+    return True, f"primary provider = {pid} 저장됨{note}. `/provider` 로 확인, `/mode` 로 routing."
+
+
+__all__ = (
+    "provider_status_lines", "provider_list_lines", "provider_doctor_lines", "apply_set_primary",
+)

--- a/apps/forgekit-console/src/forgekit_console/policy/setup_state.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/setup_state.py
@@ -85,9 +85,10 @@ def resolve_setup_state(config: Optional[Mapping] = None) -> SetupState:
                 SetupCheck("brain/vault path", CHECK_UNKNOWN, "provider 후 확인"),
             ),
             next_actions=(
-                "최소 1개 main provider 를 설정하세요 — `~/.forgekit/config.json` 의 "
-                "`main_provider`, 또는 로컬 ollama 실행 (http://localhost:11434).",
-                "설정 후 `/doctor` 로 환경을 점검하세요.",
+                "primary provider 를 정하세요 — 콘솔에서 `/provider set <id>` "
+                "(claude/codex/gemini/ollama) 또는 `~/.forgekit/config.json` 의 `primary_provider`. "
+                "ForgeKit 은 자동으로 ollama 를 쓰지 않습니다(operator 주도).",
+                "설정 후 `/provider` / `/doctor` 로 점검, `/mode` 로 routing 확인.",
             ),
         )
 

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -17,7 +17,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | discovery collectors (free-first) | working; YouTube/IG/Google planned | `/sources` | `examples/sources/` |
 | design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |
 | red/blue planning (owned assets) | working (plan-only) | `/red-blue` | `examples/security/` |
-| `/provider`·/setup console config | planned (engine merged, command not wired) | — | — |
+| `/provider` console config (set primary / list / doctor) | working | `/provider [set <id>\|list\|doctor]` | `test_provider_surface` |
 
 ## Provider reality matrix
 | provider | connection | live submit | usage basis | mode influence |

--- a/tests/forgekit/test_palette.py
+++ b/tests/forgekit/test_palette.py
@@ -35,16 +35,18 @@ class RefilterTests(unittest.TestCase):
 class CycleTests(unittest.TestCase):
     def test_tab_from_empty_selects_first(self) -> None:
         s = P.cycle(P.refilter("/p", _CMDS), 1)
-        self.assertEqual(P.selected(s).name, "pm-agent")
+        self.assertEqual(P.selected(s).name, "provider")   # /p → provider, pm-agent, planning-agent
 
     def test_tab_cycles_forward_and_wraps(self) -> None:
-        s = P.refilter("/p", _CMDS)  # pm-agent, planning-agent
+        s = P.refilter("/p", _CMDS)  # provider, pm-agent, planning-agent
+        s = P.cycle(s, 1)
+        self.assertEqual(P.selected(s).name, "provider")
         s = P.cycle(s, 1)
         self.assertEqual(P.selected(s).name, "pm-agent")
         s = P.cycle(s, 1)
         self.assertEqual(P.selected(s).name, "planning-agent")
         s = P.cycle(s, 1)  # wrap
-        self.assertEqual(P.selected(s).name, "pm-agent")
+        self.assertEqual(P.selected(s).name, "provider")
 
     def test_shift_tab_from_empty_selects_last(self) -> None:
         s = P.cycle(P.refilter("/p", _CMDS), -1)

--- a/tests/forgekit/test_provider_surface.py
+++ b/tests/forgekit/test_provider_surface.py
@@ -1,0 +1,72 @@
+"""`/provider` operator surface — setup UX over the provider_ops engine.
+
+Proves the operator can actually set the primary provider (persisted), that no-config
+is honest setup-required (and explicitly NOT implicit-ollama), that live vs
+unsupported_in_console is shown, and that the command routes.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.policy import provider_ops as ops
+from forgekit_console.policy import provider_surface as ps
+
+
+class ApplyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.path = self.tmp / "config.json"
+
+    def test_set_primary_persists(self) -> None:
+        ok, msg = ps.apply_set_primary("ollama", path=self.path)
+        self.assertTrue(ok, msg)
+        self.assertEqual(ops.load_raw_config(path=self.path)["primary_provider"], "ollama")
+
+    def test_set_unknown_fails(self) -> None:
+        ok, msg = ps.apply_set_primary("nope", path=self.path)
+        self.assertFalse(ok)
+        self.assertIn("알 수 없는 provider", msg)
+        self.assertFalse(self.path.exists())
+
+    def test_set_cli_provider_notes_unsupported(self) -> None:
+        ok, msg = ps.apply_set_primary("claude", path=self.path)
+        self.assertTrue(ok)
+        self.assertIn("unsupported_in_console", msg)   # honest — claude can't live-submit
+
+
+class SurfaceTests(unittest.TestCase):
+    def test_no_config_is_setup_required_not_implicit_ollama(self) -> None:
+        lines = "\n".join(ps.provider_status_lines({}))
+        self.assertIn("setup-required", lines)
+        self.assertIn("자동 Ollama 사용 안 함", lines)    # kills the implicit-ollama misconception
+
+    def test_list_shows_live_vs_unsupported(self) -> None:
+        lines = "\n".join(ps.provider_list_lines({}))
+        self.assertIn("ollama", lines)
+        self.assertIn("live", lines)
+        self.assertIn("unsupported_in_console", lines)    # claude/codex
+
+    def test_status_after_primary(self) -> None:
+        lines = "\n".join(ps.provider_status_lines({"primary_provider": "ollama"}))
+        self.assertIn("primary : ollama", lines)
+        self.assertIn("implicit local fallback: off", lines)
+
+
+class RoutingTests(unittest.TestCase):
+    def test_provider_command_routes(self) -> None:
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+
+        ctx = build_default_context(Path("."))
+        r = route(parse_input("/provider list"), ctx)
+        self.assertIn("provider list", "\n".join(r.lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -255,10 +255,10 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             await pilot.press("tab")
             await pilot.pause()
-            self.assertEqual(prompt.value, "/pm-agent ")
+            self.assertEqual(prompt.value, "/provider ")   # /p → provider, pm-agent, planning-agent
             await pilot.press("tab")
             await pilot.pause()
-            self.assertEqual(prompt.value, "/planning-agent ")
+            self.assertEqual(prompt.value, "/pm-agent ")
 
     async def test_escape_closes_palette(self) -> None:
         from textual.widgets import Input


### PR DESCRIPTION
> stacked on docs PR #266 (`feature/forgekit-docs-readme-evidence-consolidation`)

## 목적
operator 가 primary provider 를 명시적으로 설정/진단하는 `/provider` operator surface 추가 — 이미 머지된 multi-provider 엔진(provider_ops)을 콘솔에서 쓸 수 있게.

## 범위
- `/provider`(상태) · `/provider set <id>`(primary 설정 + config 영속) · `/provider list`(live vs unsupported_in_console) · `/provider doctor`(provider 한정 진단).
- setup-required UX 개선 · **implicit ollama off 명시** · primary_provider operator 주도 wording 정리.

## 안 한 것
- provider policy 대공사 없음 · custom provider full editor 없음 · `/provider link/unlink/route` surface 없음 · setup wizard 없음.

## 정직성
- no provider = `setup-required` ("자동 Ollama 사용 안 함"). implicit local fallback = off(기본). built-in id set 만 surface.
- claude/codex = unsupported_in_console, gemini(key)/ollama = live.

## 테스트
`test_provider_surface` green + palette/tui prefix 갱신. forgekit OK ×2 venv.

## 다음 후속
provider link/unlink/route · Nexus live adapter · per-provider usage surface.

## stacked
base = docs consolidation 브랜치(PR #266, 미머지). PR1~3 은 이미 main 머지(#263~265).
