### PR TITLE
✨ Claude parity QA + large-paste lifecycle (expand/resend/copy raw)

### DIFF
--- a/apps/forgekit-console/examples/tui-qa/qa-results.txt
+++ b/apps/forgekit-console/examples/tui-qa/qa-results.txt
@@ -1,0 +1,24 @@
+ForgeKit Claude-parity QA — 실측 (geometry / clipboard round-trip / payload)
+======================================================================
+
+[A] slash palette 위치
+  palette.top(24) >= input.bottom(24): True · gap=0 · parent=Composer:True · 수동스크롤 불필요(visible):True
+  scroll owner 단일(reading): SessionFlow allow=True, Palette allow=False
+
+[B] copy / clipboard round-trip (kr/en, multiline)
+  /copy last → pbpaste: '응답'
+  /copy turn 1 → pbpaste: '질문 hello\n둘째\n응답'
+  empty payload 실패: True
+
+[C] long paste(250줄 kr/en) ingestion + lifecycle
+  raw 보존: store#1 lines=250 · provider got lines=250 · placeholder 미전송:True
+  /copy paste 1 raw readback 일치: True
+  /paste resend → full 재제출(250 lines)
+
+[E] image attachment lifecycle
+  stage_file → state=staged · real bytes=204 · ingest 성공 ≠ submit 가능: sendable=False(provider text-only → staged_only)
+
+[D] process status — 현황(정직)
+  현재: livestatus(thinking→generating) + 명령별 receipt 줄만 존재.
+  미구현: Reading/Routing/Bash/Done 류 구조화 event timeline(duration/status, feed 분리).
+  → 다음 전용 build 로 분리(가짜 status 안 만듦).

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -35,6 +35,7 @@ H_NEXUS = "nexus"
 H_DAEMON = "daemon"
 H_COPY = "copy"
 H_ATTACH = "attach"
+H_PASTE = "paste"
 H_AGENT_ENTER = "agent_enter"
 H_LAYOUT = "layout"
 H_QUIT = "quit"
@@ -89,8 +90,9 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("design", "restricted design source 상태 — design role만 raw, 그외 projection", H_MODE, "status"),
     SlashCommand("usage", "토큰 사용량 — today rollup(provider/mode/live·estimate) + budget", H_MODE, "status"),
     SlashCommand("blocked", "반복 실패 에스컬레이션 목록 (왜·대안·다음 단계)", H_BLOCKED, "status"),
-    SlashCommand("copy", "OS clipboard 로 복사 — `/copy [last|all|turn <n>|block <n>]` (plain-text, pbcopy/xclip)", H_COPY, "status"),
+    SlashCommand("copy", "OS clipboard 로 복사 — `/copy [last|all|turn <n>|block <n>|paste <id>]` (plain-text, pbcopy/xclip)", H_COPY, "status"),
     SlashCommand("attach", "첨부 staging — `/attach [<path>|status|clear]` 또는 이미지 붙여넣기. 실제 stage(미전송 staged_only — provider 텍스트 전용)", H_ATTACH, "status"),
+    SlashCommand("paste", "보존된 large paste 조작 — `/paste [list|expand <id>|resend <id>]` (원문 보존, placeholder 아님)", H_PASTE, "status"),
     SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
     SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve (`/resolve <요청>`)", H_RESOLVE, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -98,6 +98,8 @@ class ForgekitConsoleApp(App):
         self._store = TranscriptStore()  # copyable plain-text model (/copy last|turn|block|all)
         from .attachment import AttachmentStore
         self._attachments = AttachmentStore()  # staged image/file attachments (honest staged_only)
+        from .paste_store import PasteStore
+        self._pastes = PasteStore()      # large-paste raw payloads (expand/resend/copy by id)
         self._reveal_interval = 0.05    # progressive-reveal tick (seconds) per body chunk
         self._suppress_refilter = False
         # Repeated-failure escalation: same blocked signature past the threshold
@@ -405,6 +407,9 @@ class ForgekitConsoleApp(App):
         if parsed.name == "attach":
             self._attach_dispatch(list(getattr(parsed, "args", ()) or ()))
             return
