### PR TITLE
Package topology cleanup TWT2: vcs pyproject 추가 + 네이밍 충돌 description 명확화

### DIFF
--- a/packages/agent-contracts/pyproject.toml
+++ b/packages/agent-contracts/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "yule-agent-contracts"
 version = "0.1.0"
-description = "Shared agent contracts (commands, events, status, messages) for the Yule Studio agent platform."
+description = "Transitional (engineering-agent) — AGENT-to-AGENT contracts (commands/events/status/messages). NOT forgekit-contracts (operator command-result/work-packet). See docs/package-topology.md."
 requires-python = ">=3.9"
 # Standard-library only by design — contracts must not pull in app deps.
 dependencies = []

--- a/packages/agent-memory/pyproject.toml
+++ b/packages/agent-memory/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "yule-agent-memory"
 version = "0.1.0"
-description = "에이전트 long-term memory (relevance/topic-index)."
+description = "Transitional (engineering-agent) — agent long-term memory (relevance/topic-index). NOT the yule_memory SQLite/FTS5 search index. See docs/package-topology.md."
 requires-python = ">=3.9"
 dependencies = []
 

--- a/packages/agent-runtime/pyproject.toml
+++ b/packages/agent-runtime/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "yule-agent-runtime"
 version = "0.1.0"
-description = "에이전트 runtime 루프 (decide/recall/understand)."
+description = "Transitional (engineering-agent) — agent runtime loop: decide/recall/understand. NOT forgekit-runtime nor the yule_runtime primitives. See docs/package-topology.md."
 requires-python = ">=3.9"
 dependencies = []
 

--- a/packages/memory/pyproject.toml
+++ b/packages/memory/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "yule-memory"
 version = "0.1.0"
-description = "Local-first SQLite/FTS5 memory index for Yule Studio agents (stdlib + sqlite only)."
+description = "Shared infra — local-first SQLite/FTS5 memory SEARCH INDEX. NOT the agent-memory long-term store (2x memory naming). See docs/package-topology.md."
 requires-python = ">=3.9"
 dependencies = []
 

--- a/packages/runtime/pyproject.toml
+++ b/packages/runtime/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "yule-runtime"
 version = "0.1.0"
-description = "Cleanly-movable runtime primitives (circuit breaker, service manifest, subprocess supervisor) for the Yule Studio agent platform."
+description = "Shared infra — runtime PRIMITIVES (circuit breaker, service manifest, subprocess supervisor). NOT the forgekit-runtime exec loop nor the agent-runtime decide/recall loop (3x runtime naming) — rename candidate. See docs/package-topology.md."
 requires-python = ">=3.9"
 dependencies = []
 

--- a/packages/vcs/pyproject.toml
+++ b/packages/vcs/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yule-vcs"
+version = "0.1.0"
+description = "Shared infra — version-control utilities (GitHub URL parsing, repo write/tag policy contract). Pure stdlib leaf extracted from the engineering-agent core. See docs/package-topology.md."
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## 목적
TWT1 audit 의 low-risk 정리 1차. **metadata 전용, import/런타임 영향 0.**

## 범위
- `packages/vcs/pyproject.toml` 신규 — 18 package 중 유일하게 없던 것(standalone 빌드 불가 해소).
- 네이밍 충돌 5개 description 명확화 (3×runtime / 2×contracts / 2×memory):
  - `runtime`(yule_runtime) → "runtime PRIMITIVES … NOT forgekit-runtime/agent-runtime, rename candidate"
  - `agent-runtime` / `agent-contracts` / `agent-memory` → "Transitional(engineering-agent) …"
  - `memory` → "SQLite/FTS5 search INDEX … NOT agent-memory store"
  - 각 description 에 `docs/package-topology.md` cross-link.

## 리스크
- pyproject metadata만 변경. 코드/import 0. broad rename 없음(전부 keep — description만).

## 검증
- TOML parse OK(6개), 터치한 package import OK, 전체 CI suite OK(skipped=110).

## 후속
TWT3(README/vision/monorepo-structure 동기화) · TWT4(QA + packages→apps import guard). rename(yule_runtime)은 별도 후속.

---
### Audit
- base: main @ ee27231
- commits: 2 (vcs pyproject / description 명확화)
- self-merge: metadata-only, CI green 시