### PR TITLE
Merge-prep QA: packages cleanup verification (verdict: merge-ready)

### DIFF
--- a/docs/evidence/package-topology-mergeprep-qa.txt
+++ b/docs/evidence/package-topology-mergeprep-qa.txt
@@ -1,0 +1,22 @@
+ForgeKit packages/ cleanup — MERGE-PREP QA (fix-forward verification)
+====================================================================
+verdict: MERGE-READY (no blockers; main already consistent)
+
+[A1] pyproject metadata drift — dir == name(dash) == python-pkg(underscore)
+     18/18 aligned, no drift. console script: forgekit = forgekit_console.app.main:main (intact).
+
+[A2] app->app direct imports (pre-existing, documented transitional debt — NOT from cleanup)
+     engineering-agent -> yule_discord, yule_planning   (apps->monolith, monorepo-structure.md §2)
+     discord-gateway   -> yule_engineering, yule_planning
+     forgekit-console  -> yule_engineering               (lazy handoff/status bridge)
+     => none introduced by the topology cleanup (which was metadata/docs only).
+
+[B] compat shim old-path IS new-path (object identity) — 17/17 OK:
+     all identity-preserved: True
+
+[C] topology doc <-> tree: 18/18 classified + have pyproject; only 'armory' is doc-only (planned, by design).
+[D] docs cross-links: all .md links in 6 entry docs resolve (pure-python normpath check).
+[E] compileall ForgeKit core packages: clean. Full CI suite: OK (skipped=110).
+
+must-fix-before-merge: NONE.
+can-fix-later (debt): app->app edges + forgekit-*->yule_engineering lazy bridges (agent-contracts 역전), 3x runtime rename, armory split.


### PR DESCRIPTION
fix-forward QA — 깨진 import/stale docs/metadata drift/경계 위반/dead ref 직접 검증. 발견된 실제 문제 0(전부 clean). compat shim 17/17 객체 동일성, pyproject 18/18 무drift, doc↔tree 18/18, docs link 전부 resolve, full suite OK(skipped=110). evidence: docs/evidence/package-topology-mergeprep-qa.txt. **verdict: merge-ready.** must-fix=none, can-fix-later=app→app/lazy bridge debt·3×runtime rename·armory split.