### PR TITLE
feat: add Nexus live adapter and /nexus surface

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -31,6 +31,7 @@ H_HEPHAISTOS = "hephaistos"
 H_SKILLS = "skills"
 H_LOADOUT = "loadout"
 H_PROVIDER = "provider"
+H_NEXUS = "nexus"
 H_AGENT_ENTER = "agent_enter"
 H_LAYOUT = "layout"
 H_QUIT = "quit"
@@ -91,6 +92,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
     SlashCommand("provider", "primary provider 설정/확인 — `/provider [set <id>|list|doctor]` (operator 주도, implicit ollama 없음)", H_PROVIDER, "status"),
+    SlashCommand("nexus", "Nexus 지식 source 연결 상태 — connected/not_connected/missing/blocked", H_NEXUS, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),
     SlashCommand("planning-agent", "Planning 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "planning-agent"),
     SlashCommand("backend-agent", "Backend 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "backend-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -37,6 +37,7 @@ from .registry import (
     H_SKILLS,
     H_LOADOUT,
     H_PROVIDER,
+    H_NEXUS,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -152,6 +153,9 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _hephaistos_result(handler, parsed)
     if handler == H_PROVIDER:
         return _provider_result(parsed)
+    if handler == H_NEXUS:
+        from ..hephaistos import projection as _proj
+        return CommandResult.info("nexus", _proj.nexus_surface_lines())
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/nexus_read.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/nexus_read.py
@@ -234,8 +234,33 @@ def read_plan_sources(plan, *, env: Optional[Mapping[str, str]] = None,
     return read_refs(getattr(plan, "nexus_refs", ()), nexus_root(env, config), role=role)
 
 
+def connection_status(env: Optional[Mapping[str, str]] = None,
+                      config: Optional[Mapping] = None) -> dict:
+    """Live Nexus connection status — connected only when a root is set AND readable.
+
+    This is what a `/nexus` surface shows so the operator knows whether Nexus is live
+    and, if not, why (not_connected / missing / blocked). Never claims a fake connection."""
+
+    root = nexus_root(env, config)
+    if root is None:
+        return {"status": SRC_NOT_CONNECTED, "root": "", "connected": False,
+                "reason": f"{ENV_NEXUS_ROOT} (env) / nexus_root (config) 미설정"}
+    try:
+        exists = root.exists()
+        readable = exists and os.access(root, os.R_OK)
+    except OSError:
+        exists = readable = False
+    if not exists:
+        return {"status": SRC_MISSING, "root": str(root), "connected": False,
+                "reason": "설정된 root 경로가 존재하지 않음"}
+    if not readable:
+        return {"status": SRC_BLOCKED, "root": str(root), "connected": False,
+                "reason": "root 읽기 불가(permission/TCC)"}
+    return {"status": SRC_EXISTS, "root": str(root), "connected": True, "reason": "연결됨"}
+
+
 __all__ = (
     "ENV_NEXUS_ROOT", "READ_RAW", "READ_PROJECTION", "READ_NONE", "DEFAULT_RESTRICTED_ROLES",
     "NexusDocument", "NexusReadResult", "nexus_root", "resolve_ref", "normalize_markdown",
-    "read_ref", "read_refs", "read_plan_sources",
+    "read_ref", "read_refs", "read_plan_sources", "connection_status",
 )

--- a/apps/forgekit-console/src/forgekit_console/hephaistos/projection.py
+++ b/apps/forgekit-console/src/forgekit_console/hephaistos/projection.py
@@ -102,7 +102,24 @@ def hephaistos_status_lines(*, env: Optional[Mapping[str, str]] = None,
     )
 
 
+def nexus_surface_lines(*, env: Optional[Mapping[str, str]] = None,
+                        config: Optional[Mapping] = None) -> Tuple[str, ...]:
+    """`/nexus` — Nexus live connection status (connected / not_connected / missing / blocked)."""
+
+    cs = nx.connection_status(env, config)
+    lines = [f"nexus: [{cs['status']}] {cs['reason']}"]
+    if cs["connected"]:
+        lines += [f"  root : {cs['root']} (connected · live read 가능)",
+                  "  restricted source 는 design/privacy role 만 raw, 그외 projection_only.",
+                  "  `/resolve <요청>` 의 nexus 줄에서 ref 별 read 결과 확인."]
+    else:
+        lines += [f"  root : {cs['root'] or '(미설정)'}",
+                  f"  연결: export {nx.ENV_NEXUS_ROOT}=<nexus repo 경로>  또는 config 의 nexus_root 설정.",
+                  "  미연결 동안 source 는 not_connected 로 정직 표면(fake-read 없음)."]
+    return tuple(lines)
+
+
 __all__ = (
     "resolve_with_sources", "nexus_status_lines", "resolve_summary_lines",
-    "skills_lines", "loadout_lines", "hephaistos_status_lines",
+    "skills_lines", "loadout_lines", "hephaistos_status_lines", "nexus_surface_lines",
 )

--- a/tests/forgekit/test_nexus_read.py
+++ b/tests/forgekit/test_nexus_read.py
@@ -116,5 +116,35 @@ class ResolverSeamTests(unittest.TestCase):
         self.assertTrue(res.resolved_docs or res.missing_refs)   # seam actually read/located
 
 
+class ConnectionStatusTests(unittest.TestCase):
+    def test_not_connected_default(self) -> None:
+        cs = nx.connection_status(env={}, config={})
+        self.assertEqual(cs["status"], models.SRC_NOT_CONNECTED)
+        self.assertFalse(cs["connected"])
+
+    def test_connected_when_root_exists(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(root, ignore_errors=True))
+        cs = nx.connection_status(env={"FORGEKIT_NEXUS_ROOT": str(root)}, config={})
+        self.assertTrue(cs["connected"])
+        self.assertEqual(cs["status"], models.SRC_EXISTS)
+
+    def test_missing_when_root_absent(self) -> None:
+        cs = nx.connection_status(env={"FORGEKIT_NEXUS_ROOT": "/no/such/nexus"}, config={})
+        self.assertEqual(cs["status"], models.SRC_MISSING)
+
+    def test_config_root_supported(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(root, ignore_errors=True))
+        self.assertTrue(nx.connection_status(env={}, config={"nexus_root": str(root)})["connected"])
+
+    def test_nexus_command_routes(self) -> None:
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+
+        r = route(parse_input("/nexus"), build_default_context(Path(".")))
+        self.assertIn("nexus:", "\n".join(r.lines))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> stacked PR1/4 · base `main`
## 목적
Nexus read foundation 위에 **live connection status + `/nexus` surface** 추가.
## 범위
`nexus_read.connection_status(env/config)`(connected/not_connected/missing/blocked + root + reason) · `/nexus` 전용 surface(충돌 회피 — /sources 는 discovery) · env+config root.
## 안 한 것
vector search · live Nexus repo 자체 연결(operator 가 root 설정 전제) · vault write 변경.
## 정직성
no fake-read · connected/not_connected/missing/blocked/restricted 정직 · 미설정=not_connected.
## 테스트
`test_nexus_read`(+connection status/route) green ×2 venv.
## 다음 stacked PR
provider link/route surface.
