### PR TITLE
✨ process event feed — 실제 행동 기반 타임라인 (Reading/Bash 가짜 금지)

### DIFF
--- a/apps/forgekit-console/examples/tui-process-feed/timeline.txt
+++ b/apps/forgekit-console/examples/tui-process-feed/timeline.txt
@@ -1,0 +1,29 @@
+forgekit process event feed — 실제 행동 기반 타임라인 (가짜 Reading/Bash 없음)
+======================================================================
+
+[1] free-text live submit (chunked generate, NOT token streaming)
+    submit_start     [done] (0.0s)
+    submit_sent      [done] · Ollama
+    generate_start   [done] (0.3s) · 3 chunks
+    done             [done]
+    feed render(rendered):
+      • Submitting to provider (0.0s)
+      • Sent Ollama
+      • Generating 3 chunks (0.3s)
+      • Done
+
+[2] blocked/failed submit — category-specific (unsupported_in_console)
+    submit_start     [failed] (0.0s)
+    error            [failed] · unsupported_in_console
+
+[3] slash route command
+    route_start      [done] (0.0s)
+    route_done       [done] · whoami
+    done             [done]
+
+[4] copy success / paste expanded
+  /copy:
+    copy_success     [done] · last response
+
+[분리] process feed 는 transcript 가 아니다 → /copy 에 event noise 미포함(검증: test_tui_process_feed).
+[정직] token streaming 아님 — paragraph/line-group chunked append. generate 이벤트가 실제 chunk 수 반영.

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -100,6 +100,8 @@ class ForgekitConsoleApp(App):
         self._attachments = AttachmentStore()  # staged image/file attachments (honest staged_only)
         from .paste_store import PasteStore
         self._pastes = PasteStore()      # large-paste raw payloads (expand/resend/copy by id)
+        from .process_events import ProcessFeed
+        self._feed = ProcessFeed()       # real process timeline (route/submit/generate/…)
         self._reveal_interval = 0.05    # progressive-reveal tick (seconds) per body chunk
         self._suppress_refilter = False
         # Repeated-failure escalation: same blocked signature past the threshold
@@ -410,13 +412,21 @@ class ForgekitConsoleApp(App):
         if parsed.name == "paste":
             self._paste_dispatch(list(getattr(parsed, "args", ()) or ()))
             return
+        # slash routing — a real, fast event group: Routing → Routed → Done/Error.
+        from . import process_events as _pe
+        self._feed.begin_turn()
+        route_ev = self._feed_emit("start", _pe.KIND_ROUTE_START, f"Routing /{parsed.name}")
         result = route(parsed, self.context)
+        self._feed.finish(route_ev, _pe.ST_DONE)
+        self._feed_emit("mark", _pe.KIND_ROUTE_DONE, "Routed", detail=parsed.name)
         if result.kind == KIND_QUIT:
             self.exit()
             return
         if result.kind == KIND_CLEAR:
             self._transcript.clear()
             self._store.clear()   # copy model tracks the visible transcript
+            self._feed.clear()
+            self._render_feed()
             self._main.show_transcript()
             return
         if result.kind in (KIND_HELP, KIND_LAYOUT):
@@ -435,6 +445,10 @@ class ForgekitConsoleApp(App):
             self._refresh_chrome()
         if result.kind == KIND_ERROR:
             self._record_failure(parsed, result)
+            self._feed_emit("mark", _pe.KIND_ERROR, "Command error", status=_pe.ST_FAILED,
+                            detail=result.title, severity=_pe.SEV_ERROR)
+        else:
+            self._feed_emit("mark", _pe.KIND_DONE, "Done")
         if (parsed.name or "") == "render":
             self._observe_render()  # repeated blocked render → escalate w/ alternatives
         if parsed.name in _STATUS_COMMANDS:
@@ -458,12 +472,17 @@ class ForgekitConsoleApp(App):
 
         # rehydrate a host paste placeholder from the clipboard BEFORE submitting — the
         # FULL multiline payload goes to the provider, never the bare placeholder.
+        from . import process_events as _pe
+
+        self._feed.begin_turn()             # one event group per turn (real timeline)
         res = ingest.resolve_submit_text(raw, clipboard.read_text())
         if res.blocked:
             self._transcript.begin_turn()
             self._transcript.write_echo(raw)
             self._transcript.write(
                 f"[{theme.WARNING}]⚠ paste 차단[/{theme.WARNING}] [dim]{res.note}[/dim]")
+            self._feed_emit("mark", _pe.KIND_SUBMIT_BLOCKED, "Paste blocked",
+                            status=_pe.ST_BLOCKED, detail="raw payload unavailable", severity=_pe.SEV_WARN)
             self._follow_tail()
             return
         text = (res.text if res.rehydrated else raw).strip()
