### PR TITLE
콘솔 parity 정정 + setup gate persistence 버그 수정 (closes #293)

### DIFF
--- a/apps/forgekit-console/examples/tui-parity-correction/results.txt
+++ b/apps/forgekit-console/examples/tui-parity-correction/results.txt
@@ -1,0 +1,14 @@
+ForgeKit parity correction — 실측 (입력 위치 / copyable setup / setup gate)
+======================================================================
+
+[1 입력 위치] idle empty: input y=11 (H=30) → 상단 근처:True, 아래 빈공간:True
+           long+tail: input bottom=29 → tail-follow 하단 visible:True
+[3 palette] below input:True gap=0
+
+[2 copyable setup] /copy all → pbpaste 에 setup 안내 포함:True
+   readback head: 'setup-required — primary provider 가 아직 설정되지 않았습니다.'
+
+[4 setup gate] /provider set claude persist→ {'primary_provider': 'claude', 'linked_providers': ['claude']}
+   재실행 state=configured-no-live blocked=False (canonical primary_provider 읽음 — 더 이상 setup-required 오인 X)
+   link ollama → state=ready live_capable=True
+[no config] state=setup-required · stale 'main_provider' wording 제거됨

--- a/apps/forgekit-console/src/forgekit_console/policy/setup_state.py
+++ b/apps/forgekit-console/src/forgekit_console/policy/setup_state.py
@@ -18,11 +18,13 @@ from dataclasses import dataclass, field
 from typing import Mapping, Optional, Tuple
 
 from ..providers import builtins
-from ..providers.registry import no_provider_configured
 from .main_profile import MainProviderProfile, profile_for
+from . import provider_config as pc
+from . import routing as rt
 
 STATE_READY = "ready"
 STATE_SETUP_REQUIRED = "setup-required"
+STATE_NO_LIVE = "configured-no-live"   # primary set, but no live-submit-capable linked provider
 STATE_DEGRADED = "degraded"
 
 CHECK_OK = "ok"
@@ -47,13 +49,21 @@ class SetupState:
     """The honest setup verdict + per-item checklist + operator next actions."""
 
     state: str
-    main_provider: str = ""
+    primary_provider: str = ""
     profile: Optional[MainProviderProfile] = None
     checks: Tuple[SetupCheck, ...] = field(default_factory=tuple)
     next_actions: Tuple[str, ...] = field(default_factory=tuple)
+    live_capable: bool = False
+
+    # back-compat alias (legacy readers); canonical is primary_provider.
+    @property
+    def main_provider(self) -> str:
+        return self.primary_provider
 
     @property
     def blocked(self) -> bool:
+        # ONLY no-primary is a hard block. "configured-no-live" is configured (not blocked) —
+        # it is an honest capability state, not "설정 안 됨".
         return self.state == STATE_SETUP_REQUIRED
 
     @property
@@ -61,24 +71,39 @@ class SetupState:
         return self.state == STATE_READY
 
 
-def _main_provider_id(config: Mapping) -> str:
-    return str((config or {}).get("main_provider", "") or (config or {}).get("id", "")).strip()
+def _has_live_capable(cfg: pc.ProviderConfig) -> bool:
+    """True when at least one linked provider can do console live-submit (openai-compat).
+
+    claude/codex (CLI) are routable but NOT live in the console; a brain of only those
+    is `configured-no-live`, not ready. Custom providers can't be verified here → treated
+    as potentially live (their submit is checked at call time)."""
+
+    for pid in (cfg.primary_provider, *cfg.linked_providers):
+        spec = builtins.builtin(pid)
+        if spec is None:
+            return True   # custom/unknown built-in → can't disprove; honest at submit time
+        if rt.submit_supported(spec):
+            return True
+    return False
 
 
 def resolve_setup_state(config: Optional[Mapping] = None) -> SetupState:
     """Resolve the setup verdict from *config* (the on-disk ``~/.forgekit/config.json``).
 
-    No provider → ``setup-required`` (blocked) with a clear next action. A provider
-    present → ``ready`` with the derived profile, plus a checklist that is honest
-    about which items are verified vs derived.
+    Reads the CANONICAL ``primary_provider`` (via :func:`provider_config.load_provider_config`,
+    which also migrates a legacy ``main_provider``/``id``). No primary → ``setup-required``
+    (blocked). Primary set but NO live-submit-capable linked provider → ``configured-no-live``
+    (configured, NOT blocked — honest). Primary + a live path → ``ready``.
     """
 
     config = config or {}
-    if no_provider_configured(config):
+    brain = pc.load_provider_config(config)
+    primary = brain.primary_provider
+    if not primary:
         return SetupState(
             state=STATE_SETUP_REQUIRED,
             checks=(
-                SetupCheck("main provider", CHECK_MISSING, "설정된 provider 가 없습니다"),
+                SetupCheck("primary provider", CHECK_MISSING, "설정된 provider 가 없습니다"),
                 SetupCheck("auth/endpoint", CHECK_UNKNOWN, "provider 설정 후 확인"),
                 SetupCheck("budget/usage policy", CHECK_UNKNOWN, "provider 후 derive"),
                 SetupCheck("approval policy", CHECK_UNKNOWN, "provider 후 derive"),
@@ -86,15 +111,16 @@ def resolve_setup_state(config: Optional[Mapping] = None) -> SetupState:
             ),
             next_actions=(
                 "primary provider 를 정하세요 — 콘솔에서 `/provider set <id>` "
-                "(claude/codex/gemini/ollama) 또는 `~/.forgekit/config.json` 의 `primary_provider`. "
-                "ForgeKit 은 자동으로 ollama 를 쓰지 않습니다(operator 주도).",
+                "(claude/codex/gemini/ollama) 또는 `/provider preset <claude|codex|gemini|ollama>-brain`. "
+                "ForgeKit 은 자동으로 ollama 를 쓰지 않습니다(operator 가 primary_provider 를 정합니다).",
                 "설정 후 `/provider` / `/doctor` 로 점검, `/mode` 로 routing 확인.",
             ),
         )
 
-    main = _main_provider_id(config)
+    main = primary
     spec = builtins.builtin(main)
     profile = profile_for(main, spec)
+    live = _has_live_capable(brain)
     # auth/endpoint: we know the provider's auth KIND from the spec; whether the
     # secret is actually present is checked at submit time (chat.service), so we
     # report the requirement honestly rather than claiming it's satisfied.
@@ -103,27 +129,38 @@ def resolve_setup_state(config: Optional[Mapping] = None) -> SetupState:
         auth_check = SetupCheck("auth/endpoint", CHECK_DERIVED, auth_detail)
     else:
         auth_check = SetupCheck("auth/endpoint", CHECK_DERIVED, "custom provider — config 의 auth/endpoint 사용")
+    live_check = (SetupCheck("live submit", CHECK_OK, "live-capable linked provider 있음") if live
+                  else SetupCheck("live submit", CHECK_MISSING,
+                                  "linked provider 가 전부 unsupported_in_console (claude/codex) — "
+                                  "console live-submit 불가"))
     checks = (
-        SetupCheck("main provider", CHECK_OK, main),
+        SetupCheck("primary provider", CHECK_OK, main),
         auth_check,
+        live_check,
         SetupCheck("budget/usage policy", CHECK_DERIVED, f"profile usage={profile.default_usage_mode}"),
         SetupCheck("approval policy", CHECK_DERIVED, f"policy={profile.default_policy_mode}"),
         SetupCheck("brain/vault path", CHECK_DERIVED, "runtime_paths 기본 경로"),
     )
-    next_actions: Tuple[str, ...] = ()
-    if profile.warnings:
-        next_actions = profile.warnings
+    next_actions: Tuple[str, ...] = tuple(profile.warnings or ())
+    if not live:
+        next_actions = (
+            "primary 는 설정됐지만 console live-submit 가능한 provider 가 없습니다 "
+            "(claude/codex 는 routable 이나 미구현). `/provider link gemini` 또는 "
+            "`/provider link ollama` 로 live 경로를 추가하세요.",
+            *next_actions,
+        )
     return SetupState(
-        state=STATE_READY,
-        main_provider=main,
+        state=STATE_READY if live else STATE_NO_LIVE,
+        primary_provider=main,
         profile=profile,
         checks=checks,
         next_actions=next_actions,
+        live_capable=live,
     )
 
 
 __all__ = (
-    "STATE_READY", "STATE_SETUP_REQUIRED", "STATE_DEGRADED",
+    "STATE_READY", "STATE_SETUP_REQUIRED", "STATE_NO_LIVE", "STATE_DEGRADED",
     "CHECK_OK", "CHECK_MISSING", "CHECK_DERIVED", "CHECK_UNKNOWN",
     "SetupCheck", "SetupState", "resolve_setup_state",
 )

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -167,19 +167,18 @@ class ForgekitConsoleApp(App):
             profile=self.context.profile,
             id="intro",
         )
