### PR TITLE
feat: add provider link, unlink, and route surface

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -91,7 +91,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
-    SlashCommand("provider", "primary provider 설정/확인 — `/provider [set <id>|list|doctor]` (operator 주도, implicit ollama 없음)", H_PROVIDER, "status"),
+    SlashCommand("provider", "provider 설정 — `/provider [set <id>|link <id>|unlink <id>|route show|route set <slot> <id>|list|doctor]` (operator 주도)", H_PROVIDER, "status"),
     SlashCommand("nexus", "Nexus 지식 source 연결 상태 — connected/not_connected/missing/blocked", H_NEXUS, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),
     SlashCommand("planning-agent", "Planning 에이전트 모드 진입 (stub)", H_AGENT_ENTER, "agent", "planning-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -197,6 +197,21 @@ def _provider_result(parsed) -> CommandResult:
         return CommandResult.info("provider list", ps.provider_list_lines(cfg))
     if sub == "doctor":
         return CommandResult.info("provider doctor", ps.provider_doctor_lines(cfg))
+    if sub == "link":
+        ok, msg = ps.apply_link(args[1] if len(args) > 1 else "")
+        return (CommandResult.info if ok else CommandResult.error)("provider link", (msg,))
+    if sub == "unlink":
+        ok, msg = ps.apply_unlink(args[1] if len(args) > 1 else "")
+        return (CommandResult.info if ok else CommandResult.error)("provider unlink", (msg,))
+    if sub == "route":
+        op = args[1].lower() if len(args) > 1 else "show"
+        if op == "set":
+            ok, msg = ps.apply_route_set(args[2] if len(args) > 2 else "", args[3] if len(args) > 3 else "")
+            return (CommandResult.info if ok else CommandResult.error)("provider route", (msg,))
+        if op == "clear":
+            ok, msg = ps.apply_route_clear(args[2] if len(args) > 2 else "")
+            return (CommandResult.info if ok else CommandResult.error)("provider route", (msg,))
+        return CommandResult.info("provider route", ps.route_show_lines(cfg))
     return CommandResult.info("provider", ps.provider_status_lines(cfg))
 
 

--- a/apps/forgekit-console/src/forgekit_console/policy/provider_surface.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/provider_surface.py
@@ -111,6 +111,77 @@ def apply_set_primary(pid: str, *, env: Optional[Mapping[str, str]] = None,
     return True, f"primary provider = {pid} 저장됨{note}. `/provider` 로 확인, `/mode` 로 routing."
 
 
+def _persist(new_cfg, env, path):
+    ok, where = ops.persist_config(new_cfg, env=env, path=path)
+    return (True, "") if ok else (False, f"저장 실패: {where}")
+
+
+def apply_link(pid: str, *, env=None, path=None) -> Tuple[bool, str]:
+    """`/provider link <id>` — add to linked providers + persist."""
+
+    pid = (pid or "").strip()
+    if not builtins.is_builtin(pid):
+        return False, f"알 수 없는 provider: {pid} (built-in: {', '.join(builtins.BUILTIN_PROVIDERS)})."
+    cur = ops.load_raw_config(env=env, path=path)
+    if pid in (cur.get("linked_providers") or []):
+        return False, f"{pid} 는 이미 linked 입니다."
+    ok, msg = _persist(ops.link_provider(cur, pid), env, path)
+    return (True, f"{pid} linked ({_live_word(pid)}).") if ok else (False, msg)
+
+
+def apply_unlink(pid: str, *, env=None, path=None) -> Tuple[bool, str]:
+    """`/provider unlink <id>` — remove from linked (primary 는 안전하게 거부)."""
+
+    pid = (pid or "").strip()
+    cur = ops.load_raw_config(env=env, path=path)
+    parsed = pc.load_provider_config(cur)
+    if pid == parsed.primary_provider:
+        return False, f"{pid} 는 primary 입니다 — `/provider set <other>` 로 primary 변경 후 unlink 하세요."
+    if pid not in parsed.linked_providers:
+        return False, f"{pid} 는 linked 가 아닙니다."
+    ok, msg = _persist(ops.unlink_provider(cur, pid), env, path)
+    return (True, f"{pid} unlinked (해당 slot route 도 정리).") if ok else (False, msg)
+
+
+def route_show_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
+    """`/provider route show` — slot routing + fallback policy 가시화."""
+
+    parsed = pc.load_provider_config(cfg)
+    lines = ["slot routing (declared → primary if unset):"]
+    for slot in pc.ROUTING_SLOTS:
+        tgt = parsed.slot_target(slot)
+        lines.append(f"  {slot:<14} → {tgt} ({_live_word(tgt)})")
+    lines.append(f"  fallback: implicit_local={'on' if parsed.implicit_local_fallback else 'off (기본)'}")
+    return tuple(lines)
+
+
+def apply_route_set(slot: str, pid: str, *, env=None, path=None) -> Tuple[bool, str]:
+    """`/provider route set <slot> <provider>` — slot 을 linked provider 로 라우팅 + persist."""
+
+    slot, pid = (slot or "").strip(), (pid or "").strip()
+    if slot not in pc.ROUTING_SLOTS:
+        return False, f"알 수 없는 slot: {slot} (허용: {', '.join(pc.ROUTING_SLOTS)})."
+    cur = ops.load_raw_config(env=env, path=path)
+    if pid not in pc.load_provider_config(cur).linked_providers:
+        return False, f"{pid} 는 linked 가 아닙니다 — 먼저 `/provider link {pid}`."
+    ok, msg = _persist(ops.route_slot(cur, slot, pid), env, path)
+    return (True, f"route {slot} → {pid} 저장됨.") if ok else (False, msg)
+
+
+def apply_route_clear(slot: str, *, env=None, path=None) -> Tuple[bool, str]:
+    """`/provider route clear <slot>` — slot route 제거(→ primary 로 복귀)."""
+
+    slot = (slot or "").strip()
+    if slot not in pc.ROUTING_SLOTS:
+        return False, f"알 수 없는 slot: {slot}."
+    cur = ops.load_raw_config(env=env, path=path)
+    routes = {s: t for s, t in (cur.get("slot_routing") or {}).items() if s != slot}
+    cur = {**cur, "slot_routing": routes}
+    ok, msg = _persist(cur, env, path)
+    return (True, f"route {slot} 제거됨 (→ primary).") if ok else (False, msg)
+
+
 __all__ = (
     "provider_status_lines", "provider_list_lines", "provider_doctor_lines", "apply_set_primary",
+    "apply_link", "apply_unlink", "route_show_lines", "apply_route_set", "apply_route_clear",
 )

--- a/tests/forgekit/test_provider_surface.py
+++ b/tests/forgekit/test_provider_surface.py
@@ -58,14 +58,65 @@ class SurfaceTests(unittest.TestCase):
         self.assertIn("implicit local fallback: off", lines)
 
 
+class LinkRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.path = self.tmp / "config.json"
+        ps.apply_set_primary("ollama", path=self.path)   # a base config
+
+    def test_link_persists(self) -> None:
+        ok, _ = ps.apply_link("gemini", path=self.path)
+        self.assertTrue(ok)
+        self.assertIn("gemini", ops.load_raw_config(path=self.path)["linked_providers"])
+
+    def test_link_unknown_fails(self) -> None:
+        self.assertFalse(ps.apply_link("nope", path=self.path)[0])
+
+    def test_link_already_linked(self) -> None:
+        ps.apply_link("gemini", path=self.path)
+        self.assertFalse(ps.apply_link("gemini", path=self.path)[0])
+
+    def test_unlink_primary_refused(self) -> None:
+        ok, msg = ps.apply_unlink("ollama", path=self.path)
+        self.assertFalse(ok)
+        self.assertIn("primary", msg)
+
+    def test_unlink_linked(self) -> None:
+        ps.apply_link("gemini", path=self.path)
+        ok, _ = ps.apply_unlink("gemini", path=self.path)
+        self.assertTrue(ok)
+        self.assertNotIn("gemini", ops.load_raw_config(path=self.path)["linked_providers"])
+
+    def test_route_set_requires_linked(self) -> None:
+        # claude not linked → refused
+        self.assertFalse(ps.apply_route_set("research", "claude", path=self.path)[0])
+
+    def test_route_set_and_clear(self) -> None:
+        ps.apply_link("gemini", path=self.path)
+        ok, _ = ps.apply_route_set("research", "gemini", path=self.path)
+        self.assertTrue(ok)
+        self.assertEqual(ops.load_raw_config(path=self.path)["slot_routing"]["research"], "gemini")
+        ps.apply_route_clear("research", path=self.path)
+        self.assertNotIn("research", ops.load_raw_config(path=self.path).get("slot_routing", {}))
+
+    def test_unknown_slot_refused(self) -> None:
+        self.assertFalse(ps.apply_route_set("nonsense", "ollama", path=self.path)[0])
+
+    def test_route_show_lists_slots(self) -> None:
+        lines = "\n".join(ps.route_show_lines({"primary_provider": "ollama"}))
+        self.assertIn("default_chat", lines)
+        self.assertIn("implicit_local", lines)
+
+
 class RoutingTests(unittest.TestCase):
-    def test_provider_command_routes(self) -> None:
+    def test_provider_subcommands_route(self) -> None:
         from forgekit_console.commands.parser import parse_input
         from forgekit_console.commands.router import build_default_context, route
 
         ctx = build_default_context(Path("."))
-        r = route(parse_input("/provider list"), ctx)
-        self.assertIn("provider list", "\n".join(r.lines))
+        self.assertIn("provider list", "\n".join(route(parse_input("/provider list"), ctx).lines))
+        self.assertIn("slot routing", "\n".join(route(parse_input("/provider route show"), ctx).lines))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> stacked PR2/4 · base `feature/forgekit-nexus-live-adapter`
## 목적
operator 가 linked providers + slot routing 을 조정하는 `/provider link/unlink/route` surface.
## 범위
apply_link/unlink(primary 안전 거부)/route show·set(미linked 거부)·clear — 전부 config 영속.
## 안 한 것
provider policy 엔진 대공사 · custom provider editor · fallback order 편집 surface.
## 정직성
unknown provider/미linked target 거부 · implicit local fallback off 가시화 유지.
## 테스트
`test_provider_surface`(+LinkRoute) green ×2 venv.
## 다음 stacked PR
per-provider usage breakdown.