@@ -480,6 +499,8 @@ class ForgekitConsoleApp(App):
             self._transcript.write_echo(payload.compact_label())
             self._transcript.write(
                 f"[dim]↳ /paste expand {payload.id} · /paste resend {payload.id} · /copy paste {payload.id}[/dim]")
+            self._feed_emit("mark", _pe.KIND_PASTE_STORED, "Paste stored",
+                            detail=f"#{payload.id} · {payload.line_count} lines")
         else:
             self._transcript.write_echo(text)
             if res.rehydrated:
@@ -492,6 +513,9 @@ class ForgekitConsoleApp(App):
         # provider call; the held result is rendered. Logic lives in chat.policy_gate.
         from ..chat.policy_gate import evaluate_gate
 
+        provider = getattr(self._effective_policy, "main_provider", "") or "provider"
+        self._submit_ev = self._feed_emit("start", _pe.KIND_SUBMIT_START,
+                                          f"Submitting to {provider}", source=provider)
         ctx = self._build_submit_context()
         decision = evaluate_gate(ctx)
         if not decision.allowed:
@@ -499,11 +523,15 @@ class ForgekitConsoleApp(App):
             for line in result.to_lines():
                 self._transcript.write(line)
             self._record_usage(result)  # held/throttled events are in the ledger too
+            # honest blocked event with the SPECIFIC category (no "실패" 뭉개기).
+            self._feed.finish(self._submit_ev, _pe.ST_BLOCKED)
+            self._feed_emit("mark", _pe.KIND_SUBMIT_BLOCKED, "Blocked", status=_pe.ST_BLOCKED,
+                            detail=result.category, severity=_pe.SEV_WARN)
             self._follow_tail()
             return
-        # stage 1 — THINKING: a transient status line under the conversation while the
-        # provider call runs off the event loop (real stage, cleared when the reply lands).
-        self._set_live_status("[dim]● 생각 중…[/dim]")
+        # the submit event stays RUNNING ("Submitting to <provider>…") while the provider
+        # call runs off the event loop; it is finished in _on_submit_result.
+        self._render_feed()
         self._follow_tail()
         self.run_worker(
             lambda: self._submit_blocking(text, ctx), thread=True, group="submit", exclusive=False
@@ -924,21 +952,32 @@ class ForgekitConsoleApp(App):
 
         self._transcript.begin_turn()
         self._transcript.write_echo("/copy " + " ".join(args) if args else "/copy")
+        from . import process_events as _pe
+        self._feed.begin_turn()
         label, text = self._copy_target(args)
         if label is None:
             self._transcript.write(
                 f"[{theme.WARNING}]⚠ 사용법[/{theme.WARNING}] "
-                "[dim]/copy [last|all|turn <n>|block <n>][/dim]")
+                "[dim]/copy [last|all|turn <n>|block <n>|paste <id>][/dim]")
+            self._feed_emit("mark", _pe.KIND_COPY_FAILED, "Copy", status=_pe.ST_FAILED,
+                            detail="usage", severity=_pe.SEV_WARN)
         elif not (text or "").strip():
             # empty payload is a FAILURE — never claim a copy happened.
             self._transcript.write(
                 f"[{theme.WARNING}]⚠ 복사 실패[/{theme.WARNING}] "
                 f"[dim]{label}: 복사할 내용이 없습니다 — 먼저 질문/명령을 실행하세요.[/dim]")
+            self._feed_emit("mark", _pe.KIND_COPY_FAILED, "Copy failed", status=_pe.ST_FAILED,
+                            detail="empty payload", severity=_pe.SEV_WARN)
         else:
             ok, msg = clipboard.copy_text(text)
             self._transcript.write(
                 (f"[{theme.SUCCESS}]✓ 복사됨[/{theme.SUCCESS}] [dim]{label} · {msg}[/dim]")
                 if ok else f"[{theme.WARNING}]⚠ 복사 실패[/{theme.WARNING}] [dim]{label} · {msg}[/dim]")
+            if ok:
+                self._feed_emit("mark", _pe.KIND_COPY_SUCCESS, "Copied", detail=label)
+            else:
+                self._feed_emit("mark", _pe.KIND_COPY_FAILED, "Copy failed",
+                                status=_pe.ST_FAILED, detail=msg, severity=_pe.SEV_WARN)
         self._sync_intro()
         self._follow_tail()
 
@@ -952,8 +991,11 @@ class ForgekitConsoleApp(App):
 
         from . import attachment as att
 
+        from . import process_events as _pe
+
         sub = (args[0].lower() if args else "")
         self._transcript.begin_turn()
+        self._feed.begin_turn()
         self._transcript.write_echo("/attach " + " ".join(args) if args else "/attach")
         if sub == "status":
             for line in self._attachments.status_lines():