-        # THE SCROLL REGION (1fr) — only the reading flow scrolls: issue line + the
-        # transcript XOR help view. It is the SINGLE scroll owner. The composer is NOT
-        # inside it — it is DOCKED below (Claude: the input bar stays at the bottom of
-        # the viewport and the conversation scrolls above it).
+        # THE SESSION FLOW (1fr) — the SINGLE scroll owner, TOP-ALIGNED. The whole session
+        # stacks inside it: issue line → transcript/help → process feed → INLINE composer.
+        # The composer is INLINE (not docked): on an empty session it sits near the TOP
+        # with empty space below (Claude); as the transcript grows it is pushed down and
+        # follow_tail keeps it in view — "typing at the tail of the current session".
         with SessionFlow(id="flow"):
             yield Static(id="issue")               # one quiet status line at the top
             yield MainPanel(id="main")             # transcript XOR help (height: auto)
-        # live status line — a TRANSIENT stage marker (thinking → generating) shown just
-        # above the docked composer while a response is produced/revealed, then cleared.
-        yield Static(id="livestatus")
-        # the DOCKED composer — input bar + slash palette DIRECTLY BELOW it + sub-hint
-        # row. Pinned to the viewport bottom; the palette opens flush under the input.
-        yield Composer(id="composer")
+            # process event feed (route/submit/generate/…); empty → collapses to 0 rows.
+            yield Static(id="livestatus")
+            # inline composer — input bar + slash palette DIRECTLY BELOW it + sub-hint row.
+            yield Composer(id="composer")
 
     def on_mount(self) -> None:
         self.title = render.BRAND
