### PR TITLE
ForgeKit 경계 WT2(1/n): forgekit-config 추출 (runtime_paths → package) (closes #297)

### DIFF
--- a/apps/forgekit-console/src/forgekit_console/runtime_paths.py
+++ b/apps/forgekit-console/src/forgekit_console/runtime_paths.py
@@ -1,0 +1,32 @@
+"""Forward-compat shim — runtime paths now live in ``packages/forgekit-config``.
+
+The canonical module moved to :mod:`forgekit_config.paths` (ForgeKit core, WT2).
+This shim re-exports every public name and aliases itself to the real module via
+``sys.modules`` so existing importers keep working with object identity preserved:
+
+    from .. import runtime_paths            # module ref → forgekit_config.paths
+    from ..runtime_paths import config_path # name import → same function object
+
+New code should import :mod:`forgekit_config.paths` directly. Owner matrix:
+``docs/forgekit-architecture-ownership.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from forgekit_config import paths as _paths
+from forgekit_config.paths import (  # noqa: F401
+    ENV_HOME,
+    brain_root,
+    config_path,
+    escalation_ledger_path,
+    forgekit_home,
+    operator_inbox_path,
+    personal_brain_dir,
+    starter_pack_dir,
+    state_dir,
+)
+
+# Identity alias: ``forgekit_console.runtime_paths is forgekit_config.paths``.
+sys.modules[__name__] = _paths

--- a/docs/forgekit-architecture-ownership.md
+++ b/docs/forgekit-architecture-ownership.md
@@ -143,7 +143,7 @@ ForgeKit contracts/core 를 **공유**하는 실행 유닛이다.
 | `selfimprove/` | 190 | self-improvement loop | `packages/forgekit-runtime` | planned |
 | `notify/` | 336 | approval/alert inbox (operator action) | `packages/forgekit-runtime` | planned |
 | `security/` | 239 | red/blue 계획(plan-only) | `packages/forgekit-runtime` | planned |
-| `runtime_paths.py` | 78 | `~/.forgekit` 경로 해석 | `packages/forgekit-config` | planned |
+| `runtime_paths.py` | 78 | `~/.forgekit` 경로 해석 | `packages/forgekit-config` (`forgekit_config.paths`) | **done** (옛 경로 compat shim) |
 | `identity/` | 409 | agent identity(git author/app) | `packages/forgekit-config` | planned |
 | `data/status_loader.py` | 211 | 대시보드 데이터 bridge(→yule_engineering) | `packages/forgekit-config` adapter + console (bridge 잔존 debt) | planned |
 | `models.py` | 137 | work packet/command/event 모델 | `packages/forgekit-contracts` | planned |
@@ -194,6 +194,12 @@ packages/* ──X──▶ apps/*   (역방향 금지, 기존 hard rail 유지)
 | WT | 범위 | 산출물 | 검증 |
 | --- | --- | --- | --- |
 | **WT2** | `forgekit-provider`(provider/policy/usage/chat/brain) · `forgekit-runtime`(runtime/autopilot/lifecycle/notify/runtime_mode) · `forgekit-config`(paths/identity) · `forgekit-contracts`(models/handoff) 추출 | 4 package + console 옛 경로 compat shim | import smoke + 기존 테스트 green |
+
+> **WT2 진행:** `forgekit-config` 의 첫 추출 완료 — `runtime_paths.py` → `forgekit_config.paths`
+> (옛 경로 `forgekit_console.runtime_paths` 는 `sys.modules` alias compat shim, 객체 동일성
+> 보존). 10개 console importer 무수정 동작, root CI 6571 OK + package smoke 4 OK 검증. 이 패턴
+> (package 생성 → git mv → 옛 경로 shim → root `pyproject` where 등록 → editable 재설치 →
+> root `tests/` 회귀)이 나머지 provider/runtime/contracts 추출의 템플릿이다.
 | **WT3** | `hephaistos`(forge core) · `nexus`(sources/vault/discovery/design/nexus_read) · `armory`(catalog) 승격 | 3 package + console 은 projection 만 | resolve/nexus/armory 테스트 green |
 | **WT4** | console 을 surface/TUI/CLI/render 로 축소 · app dependency 방향 최종 점검 · examples/docs/QA | import 방향 검증 스크립트 + evidence | 전체 suite green |
 

--- a/packages/forgekit-config/README.md
+++ b/packages/forgekit-config/README.md
@@ -1,0 +1,28 @@
+# forgekit-config
+
+> ForgeKit **config core** — the owner of ForgeKit's on-disk shape. Pure, stdlib-first,
+> so every app (`forgekit-console` + the sibling execution apps) shares one config
+> contract instead of reaching into the console.
+
+This package is part of the **WT2** extraction that moves ForgeKit core out of
+`apps/forgekit-console` and into `packages/*`. Owner matrix + roadmap:
+[`docs/forgekit-architecture-ownership.md`](../../docs/forgekit-architecture-ownership.md).
+
+## 현재 보유
+
+- `forgekit_config.paths` — runtime 데이터 home(`~/.forgekit`, `FORGEKIT_HOME` override)
+  과 그 하위 경로(personal brain / starter pack / config / state / escalation ledger /
+  operator inbox). 순수·무부작용(경로 계산만, 디렉터리 생성은 호출부 책임).
+  - 구 경로 `forgekit_console.runtime_paths` 는 본 모듈을 가리키는 **forward-compat
+    shim**(`sys.modules` alias, 객체 동일성 보존). 신규 코드는 `forgekit_config.paths`
+    직접 import.
+
+## 로드맵 (WT2 후속)
+
+- agent identity(`forgekit_console.identity`) → `forgekit_config.identity`.
+- config schema / persistence(`provider_config` 등 저장 로직의 공통 기반) 정리.
+
+## 의존 규칙
+
+- stdlib only. `apps/*` 를 import 하지 않는다(역방향 금지 hard rail).
+- `forgekit-provider` / `forgekit-runtime` 가 본 package 를 의존한다(역은 금지).

--- a/packages/forgekit-config/pyproject.toml
+++ b/packages/forgekit-config/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "forgekit-config"
+version = "0.1.0"
+description = "ForgeKit config core — runtime data-home paths (and, as WT2 lands, config schema/persistence + agent identity). Pure, stdlib-first, shared by every ForgeKit app."
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/forgekit-config/src/forgekit_config/__init__.py
+++ b/packages/forgekit-config/src/forgekit_config/__init__.py
@@ -1,0 +1,16 @@
+"""forgekit-config — ForgeKit config/paths/identity core (WT2).
+
+The owner of ForgeKit's on-disk shape: runtime data home (`paths`), and — as WT2
+progresses — config schema/persistence and agent identity. Pure, stdlib-first, so
+every app (`forgekit-console` and the sibling execution apps) shares one config
+contract instead of each reaching into the console.
+
+Currently extracted: `paths` (was `forgekit_console.runtime_paths`). Roadmap and
+owner matrix: `docs/forgekit-architecture-ownership.md`.
+"""
+
+from __future__ import annotations
+
+from . import paths
+
+__all__ = ("paths",)

--- a/packages/forgekit-config/src/forgekit_config/paths.py
+++ b/packages/forgekit-config/src/forgekit_config/paths.py
@@ -5,6 +5,10 @@ under a single home dir so an install is self-contained and removable. Default i
 ``~/.forgekit``; ``FORGEKIT_HOME`` overrides it. Every helper takes an optional
 ``env`` mapping so tests point the whole tree at a tempdir — nothing here ever
 writes; callers create dirs explicitly.
+
+Owner: ``packages/forgekit-config`` (ForgeKit core, WT2). Moved out of
+``forgekit_console.runtime_paths`` — that old path is now a forward-compat shim
+re-exporting this module. See ``docs/forgekit-architecture-ownership.md``.
 """
 
 from __future__ import annotations

--- a/packages/forgekit-config/tests/test_paths_smoke.py
+++ b/packages/forgekit-config/tests/test_paths_smoke.py
@@ -1,0 +1,54 @@
+"""forgekit-config paths smoke — public surface + env override + compat-shim identity.
+
+Pure/CI-safe (no textual, no IO writes). Proves the WT2 extraction: the canonical
+module is ``forgekit_config.paths`` and the old ``forgekit_console.runtime_paths``
+path still resolves to the SAME module object (object identity preserved).
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from forgekit_config import paths as P
+
+
+class PathsSurfaceTests(unittest.TestCase):
+    def test_default_home_and_env_override(self) -> None:
+        # forgekit_home() resolves symlinks (.resolve()), so compare against the same
+        # resolution — portable across macOS (/tmp→/private/tmp) and Linux CI (/tmp).
+        self.assertEqual(P.forgekit_home({}), Path("~/.forgekit").expanduser().resolve())
+        # FORGEKIT_HOME override points the whole tree at a tempdir-like root
+        env = {P.ENV_HOME: "/tmp/fk-test-home"}
+        self.assertEqual(P.forgekit_home(env), Path("/tmp/fk-test-home").resolve())
+        self.assertEqual(P.forgekit_home(env).name, "fk-test-home")
+
+    def test_subpaths_are_under_home(self) -> None:
+        env = {P.ENV_HOME: "/tmp/fk-test-home"}
+        home = P.forgekit_home(env)
+        for fn in (
+            P.brain_root, P.personal_brain_dir, P.starter_pack_dir,
+            P.config_path, P.state_dir, P.escalation_ledger_path, P.operator_inbox_path,
+        ):
+            self.assertTrue(str(fn(env)).startswith(str(home)), fn.__name__)
+
+    def test_pure_no_side_effects(self) -> None:
+        # calling a path helper never creates anything on disk
+        env = {P.ENV_HOME: "/tmp/fk-nonexistent-xyz"}
+        _ = P.config_path(env)
+        self.assertFalse(Path("/tmp/fk-nonexistent-xyz").exists())
+
+
+class CompatShimTests(unittest.TestCase):
+    def test_old_console_path_aliases_same_module(self) -> None:
+        try:
+            from forgekit_console import runtime_paths as old
+        except ImportError:
+            self.skipTest("forgekit_console not on path")
+        # the shim aliases itself to the canonical module → identity preserved
+        self.assertIs(old, P)
+        self.assertIs(old.config_path, P.config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,6 @@ where = [
     "packages/learning/src",
     "packages/agent-memory/src",
     "packages/agent-runtime/src",
+    "packages/forgekit-config/src",
     "apps/forgekit-console/src",
 ]

--- a/tests/forgekit/test_forgekit_config_extraction.py
+++ b/tests/forgekit/test_forgekit_config_extraction.py
@@ -1,0 +1,52 @@
+"""WT2 extraction guard — forgekit-config owns runtime paths; console keeps a shim.
+
+CI-run (root ``tests/`` tree). Proves the ForgeKit-core extraction held:
+- the canonical module is ``forgekit_config.paths`` (a real package, not console);
+- the old ``forgekit_console.runtime_paths`` path still resolves to the SAME module
+  object (compat shim, object identity preserved) so the 10 console importers work;
+- a representative console module that pulls in runtime_paths still imports cleanly.
+
+This is the seam check for ``docs/forgekit-architecture-ownership.md`` WT2.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+
+class ForgekitConfigExtractionTests(unittest.TestCase):
+    def test_canonical_module_is_the_package(self) -> None:
+        from forgekit_config import paths as P
+
+        # owner is the package, not the console app
+        self.assertIn("forgekit_config", P.__name__)
+        self.assertEqual(P.forgekit_home({}), Path("~/.forgekit").expanduser())
+
+    def test_old_console_path_is_a_compat_alias(self) -> None:
+        from forgekit_config import paths as P
+        from forgekit_console import runtime_paths as old
+
+        # sys.modules alias → identical module + identical function objects
+        self.assertIs(old, P)
+        self.assertIs(old.config_path, P.config_path)
+        self.assertIs(old.state_dir, P.state_dir)
+
+    def test_console_importers_still_resolve(self) -> None:
+        # provider_ops/setup_state import runtime_paths; if the shim broke, this raises
+        from forgekit_console.policy import provider_ops, setup_state  # noqa: F401
+
+        env = {"FORGEKIT_HOME": "/tmp/fk-extraction-test"}
+        from forgekit_config import paths as P
+
+        # compare against the resolved home (forgekit_home() calls .resolve(), which
+        # on macOS maps /tmp → /private/tmp; on Linux CI it stays /tmp — portable).
+        home = str(P.forgekit_home(env))
+        self.assertTrue(str(P.config_path(env)).startswith(home))
+        self.assertEqual(P.config_path(env).name, "config.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
WT2 의 첫 코어 추출. `runtime_paths`(stdlib leaf, 10 importer)를 `apps/forgekit-console` 밖 `packages/forgekit-config`(`forgekit_config.paths`)로 옮겨 ForgeKit 코어 분리 패턴을 확립한다. closes #297.

## 범위
- `packages/forgekit-config/` 신설 (pyproject/README/`__init__`/paths/tests).
- `git mv runtime_paths.py → forgekit_config/paths.py` (이력 보존).
- `forgekit_console/runtime_paths.py` → forward-compat shim (`sys.modules` alias, 객체 동일성).
- root `pyproject.toml` where= 에 `packages/forgekit-config/src` 등록.
- 회귀: `tests/forgekit/test_forgekit_config_extraction.py`(CI-run) + package standalone smoke.

## 리스크
- 옛 경로 동일성: `forgekit_console.runtime_paths is forgekit_config.paths` → 10 importer 무수정. CI-guard 로 고정.
- editable 재설치 필요(머지 후 `pip install -e .`). where= 에 신규 src 추가됨.
- 행위 변화 없음(순수 경로 계산). 코드 수정 0줄(이동 + shim만).

## 테스트
- root CI(`.venv-ci`, = CI): `Ran 6571 OK (skipped=110)`.
- package standalone(`forgekit-config/tests`): 4 OK (surface/env override/무부작용/shim identity).
- console 서브셋(`.venv-console`): `766 OK (skipped=1)`.
- 포터블: `forgekit_home().resolve()` 의 macOS `/tmp→/private/tmp` vs Linux `/tmp` 차이를 resolve-consistent 비교로 처리.

## 이슈 linkage
closes #297. WT1: #296. 후속: identity + provider/runtime/contracts 추출.

---
### Audit
- base: main @ deb8251 (#296 머지 후)
- commits: 3 (package+이동 / shim / 회귀+doc)
- self-merge: 분리 리팩터, 행위 변화 0, CI green 시