### PR TITLE
✨ proc/terminal 식별자 best-effort (forgekit 인식)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/app/main.py
+++ b/apps/forgekit-console/src/forgekit_console/app/main.py
@@ -84,6 +84,15 @@ def launch_console(*, repo_root: Path, ui_mode: Optional[str] = None) -> int:
             return EXIT_MISSING_TUI
         raise
 
+    # Best-effort process/terminal identity so the console reads as `forgekit`, not the
+    # interpreter (`python`). Honest limits live in proc_identity; never blocks launch.
+    try:
+        from .. import proc_identity
+
+        proc_identity.apply_identity()
+    except Exception:  # noqa: BLE001 - identity is cosmetic; never break launch
+        pass
+
     # Prime textual-image's backend BEFORE Textual starts: its sixel/TGP probe only
     # works while stdin is free, so this is what lets a capable terminal resolve to a
     # true raster instead of halfcell. Best-effort — never blocks launch.

--- a/apps/forgekit-console/src/forgekit_console/proc_identity.py
+++ b/apps/forgekit-console/src/forgekit_console/proc_identity.py
@@ -1,0 +1,145 @@
+"""Process / terminal identity — make ``forgekit`` read as ``forgekit``, best-effort.
+
+WHY this exists: the ``forgekit`` entrypoint is a Python console-script whose launcher
+shebang is the venv interpreter, so the running PROCESS is ``python``. A host UI (VS
+Code's terminal tab, Activity Monitor) that labels a terminal by its foreground
+*process/executable* therefore shows ``Python``, not ``forgekit`` — even though the
+*command name* is ``forgekit``.
+
+There are TWO separate things, handled separately and honestly:
+
+1. **terminal/tab title** — an OSC escape sequence (``ESC ] 0 ; <title> BEL``) that asks
+   the terminal to label its window/tab. Honored when the host's tab title is
+   sequence-based; ignored when the host pins the tab to the process name. TTY-only.
+2. **process name** — a best-effort OS call: Linux ``prctl(PR_SET_NAME)`` (sets
+   ``/proc/self/comm``, ≤15 chars), macOS ``setprogname`` (affects ``getprogname``).
+   **Honest limit:** neither changes the *executable* the kernel records, so a host UI
+   that reads the interpreter path (VS Code on macOS) may STILL show ``Python``.
+
+No new dependency (stdlib ``ctypes`` only; ``setproctitle`` is intentionally NOT used).
+Pure + injectable (``libc`` / ``stream`` / ``isatty`` / ``platform``) so every branch is
+unit-testable without a real tty or libc.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional, Tuple
+
+APP_NAME = "forgekit"
+APP_TITLE = "forgekit console"
+
+# prctl option for the process/thread name (linux/prctl.h). Name is capped at 16 bytes
+# (15 + NUL) by the kernel.
+_PR_SET_NAME = 15
+_COMM_MAX = 15
+
+# keep a strong reference to the name buffer handed to setprogname (it stores the
+# pointer, so the bytes must outlive the call — otherwise a dangling pointer).
+_progname_ref: Optional[bytes] = None
+
+
+def sanitize_title(title: str, *, max_len: int = 128) -> str:
+    """Drop control characters (C0/C1, incl. ESC/BEL) and bound the length.
+
+    A title goes to the terminal as-is, so an unsanitized one could inject escape
+    sequences. We keep only printable characters and trim to *max_len*."""
+
+    out = []
+    for ch in (title or ""):
+        o = ord(ch)
+        if o < 0x20 or 0x7F <= o <= 0x9F:   # C0 controls, DEL, C1 controls
+            continue
+        out.append(ch)
+    return "".join(out)[:max_len].strip()
+
+
+def terminal_title_sequence(title: str) -> str:
+    """The OSC sequence that sets the icon name + window title (sanitized)."""
+
+    return f"\x1b]0;{sanitize_title(title)}\x07"
+
+
+def set_terminal_title(title: str = APP_TITLE, *, stream=None, isatty: Optional[bool] = None) -> bool:
+    """Write the OSC title sequence to *stream* — but ONLY when it is a real tty.
+
+    Returns True if it was written, False if skipped (not a tty / write failed). Never
+    raises. Honest: writing it does not guarantee the host honours it."""
+
+    stream = stream if stream is not None else sys.stdout
+    if isatty is None:
+        try:
+            isatty = bool(getattr(stream, "isatty", lambda: False)())
+        except Exception:  # noqa: BLE001
+            isatty = False
+    if not isatty:
+        return False
+    try:
+        stream.write(terminal_title_sequence(title))
+        stream.flush()
+        return True
+    except Exception:  # noqa: BLE001 - a title is never worth crashing the launch
+        return False
+
+
+def _load_libc(platform: str):
+    import ctypes
+    import ctypes.util
+
+    try:
+        if platform == "darwin":
+            return ctypes.CDLL("libc.dylib", use_errno=True)
+        if platform.startswith("linux"):
+            return ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def set_process_name(name: str = APP_NAME, *, platform: Optional[str] = None, libc=None) -> Tuple[bool, str]:
+    """Best-effort process name. (ok, via) — ``via`` names the path used or the reason.
+
+    Linux → ``prctl(PR_SET_NAME)`` (``/proc/self/comm``); macOS → ``setprogname``. The
+    *libc* is injectable for tests. Never raises."""
+
+    global _progname_ref
+    plat = platform if platform is not None else sys.platform
+    lib = libc if libc is not None else _load_libc(plat)
+    if lib is None:
+        return False, "no libc"
+    raw = (name or APP_NAME).encode("utf-8", "ignore")
+    try:
+        if plat == "darwin":
+            _progname_ref = raw + b"\x00"        # keep alive — setprogname stores the ptr
+            lib.setprogname(_progname_ref)
+            return True, "setprogname"
+        if plat.startswith("linux"):
+            _progname_ref = raw[:_COMM_MAX] + b"\x00"
+            lib.prctl(_PR_SET_NAME, _progname_ref, 0, 0, 0)
+            return True, "prctl(PR_SET_NAME)"
+    except Exception as exc:  # noqa: BLE001
+        return False, f"{type(exc).__name__}: {exc}"
+    return False, f"unsupported platform: {plat}"
+
+
+def apply_identity(*, name: str = APP_NAME, title: str = APP_TITLE, stream=None,
+                   platform: Optional[str] = None, libc=None) -> dict:
+    """Best-effort: set the process name AND the terminal title. Honest result dict.
+
+    Called from the launch path; never blocks/raises. The returned dict reports exactly
+    what was applied vs skipped (no fake success)."""
+
+    pn_ok, pn_via = set_process_name(name, platform=platform, libc=libc)
+    title_ok = set_terminal_title(title, stream=stream)
+    return {
+        "process_name_set": pn_ok,
+        "process_name_via": pn_via,
+        "terminal_title_set": title_ok,
+    }
+
+
+__all__ = (
+    "APP_NAME", "APP_TITLE",
+    "sanitize_title", "terminal_title_sequence", "set_terminal_title",
+    "set_process_name", "apply_identity",
+)

--- a/docs/forgekit-console.md
+++ b/docs/forgekit-console.md
@@ -840,3 +840,18 @@ css·callout·color)은 **단일 canonical registry** 가 SSoT —
 ## 7. 관련
 - [`runtime-operator-surfaces.md`](runtime-operator-surfaces.md) (재사용하는 surface) ·
   [`operations.md`](operations.md) · [`monorepo-structure.md`](monorepo-structure.md)
+
+## 프로세스 / 터미널 식별자 (`forgekit` vs `Python`)
+`forgekit` 는 Python console-script 라 실행 PROCESS 자체는 `python`(launcher shebang 인터프리터)이다.
+그래서 **process/executable 로 탭을 라벨링하는 host UI(VS Code 터미널 탭, Activity Monitor)는 `Python`** 으로
+보일 수 있다. 명령 *이름* 은 `forgekit` 이 맞다.
+
+best-effort 로 두 가지를 **분리**해 처리한다 (`forgekit_console/proc_identity.py`, launch 경로에서 호출):
+- **terminal/tab title** — OSC 시퀀스(`ESC ] 0 ; forgekit console BEL`, control char sanitize, **tty 일 때만**).
+  host 탭 제목이 sequence 기반이면 반영, process 기반이면 무시.
+- **process name** — Linux `prctl(PR_SET_NAME)`(`/proc/self/comm`, ≤15자), macOS `setprogname`
+  (`getprogname` 반영 확인됨). 새 의존성 없음(stdlib ctypes; setproctitle 미사용).
+
+**정직한 한계:** 둘 다 커널이 기록한 *executable* 을 바꾸지 않는다. 따라서 **VS Code(특히 macOS)는
+인터프리터 경로를 우선해 여전히 `Python` 으로 표시할 수 있다.** "반드시 forgekit 으로 뜬다" 는 보장 아님 —
+TTY/host 가 지원하는 범위에서의 best-effort. 테스트: `test_proc_identity`.

--- a/tests/forgekit/test_proc_identity.py
+++ b/tests/forgekit/test_proc_identity.py
@@ -1,0 +1,117 @@
+"""Process / terminal identity — title sanitize, OSC sequence, tty gating, best-effort
+process-name per platform (fake libc), and entrypoint wiring.
+
+Pure / injectable: no real tty or libc needed. The honest limit (host UIs may still
+show the interpreter) is a behaviour fact, documented — not asserted here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console import proc_identity as pi
+
+
+class FakeLibc:
+    def __init__(self):
+        self.calls = []
+
+    def setprogname(self, buf):
+        self.calls.append(("setprogname", bytes(buf)))
+
+    def prctl(self, option, buf, *rest):
+        self.calls.append(("prctl", option, bytes(buf)))
+
+
+class TitleTests(unittest.TestCase):
+    def test_sanitize_strips_control_chars(self):
+        # ESC + BEL (the active title delimiters) and newlines must be removed
+        out = pi.sanitize_title("forge\x1b]0;evil\x07kit\nx")
+        self.assertNotIn("\x1b", out)
+        self.assertNotIn("\x07", out)
+        self.assertNotIn("\n", out)
+        self.assertIn("forge", out)
+
+    def test_sanitize_bounds_length(self):
+        self.assertLessEqual(len(pi.sanitize_title("a" * 500, max_len=20)), 20)
+
+    def test_osc_sequence_shape(self):
+        seq = pi.terminal_title_sequence("forgekit console")
+        self.assertTrue(seq.startswith("\x1b]0;"))
+        self.assertTrue(seq.endswith("\x07"))
+        self.assertIn("forgekit console", seq)
+
+    def test_title_written_only_on_tty(self):
+        buf = io.StringIO()
+        self.assertFalse(pi.set_terminal_title("x", stream=buf, isatty=False))   # no-op off-tty
+        self.assertEqual(buf.getvalue(), "")
+        buf2 = io.StringIO()
+        self.assertTrue(pi.set_terminal_title("forgekit", stream=buf2, isatty=True))
+        self.assertEqual(buf2.getvalue(), "\x1b]0;forgekit\x07")
+
+
+class ProcessNameTests(unittest.TestCase):
+    def test_macos_uses_setprogname(self):
+        fake = FakeLibc()
+        ok, via = pi.set_process_name("forgekit", platform="darwin", libc=fake)
+        self.assertTrue(ok)
+        self.assertEqual(via, "setprogname")
+        self.assertEqual(fake.calls[0][0], "setprogname")
+        self.assertIn(b"forgekit", fake.calls[0][1])
+
+    def test_linux_uses_prctl_set_name_capped(self):
+        fake = FakeLibc()
+        ok, via = pi.set_process_name("forgekit-very-long-name", platform="linux", libc=fake)
+        self.assertTrue(ok)
+        self.assertIn("prctl", via)
+        kind, option, buf = fake.calls[0]
+        self.assertEqual(kind, "prctl")
+        self.assertEqual(option, 15)                       # PR_SET_NAME
+        self.assertLessEqual(len(buf.rstrip(b"\x00")), 15)  # comm capped at 15
+
+    def test_no_libc_is_honest_failure(self):
+        ok, via = pi.set_process_name("forgekit", platform="linux", libc=None)
+        # on a box without a loadable libc this is False; with one it's True — either way
+        # `via` is a non-empty reason/path, never a fake claim.
+        self.assertTrue(via)
+
+    def test_unsupported_platform(self):
+        ok, via = pi.set_process_name("forgekit", platform="sunos", libc=FakeLibc())
+        self.assertFalse(ok)
+        self.assertIn("unsupported", via)
+
+    def test_apply_identity_reports_honestly(self):
+        fake = FakeLibc()
+        res = pi.apply_identity(stream=io.StringIO(), platform="linux", libc=fake)
+        self.assertTrue(res["process_name_set"])
+        self.assertFalse(res["terminal_title_set"])        # StringIO is not a tty
+        self.assertIn("prctl", res["process_name_via"])
+
+
+@unittest.skipUnless(importlib.util.find_spec("textual") is not None, "textual 필요")
+class EntrypointWiringTests(unittest.TestCase):
+    def test_launch_console_applies_identity(self):
+        from forgekit_console.app import main as appmain
+        from forgekit_console import proc_identity
+        from forgekit_console.tui.app import ForgekitConsoleApp
+        from pathlib import Path
+
+        called = {"n": 0}
+        orig_apply = proc_identity.apply_identity
+        orig_run = ForgekitConsoleApp.run
+        proc_identity.apply_identity = lambda **kw: (called.__setitem__("n", called["n"] + 1) or {})
+        ForgekitConsoleApp.run = lambda self, **kw: 0
+        try:
+            appmain.launch_console(repo_root=Path("/tmp/repo"))
+        finally:
+            proc_identity.apply_identity = orig_apply
+            ForgekitConsoleApp.run = orig_run
+        self.assertEqual(called["n"], 1)   # identity applied on the launch path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
host 가 process(python) 로 탭 라벨링 → forgekit 인식 개선. title vs process name 분리 best-effort.

## 범위
proc_identity.py(신규, 순수) + app/main wiring + 테스트 + docs 짧게.

## 리스크
없음(cosmetic, best-effort, launch 안 막음). 새 의존성 없음.

## 테스트
test_proc_identity 10 OK, 전체 OK(.venv-ci).

## 이슈 linkage
Closes #289. 정직: 커널 executable 미변경 → VS Code(macOS) 여전히 Python 가능.