@@ -192,8 +191,22 @@ class ForgekitConsoleApp(App):
         # hint row, so the welcome line was redundant and showed as a stray band.
         self._refresh_issue()
         self._refresh_chrome()
+        # setup-required → a COPYABLE explanation block in the transcript (not UI-only).
+        # The issue line stays a short pill; this block is the readable, /copy-able guidance.
+        if getattr(self._setup, "blocked", False):
+            self._write_system(render.setup_explanation_lines())
         self._sync_intro()  # empty + idle → wide hero art; working state → compact
         self.query_one("#prompt", PromptArea).focus()
+        self._follow_tail()
+
+    def _write_system(self, lines) -> None:
+        """Write an operator-facing SYSTEM explanation block to the transcript AND the
+        plain-text store, so it is visible AND copyable (`/copy last|turn|all`). System
+        blocks are real content (setup guidance, mode-switch reasons), NOT UI chrome."""
+
+        for ln in lines:
+            self._transcript.write(ln)
+        self._store.add_lines("system", lines)   # copyable plain-text (markup stripped)
         self._follow_tail()
 
     # --- input / palette ----------------------------------------------------
@@ -320,12 +333,14 @@ class ForgekitConsoleApp(App):
             widget.hide()
         self._refresh_chrome()
         self._sync_intro()  # opening the palette folds a fresh hero to compact
-        # Auto-reveal policy (docked composer): the palette is ALWAYS visible (it opens
-        # DIRECTLY BELOW the docked input bar, inside the bottom-docked composer zone),
-        # so the operator never scrolls to see it. When the palette opens the flow region
-        # shrinks from the bottom — if the operator was at the tail we keep the newest
-        # line visible (follow_tail); if browsing history we PRESERVE their scroll.
-        if is_open and self._at_tail():
+        # Auto-reveal policy (INLINE composer): the composer lives in the scroll flow, so
+        # it is not structurally always-visible. On the OPEN transition — explicit
+        # command-entry intent — scroll the flow to the tail so the input + the palette
+        # (directly below it) are immediately on-screen, NO manual scroll. While the
+        # palette stays open and the operator is at the tail, keep following; if they
+        # scrolled up to browse mid-open we don't yank them.
+        opening = is_open and not self._palette_was_open
+        if is_open and (opening or self._at_tail()):
             self._follow_tail()
         self._palette_was_open = is_open
 
@@ -1408,8 +1423,13 @@ class ForgekitConsoleApp(App):
             self.query_one("#issue", Static).update(render.blocked_banner())
             return
         if self._setup.blocked:
-            # no provider configured → forgekit can't run; surface setup-required.
+            # no primary provider configured → forgekit can't run; surface setup-required.
             self.query_one("#issue", Static).update(render.setup_required_banner())
+            return
+        if not getattr(self._setup, "live_capable", True):
+            # configured (primary set) but no console live-submit path — honest, NOT blocked.
+            self.query_one("#issue", Static).update(
+                render.no_live_banner(getattr(self._setup, "primary_provider", "")))
             return
         pol = self._effective_policy
         if pol is not None:
@@ -1442,11 +1462,11 @@ class ForgekitConsoleApp(App):
         from ..policy import runtime_mode as rm
 
         if self._setup.blocked:
-            self._transcript.write(
-                "[dim]provider 미설정 — 모드 전환 전에 setup 이 필요합니다 (`/doctor`).[/dim]"
-            )
+            # copyable operator guidance (not UI-only) — goes to transcript + store.
+            self._write_system(
+                ("provider 미설정 — 모드 전환 전에 setup 이 필요합니다.",
+                 "  • `/provider set <id>` 로 primary provider 설정 · `/doctor` 로 점검"))
             self._sync_intro()
-            self._follow_tail()
             return
         self._runtime_mode = rm.cycle_mode(self._runtime_mode, direction)
         self._mode_pinned = True  # explicit operator action → auto won't override
