### PR TITLE
test/docs: add integration evidence for provider, Nexus, and usage flows

### DIFF
--- a/docs/evidence-map.md
+++ b/docs/evidence-map.md
@@ -7,6 +7,7 @@ Where each capability's evidence lives. Paths under `apps/forgekit-console/examp
 | --- | --- | --- | --- |
 | Hephaistos resolve (MVP) | `examples/hephaistos/` (+ `test_hephaistos`) | yes | `pytest`-style unittest |
 | Nexus read foundation | `examples/hephaistos/nexus-read-foundation/` | yes | see its README |
+| per-provider usage breakdown | `examples/usage/per-provider-breakdown/` | yes | `/usage` (breakdown lines) |
 | usage ledger / live vs estimate | `examples/usage/` (+ `native-usage-live/`) | yes | `/usage` writes `runs/forgekit/usage/` |
 | runtime-teeth (submit gate) | `examples/runtime-teeth/` | yes | — |
 | always-on daemon | `examples/runtime/` (`daemon-execution/`, heartbeat) | yes | `forgekit runtime serve --max-ticks N` |

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -10,7 +10,9 @@ Honest status of each console surface (working / partial / planned). Code:
 | forge status | working | `/hephaistos` | `test_hephaistos_surface` |
 | loadout verify (real env) | working | `/loadout <id>` | `test_hephaistos` |
 | Nexus read | partial (not_connected default) | `/resolve` nexus line | `examples/hephaistos/nexus-read-foundation/` |
+| Nexus connection status | working | `/nexus` | `test_nexus_read` |
 | usage ledger (live vs estimate) | working | `/usage` | `examples/usage/` |
+| per-provider/model/mode usage breakdown | working | `/usage` | `examples/usage/per-provider-breakdown/` |
 | runtime modes (real routing/budget/approval) | working | `/mode`, Shift+Tab | `examples/runtime-teeth/` |
 | always-on daemon + safe-class autopilot | working (bounded) | `forgekit runtime serve`, `/autopilot` | `examples/runtime/`, `examples/autopilot/` |
 | agent identity (git author / app status) | working | `/whoami` | `test_identity_attribution` |
@@ -18,6 +20,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |
 | red/blue planning (owned assets) | working (plan-only) | `/red-blue` | `examples/security/` |
 | `/provider` console config (set primary / list / doctor) | working | `/provider [set <id>\|list\|doctor]` | `test_provider_surface` |
+| provider link / unlink / slot route | working | `/provider [link\|unlink\|route show\|route set <slot> <id>]` | `test_provider_surface` |
 
 ## Provider reality matrix
 | provider | connection | live submit | usage basis | mode influence |

--- a/tests/forgekit/test_forgekit_integration.py
+++ b/tests/forgekit/test_forgekit_integration.py
@@ -1,0 +1,70 @@
+"""Integration pass (WT4) — provider config → resolve → nexus status → usage breakdown.
+
+Threads WT1 (nexus live status) + WT2 (provider link/route) + WT3 (per-provider usage)
+into one operator flow, on representative scenarios, asserting honest seams hold end to
+end (not_connected nexus, language-gated resolve, per-provider live/estimate usage).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.hephaistos import nexus_read as nx, resolver
+from forgekit_console.policy import provider_ops as ops
+from forgekit_console.policy import provider_surface as ps
+from forgekit_console.usage import breakdown
+
+
+class IntegrationFlowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.cfg = self.tmp / "config.json"
+
+    def test_provider_config_flow_persists(self) -> None:
+        # set primary → link → route, each persisted (WT2)
+        self.assertTrue(ps.apply_set_primary("ollama", path=self.cfg)[0])
+        self.assertTrue(ps.apply_link("gemini", path=self.cfg)[0])
+        self.assertTrue(ps.apply_route_set("research", "gemini", path=self.cfg)[0])
+        cfg = ops.load_raw_config(path=self.cfg)
+        self.assertEqual(cfg["primary_provider"], "ollama")
+        self.assertIn("gemini", cfg["linked_providers"])
+        self.assertEqual(cfg["slot_routing"]["research"], "gemini")
+
+    def test_resolve_then_nexus_status(self) -> None:
+        # WT-hephaistos resolve + WT1 nexus status (not_connected by default — honest)
+        plan = resolver.resolve("Spring Boot + JWT + MySQL 관리자 API")
+        self.assertEqual(plan.selected_loadout, "backend-java-local")
+        cs = nx.connection_status(env={}, config={})
+        self.assertFalse(cs["connected"])                 # honest not_connected, no fake
+        read = nx.read_plan_sources(plan, env={}, config={})
+        self.assertTrue(read.not_connected)
+
+    def test_representative_scenarios(self) -> None:
+        cases = {
+            "Spring Boot + JWT + MySQL 관리자 API": ("backend-engineer", "backend-java-local"),
+            "Next.js 대시보드 레이아웃 개선": ("frontend-engineer", "frontend-react-local"),
+            "Terraform + ECS 배포 가이드": ("devops-engineer", "devops-cloud-local"),
+        }
+        for req, (agent, loadout) in cases.items():
+            p = resolver.resolve(req)
+            self.assertEqual(p.selected_agent, agent, req)
+            self.assertEqual(p.selected_loadout, loadout, req)
+            self.assertTrue(p.selected_skills, req)        # not shallow for covered stacks
+
+    def test_usage_breakdown_per_provider(self) -> None:
+        rows = [{"provider": "ollama", "model": "m", "mode": "interactive",
+                 "total_tokens": 30, "input_tokens": 10, "output_tokens": 20, "usage_basis": "live"},
+                {"provider": "gemini", "model": "g", "mode": "research",
+                 "total_tokens": 50, "input_tokens": 20, "output_tokens": 30, "usage_basis": "estimate"}]
+        by = {k.key: k for k in breakdown.breakdown_by(rows, "provider")}
+        self.assertEqual(by["ollama"].live_tokens, 30)
+        self.assertEqual(by["gemini"].estimate_tokens, 50)  # live/estimate per-provider, separate
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> stacked PR4/4 · base `feature/forgekit-per-provider-usage-surface`
## 목적
WT1~WT3 를 하나의 운영 흐름으로 검증 + evidence/docs 동기화 (기능 추가 아님, **검증/증거 PR**).
## 범위
`test_forgekit_integration`(provider set/link/route→resolve→nexus status→usage breakdown + 대표 3시나리오) · operator-surfaces.md/evidence-map.md 최소 동기화.
## 안 한 것
새 기능 · README 전면개편 · 새 surface.
## 정직성
nexus not_connected 정직 유지 · broken link 0 · evidence 경로 실재.
## 테스트
`test_forgekit_integration`(4) + 전체 회귀 0(forgekit ×2 venv, root 6454 green).
## 다음 stacked PR
merge-prep audit → merge.
