### PR TITLE
feat: add per-provider usage breakdown surface

### DIFF
--- a/apps/forgekit-console/examples/usage/per-provider-breakdown/README.md
+++ b/apps/forgekit-console/examples/usage/per-provider-breakdown/README.md
@@ -1,0 +1,13 @@
+# per-provider usage breakdown — evidence (WT3)
+
+`/usage` 가 today total 을 넘어 **provider / model / mode 단위 + live vs estimate 분리**로 읽히는 실측.
+
+| 파일 | 무엇 |
+| --- | --- |
+| `breakdown.txt` | operator 라인(by provider/model/mode, live/est 분리) |
+| `breakdown.json` | 기계 재사용용 |
+
+## 정직성
+- live 와 estimate 는 **합산 안 함**(`live N / est M [basis]`). basis = live / estimate / live+estimate / unknown.
+- in/out/total 토큰 dimension 별 집계. unsupported provider 는 estimate(콘솔 live-submit 미연결) 로 정직.
+- 코드 SSoT: `usage/breakdown.py`. `/usage` 가 rollup 요약 + 이 breakdown 을 함께 출력.

--- a/apps/forgekit-console/examples/usage/per-provider-breakdown/breakdown.json
+++ b/apps/forgekit-console/examples/usage/per-provider-breakdown/breakdown.json
@@ -1,0 +1,78 @@
+{
+  "by_provider": [
+    {
+      "key": "gemini",
+      "events": 1,
+      "input_tokens": 40,
+      "output_tokens": 60,
+      "total_tokens": 100,
+      "live_tokens": 100,
+      "estimate_tokens": 0,
+      "basis": "live"
+    },
+    {
+      "key": "ollama",
+      "events": 2,
+      "input_tokens": 15,
+      "output_tokens": 25,
+      "total_tokens": 40,
+      "live_tokens": 30,
+      "estimate_tokens": 10,
+      "basis": "live+estimate"
+    }
+  ],
+  "by_model": [
+    {
+      "key": "gemini-2.5",
+      "events": 1,
+      "input_tokens": 40,
+      "output_tokens": 60,
+      "total_tokens": 100,
+      "live_tokens": 100,
+      "estimate_tokens": 0,
+      "basis": "live"
+    },
+    {
+      "key": "gemma3",
+      "events": 2,
+      "input_tokens": 15,
+      "output_tokens": 25,
+      "total_tokens": 40,
+      "live_tokens": 30,
+      "estimate_tokens": 10,
+      "basis": "live+estimate"
+    }
+  ],
+  "by_mode": [
+    {
+      "key": "research",
+      "events": 1,
+      "input_tokens": 40,
+      "output_tokens": 60,
+      "total_tokens": 100,
+      "live_tokens": 100,
+      "estimate_tokens": 0,
+      "basis": "live"
+    },
+    {
+      "key": "interactive",
+      "events": 1,
+      "input_tokens": 10,
+      "output_tokens": 20,
+      "total_tokens": 30,
+      "live_tokens": 30,
+      "estimate_tokens": 0,
+      "basis": "live"
+    },
+    {
+      "key": "cost-save",
+      "events": 1,
+      "input_tokens": 5,
+      "output_tokens": 5,
+      "total_tokens": 10,
+      "live_tokens": 0,
+      "estimate_tokens": 10,
+      "basis": "estimate"
+    }
+  ]
+}

--- a/apps/forgekit-console/examples/usage/per-provider-breakdown/breakdown.txt
+++ b/apps/forgekit-console/examples/usage/per-provider-breakdown/breakdown.txt
@@ -1,0 +1,11 @@
+usage breakdown (live / estimate 분리):
+  by provider:
+    gemini               100tok (in 40/out 60) · live 100 / est 0 [live]
+    ollama                40tok (in 15/out 25) · live 30 / est 10 [live+estimate]
+  by model:
+    gemini-2.5           100tok (in 40/out 60) · live 100 / est 0 [live]
+    gemma3                40tok (in 15/out 25) · live 30 / est 10 [live+estimate]
+  by mode:
+    research             100tok (in 40/out 60) · live 100 / est 0 [live]
+    interactive           30tok (in 10/out 20) · live 30 / est 0 [live]
+    cost-save             10tok (in 5/out 5) · live 0 / est 10 [estimate]

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -496,6 +496,10 @@ class ForgekitConsoleApp(App):
         roll = rollup(rows, scope=f"today({today()})")
         for line in to_txt(roll, top_by_tokens(rows, limit=3)).splitlines():
             log.write(f"[dim]{line}[/dim]" if line.startswith("  ") else line)