@@ -967,8 +1009,12 @@ class ForgekitConsoleApp(App):
                 self._attachments.add(attachment)
                 self._transcript.write(f"[{theme.SUCCESS}]✓ {state}[/{theme.SUCCESS}] [dim]{msg}[/dim]")
                 self._transcript.write(f"[dim]↳ {att.PROVIDER_TEXT_ONLY_REASON} — 제출 시 staged_only 로 표시[/dim]")
+                self._feed_emit("mark", _pe.KIND_ATTACH_STAGED, "Attached",
+                                detail=f"{attachment.preview_label} · staged_only")
             else:
                 self._transcript.write(f"[{theme.WARNING}]⚠ {state}[/{theme.WARNING}] [dim]{msg}[/dim]")
+                self._feed_emit("mark", _pe.KIND_ATTACH_BLOCKED, "Attach blocked",
+                                status=_pe.ST_BLOCKED, detail=state, severity=_pe.SEV_WARN)
         else:
             # no args, no subcommand → try the clipboard image, else show usage + status.
             if not self._stage_clipboard_image(origin="attach"):
@@ -998,10 +1044,14 @@ class ForgekitConsoleApp(App):
                 self._transcript.write(f"[{theme.WARNING}]⚠ paste #{args[1]} 없음[/{theme.WARNING}]")
                 self._sync_intro(); self._follow_tail(); return
             if sub == "expand":
+                from . import process_events as _pe
+                self._feed.begin_turn()
                 self._transcript.write(f"[dim]── paste #{payload.id} 본문 ({payload.line_count} lines) ──[/dim]")
                 for line in payload.raw_text.splitlines():
                     self._transcript.write(line)
                 self._transcript.write(f"[dim]── end paste #{payload.id} ──[/dim]")
+                self._feed_emit("mark", _pe.KIND_PASTE_EXPANDED, "Paste expanded",
+                                detail=f"#{payload.id} · {payload.line_count} lines")
                 self._sync_intro(); self._follow_tail(); return
             # resend → re-run the raw payload through the free-text submit path.
             self._submit_free_text(payload.raw_text)
@@ -1056,31 +1106,49 @@ class ForgekitConsoleApp(App):
         self._attachments.clear()
 
     def _on_submit_result(self, result) -> None:
+        from . import process_events as _pe
+
         # record the assistant reply as a copyable response block (plain text, no receipt).
         self._store.add_response(result.text or self._plain_from_lines(result.to_lines()))
         # WT2: record the usage event (live or estimate basis) to the ledger.
         self._record_usage(result)
-        # held/throttled are intentional POLICY decisions, not failures → no escalation.
+        # close the Submitting event with the real outcome.
+        ev = getattr(self, "_submit_ev", None)
+        if ev is not None:
+            self._feed.finish(ev, _pe.ST_DONE if result.ok else _pe.ST_FAILED)
         if not result.ok and not result.held:
             self._record_submit_failure(result)
-        # stage 2 — GENERATING: reveal the body progressively (paragraph/line-group
-        # chunks), then the receipt, then clear the live status. NOT fake typing — real
-        # content revealed in chunks so it accumulates instead of one giant frame.
+            # honest, category-specific (unsupported_in_console / auth_missing / transport…).
+            self._feed_emit("mark", _pe.KIND_ERROR, "Submit failed", status=_pe.ST_FAILED,
+                            detail=result.category, severity=_pe.SEV_ERROR)
+            self._refocus_prompt()
+            return
+        if result.ok:
+            self._feed_emit("mark", _pe.KIND_SUBMIT_SENT, "Sent",
+                            detail=result.provider_label or result.provider_id)
+        # stage 2 — GENERATING: reveal the body progressively (paragraph/line-group chunks).
+        # chunked append (NOT token streaming) — the generate event reflects real chunks.
         self._reveal_result(result)
 
     def _reveal_result(self, result) -> None:
+        from . import process_events as _pe
+
         lines = list(result.to_lines())
         receipt = lines.pop() if lines else ""   # the trailing dim receipt line
         chunks = list(render.chunk_result_lines(lines))
-        self._set_live_status("[dim]● 생성 중…[/dim]")
+        self._gen_ev = self._feed_emit("start", _pe.KIND_GENERATE_START, "Generating")
+        self._gen_chunks = 0
         # the FIRST chunk lands immediately (snappy); the rest reveal on a timer.
         if chunks:
             self._write_chunk(chunks.pop(0))
+            self._gen_chunks += 1
+            self._gen_ev.detail = f"{self._gen_chunks} chunk"
+            self._render_feed()
             self._follow_tail()
         self._reveal_rest(chunks, receipt)
 
     def _reveal_rest(self, chunks, receipt: str) -> None:
-        """Reveal remaining chunks on a timer, then the receipt, then clear status."""
+        """Reveal remaining chunks on a timer (real chunk append), then receipt + done."""
 
         if not chunks:
             self._finish_reveal(receipt)