+        if parsed.name == "paste":
+            self._paste_dispatch(list(getattr(parsed, "args", ()) or ()))
+            return
         result = route(parsed, self.context)
         if result.kind == KIND_QUIT:
             self.exit()
@@ -465,14 +470,20 @@ class ForgekitConsoleApp(App):
         if not text:
             return
         self._transcript.begin_turn()       # vertical breathing room between turns
-        # huge paste → compact echo (first line + "[+N lines]"); submit the FULL text.
-        lines = text.splitlines()
-        if len(lines) > 8:
-            self._transcript.write_echo(f"{lines[0]}  [dim][+{len(lines) - 1} lines · {len(text)} chars][/dim]")
+        # large paste → store the RAW payload + show a compact block referencing its id
+        # (expand/resend/copy by id). The FULL text is still what gets submitted.
+        from . import ingest as _ingest
+        from . import paste_store as _ps
+        if _ps.is_large(text):
+            payload = self._pastes.add(
+                text, source=_ingest.SRC_REHYDRATED if res.rehydrated else _ingest.SRC_RAW_INPUT)
+            self._transcript.write_echo(payload.compact_label())
+            self._transcript.write(
+                f"[dim]↳ /paste expand {payload.id} · /paste resend {payload.id} · /copy paste {payload.id}[/dim]")
         else:
             self._transcript.write_echo(text)
-        if res.rehydrated:
-            self._transcript.write(f"[dim]↳ {res.note}[/dim]")
+            if res.rehydrated:
+                self._transcript.write(f"[dim]↳ {res.note}[/dim]")
         self._store.add_user(text)          # copyable FULL user turn (for /copy turn/all)
         self._surface_staged_attachments()  # honest staged_only (provider text-only)
         self._sync_intro()  # transcript now has content → compact working header
@@ -880,13 +891,18 @@ class ForgekitConsoleApp(App):
         self.call_from_thread(self._on_submit_result, result)
 
     def _copy_target(self, args):
-        """Resolve `/copy [last|all|turn <n>|block <n>]` → (label, plain_text|None)."""
+        """Resolve `/copy [last|all|turn <n>|block <n>|paste <id>]` → (label, text|None)."""
 
         sub = (args[0].lower() if args else "last")
         if sub in ("", "last"):
             return "last response", self._store.last_response()
         if sub == "all":
             return "all transcript", (self._store.all_text() or None)
+        if sub == "paste":
+            # copy the RAW large-paste payload (NOT the placeholder) — last or by id.
+            p = (self._pastes.get(int(args[1])) if len(args) >= 2 and args[1].isdigit()
+                 else self._pastes.last())
+            return (f"paste #{p.id}", p.raw_text) if p else ("paste", None)
         if sub in ("turn", "block") and len(args) >= 2 and args[1].isdigit():
             n = int(args[1])
             if sub == "turn":
@@ -959,6 +975,38 @@ class ForgekitConsoleApp(App):
                 self._transcript.write("[dim]사용법: /attach <path> · /attach status · /attach clear[/dim]")
                 for line in self._attachments.status_lines():
                     self._transcript.write(f"[dim]{line}[/dim]")