+        # WT3: per-provider / model / mode breakdown (live vs estimate kept separate)
+        from ..usage import breakdown_lines
+        for line in breakdown_lines(rows):
+            log.write(f"[dim]{line}[/dim]" if line.startswith("    ") or line.startswith("  ") else line)
         budget = budget_from_config(self._config)
         if budget > 0:
             st = evaluate_budget(roll.total_tokens, budget)

--- a/apps/forgekit-console/src/forgekit_console/usage/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/usage/__init__.py
@@ -17,6 +17,8 @@ from .ledger import (
 from .rollup import UsageRollup, rollup, top_by_tokens
 from .budget import BudgetState, alert_message, budget_from_config, evaluate_budget
 from .report import to_json, to_md, to_txt, write_reports
+from .breakdown import breakdown_by, render_lines as breakdown_lines
+from . import breakdown
 
 __all__ = (
     "BASIS_LIVE", "BASIS_ESTIMATE", "KIND_SUBMIT",
@@ -25,4 +27,5 @@ __all__ = (
     "UsageRollup", "rollup", "top_by_tokens",
     "BudgetState", "alert_message", "budget_from_config", "evaluate_budget",
     "to_json", "to_md", "to_txt", "write_reports",
+    "breakdown", "breakdown_by", "breakdown_lines",
 )

--- a/apps/forgekit-console/src/forgekit_console/usage/breakdown.py
+++ b/apps/forgekit-console/src/forgekit_console/usage/breakdown.py
@@ -1,0 +1,88 @@
+"""Per-provider / model / mode usage breakdown (WT3). Pure / stdlib-only.
+
+The rollup keeps totals; this adds the operator question "who used how much, live or
+estimate?". For each dimension (provider / model / mode) it sums input/output/total and
+keeps **live vs estimate separate** (never summed) so `/usage` reads per-provider with an
+honest basis. Reads ledger rows (dicts) — no IO.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Sequence, Tuple
+
+
+@dataclass
+class KeyUsage:
+    key: str
+    events: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    live_tokens: int = 0
+    estimate_tokens: int = 0
+
+    @property
+    def basis_label(self) -> str:
+        if self.live_tokens and self.estimate_tokens:
+            return "live+estimate"
+        if self.live_tokens:
+            return "live"
+        if self.estimate_tokens:
+            return "estimate"
+        return "unknown"
+
+    def to_dict(self) -> dict:
+        return {"key": self.key, "events": self.events, "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens, "total_tokens": self.total_tokens,
+                "live_tokens": self.live_tokens, "estimate_tokens": self.estimate_tokens,
+                "basis": self.basis_label}
+
+
+def breakdown_by(rows: Sequence[dict], key_field: str) -> Tuple[KeyUsage, ...]:
+    """Aggregate ledger rows by *key_field* (provider/model/mode), basis kept separate."""
+
+    acc: Dict[str, KeyUsage] = {}
+    for row in rows:
+        k = str(row.get(key_field, "") or "-")
+        ku = acc.setdefault(k, KeyUsage(k))
+        tot = int(row.get("total_tokens", 0) or 0)
+        ku.events += 1
+        ku.input_tokens += int(row.get("input_tokens", 0) or 0)
+        ku.output_tokens += int(row.get("output_tokens", 0) or 0)
+        ku.total_tokens += tot
+        basis = row.get("usage_basis", "")
+        if basis == "live":
+            ku.live_tokens += tot
+        elif basis == "estimate":
+            ku.estimate_tokens += tot
+    return tuple(sorted(acc.values(), key=lambda x: (-x.total_tokens, x.key)))
+
+
+def to_dict(rows: Sequence[dict]) -> dict:
+    return {
+        "by_provider": [k.to_dict() for k in breakdown_by(rows, "provider")],
+        "by_model": [k.to_dict() for k in breakdown_by(rows, "model")],
+        "by_mode": [k.to_dict() for k in breakdown_by(rows, "mode")],
+    }
+
+
+def render_lines(rows: Sequence[dict]) -> Tuple[str, ...]:
+    """Operator `/usage` breakdown — per provider / model / mode with live vs estimate."""
+
+    if not rows:
+        return ("usage breakdown: (오늘 기록 없음)",)
+    lines = ["usage breakdown (live / estimate 분리):"]
+    for dim, label in (("provider", "by provider"), ("model", "by model"), ("mode", "by mode")):
+        rows_k = breakdown_by(rows, dim)
+        if not rows_k:
+            continue
+        lines.append(f"  {label}:")
+        for ku in rows_k[:6]:
+            lines.append(f"    {ku.key:<16} {ku.total_tokens:>7}tok "
+                         f"(in {ku.input_tokens}/out {ku.output_tokens}) "
+                         f"· live {ku.live_tokens} / est {ku.estimate_tokens} [{ku.basis_label}]")
+    return tuple(lines)
+
+
+__all__ = ("KeyUsage", "breakdown_by", "to_dict", "render_lines")

--- a/tests/forgekit/test_usage_breakdown.py
+++ b/tests/forgekit/test_usage_breakdown.py
@@ -1,0 +1,58 @@
+"""Per-provider usage breakdown (WT3) — provider/model/mode + live vs estimate.
+
+Proves the breakdown aggregates per dimension, keeps live and estimate separate (never
+summed into one number), and surfaces honestly (empty → honest, not faked).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.usage import breakdown
+
+
+_ROWS = [
+    {"provider": "ollama", "model": "gemma3", "mode": "interactive",
+     "input_tokens": 10, "output_tokens": 20, "total_tokens": 30, "usage_basis": "live"},
+    {"provider": "ollama", "model": "gemma3", "mode": "interactive",
+     "input_tokens": 5, "output_tokens": 5, "total_tokens": 10, "usage_basis": "estimate"},
+    {"provider": "gemini", "model": "gemini-2.5", "mode": "research",
+     "input_tokens": 40, "output_tokens": 60, "total_tokens": 100, "usage_basis": "live"},
+]
+
+
+class BreakdownTests(unittest.TestCase):
+    def test_by_provider_separates_basis(self) -> None:
+        by = {k.key: k for k in breakdown.breakdown_by(_ROWS, "provider")}
+        self.assertEqual(by["ollama"].total_tokens, 40)
+        self.assertEqual(by["ollama"].live_tokens, 30)        # live and estimate NOT summed
+        self.assertEqual(by["ollama"].estimate_tokens, 10)
+        self.assertEqual(by["ollama"].basis_label, "live+estimate")
+        self.assertEqual(by["gemini"].live_tokens, 100)
+        self.assertEqual(by["gemini"].basis_label, "live")
+
+    def test_by_model_and_mode(self) -> None:
+        models = {k.key for k in breakdown.breakdown_by(_ROWS, "model")}
+        modes = {k.key for k in breakdown.breakdown_by(_ROWS, "mode")}
+        self.assertEqual(models, {"gemma3", "gemini-2.5"})
+        self.assertEqual(modes, {"interactive", "research"})
+
+    def test_in_out_tracked(self) -> None:
+        by = {k.key: k for k in breakdown.breakdown_by(_ROWS, "provider")}
+        self.assertEqual((by["ollama"].input_tokens, by["ollama"].output_tokens), (15, 25))
+
+    def test_render_lines_honest(self) -> None:
+        lines = "\n".join(breakdown.render_lines(_ROWS))
+        self.assertIn("by provider", lines)
+        self.assertIn("live", lines)
+        self.assertIn("est", lines)
+        self.assertIn("ollama", lines)
+
+    def test_empty_is_honest(self) -> None:
+        self.assertIn("기록 없음", "\n".join(breakdown.render_lines([])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR3/4 · base `feature/forgekit-provider-link-route-surface`
## 목적
`/usage` 를 provider/model/mode/basis 단위로 읽히는 운영 surface 로 강화.
## 범위
`usage/breakdown.py`(provider/model/mode 별 in/out/total + **live vs estimate 분리**) · `/usage` 출력 강화 · txt/json evidence.
## 안 한 것
billing/pricing engine · cost_usd 연동 · UI 대공사.
## 정직성
live/estimate 절대 합산 안 함(basis label) · unsupported provider=estimate 정직.
## 테스트
`test_usage_breakdown`(5) green ×2 venv. evidence: `examples/usage/per-provider-breakdown/`.
## 다음 stacked PR
integration / evidence pass.