@@ -1089,6 +1157,9 @@ class ForgekitConsoleApp(App):
         def step() -> None:
             if chunks:
                 self._write_chunk(chunks.pop(0))
+                self._gen_chunks += 1
+                self._gen_ev.detail = f"{self._gen_chunks} chunks"   # real chunk count
+                self._render_feed()
                 self._follow_tail()
             if not chunks:
                 timer.stop()
@@ -1097,9 +1168,14 @@ class ForgekitConsoleApp(App):
         timer = self.set_interval(self._reveal_interval, step)
 
     def _finish_reveal(self, receipt: str) -> None:
+        from . import process_events as _pe
+
         if receipt:
-            self._transcript.write(receipt)   # stage 3 — RECEIPT (who/usage/mode)
-        self._clear_live_status()
+            self._transcript.write(receipt)   # stage 3 — RECEIPT (who/usage/mode) → transcript
+        gen = getattr(self, "_gen_ev", None)
+        if gen is not None:
+            self._feed.finish(gen, _pe.ST_DONE)
+            self._feed_emit("mark", _pe.KIND_DONE, "Done")   # carries the turn's total feel
         self._follow_tail()
         self._refocus_prompt()
 
@@ -1114,14 +1190,28 @@ class ForgekitConsoleApp(App):
         body = [ln for ln in lines if not (ln or "").lstrip().startswith("[dim]↳")]
         return "\n".join(body).strip()
 
-    def _set_live_status(self, markup: str) -> None:
-        try:
-            self.query_one("#livestatus", Static).update(markup)
-        except Exception:  # noqa: BLE001 - livestatus not mounted yet
-            pass
+    # --- process event feed -------------------------------------------------
+    def _feed_emit(self, op: str, kind: str, label: str, **kw):
+        """Record a real process event and re-render the feed surface. Returns the event."""
 
-    def _clear_live_status(self) -> None:
-        self._set_live_status("")
+        ev = (self._feed.start if op == "start" else self._feed.mark)(kind, label, **kw)
+        self._render_feed()
+        return ev
+
+    def _render_feed(self) -> None:
+        """Render the recent process events into the #livestatus surface (feed zone).
+
+        Separate from the transcript: the feed is event-only, the transcript is the
+        conversation. /copy never touches this. Idle → empty (collapses to 0 rows)."""
+
+        try:
+            w = self.query_one("#livestatus", Static)
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return
+        if self._feed.empty:
+            w.update("")
+            return
+        w.update("\n".join(render.process_feed_lines(self._feed.recent(6))))
 
     def _refocus_prompt(self) -> None:
         try:

--- a/apps/forgekit-console/src/forgekit_console/tui/process_events.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/process_events.py
@@ -1,0 +1,156 @@
+"""Process event model — a REAL, structured timeline of what ForgeKit actually did.
+
+Not UI decoration: every event is emitted by an actual action (slash route, provider
+submit, chunked generate, copy, attach, paste) — never a fake ``Reading``/``Bash``/
+``Thinking`` label with nothing behind it. ForgeKit is a provider console (not a coding
+shell), so the kinds map to ForgeKit's real work, not Claude's coding-agent verbs.
+
+Durations are MEASURED: a ``start`` event records a monotonic timestamp and ``finish``
+records the end → ``duration_ms`` is real. Instant markers (``route_done``, ``copy_*``)
+carry no duration (``duration_ms is None``) — honestly modelled, never a faked "~1s".
+
+The store keeps ONE turn's event group (cleared when a new turn starts) and caps the
+recent window — the feed reflects the current/last action, not an ever-growing log. The
+clock is injectable so order + durations are deterministic in tests.
+
+Pure / stdlib → unit-testable; the feed is a SEPARATE surface from the transcript, so it
+never pollutes ``/copy`` (which copies transcript plain-text only).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Tuple
+
+# --- event kinds (ForgeKit's real actions) ---------------------------------
+KIND_ROUTE_START = "route_start"
+KIND_ROUTE_DONE = "route_done"
+KIND_SUBMIT_START = "submit_start"
+KIND_SUBMIT_BLOCKED = "submit_blocked"
+KIND_SUBMIT_SENT = "submit_sent"
+KIND_GENERATE_START = "generate_start"
+KIND_GENERATE_CHUNK = "generate_chunk"
+KIND_GENERATE_DONE = "generate_done"
+KIND_COPY_SUCCESS = "copy_success"
+KIND_COPY_FAILED = "copy_failed"
+KIND_ATTACH_STAGED = "attach_staged"
+KIND_ATTACH_BLOCKED = "attach_blocked"
+KIND_PASTE_STORED = "paste_stored"
+KIND_PASTE_EXPANDED = "paste_expanded"
+KIND_DONE = "done"
+KIND_ERROR = "error"
+
+# --- status ----------------------------------------------------------------
+ST_RUNNING = "running"
+ST_DONE = "done"
+ST_BLOCKED = "blocked"
+ST_FAILED = "failed"
+
+# --- severity (drives the dot colour) --------------------------------------
+SEV_INFO = "info"
+SEV_WARN = "warn"
+SEV_ERROR = "error"
+
+
+@dataclass
+class ProcessEvent:
+    kind: str
+    label: str
+    status: str = ST_DONE
+    started_at: float = 0.0           # monotonic seconds
+    ended_at: Optional[float] = None  # None while running / for pure markers
+    detail: str = ""
+    source: str = ""                  # e.g. provider id
+    copyable: bool = False            # excluded from default /copy regardless
+    severity: str = SEV_INFO
+
+    @property
+    def duration_ms(self) -> Optional[int]:
+        """Real measured duration, or None when there is no start→end span."""
+
+        if self.ended_at is None or self.ended_at == self.started_at:
+            return None
+        return int((self.ended_at - self.started_at) * 1000)
+
+
+@dataclass
+class ProcessFeed:
+    """A turn-scoped, capped timeline of real events. Clock injectable for tests."""
+
+    clock: Callable[[], float] = time.monotonic
+    max_recent: int = 8
+    _events: List[ProcessEvent] = field(default_factory=list)
+
+    # --- emit ---------------------------------------------------------------
+    def start(self, kind: str, label: str, *, detail: str = "", source: str = "",
+              severity: str = SEV_INFO) -> ProcessEvent:
+        """A RUNNING event (duration measured at :meth:`finish`)."""
+
+        ev = ProcessEvent(kind=kind, label=label, status=ST_RUNNING, started_at=self.clock(),
+                          detail=detail, source=source, severity=severity)
+        self._events.append(ev)
+        self._trim()
+        return ev
+
+    def mark(self, kind: str, label: str, *, status: str = ST_DONE, detail: str = "",
+             source: str = "", severity: str = SEV_INFO) -> ProcessEvent:
+        """An INSTANT marker (no duration — started == ended)."""
+
+        t = self.clock()
+        ev = ProcessEvent(kind=kind, label=label, status=status, started_at=t, ended_at=t,
+                          detail=detail, source=source, severity=severity)
+        self._events.append(ev)
+        self._trim()
+        return ev
+
+    def finish(self, ev: ProcessEvent, status: str = ST_DONE) -> ProcessEvent:
+        """Close a running event → records the end so ``duration_ms`` is real."""
+
+        ev.ended_at = self.clock()
+        ev.status = status
+        return ev
+
+    # --- turn lifecycle -----------------------------------------------------
+    def begin_turn(self) -> None:
+        """A new action starts → the feed reflects the current turn, not history."""
+
+        self._events.clear()
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    # --- read ---------------------------------------------------------------
+    @property
+    def events(self) -> Tuple[ProcessEvent, ...]:
+        return tuple(self._events)
+
+    def recent(self, n: Optional[int] = None) -> Tuple[ProcessEvent, ...]:
+        return tuple(self._events[-(n or self.max_recent):])
+
+    def active(self) -> Optional[ProcessEvent]:
+        for ev in reversed(self._events):
+            if ev.status == ST_RUNNING:
+                return ev
+        return None
+
+    @property
+    def empty(self) -> bool:
+        return not self._events
+
+    def _trim(self) -> None:
+        # keep the window bounded even within a long turn (no unbounded growth).
+        cap = self.max_recent * 2
+        if len(self._events) > cap:
+            self._events = self._events[-cap:]
+
+
+__all__ = (
+    "KIND_ROUTE_START", "KIND_ROUTE_DONE", "KIND_SUBMIT_START", "KIND_SUBMIT_BLOCKED",
+    "KIND_SUBMIT_SENT", "KIND_GENERATE_START", "KIND_GENERATE_CHUNK", "KIND_GENERATE_DONE",
+    "KIND_COPY_SUCCESS", "KIND_COPY_FAILED", "KIND_ATTACH_STAGED", "KIND_ATTACH_BLOCKED",
+    "KIND_PASTE_STORED", "KIND_PASTE_EXPANDED", "KIND_DONE", "KIND_ERROR",
+    "ST_RUNNING", "ST_DONE", "ST_BLOCKED", "ST_FAILED",
+    "SEV_INFO", "SEV_WARN", "SEV_ERROR",
+    "ProcessEvent", "ProcessFeed",
+)

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -661,6 +661,34 @@ def result_block(title: str, lines: Sequence[str]) -> Tuple[str, ...]:
     return (header, *lines, "")
 
 
+def process_feed_lines(events: Sequence) -> Tuple[str, ...]:
+    """Render process events as compact, dim timeline lines (Claude tone, ForgeKit verbs).
+
+    `• <label> <detail> (<dur>s)  <status>` — the dot colour is the severity, the whole
+    line is dim (a step lighter than the assistant body). Running → `…`; blocked/error
+    → `— <reason>`; done → a quiet `done`. Duration only shows when it was measured."""
+
+    from . import process_events as pe
+
+    out = []
+    for ev in events:
+        dot = {pe.SEV_WARN: _WARN, pe.SEV_ERROR: _ERR}.get(ev.severity, _ACCENT)
+        detail = f" [dim]{ev.detail}[/dim]" if ev.detail else ""
+        dur = f" [dim]({ev.duration_ms / 1000:.1f}s)[/dim]" if ev.duration_ms else ""
+        if ev.status == pe.ST_RUNNING:
+            tail = " [dim]…[/dim]"
+        elif ev.status == pe.ST_BLOCKED:
+            tail = f" [{_WARN}]— {ev.detail or 'blocked'}[/{_WARN}]"
+            detail = ""  # the reason is in the tail
+        elif ev.status == pe.ST_FAILED:
+            tail = f" [{_ERR}]— {ev.detail or 'error'}[/{_ERR}]"
+            detail = ""
+        else:
+            tail = ""
+        out.append(f"[{dot}]•[/{dot}] [dim]{ev.label}[/dim]{detail}{dur}{tail}")
+    return tuple(out)
+
+
 def chunk_result_lines(lines: Sequence[str], max_lines: int = 3) -> Tuple[Tuple[str, ...], ...]:
     """Group response lines into small reveal chunks for progressive rendering.
 
