### PR TITLE
Package topology cleanup TWT4: packages→apps import guard + merge-prep QA

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -14,7 +14,7 @@
 
 | 앱 | 책임 한 줄 | 현재 코드 위치 |
 | --- | --- | --- |
-| [`forgekit-console`](forgekit-console/README.md) | ForgeKit operator app — TUI/CLI/operator surface (보여주고 조작) | `apps/forgekit-console/src/forgekit_console/**` (현재 코어 혼재, packages 분리 진행 중) |
+| [`forgekit-console`](forgekit-console/README.md) | ForgeKit operator app — TUI/CLI/operator surface (보여주고 조작) | `apps/forgekit-console/src/forgekit_console/**` (코어는 packages/forgekit-*·hephaistos·nexus 로 분리됨; console 은 surface + 옛 경로 compat shim) |
 | [`engineering-agent`](engineering-agent/README.md) | 개발 작업 intake / 코드 작업 계획 / role deliberation / GitHub 연동 | `apps/engineering-agent/src/yule_engineering/agents/**`, `discord/engineering_channel_router/**` |
 | [`planning-agent`](planning-agent/README.md) | 일정·계획·브리핑, calendar 기반 작업 정리 | `apps/engineering-agent/src/yule_engineering/planning/**` |
 | [`discord-gateway`](discord-gateway/README.md) | Discord 메시지 수신/전송, agent runtime I/O 채널 연결 | `apps/engineering-agent/src/yule_engineering/discord/**` |