+        self._sync_intro()
+        self._follow_tail()
+
+    def _paste_dispatch(self, args) -> None:
+        """`/paste [list|expand <id>|resend <id>]` — operate on a preserved large paste.
+
+        The RAW payload of a large paste is kept (paste_store), so the compact block is
+        never a dead placeholder: `expand` shows the full body, `resend` re-submits the
+        raw text, `/copy paste <id>` copies it. honest 'no such paste' when id missing."""
+
+        sub = (args[0].lower() if args else "list")
+        self._transcript.begin_turn()
+        self._transcript.write_echo("/paste " + " ".join(args) if args else "/paste")
+        if sub == "list":
+            for line in self._pastes.list_lines():
+                self._transcript.write(f"[dim]{line}[/dim]")
+            self._sync_intro(); self._follow_tail(); return
+        if sub in ("expand", "resend") and len(args) >= 2 and args[1].isdigit():
+            payload = self._pastes.get(int(args[1]))
+            if payload is None:
+                self._transcript.write(f"[{theme.WARNING}]⚠ paste #{args[1]} 없음[/{theme.WARNING}]")
+                self._sync_intro(); self._follow_tail(); return
+            if sub == "expand":
+                self._transcript.write(f"[dim]── paste #{payload.id} 본문 ({payload.line_count} lines) ──[/dim]")
+                for line in payload.raw_text.splitlines():
+                    self._transcript.write(line)
+                self._transcript.write(f"[dim]── end paste #{payload.id} ──[/dim]")
+                self._sync_intro(); self._follow_tail(); return
+            # resend → re-run the raw payload through the free-text submit path.
+            self._submit_free_text(payload.raw_text)
+            return
+        self._transcript.write("[dim]사용법: /paste list · /paste expand <id> · /paste resend <id>[/dim]")
         self._sync_intro()
         self._follow_tail()
 