@@ -691,5 +719,5 @@ __all__ = (
     "palette_lines", "palette_panel_lines", "mode_badge", "mode_pill",
     "status_pill", "hint_line", "help_sections",
     "help_panel_document", "help_tab_strip", "help_body", "default_help_tab",
-    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines",
+    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
 )

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -139,3 +139,28 @@ ForgeKit 콘솔은 **full-screen Textual TUI** (alternate screen + mouse capture
 
 증거: `examples/tui-inline/` (idle/slash SVG + audit.txt), `examples/tui-full/` (idle/slash SVG),
 테스트 `test_tui_inline_mode`.
+
+## 7. Process event feed (실제 행동 타임라인)
+"무반응 후 결과가 툭" 대신 **진행 단계**를 보여준다. 단, **실제로 발생한 행동만** — 가짜
+`Reading`/`Bash`/`Thinking` 라벨 없음. ForgeKit 은 coding shell 이 아니라 provider 콘솔이라
+**ForgeKit 의 실제 행위**(route/submit/generate/copy/attach/paste)에 매핑한다. 코드:
+`tui/process_events.py`(순수 모델), `render.process_feed_lines`(line builder), `tui/app.py`(wiring만).
+
+- **모델**: `ProcessEvent`(kind/label/status/started_at/ended_at/**duration_ms**(실측)/detail/
+  source/severity) + `ProcessFeed`(turn 단위 group, 최근 window cap). `start`→`finish` 로 duration
+  **실측**; instant marker(route_done/copy_*)는 `duration_ms=None`(정직, 가짜 1초 없음).
+- **transcript 와 분리**: feed 는 `#livestatus` zone(입력 위, 별도 surface). transcript 본문에
+  안 섞임 → `/copy [last|turn|block|all]` 에 event noise **미포함**(검증).
+- **실제 순서**:
+  - free-text: `submit_start` → `submit_sent` → `generate_start`(실 chunk 수 반영) → `done`.
+  - blocked/failed: `submit_blocked`/`error` + **category-specific**(unsupported_in_console /
+    no_provider_configured / budget_throttled / transport_error …) — vague "실패" 뭉개기 없음.
+  - slash: `route_start` → `route_done` → `done`/`error`.
+  - copy: `copy_success`/`copy_failed`(empty payload). attach: `attach_staged`/`attach_blocked`.
+    paste: `paste_stored`/`paste_expanded`.
+- **chunked, NOT token streaming**: `generate_start` 이벤트 detail 이 실제 append 된 chunk 수를
+  반영. 가짜 typing 애니메이션 없음.
+- **history**: turn 단위 group(새 입력 시 reset), 최근 ~6개만 노출 — 무한 누적 없음. idle→빈
+  surface(0행). clear 시 feed 도 정리.
+
+증거: `examples/tui-process-feed/timeline.txt`, 테스트 `test_tui_process_feed`.

--- a/tests/forgekit/test_tui_process_feed.py
+++ b/tests/forgekit/test_tui_process_feed.py
@@ -1,0 +1,159 @@
+"""Process event feed — REAL, ordered events tied to actual actions (not fake labels).
+
+Pure model (injected clock → deterministic durations) + pilot event-ORDER tests for the
+real paths: slash route, free-text submit (sent → generate → done), blocked submit
+(category-specific, provider NOT called), copy success/failure, paste expand. Also that
+the feed is SEPARATE from the transcript so `/copy` never includes feed noise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+# --------------------------------------------------------------------------- #
+# pure model
+# --------------------------------------------------------------------------- #
+class ProcessEventModelTests(unittest.TestCase):
+    def _clock(self):
+        t = {"v": 0.0}
+        return (lambda: t["v"]), t
+
+    def test_running_event_has_measured_duration(self):
+        from forgekit_console.tui import process_events as pe
+        clock, t = self._clock()
+        feed = pe.ProcessFeed(clock=clock)
+        ev = feed.start(pe.KIND_SUBMIT_START, "Submitting")
+        self.assertEqual(ev.status, pe.ST_RUNNING)
+        self.assertIsNone(ev.duration_ms)           # still running
+        t["v"] = 2.5
+        feed.finish(ev, pe.ST_DONE)
+        self.assertEqual(ev.duration_ms, 2500)      # REAL measured (2.5s)
+
+    def test_instant_marker_has_no_duration(self):
+        from forgekit_console.tui import process_events as pe
+        feed = pe.ProcessFeed(clock=lambda: 1.0)
+        ev = feed.mark(pe.KIND_ROUTE_DONE, "Routed")
+        self.assertIsNone(ev.duration_ms)           # no start→end span — honest
+
+    def test_begin_turn_scopes_to_one_group(self):
+        from forgekit_console.tui import process_events as pe
+        feed = pe.ProcessFeed(clock=lambda: 0.0)
+        feed.mark(pe.KIND_DONE, "Done")
+        feed.begin_turn()
+        self.assertTrue(feed.empty)                 # new turn → fresh group, no infinite log
+
+
+# --------------------------------------------------------------------------- #
+# pilot: real event order per path
+# --------------------------------------------------------------------------- #
+@unittest.skipUnless(_TEXTUAL, "textual 필요")
+class ProcessFeedPilotTests(unittest.IsolatedAsyncioTestCase):
+    def _app(self, svc=None, config=None):
+        from forgekit_console.commands.registry import load_agents, load_commands
+        from forgekit_console.commands.router import ConsoleContext
+        from forgekit_console.tui.app import ForgekitConsoleApp
+        ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
+        return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, submit_service=svc, config=config)
+
+    def _live(self):
+        from forgekit_console.chat import models as m
+
+        class Svc:
+            def __init__(s): s.calls = 0
+            def submit(s, t, **_):
+                s.calls += 1
+                return m.SubmitResult(ok=True, mode=m.MODE_LIVE, category=m.CAT_OK, text="문단.\n\n끝.",
+                                      provider_id="ollama", provider_label="Ollama",
+                                      source=m.SOURCE_LOCAL_DEFAULT, model="g")
+        return Svc()
+
+    def _kinds(self, app):
+        return [e.kind for e in app._feed.events]
+
+    async def test_free_text_submit_order(self):
+        app = self._app(self._live())
+        async with app.run_test(size=(90, 28)) as pilot:
+            await pilot.pause()
+            app.query_one("#prompt").value = "설명"
+            await pilot.press("enter")
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            for _ in range(20):
+                await pilot.pause(0.03)
+            kinds = self._kinds(app)
+            # submit_start → submit_sent → generate_start → … → done, in order
+            self.assertEqual(kinds[0], "submit_start")
+            self.assertIn("submit_sent", kinds)
+            self.assertIn("generate_start", kinds)
+            self.assertEqual(kinds[-1], "done")
+            self.assertLess(kinds.index("submit_sent"), kinds.index("generate_start"))
+
+    async def test_failed_submit_event_is_category_specific(self):
+        from forgekit_console.chat import models as m
+
+        class UnsupportedSvc:   # e.g. claude/codex — routable but no console live-submit
+            def submit(self, t, **_):
+                return m.SubmitResult(ok=False, mode=m.MODE_ERROR, category=m.CAT_UNSUPPORTED,
+                                      provider_id="claude", provider_label="Claude",
+                                      text="unsupported_in_console")
+
+        app = self._app(UnsupportedSvc())
+        async with app.run_test(size=(90, 28)) as pilot:
+            await pilot.pause()
+            app.query_one("#prompt").value = "질문"
+            await pilot.press("enter")
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            kinds = self._kinds(app)
+            self.assertIn("submit_start", kinds)
+            self.assertIn("error", kinds)                  # honest failure event
+            err = [e for e in app._feed.events if e.kind == "error"][0]
+            self.assertEqual(err.detail, m.CAT_UNSUPPORTED)   # SPECIFIC category, not vague "실패"
+            self.assertNotIn("submit_sent", kinds)           # not claimed as sent
+
+    async def test_slash_route_order(self):
+        app = self._app()
+        async with app.run_test(size=(90, 28)) as pilot:
+            await pilot.pause()
+            app._execute("/help") if False else app._execute("/whoami")
+            await pilot.pause()
+            kinds = self._kinds(app)
+            self.assertEqual(kinds[0], "route_start")
+            self.assertEqual(kinds[1], "route_done")
+            self.assertIn(kinds[-1], ("done", "error"))
+
+    async def test_copy_event_and_not_in_transcript_copy(self):
+        app = self._app(self._live())
+        async with app.run_test(size=(90, 28)) as pilot:
+            await pilot.pause()
+            app.query_one("#prompt").value = "설명"
+            await pilot.press("enter")
+            await pilot.pause(); await app.workers.wait_for_complete()
+            for _ in range(15):
+                await pilot.pause(0.03)
+            app._copy_dispatch([])
+            await pilot.pause()
+            self.assertIn("copy_success", self._kinds(app))
+            # the process feed is NEVER part of the copyable transcript text
+            self.assertNotIn("Generating", app._store.all_text() or "")
+            self.assertNotIn("Submitting", app._store.all_text() or "")
+
+    async def test_copy_empty_is_failed_event(self):
+        app = self._app()
+        async with app.run_test(size=(90, 28)) as pilot:
+            await pilot.pause()
+            app._copy_dispatch([])   # nothing recorded → failure
+            await pilot.pause()
+            self.assertIn("copy_failed", self._kinds(app))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_tui_ux_redesign.py
+++ b/tests/forgekit/test_tui_ux_redesign.py
@@ -163,17 +163,20 @@ class ProgressiveRenderTests(unittest.IsolatedAsyncioTestCase):
             await pilot.pause(0.05)
             partial = len(app._transcript.lines)
             gen = str(app.query_one("#livestatus", Static).render())
-            self.assertIn("생성", gen)                       # GENERATING stage visible
+            self.assertIn("Generating", gen)                 # GENERATING event visible in the feed
             for _ in range(25):
                 await pilot.pause(0.1)
             full = len(app._transcript.lines)
             joined = "\n".join(str(s) for s in app._transcript.lines)
             self.assertGreater(full, partial)                # grew progressively (chunked)
             self.assertTrue(all(p in joined for p in ["문단 하나", "문단 둘", "문단 셋"]))
-            self.assertIn("Ollama", joined)                  # RECEIPT at the end
-            self.assertEqual(str(app.query_one("#livestatus", Static).render()), "")  # cleared
+            self.assertIn("Ollama", joined)                  # RECEIPT at the end (transcript)
+            # the feed ends with a Done event (real timeline), not the old transient string
+            kinds = [e.kind for e in app._feed.events]
+            self.assertIn("generate_start", kinds)
+            self.assertIn("done", kinds)
 
-    async def test_thinking_stage_shows_while_provider_runs(self) -> None:
+    async def test_submitting_event_shows_while_provider_runs(self) -> None:
         from textual.widgets import Static
         from forgekit_console.chat import models as m
 
@@ -183,7 +186,7 @@ class ProgressiveRenderTests(unittest.IsolatedAsyncioTestCase):
         class BlockingSvc:
             def submit(self, text, **_):
                 released.set()
-                gate.wait(2.0)   # hold the worker so the THINKING stage is observable
+                gate.wait(2.0)   # hold the worker so the running Submit event is observable
                 return m.SubmitResult(ok=True, mode=m.MODE_LIVE, category=m.CAT_OK,
                                       text="끝", provider_id="ollama", provider_label="Ollama",
                                       source=m.SOURCE_LOCAL_DEFAULT, model="g")
@@ -197,11 +200,14 @@ class ProgressiveRenderTests(unittest.IsolatedAsyncioTestCase):
                 await pilot.pause(0.02)
                 if released.is_set():
                     break
-            think = str(app.query_one("#livestatus", Static).render())
+            # while the provider call runs, the feed shows a RUNNING "Submitting…" event
+            feed = str(app.query_one("#livestatus", Static).render())
+            active = app._feed.active()
             gate.set()
             await app.workers.wait_for_complete()
             await pilot.pause()
-            self.assertIn("생각", think)   # THINKING shown while the provider call ran
+            self.assertIn("Submitting", feed)
+            self.assertIsNotNone(active)                  # a real running event, not a fake string
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## 목적
'무반응 후 결과' → '과정이 보이는 콘솔'. 실제 행동에만 연결된 event timeline.

## 범위
tui/{process_events(신규),render,app} + 테스트 + examples/tui-process-feed + docs §7.

## 리스크
livestatus 의미 변경(thinking/generating → event) → ux_redesign 테스트 갱신.

## 테스트
forgekit OK(both venvs), 전체 OK(.venv-ci). event 순서/실측 기준.

## 이슈 linkage
Closes #291. token streaming 아님(chunked) — 정직 표기.