@@ -1482,7 +1502,7 @@ class ForgekitConsoleApp(App):
         pol = self._effective_policy
         lines = [
             f"현재 모드: [b]{pol.mode_label}[/b]  (Shift+Tab 으로 순환)",
-            f"  main provider : {pol.main_provider}",
+            f"  primary provider : {pol.main_provider}",
             f"  routing       : {pol.provider_policy_mode}  → chat slot = {pol.routing_target()}",
             f"  usage         : {pol.usage.usage_mode} (reserve {pol.usage.reserve})",
             f"  autonomy      : {pol.autonomy}",

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -105,8 +105,39 @@ def setup_required_banner() -> str:
     """Issue-line banner when no provider is configured (forgekit can't run yet)."""
 
     return (
-        f"[{_WARN}]● setup-required[/{_WARN}] [dim]main provider 미설정 — "
-        f"`/doctor` 로 점검, config 의 `main_provider` 설정 (또는 로컬 ollama)[/dim]"
+        f"[{_WARN}]● setup-required[/{_WARN}] [dim]primary provider 미설정 — "
+        f"`/provider set <id>` 또는 `/provider preset <…>-brain` (자동 ollama 안 함)[/dim]"
+    )
+
+
+def no_live_banner(primary: str = "") -> str:
+    """Issue-line banner when a primary IS set but no live-submit-capable provider exists.
+
+    Honest: the brain is CONFIGURED (not setup-required) — but claude/codex are
+    unsupported_in_console, so there is no console live path until a live provider is
+    linked. NOT "설정 안 됨"."""
+
+    who = f" (primary={primary})" if primary else ""
+    return (
+        f"[{_WARN}]● configured · no live-submit[/{_WARN}] [dim]primary 설정됨{who} — "
+        f"live 경로(gemini/ollama) 미연결. `/provider link gemini|ollama`[/dim]"
+    )
+
+
+def setup_explanation_lines() -> Tuple[str, ...]:
+    """The copyable operator-facing setup/provider explanation (transcript + /copy).
+
+    Distinct from :func:`setup_required_banner` (the short status PILL on the issue line):
+    this is the readable BLOCK that lands in the transcript / plain-text store, so the
+    operator can `/copy` the guidance — not a UI-only decoration."""
+
+    return (
+        "[b]setup-required[/b] — primary provider 가 아직 설정되지 않았습니다.",
+        "ForgeKit 은 operator 가 정한 primary provider 로 동작합니다 — 자동으로 ollama 를 쓰지 않습니다.",
+        "다음 단계:",
+        "  • `/provider set <id>`  (claude · codex · gemini · ollama 중 하나)",
+        "  • `/doctor` 로 환경 점검 · `/provider list` 로 후보 확인",
+        "  • 로컬 ollama 로 시작하려면: `/provider set ollama`",
     )
 
 
@@ -713,7 +744,7 @@ def chunk_result_lines(lines: Sequence[str], max_lines: int = 3) -> Tuple[Tuple[
 __all__ = (
     "BRAND", "TAGLINE",
     "welcome_banner", "intro_meta_lines", "renderer_debug_line", "blocked_banner",
-    "setup_required_banner", "runtime_mode_line", "submit_held_line",
+    "setup_required_banner", "setup_explanation_lines", "runtime_mode_line", "submit_held_line",
     "issue_line", "agent_pane_lines",
     "status_pane_lines",
     "palette_lines", "palette_panel_lines", "mode_badge", "mode_pill",

--- a/tests/forgekit/test_runtime_mode.py
+++ b/tests/forgekit/test_runtime_mode.py
@@ -103,14 +103,37 @@ class SetupGateTests(unittest.TestCase):
         self.assertTrue(state.blocked)
         self.assertEqual(state.state, ss.STATE_SETUP_REQUIRED)
         self.assertTrue(state.next_actions)
-        self.assertFalse(next(c for c in state.checks if c.name == "main provider").ok)
+        self.assertFalse(next(c for c in state.checks if c.name == "primary provider").ok)
 
-    def test_provider_present_is_ready(self) -> None:
-        state = ss.resolve_setup_state({"main_provider": "claude"})
+    def test_canonical_primary_provider_is_read(self) -> None:
+        # the bug fix: canonical primary_provider (live-capable) → ready, not setup-required
+        state = ss.resolve_setup_state({"primary_provider": "ollama", "linked_providers": ["ollama"]})
         self.assertTrue(state.ready)
-        self.assertEqual(state.main_provider, "claude")
-        self.assertIsNotNone(state.profile)
-        self.assertTrue(next(c for c in state.checks if c.name == "main provider").ok)
+        self.assertEqual(state.primary_provider, "ollama")
+        self.assertTrue(state.live_capable)
+        self.assertEqual(state.main_provider, "ollama")   # legacy alias still works
+
+    def test_legacy_main_provider_still_migrates(self) -> None:
+        # legacy field is read-compat only → migrated to primary
+        state = ss.resolve_setup_state({"main_provider": "ollama"})
+        self.assertTrue(state.ready)
+        self.assertEqual(state.primary_provider, "ollama")
+
+    def test_claude_only_is_configured_no_live_not_blocked(self) -> None:
+        # claude/codex are unsupported_in_console → CONFIGURED but no live path (honest),
+        # NOT setup-required (it IS configured) and NOT ready (no live submit).
+        state = ss.resolve_setup_state({"primary_provider": "claude", "linked_providers": ["claude", "codex"]})
+        self.assertEqual(state.state, ss.STATE_NO_LIVE)
+        self.assertFalse(state.blocked)
+        self.assertFalse(state.ready)
+        self.assertFalse(state.live_capable)
+
+    def test_claude_with_live_linked_is_ready(self) -> None:
+        # claude primary + a live-capable linked (gemini/ollama) → ready
+        state = ss.resolve_setup_state(
+            {"primary_provider": "claude", "linked_providers": ["claude", "codex", "gemini", "ollama"]})
+        self.assertTrue(state.ready)
+        self.assertTrue(state.live_capable)
 
     def test_ollama_ready_with_capability_warning(self) -> None:
         state = ss.resolve_setup_state({"main_provider": "ollama"})

--- a/tests/forgekit/test_tui_palette_below.py
+++ b/tests/forgekit/test_tui_palette_below.py
@@ -17,23 +17,26 @@ from tests.forgekit import _SRC  # noqa: F401
 _TEXTUAL = importlib.util.find_spec("textual") is not None
 
 
-def _app():
+def _app(config=None):
     from forgekit_console.commands.registry import load_agents, load_commands
     from forgekit_console.commands.router import ConsoleContext
     from forgekit_console.tui.app import ForgekitConsoleApp
     ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
-    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx)
+    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx,
+                              config={"primary_provider": "ollama", "linked_providers": ["ollama"]}
+                              if config is None else config)
 
 
 @unittest.skipUnless(_TEXTUAL, "textual 필요")
 class PaletteBelowGeometryTests(unittest.IsolatedAsyncioTestCase):
-    async def test_input_bottom_anchored_before_slash(self):
+    async def test_input_inline_near_top_before_slash(self):
         from forgekit_console.tui.composer import Composer
         app = _app()
         async with app.run_test(size=(100, 28)) as pilot:
             await pilot.pause()
             comp = app.query_one(Composer).region
-            self.assertGreaterEqual(comp.bottom, app.size.height - 1)   # composer docked at bottom
+            # INLINE: empty session → composer near the TOP, not docked at the bottom
+            self.assertLess(comp.bottom, app.size.height - 2)
 
     async def test_palette_flush_below_input_and_visible(self):
         from forgekit_console.tui.palette import CommandPalette
@@ -61,10 +64,15 @@ class PaletteBelowGeometryTests(unittest.IsolatedAsyncioTestCase):
             await pilot.press("slash", "h")
             await pilot.pause()
             pal = app.query_one(CommandPalette)
-            # 4 (responsibility split): palette's parent is the Composer, NOT the SessionFlow
+            # 4 (responsibility split): palette's parent is the Composer, NOT the MainPanel
+            # (transcript). The composer is inline in the flow, but the palette belongs to
+            # the composer command-entry zone — never the transcript content.
+            from forgekit_console.tui.main_panel import MainPanel
             self.assertIsInstance(pal.parent, Composer)
-            flow = app.query_one(SessionFlow).region
-            self.assertGreaterEqual(pal.region.y, flow.bottom)    # below the transcript zone
+            self.assertNotIsInstance(pal.parent, MainPanel)
+            main = app.query_one(MainPanel).region
+            bar = app.query_one("#composer-input-shell").region
+            self.assertGreaterEqual(pal.region.y, bar.bottom)     # directly below the input bar
 
     async def test_long_transcript_palette_still_flush_below_input_no_scroll(self):
         from forgekit_console.tui.palette import CommandPalette

--- a/tests/forgekit/test_tui_parity_hotfix2.py
+++ b/tests/forgekit/test_tui_parity_hotfix2.py
@@ -27,9 +27,9 @@ def _ctx():
     return ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
 
 
-def _app(submit_service=None):
+def _app(submit_service=None, config=None):
     from forgekit_console.tui.app import ForgekitConsoleApp
-    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=_ctx(), submit_service=submit_service)
+    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=_ctx(), submit_service=submit_service, config=config)
 
 
 # --------------------------------------------------------------------------- #