--- a/docs/evidence/package-topology-twt4-qa.txt
+++ b/docs/evidence/package-topology-twt4-qa.txt
@@ -1,0 +1,39 @@
+ForgeKit package topology — TWT4 merge-prep QA evidence
+=======================================================
+
+[1] packages → apps hard rail (production src only)
+    package→app import edges in src/: 2 (sanctioned: 1 = forgekit-runtime lifecycle lazy bridge)
+      forgekit-runtime/src/forgekit_runtime/lifecycle/failure_escalation.py:458:        from yule_engineering.agents.lifecycle.troubleshooting_ledger import (  # noqa: WPS433
+      forgekit-runtime/src/forgekit_runtime/lifecycle/failure_escalation.py:462:        from yule_engineering.agents.lifecycle.troubleshooting_record import CaptureReason
+
+[2] every package classified in docs/package-topology.md + has pyproject.toml
+      agent-contracts    doc:Y pyproject:Y
+      agent-memory       doc:Y pyproject:Y
+      agent-runtime      doc:Y pyproject:Y
+      core               doc:Y pyproject:Y
+      forgekit-config    doc:Y pyproject:Y
+      forgekit-contracts doc:Y pyproject:Y
+      forgekit-provider  doc:Y pyproject:Y
+      forgekit-runtime   doc:Y pyproject:Y
+      hephaistos         doc:Y pyproject:Y
+      integrations       doc:Y pyproject:Y
+      learning           doc:Y pyproject:Y
+      llm-gateway        doc:Y pyproject:Y
+      memory             doc:Y pyproject:Y
+      nexus              doc:Y pyproject:Y
+      runtime            doc:Y pyproject:Y
+      security           doc:Y pyproject:Y
+      storage            doc:Y pyproject:Y
+      vcs                doc:Y pyproject:Y
+
+[3] ForgeKit core import smoke (standalone)
+      OK forgekit_config
+      OK forgekit_contracts
+      OK forgekit_provider
+      OK forgekit_runtime
+      OK hephaistos
+      OK nexus
+
+[4] topology guard test
+      Ran 5 tests in 0.020s
+      OK

--- a/tests/forgekit/test_package_topology_guard.py
+++ b/tests/forgekit/test_package_topology_guard.py
@@ -1,0 +1,94 @@
+"""TWT4 merge-prep guard — locks the packages/* topology into CI.
+
+Pure / CI-safe (no textual). Enforces the structural invariants established by the
+ForgeKit package-topology cleanup so they cannot silently regress:
+
+1. **packages → apps hard rail**: no module under ``packages/*/src`` may import an app
+   (``yule_engineering`` / ``forgekit_console`` / ``apps.*``) — with ONE allow-listed,
+   documented best-effort lazy bridge (forgekit-runtime lifecycle → yule_engineering
+   troubleshooting ledger). Any NEW package→app edge fails here.
+2. **topology doc ↔ tree**: every real ``packages/<name>`` appears in
+   ``docs/package-topology.md`` (no stale / missing classification).
+3. **every package builds standalone**: each has its own ``pyproject.toml``.
+
+This is the keystone that protects the WT/TWT extraction work from drift.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+PKGS = REPO / "packages"
+
+# The only sanctioned packages→apps edge: forgekit-runtime mirrors failures into the
+# heavy engineering-agent troubleshooting ledger as a best-effort, lazy, try/excepted
+# call that degrades to a no-op when the app is absent. Documented in
+# docs/package-topology.md §7 and docs/forgekit-architecture-ownership.md. To be
+# replaced by an agent-contracts event (WT4 of the ownership doc).
+_ALLOWED_APP_EDGE = "forgekit-runtime/src/forgekit_runtime/lifecycle/failure_escalation.py"
+
+_APP_IMPORT = re.compile(r"^\s*(?:from|import)\s+(yule_engineering|forgekit_console|apps\.)")
+
+
+class PackagesToAppsRailTests(unittest.TestCase):
+    def test_no_unsanctioned_package_imports_an_app(self) -> None:
+        # Production code only — a package's own tests/ legitimately import old
+        # ``yule_engineering.X`` paths to verify the back-compat shims (object identity)
+        # from the engineering-agent monolith extraction; that is not a runtime edge.
+        offenders = []
+        for py in PKGS.glob("*/src/**/*.py"):
+            if "__pycache__" in str(py):
+                continue
+            rel = py.relative_to(REPO).as_posix().replace("packages/", "", 1)
+            text = py.read_text(encoding="utf-8", errors="ignore")
+            if any(_APP_IMPORT.match(line) for line in text.splitlines()):
+                if rel != _ALLOWED_APP_EDGE:
+                    offenders.append(rel)
+        self.assertEqual(
+            offenders, [],
+            f"packages/* must not import apps/* (hard rail). New offenders: {offenders}. "
+            f"Use a seam/injection or agent-contracts event instead.",
+        )
+
+    def test_the_one_allowed_edge_still_exists_and_is_lazy(self) -> None:
+        # guard the allow-list itself: if the bridge is removed/cleaned, tighten this test.
+        f = PKGS / _ALLOWED_APP_EDGE
+        self.assertTrue(f.exists(), "allow-listed bridge file moved — update the guard")
+        text = f.read_text(encoding="utf-8")
+        # the app import must be inside a function (indented), not module top-level
+        top_level = [l for l in text.splitlines()
+                     if l.startswith("from yule_engineering") or l.startswith("import yule_engineering")]
+        self.assertEqual(top_level, [], "the bridge must stay lazy (in-function), never top-level")
+
+
+class TopologyDocConsistencyTests(unittest.TestCase):
+    def test_every_package_is_classified_in_the_topology_doc(self) -> None:
+        doc = (REPO / "docs" / "package-topology.md").read_text(encoding="utf-8")
+        real = sorted(p.name for p in PKGS.iterdir()
+                      if p.is_dir() and (p / "src").exists())
+        missing = [name for name in real if f"`{name}`" not in doc]
+        self.assertEqual(
+            missing, [],
+            f"docs/package-topology.md is missing these packages: {missing}",
+        )
+
+    def test_every_package_has_its_own_pyproject(self) -> None:
+        missing = [p.name for p in PKGS.iterdir()
+                   if p.is_dir() and (p / "src").exists() and not (p / "pyproject.toml").exists()]
+        self.assertEqual(missing, [], f"packages without pyproject.toml (standalone-unbuildable): {missing}")
+
+
+class ForgekitCoreImportSmokeTests(unittest.TestCase):
+    def test_core_packages_import_standalone(self) -> None:
+        import importlib
+
+        for mod in ("forgekit_config", "forgekit_contracts", "forgekit_provider",
+                    "forgekit_runtime", "hephaistos", "nexus"):
+            self.assertTrue(importlib.import_module(mod))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
TWT1~3 으로 세운 토폴로지 불변식을 CI 로 잠근다(merge-prep QA). 직전 forgekit-console 경계 리팩터의 WT4(최종 경계 검증)도 본 가드로 함께 닫힌다.

## 범위
- `tests/forgekit/test_package_topology_guard.py` (CI-run, 5 test):
  1. packages/*/**src** 가 app 을 import 안 함 — 유일 allow-list = forgekit-runtime lifecycle lazy bridge(문서화 debt). package `tests/`(compat-shim 검증)는 제외.
  2. allow-list bridge 가 여전히 in-function lazy 인지(top-level import 금지).
  3. `docs/package-topology.md` ↔ 실제 18 package 일치.
  4. 모든 package 자체 pyproject.toml 보유.
  5. ForgeKit core 6개 standalone import smoke.
- `docs/evidence/package-topology-twt4-qa.txt`: QA 결과 evidence.
- `apps/README.md`: console "코어 혼재" stale 문구 갱신.

## 검증
- guard 5 OK, 전체 CI suite OK(skipped=110).
- package→app edge = 1 (sanctioned, lazy). doc↔tree 18/18. core import smoke 6/6.
- stale 'core in console' sweep clean.

## 마무리 (직전 WT4 흡수)
이 가드로 packages→apps hard rail 이 CI 에 고정되어, console 경계 검증(직전 WT4)이 완료된다.

## Audit
- base: main @ 16a4cf9
- commits: 1 (guard+evidence+stale-fix)
- self-merge: 테스트+문서, CI green 시