--- a/apps/forgekit-console/src/forgekit_console/tui/paste_store.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/paste_store.py
@@ -1,0 +1,85 @@
+"""Paste payload store — large pastes kept as REAL retrievable payloads, not placeholders.
+
+A long paste is shown in the transcript as a compact block (`[Pasted #3 · 255 lines]`)
+but its RAW text is preserved here, addressable by id, so the operator can later
+``/paste expand <id>`` (see the full body), ``/paste resend <id>`` (re-submit the raw),
+or ``/copy paste <id>`` (copy the raw, NOT the placeholder). Screen representation and
+stored payload are separated — "paste 성공" means the raw was preserved.
+
+Pure / stdlib → unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from . import ingest
+
+
+@dataclass(frozen=True)
+class PastePayload:
+    id: int
+    kind: str          # ingest.KIND_TEXT (image pastes go through the attachment store)
+    raw_text: str
+    line_count: int
+    char_count: int
+    source: str        # ingest.SRC_*
+    preview: str
+
+    def compact_label(self) -> str:
+        return f"[Pasted #{self.id} · {self.line_count} lines · {self.char_count} chars] {self.preview}"
+
+
+@dataclass
+class PasteStore:
+    """Append-only store of large-paste raw payloads, addressable by id."""
+
+    _items: List[PastePayload] = field(default_factory=list)
+
+    def add(self, raw_text: str, *, source: str = ingest.SRC_REHYDRATED) -> PastePayload:
+        raw_text = raw_text or ""
+        payload = PastePayload(
+            id=len(self._items) + 1, kind=ingest.KIND_TEXT, raw_text=raw_text,
+            line_count=len(raw_text.splitlines()) or (1 if raw_text else 0),
+            char_count=len(raw_text), source=source,
+            preview=ingest._preview(raw_text, 50),
+        )
+        self._items.append(payload)
+        return payload
+
+    def get(self, pid: int) -> Optional[PastePayload]:
+        if pid < 1 or pid > len(self._items):
+            return None
+        return self._items[pid - 1]
+
+    def last(self) -> Optional[PastePayload]:
+        return self._items[-1] if self._items else None
+
+    @property
+    def items(self):
+        return tuple(self._items)
+
+    def clear(self) -> int:
+        n = len(self._items)
+        self._items.clear()
+        return n
+
+    def list_lines(self):
+        if not self._items:
+            return ("paste: 저장된 large paste 없음 — 큰 텍스트를 붙여넣으면 여기 보존됩니다.",)
+        out = [f"paste: {len(self._items)} 보존됨 (`/paste expand|resend <id>` · `/copy paste <id>`)"]
+        for p in self._items:
+            out.append(f"  #{p.id} · {p.line_count} lines · {p.char_count} chars — {p.preview}")
+        return tuple(out)
+
+
+# threshold (lines) above which a paste is promoted to a stored payload + compact block.
+LARGE_PASTE_LINES = 8
+
+
+def is_large(text: str) -> bool:
+    return len((text or "").splitlines()) > LARGE_PASTE_LINES
+
+
+__all__ = ("PastePayload", "PasteStore", "LARGE_PASTE_LINES", "is_large")

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -83,8 +83,13 @@ ForgeKit 콘솔은 **full-screen Textual TUI** (alternate screen + mouse capture
 
 - **large text** — `on_paste` 가 placeholder 를 감지하면 OS clipboard(pbpaste)에서 **raw 본문을
   복원**해 composer buffer 를 multiline 으로 rehydrate. 제출 시에도 한 번 더 resolve → provider
-  는 **full 본문**을 받는다(placeholder 미전송). 8줄 초과는 transcript echo 만 compact, 실제
-  제출/`/copy` 는 full. clipboard 복구 불가면 **정직 blocked**(제출 안 함, 조용한 truncate 없음).
+  는 **full 본문**을 받는다(placeholder 미전송). clipboard 복구 불가면 **정직 blocked**(제출
+  안 함, 조용한 truncate 없음).
+- **paste lifecycle** (`tui/paste_store.py`) — 큰 paste(>8줄)는 raw 를 `PasteStore` 에 id 로
+  **보존**하고 transcript 에는 compact block `[Pasted #<id> · N lines]` + seam 줄을 보인다.
+  `/paste list` · `/paste expand <id>`(본문 표시) · `/paste resend <id>`(raw 재제출) ·
+  `/copy paste <id>`(raw 복사 — placeholder 아님). 화면 표현과 저장 payload 분리 → "paste 성공"
+  은 raw 보존 시에만. 실측: `examples/tui-qa/qa-results.txt` [C], 테스트 `test_tui_paste_lifecycle`.
 - **image** — `/attach <path>` 파일 stage, 또는 `[Image #N]` paste / `/attach` 시 clipboard 이미지
   (pngpaste/osascript/xclip)로 실파일 stage. `/attach status|clear`. honest 상태:
   `staged`/`missing`/`blocked`/`no_attachment`.

--- a/tests/forgekit/test_palette.py
+++ b/tests/forgekit/test_palette.py
@@ -35,10 +35,12 @@ class RefilterTests(unittest.TestCase):
 class CycleTests(unittest.TestCase):
     def test_tab_from_empty_selects_first(self) -> None:
         s = P.cycle(P.refilter("/p", _CMDS), 1)
-        self.assertEqual(P.selected(s).name, "provider")   # /p → provider, pm-agent, planning-agent
+        self.assertEqual(P.selected(s).name, "paste")   # /p → paste, provider, pm-agent, planning-agent
 
     def test_tab_cycles_forward_and_wraps(self) -> None:
-        s = P.refilter("/p", _CMDS)  # provider, pm-agent, planning-agent
+        s = P.refilter("/p", _CMDS)  # paste, provider, pm-agent, planning-agent
+        s = P.cycle(s, 1)
+        self.assertEqual(P.selected(s).name, "paste")
         s = P.cycle(s, 1)
         self.assertEqual(P.selected(s).name, "provider")
         s = P.cycle(s, 1)
@@ -46,7 +48,7 @@ class CycleTests(unittest.TestCase):
         s = P.cycle(s, 1)
         self.assertEqual(P.selected(s).name, "planning-agent")
         s = P.cycle(s, 1)  # wrap
-        self.assertEqual(P.selected(s).name, "provider")
+        self.assertEqual(P.selected(s).name, "paste")
 
     def test_shift_tab_from_empty_selects_last(self) -> None:
         s = P.cycle(P.refilter("/p", _CMDS), -1)

--- a/tests/forgekit/test_tui_paste_lifecycle.py
+++ b/tests/forgekit/test_tui_paste_lifecycle.py
@@ -1,0 +1,178 @@
+"""Large-paste lifecycle — raw payload preserved + expand / resend / copy by id.
+
+A long paste is shown compactly (`[Pasted #1 · N lines]`) but its RAW text is preserved
+(paste_store), so it is a real retrievable payload, not a dead placeholder:
+`/paste expand <id>` shows the body, `/paste resend <id>` re-submits the raw,
+`/copy paste <id>` copies the raw (real OS round-trip on macOS). Provider always gets
+the FULL text — never the placeholder.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+# --------------------------------------------------------------------------- #
+# pure: the paste store
+# --------------------------------------------------------------------------- #
+class PasteStorePureTests(unittest.TestCase):
+    def test_preserves_raw_and_addressable_by_id(self):
+        from forgekit_console.tui.paste_store import PasteStore, is_large
+        s = PasteStore()
+        raw = "\n".join(f"line {i}" for i in range(50))
+        p = s.add(raw)
+        self.assertEqual(p.id, 1)
+        self.assertEqual(p.line_count, 50)
+        self.assertEqual(s.get(1).raw_text, raw)         # raw preserved, not a placeholder
+        self.assertIsNone(s.get(99))
+        self.assertIn("Pasted #1", p.compact_label())
+        self.assertTrue(is_large(raw))
+        self.assertFalse(is_large("one\ntwo"))
+
+
+# --------------------------------------------------------------------------- #
+# pilot: the real composer paste lifecycle
+# --------------------------------------------------------------------------- #
+@unittest.skipUnless(_TEXTUAL, "textual 필요")
+class PasteLifecyclePilotTests(unittest.IsolatedAsyncioTestCase):
+    def _svc(self):
+        from forgekit_console.chat import models as m
+
+        class Svc:
+            def __init__(s): s.got = []
+            def submit(s, t, **_):
+                s.got.append(t)
+                return m.SubmitResult(ok=True, mode=m.MODE_LIVE, category=m.CAT_OK, text="ok",
+                                      provider_id="ollama", provider_label="Ollama",
+                                      source=m.SOURCE_LOCAL_DEFAULT, model="g")
+        return Svc()
+
+    def _app(self, svc):
+        from forgekit_console.commands.registry import load_agents, load_commands
+        from forgekit_console.commands.router import ConsoleContext
+        from forgekit_console.tui.app import ForgekitConsoleApp
+        ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
+        return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, submit_service=svc)
+
+    def _body(self, app):
+        from forgekit_console.tui.transcript import Transcript
+        return "\n".join("".join(seg.text for seg in s) for s in app.query_one(Transcript).lines)
+
+    async def test_large_paste_preserved_compact_and_full_submit(self):
+        from textual import events
+        from forgekit_console.tui import clipboard
+        raw = "\n".join(f"코드 {i} mix {i}" for i in range(60))
+        clipboard.copy_text(raw)
+        svc = self._svc()
+        app = self._app(svc)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.post_message(events.Paste("[Pasted text #7 +59 lines]"))
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            self.assertEqual(len(app._pastes.items), 1)
+            self.assertEqual(app._pastes.get(1).line_count, 60)              # raw preserved
+            self.assertEqual(len(svc.got[-1].splitlines()), 60)             # FULL text submitted
+            self.assertNotIn("[Pasted", svc.got[-1])                         # not the placeholder
+            body = self._body(app)
+            self.assertIn("Pasted #1", body)                                # compact block
+            self.assertIn("/paste expand 1", body)                          # lifecycle seam shown
+
+    async def test_expand_and_resend(self):
+        from textual import events
+        from forgekit_console.tui import clipboard
+        raw = "\n".join(f"row {i}" for i in range(30))
+        clipboard.copy_text(raw)
+        svc = self._svc()
+        app = self._app(svc)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.post_message(events.Paste("[Pasted text #2 +29 lines]"))
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause(); await app.workers.wait_for_complete(); await pilot.pause()
+            n = len(svc.got)
+            app._paste_dispatch(["expand", "1"])
+            await pilot.pause()
+            self.assertIn("row 29", self._body(app))                         # expand shows raw body
+            app._paste_dispatch(["resend", "1"])
+            await pilot.pause(); await app.workers.wait_for_complete(); await pilot.pause()
+            self.assertEqual(len(svc.got[-1].splitlines()), 30)             # resend = full raw again
+            self.assertGreater(len(svc.got), n)
+
+    async def test_copy_paste_copies_raw_not_placeholder(self):
+        from textual import events
+        from forgekit_console.tui import clipboard
+        raw = "\n".join(f"line {i} 한글" for i in range(40))
+        clipboard.copy_text(raw)
+        captured = {}
+        orig = clipboard.copy_text
+        clipboard.copy_text = lambda t: (captured.__setitem__("t", t) or (True, "stub"))
+        try:
+            app = self._app(self._svc())
+            async with app.run_test(size=(100, 30)) as pilot:
+                await pilot.pause()
+                # restore real copy_text only for the paste-rehydrate read; stub for /copy
+                clipboard.copy_text = orig
+                app.post_message(events.Paste("[Pasted text #3 +39 lines]"))
+                await pilot.pause()
+                await pilot.press("enter"); await pilot.pause()
+                await app.workers.wait_for_complete(); await pilot.pause()
+                clipboard.copy_text = lambda t: (captured.__setitem__("t", t) or (True, "stub"))
+                app._copy_dispatch(["paste", "1"])
+                await pilot.pause()
+                self.assertEqual(captured["t"], raw)                         # RAW, not placeholder
+        finally:
+            clipboard.copy_text = orig
+
+
+# --------------------------------------------------------------------------- #
+# real OS round-trip (macOS): /copy paste → pbpaste matches the raw payload
+# --------------------------------------------------------------------------- #
+@unittest.skipUnless(
+    _TEXTUAL and sys.platform == "darwin" and shutil.which("pbcopy") and shutil.which("pbpaste"),
+    "pbcopy/pbpaste 필요",
+)
+class PasteCopyReadbackTests(unittest.IsolatedAsyncioTestCase):
+    async def test_copy_paste_real_readback(self):
+        from textual import events
+        from forgekit_console.tui import clipboard
+        from forgekit_console.commands.registry import load_agents, load_commands
+        from forgekit_console.commands.router import ConsoleContext
+        from forgekit_console.tui.app import ForgekitConsoleApp
+        from forgekit_console.chat import models as m
+
+        class Svc:
+            def submit(self, t, **_):
+                return m.SubmitResult(ok=True, mode=m.MODE_LIVE, category=m.CAT_OK, text="ok",
+                                      provider_id="ollama", provider_label="Ollama",
+                                      source=m.SOURCE_LOCAL_DEFAULT, model="g")
+
+        raw = "\n".join(f"raw line {i}" for i in range(45))
+        clipboard.copy_text(raw)
+        ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
+        app = ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, submit_service=Svc())
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.post_message(events.Paste("[Pasted text #1 +44 lines]"))
+            await pilot.pause()
+            await pilot.press("enter"); await pilot.pause()
+            await app.workers.wait_for_complete(); await pilot.pause()
+            app._copy_dispatch(["paste", "1"])
+            await pilot.pause()
+            self.assertEqual(clipboard.read_text(), raw)   # real pbcopy→pbpaste of the RAW paste
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -253,10 +253,10 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             await pilot.press("tab")
             await pilot.pause()
-            self.assertEqual(prompt.value, "/provider ")   # /p → provider, pm-agent, planning-agent
+            self.assertEqual(prompt.value, "/paste ")   # /p → paste, provider, pm-agent, planning-agent
             await pilot.press("tab")
             await pilot.pause()
-            self.assertEqual(prompt.value, "/pm-agent ")
+            self.assertEqual(prompt.value, "/provider ")
 
     async def test_escape_closes_palette(self) -> None:
         from forgekit_console.tui.prompt_area import PromptArea


### PR DESCRIPTION
## 목적
parity QA(실측) + 최대 gap(긴 paste raw 재사용 부재) fix-forward.

## 범위
tui/{paste_store(신규),app}, commands/registry + 테스트 + examples/tui-qa + docs §5.

## 리스크
/paste 추가로 /p palette prefix 첫 매치 변경 → 관련 테스트 갱신.

## 테스트
forgekit OK(both venvs), 전체 OK(.venv-ci). paste lifecycle macOS pbpaste readback 포함.

## 이슈 linkage
Closes #287. process event feed 는 미구현으로 정직 분리(다음 build).