@@ -73,29 +73,24 @@ class TranscriptStoreTests(unittest.TestCase):
 # --------------------------------------------------------------------------- #
 @unittest.skipUnless(_TEXTUAL, "textual 필요")
 class DockedLayoutTests(unittest.IsolatedAsyncioTestCase):
-    async def test_input_docked_and_palette_pushes_flow_up(self) -> None:
+    async def test_input_inline_and_palette_directly_below(self) -> None:
         from forgekit_console.tui.composer import Composer
-        from forgekit_console.tui.session_flow import SessionFlow
         from forgekit_console.tui.palette import CommandPalette
 
-        app = _app()
+        app = _app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 28)) as pilot:
             await pilot.pause()
             H = app.size.height
             comp = app.query_one(Composer)
             bar = app.query_one("#composer-input-shell")
-            flow = app.query_one(SessionFlow)
-            self.assertGreaterEqual(comp.region.bottom, H - 1)          # docked at bottom
-            flow_h_before = flow.region.height
-            # open palette → composer grows, flow region shrinks; palette is DIRECTLY
-            # BELOW the input bar (Claude), inside the bottom-docked composer zone.
+            # INLINE: empty session → composer near the top, NOT docked at the bottom
+            self.assertLess(comp.region.bottom, H - 2)
+            # open palette → it opens DIRECTLY BELOW the input bar (flush, gap ≈ 0)
             await pilot.press("slash", "h", "e")
             await pilot.pause()
             pal = app.query_one(CommandPalette)
             self.assertGreaterEqual(pal.region.y, bar.region.bottom)        # palette BELOW input
             self.assertLessEqual(pal.region.y - bar.region.bottom, 1)       # flush (gap ≈ 0)
-            self.assertGreaterEqual(comp.region.bottom, H - 1)          # composer still docked
-            self.assertLess(flow.region.height, flow_h_before)         # transcript zone shrank
 
     async def test_session_flow_is_sole_owner_no_gutter(self) -> None:
         from forgekit_console.tui.session_flow import SessionFlow
@@ -161,7 +156,7 @@ class CopyVariantsTests(unittest.IsolatedAsyncioTestCase):
         orig = clipboard.copy_text
         clipboard.copy_text = lambda t: (captured.__setitem__("t", t) or (True, "stub"))
         try:
-            app = _app(self._svc(["답변A", "답변B"]))
+            app = _app(self._svc(["답변A", "답변B"]), config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
             async with app.run_test(size=(100, 28)) as pilot:
                 await pilot.pause()
                 await self._two_turns(app, pilot)
@@ -197,7 +192,7 @@ class CopyVariantsTests(unittest.IsolatedAsyncioTestCase):
     async def test_copy_real_pbpaste_readback(self) -> None:
         from forgekit_console.tui import clipboard
 
-        app = _app(self._svc(["진짜 응답입니다"]))
+        app = _app(self._svc(["진짜 응답입니다"]), config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 28)) as pilot:
             await pilot.pause()
             app.query_one("#prompt").value = "질문"

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -44,12 +44,12 @@ def _fake_context():
 
 @unittest.skipUnless(_TEXTUAL, "textual not installed")
 class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
-    def _app(self, *, escalator=None, submit_service=None):
+    def _app(self, *, escalator=None, submit_service=None, config=None):
         from forgekit_console.tui.app import ForgekitConsoleApp
 
         return ForgekitConsoleApp(
             repo_root=Path("/tmp/repo"), context=_fake_context(),
-            escalator=escalator, submit_service=submit_service,
+            escalator=escalator, submit_service=submit_service, config=config,
         )
 
     def _tempdir_escalator(self, *, threshold=3):
@@ -87,41 +87,40 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             # Claude-style idle: the mode pill is hidden (no `● operator` row)
             self.assertFalse(app.query_one("#modepill", Static).display)
 
-    async def test_composer_is_docked_at_viewport_bottom(self) -> None:
-        """Composer is DOCKED at the viewport bottom (Claude): the input bar stays at
-        the bottom edge on a short session — it does NOT float mid-screen — and the
-        conversation scrolls above it. (Parity hotfix 2: was inline/floating before.)
-        """
+    async def test_composer_inline_near_top_when_idle(self) -> None:
+        """Composer is INLINE (Claude): on an EMPTY session the input sits near the TOP
+        (just under the intro/issue) with empty space below — NOT docked at the bottom,
+        NOT floating mid-screen. (Parity correction: reverted the dock.)"""
         from forgekit_console.tui.prompt_area import PromptArea
         from forgekit_console.tui.composer import Composer
 
-        app = self._app()
+        app = self._app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             composer = app.query_one("#composer", Composer)
             self.assertTrue(composer.display)
             self.assertTrue(app.query_one("#prompt", PromptArea).display)
-            # short session → composer sits at the BOTTOM edge (not floating in the upper half)
-            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
-            self.assertGreater(composer.region.y, app.size.height // 2)
+            # empty session → composer near the TOP, empty space BELOW it (not docked)
+            self.assertLess(composer.region.y, app.size.height // 2)
+            self.assertLess(composer.region.bottom, app.size.height - 2)
 
-    async def test_composer_stays_docked_as_transcript_grows(self) -> None:
-        """As the transcript grows, the docked composer STAYS at the bottom (it does not
-        move) and the conversation scrolls above it."""
+    async def test_composer_follows_content_down_as_transcript_grows(self) -> None:
+        """As the transcript grows, the inline composer is pushed DOWN (tail-follow) and
+        stays visible — it does not stay pinned near the top."""
         from forgekit_console.tui.composer import Composer
 
-        app = self._app()
+        app = self._app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             composer = app.query_one("#composer", Composer)
-            short_bottom = composer.region.bottom
+            short_y = composer.region.y
             for _ in range(30):
                 app._execute("/status")
-            await pilot.pause()
-            await pilot.pause()
-            # the composer is still pinned at the bottom edge (did not drift up/down)
-            self.assertEqual(composer.region.bottom, short_bottom)
-            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
+            for _ in range(4):
+                await pilot.pause()
+            # the composer moved DOWN with the content (inline tail-follow), still visible
+            self.assertGreater(composer.region.y, short_y)
+            self.assertTrue(composer.display)
 
     async def test_help_tabs_first_with_cyan_divider_no_branding(self) -> None:
         """Help reads tabs-first (Help General …, no 'forgekit help' header) with a
@@ -299,15 +298,15 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
 
         Stands in for an SVG snapshot (the CI sweep runs unittest, not the
         textual-snapshot pytest plugin): it asserts the y-order of the regions.
-        The composer is DOCKED at the viewport bottom (Claude); the conversation
-        (intro · issue · content) sits above it.
+        The composer is INLINE in the top-aligned flow: intro · issue · content ·
+        composer · hint, near the top on an empty session (NOT docked at the bottom).
         """
         from textual.widgets import Static
         from forgekit_console.tui.composer import Composer
         from forgekit_console.tui.header import IntroHeader
         from forgekit_console.tui.main_panel import MainPanel
 
-        app = self._app()
+        app = self._app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             intro = app.query_one("#intro", IntroHeader).region
@@ -315,15 +314,15 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             log = app.query_one("#main", MainPanel).region
             composer = app.query_one("#composer", Composer).region
             hint = app.query_one("#hint", Static).region
-            # top → down: intro · issue · content · (docked) composer-bar
+            # top → down: intro · issue · content · (inline) composer-bar
             self.assertLessEqual(intro.y, issue.y)
             self.assertLessEqual(issue.y, log.y)
             self.assertLessEqual(log.bottom, composer.y)
             # the hint is the FOOT of the composer bar (inside it), not a stray line
             self.assertGreaterEqual(hint.y, composer.y)
             self.assertLessEqual(hint.bottom, composer.bottom)
-            # composer bar IS pinned to the viewport bottom (docked)
-            self.assertGreaterEqual(composer.bottom, app.size.height - 1)
+            # composer is INLINE near the top (empty session) — NOT pinned to the bottom
+            self.assertLess(composer.bottom, app.size.height - 2)
 
     async def test_intro_avatar_renderer_selected(self) -> None:
         from forgekit_console.tui.header import IntroHeader

--- a/tests/forgekit/test_tui_ux_redesign.py
+++ b/tests/forgekit/test_tui_ux_redesign.py
@@ -28,11 +28,11 @@ def _fake_context():
     return ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
 
 
-def _app(submit_service=None):
+def _app(submit_service=None, config=None):
     from forgekit_console.tui.app import ForgekitConsoleApp
 
     return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=_fake_context(),
-                              submit_service=submit_service)
+                              submit_service=submit_service, config=config)
 
 
 def _visible(flow, w) -> bool:
@@ -216,7 +216,8 @@ class ProgressiveRenderTests(unittest.IsolatedAsyncioTestCase):
 @unittest.skipUnless(_TEXTUAL, "textual 필요")
 class TurnCadenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_begin_turn_inserts_blank_between_turns(self) -> None:
-        app = _app()
+        # configured provider → no setup-required explanation block → empty transcript start
+        app = _app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test() as pilot:
             await pilot.pause()
             tr = app._transcript


### PR DESCRIPTION
## 목적
Claude Code parity 정정 4개 실패 + provider setup persistence 버그 수정. closes #293.

## 범위
- `policy/setup_state.py` — canonical `primary_provider` read, `STATE_NO_LIVE`, `live_capable`.
- `tui/render.py` — `setup_explanation_lines`(copyable), `no_live_banner`, banner 문구.
- `tui/app.py` — inline 레이아웃 환원, `_write_system`(copyable setup), palette auto-reveal, "primary provider" 문구.
- tests 5개 + `examples/tui-parity-correction/results.txt`.

## 리스크
- 레이아웃을 docked→inline 으로 되돌림 → 빈-transcript 가정 테스트 재작성으로 흡수.
- setup gate semantics 변경(claude-only 가 더 이상 blocked 아님) → 회귀로 고정.
- 순수 모듈 변경, 외부 부작용 없음.

## 테스트
- `.venv-ci`(=CI, textual 미설치): `Ran 763 OK (skipped=110)`.
- `.venv-console`(textual): `OK (skipped=1)`.
- 실측: idle input y=11/H=30(상단), long+tail bottom=29(하단 visible), palette gap=0, `/copy all`→pbpaste 에 setup-required 안내 포함, `/provider set claude`→재실행 `configured-no-live`(not setup-required), link ollama→ready.

## 이슈 linkage
closes #293

---
### Audit
- base: main @ 487eb81 (#292 머지 후 최신)
- commits: 3 (🐛 setup gate / 💄 inline+copyable+palette / ✅ tests+evidence)
- self-merge: parity/persistence 버그 수정, CI+회귀 green 조건 충족 시