### PR TITLE
콘솔 inline: 고정 14줄 박스 → content-driven 누적 흐름 + print-flow seam

### DIFF
--- a/apps/forgekit-console/examples/inline-accumulating-flow/render-evidence.txt
+++ b/apps/forgekit-console/examples/inline-accumulating-flow/render-evidence.txt
@@ -1,0 +1,42 @@
+ForgeKit inline accumulating-flow — REAL render evidence (Textual pilot, inline mode)
+==================================================================================
+policy: Screen.-inline #flow { height: auto; max-height: 100% }  (was: height: 14)
+        #composer docked at bottom in inline.  screen = 100x30.
+
+[/doctor (long env report)]
+  transcript lines written : 6
+  flow height  empty=2  after=10   (OLD policy would cap at 14)
+  composer     input_y=26 bottom=29 on_screen=True (pinned at bottom)
+  flow scrollable=False  scroll_y=0 max_scroll_y=0
+  → content beyond viewport is REACHABLE via the single SessionFlow scroll (not lost)
+
+[/provider (brain + declared→actual)]
+  transcript lines written : 12
+  flow height  empty=2  after=16   (OLD policy would cap at 14)
+  composer     input_y=26 bottom=29 on_screen=True (pinned at bottom)
+  flow scrollable=False  scroll_y=0 max_scroll_y=0
+  → content beyond viewport is REACHABLE via the single SessionFlow scroll (not lost)
+
+[/usage]
+  transcript lines written : 31
+  flow height  empty=2  after=25   (OLD policy would cap at 14)
+  composer     input_y=26 bottom=29 on_screen=True (pinned at bottom)
+  flow scrollable=True  scroll_y=8 max_scroll_y=8
+  → content beyond viewport is REACHABLE via the single SessionFlow scroll (not lost)
+
+[long multiline paste (35 lines)]
+  transcript lines written : 35
+  flow height  empty=2  after=25   (OLD policy would cap at 14)
+  composer     input_y=26 bottom=29 on_screen=True (pinned at bottom)
+  flow scrollable=True  scroll_y=12 max_scroll_y=12
+  → content beyond viewport is REACHABLE via the single SessionFlow scroll (not lost)
+
+[long assistant response (45 lines)]
+  transcript lines written : 45
+  flow height  empty=2  after=25   (OLD policy would cap at 14)
+  composer     input_y=26 bottom=29 on_screen=True (pinned at bottom)
+  flow scrollable=True  scroll_y=22 max_scroll_y=22
+  → content beyond viewport is REACHABLE via the single SessionFlow scroll (not lost)
+
+Honest limit: flow grows up to the viewport then scrolls (single owner) — NOT yet true
+terminal-native scrollback accumulation. Print-flow seam: tui/transcript_sink.py.

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -167,18 +167,21 @@ class ForgekitConsoleApp(App):
             profile=self.context.profile,
             id="intro",
         )
-        # THE SESSION FLOW (1fr) — the SINGLE scroll owner, TOP-ALIGNED. The whole session
-        # stacks inside it: issue line → transcript/help → process feed → INLINE composer.
-        # The composer is INLINE (not docked): on an empty session it sits near the TOP
-        # with empty space below (Claude); as the transcript grows it is pushed down and
-        # follow_tail keeps it in view — "typing at the tail of the current session".
+        # THE SESSION FLOW — the SINGLE scroll owner of the READING flow only:
+        #   issue line → transcript/help → process feed.
+        # It is CONTENT-DRIVEN in inline mode (height: auto — see styles.SCREEN_CSS): the
+        # block grows with the conversation and the terminal renders that many rows, so
+        # output ACCUMULATES downward instead of being trapped in a fixed bounded box. The
+        # composer is NOT inside it — it is DOCKED at the bottom (below), so the chat bar
+        # stays pinned while the conversation grows above it (Claude-Code cadence).
         with SessionFlow(id="flow"):
             yield Static(id="issue")               # one quiet status line at the top
             yield MainPanel(id="main")             # transcript XOR help (height: auto)
             # process event feed (route/submit/generate/…); empty → collapses to 0 rows.
             yield Static(id="livestatus")
-            # inline composer — input bar + slash palette DIRECTLY BELOW it + sub-hint row.
-            yield Composer(id="composer")
+        # the DOCKED composer (input bar + slash palette DIRECTLY BELOW it + sub-hint row).
+        # bottom-pinned; opening the palette grows it UPWARD (command area), never a pane.
+        yield Composer(id="composer")
 
     def on_mount(self) -> None:
         self.title = render.BRAND

--- a/apps/forgekit-console/src/forgekit_console/tui/styles.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/styles.py
@@ -27,11 +27,28 @@ Screen { layout: vertical; background: transparent; }
 /* transient stage marker (thinking → generating); collapses to 0 rows when empty. */
 #livestatus { height: auto; padding: 0 1; color: $text-muted; }
 
-/* INLINE mode (`.-inline`, set on the Screen by the app when run inline): the console
-   is a BOUNDED terminal-flow region, not a full-screen takeover. The reading flow is
-   capped so the inline block stays compact (recent conversation + docked composer);
-   the terminal keeps its native scrollback above/below the region. */
-Screen.-inline #flow { height: 14; }
+/* Full mode: the composer is the last child after the 1fr flow, so it naturally sits at
+   the bottom (the 1fr flow fills the space above it) — no dock needed, no overlap.
+   Inline mode (below): the flow is content-driven (auto), so the composer is DOCKED at the
+   bottom to stay pinned as the flow grows past the viewport. Opening the slash palette
+   grows the composer UPWARD (it is `height: auto`), so the command area never reads as a box. */
+Screen.-inline #composer { dock: bottom; }
+
+/* INLINE mode (`.-inline`, set on the Screen by the app when run inline): the reading
+   flow is CONTENT-DRIVEN (`height: auto`), NOT a fixed bounded box. So a short session
+   renders only a few rows and a long /doctor|/provider|/usage output makes the inline
+   block GROW — the terminal draws that many rows and output accumulates downward instead
+   of the old hard 14-row cap pushing earlier content out of a tiny window.
+   `max-height: 100%` keeps the flow content-driven up to the viewport, then (and only
+   then) it scrolls — so a short session is COMPACT (a few rows, no empty box) while a long
+   session fills the viewport and stays scrollable (older content is never lost, and
+   SessionFlow remains the single scroll owner).
+   Honest Textual limit: the inline region can only grow up to the terminal viewport; once
+   the conversation exceeds the viewport the flow still scrolls internally (it is not yet
+   true native-scrollback accumulation — that is the print-flow seam, see
+   tui/transcript_sink.py and docs/forgekit-console-ui.md). In `--full` the flow stays
+   `1fr` (fills the alt-screen) with the composer as its last (bottom) child. */
+Screen.-inline #flow { height: auto; max-height: 100%; }
 """
 
 __all__ = ("SCREEN_CSS",)

--- a/apps/forgekit-console/src/forgekit_console/tui/transcript_sink.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/transcript_sink.py
@@ -1,0 +1,119 @@
+"""Transcript sink — the seam between in-widget rendering and print-flow scrollback.
+
+WHY THIS EXISTS (honest current limitation)
+-------------------------------------------
+The reading flow is rendered by a Textual ``RichLog`` (:class:`tui.transcript.Transcript`)
+inside the ``SessionFlow`` scroll region. In inline mode the flow is now content-driven
+(``height: auto; max-height: 100%`` — see ``tui.styles``), so a short session is compact
+and a long one fills the viewport and stays scrollable. That removes the old fixed 14-row
+box that pushed earlier output out of a tiny window.
+
+But it is **not yet true terminal-native scrollback accumulation**: Textual inline mode
+re-renders its region every frame, so content that scrolls above the region is owned by
+the app (scrollable within ``SessionFlow``), NOT written into the terminal's own
+scrollback the way a print-based CLI (Claude Code) does. Once a conversation exceeds the
+viewport, older turns live in the app's scroll buffer, not in the terminal history.
+
+THE SEAM
+--------
+``TranscriptSink`` is the single write surface for the reading flow. Today the only
+implementation is :class:`WidgetSink` (writes to the RichLog — the current behaviour).
+The NEXT step toward Claude-Code-style accumulation is :class:`PrintFlowSink`: when a turn
+is *finalized* it would be printed to stdout ABOVE the inline region, handing that turn to
+the terminal's native scrollback, while the live region keeps only the in-progress turn +
+composer. That migration is intentionally NOT wired yet (it needs an inline driver that
+can emit above-region lines without the next frame overwriting them); ``PrintFlowSink``
+documents the contract and fails honestly rather than pretending.
+
+Migration path (what still has to change to go print-flow):
+  1. route all reading-flow writes in ``tui.app`` through a ``TranscriptSink`` (today they
+     call ``Transcript.write`` directly);
+  2. mark turn boundaries (``begin_turn`` / ``finalize_turn``) so a finalized turn is a unit
+     that can be emitted to scrollback;
+  3. implement ``PrintFlowSink.finalize_turn`` against the inline driver's above-region
+     write primitive (Textual does not expose this yet — the real blocker);
+  4. keep ``WidgetSink`` as the ``--full`` (alt-screen) implementation, where scrollback
+     emission does not apply.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class TranscriptSink(Protocol):
+    """Where finalized reading-flow lines go. One write surface; many backends."""
+
+    def begin_turn(self) -> None:
+        """Mark the start of a new user→response turn (vertical breathing room)."""
+
+    def write(self, line: str) -> None:
+        """Append one rendered line to the current turn."""
+
+    def write_lines(self, lines: Sequence[str]) -> None:
+        """Append several lines (convenience)."""
+
+    def finalize_turn(self) -> None:
+        """Mark the current turn complete. A scrollback sink would emit it to the
+        terminal's native history here; the widget sink is a no-op (the RichLog already
+        holds it)."""
+
+
+class WidgetSink:
+    """Current implementation — writes to the in-app ``Transcript`` RichLog.
+
+    This is the behaviour today: the reading flow is owned by the app's scroll region.
+    ``finalize_turn`` is a no-op because the RichLog already retains every line.
+    """
+
+    def __init__(self, transcript) -> None:
+        self._t = transcript
+
+    def begin_turn(self) -> None:
+        self._t.begin_turn()
+
+    def write(self, line: str) -> None:
+        self._t.write(line)
+
+    def write_lines(self, lines: Sequence[str]) -> None:
+        for line in lines:
+            self._t.write(line)
+
+    def finalize_turn(self) -> None:  # noqa: D401 - intentional no-op (RichLog retains lines)
+        return None
+
+
+class PrintFlowSink:
+    """SEAM (not wired): emit finalized turns to the terminal's native scrollback.
+
+    This is the next step toward true Claude-Code accumulation. It is deliberately not
+    implemented against a real inline driver yet — Textual's inline mode does not expose a
+    supported "write above the region" primitive, so wiring it now would be faking it. The
+    contract is captured so the migration is a known, named piece of work, not a vague
+    aspiration. See the module docstring's migration path.
+    """
+
+    def __init__(self, *, emit_line=None) -> None:
+        # emit_line: callable that writes one line into terminal scrollback above the
+        # inline region. None until a supported primitive exists.
+        self._emit_line = emit_line
+
+    def begin_turn(self) -> None:
+        return None
+
+    def write(self, line: str) -> None:  # pragma: no cover - seam, not wired
+        raise NotImplementedError(
+            "PrintFlowSink is the print-flow seam — not wired yet (Textual inline has no "
+            "supported above-region write). Use WidgetSink today; see transcript_sink.py."
+        )
+
+    def write_lines(self, lines: Sequence[str]) -> None:  # pragma: no cover - seam
+        for line in lines:
+            self.write(line)
+
+    def finalize_turn(self) -> None:  # pragma: no cover - seam
+        raise NotImplementedError("print-flow scrollback emission is not wired yet")
+
+
+__all__ = ("TranscriptSink", "WidgetSink", "PrintFlowSink")

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -12,24 +12,39 @@
 `tui/session_flow.py` (scroll owner), `tui/composer.py`·`tui/palette.py` (docked
 composer + 입력창 바로 아래 열리는 palette), `tui/transcript_store.py` (copy 모델), `tui/clipboard.py`.
 
-## 1. Layout — docked composer (단일 세션 흐름)
+## 1. Layout — content-driven reading flow + 하단 고정 composer
 ```
-IntroHeader        (fixed top banner)
-SessionFlow (1fr)  ← 유일한 vertical scroll owner. issue + transcript/help 만.
-  #issue
-  #main (transcript XOR help, height auto)
-#livestatus        (thinking→generating 마커)
-Composer           ← 하단 DOCK. 입력 bar + palette(입력 바로 아래) + hint.
+IntroHeader              (fixed top banner)
+SessionFlow              ← 유일한 vertical scroll owner. issue + transcript/help 만 (composer 제외).
+  #issue                   inline: height auto, max-height 100% (content-driven)
+  #main (transcript XOR help, height auto)   full : height 1fr (alt-screen 채움)
+  #livestatus            (thinking→generating 마커)
+Composer                 ← inline 에서 dock:bottom. full 에서는 1fr flow 뒤 마지막 child(자연히 하단).
+                           입력 bar + palette(입력 바로 아래) + hint.
 ```
-- 입력 bar 는 **항상 viewport 하단 영역에 고정**(Claude). 짧은 세션에서 중앙에 부유하지 않는다.
-- `/` 입력 시 palette 가 **입력 bar 바로 아래**(flush, gap ≈ 0)에 열린다 — composer zone 의
-  일부이며 transcript 가 아니다. 수동 스크롤 없이 즉시 보인다. palette 가 열리면 composer 가
-  자라 SessionFlow(1fr) 가 위로 밀린다(전사 zone 만 줄어듦). 측정: `test_tui_palette_below`.
+**inline 누적 흐름(이번 라운드 핵심):** 예전엔 `Screen.-inline #flow { height: 14 }` 로 reading
+flow 를 **14줄 고정 박스**로 잘라, 출력이 길어지면 이전 내용이 그 작은 창 밖으로 밀려나 "내용이
+날아간다"는 느낌을 줬다. 이제 inline flow 는 **content-driven**(`height: auto; max-height: 100%`):
+- 짧은 세션 → flow 가 내용 높이만큼만(예: 2~10줄) — 빈 박스 없음.
+- 긴 `/doctor`·`/provider`·`/usage`·긴 paste·긴 응답 → flow 가 **viewport 까지 자라며 누적**
+  (고정 14 cap 제거). viewport 를 넘으면 그때 비로소 SessionFlow(단일 owner)가 스크롤되어 이전
+  내용이 **사라지지 않고 접근 가능**. 실측 evidence: `examples/inline-accumulating-flow/render-evidence.txt`
+  (flow 2→10→16→25, composer 하단 고정, overflow 시 scrollable·max_scroll_y>0).
+- composer 는 **항상 viewport 하단**(inline=dock, full=마지막 child). 긴 대화에도 위로 스크롤되어
+  사라지지 않는다.
+- `/` 입력 시 palette 가 **입력 bar 바로 아래**(flush, gap ≈ 0)에 열리고, composer 가 위로 자란다
+  (command area — bounded pane 아님). 측정: `test_tui_palette_below` · `test_inline_accumulating_flow`.
+
+> **정직한 한계:** 이건 "viewport 까지 누적 + 그 뒤 단일 스크롤"이지 **진짜 terminal-native
+> scrollback 누적(print-flow)은 아직 아니다.** Textual inline 은 매 프레임 region 을 다시 그려서,
+> region 위로 넘어간 내용은 앱의 scroll buffer 가 갖지(터미널 native history 가 아님). 다음 단계
+> seam 은 `tui/transcript_sink.py` (TranscriptSink/WidgetSink=현재, PrintFlowSink=미연결 seam).
 
 ## 2. Scroll model — 읽기 흐름 단일 owner + visible gutter 0
-**선택한 모델: bounded app viewport, 단일 reading-flow scroll owner, gutter 없음**
-(inline 모드는 추가로 alt-screen/mouse capture 제거 — §6). 진짜 terminal-native scrollback
-누적(print-flow)은 다음 단계 seam(§6).
+**선택한 모델: content-driven reading flow(고정 박스 아님) + 단일 reading-flow scroll owner +
+gutter 없음** (inline 모드는 추가로 alt-screen/mouse capture 제거 — §6). flow 는 viewport 까지
+자라며 누적하고 그 뒤에만 SessionFlow 가 스크롤한다(§1). 진짜 terminal-native scrollback
+누적(print-flow)은 다음 단계 seam(§6 · `tui/transcript_sink.py`).
 
 런타임 감사(실 widget property, CSS 추측 아님 — `examples/tui-scroll/audit.txt`):
 - **content scroll owner = `SessionFlow` 단 하나.** Transcript/Help/Palette/Composer 는 전부

--- a/tests/forgekit/test_inline_accumulating_flow.py
+++ b/tests/forgekit/test_inline_accumulating_flow.py
@@ -1,0 +1,94 @@
+"""Inline accumulating-flow guard — content-driven flow + docked composer + print-flow seam.
+
+Real render checks via the Textual pilot (not CSS assertions): proves the inline reading
+flow is content-driven (no fixed bounded box / 14-row cap), grows with output, keeps the
+composer pinned at the bottom, and that the print-flow seam exists and is honest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+def _inline_app():
+    from forgekit_console.commands.registry import load_agents, load_commands
+    from forgekit_console.commands.router import ConsoleContext
+    from forgekit_console.tui.app import ForgekitConsoleApp
+    ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
+    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx,
+                              config={"primary_provider": "ollama", "linked_providers": ["ollama"]},
+                              inline=True)
+
+
+# --------------------------------------------------------------------------- #
+# print-flow seam (pure — no textual needed)
+# --------------------------------------------------------------------------- #
+class TranscriptSinkSeamTests(unittest.TestCase):
+    def test_widget_sink_forwards_to_the_transcript(self) -> None:
+        from forgekit_console.tui.transcript_sink import WidgetSink, TranscriptSink
+
+        class Recorder:
+            def __init__(self):
+                self.calls = []
+            def begin_turn(self):
+                self.calls.append(("begin_turn",))
+            def write(self, line):
+                self.calls.append(("write", line))
+
+        rec = Recorder()
+        sink = WidgetSink(rec)
+        self.assertIsInstance(sink, TranscriptSink)   # satisfies the protocol
+        sink.begin_turn()
+        sink.write_lines(["a", "b"])
+        sink.finalize_turn()                          # no-op for the widget sink (no call)
+        self.assertEqual(rec.calls, [("begin_turn",), ("write", "a"), ("write", "b")])
+
+    def test_printflow_sink_is_an_honest_unwired_seam(self) -> None:
+        from forgekit_console.tui.transcript_sink import PrintFlowSink
+
+        sink = PrintFlowSink()
+        with self.assertRaises(NotImplementedError):   # not faked — fails clearly
+            sink.write("x")
+        with self.assertRaises(NotImplementedError):
+            sink.finalize_turn()
+
+
+# --------------------------------------------------------------------------- #
+# content-driven inline flow (real render)
+# --------------------------------------------------------------------------- #
+@unittest.skipUnless(_TEXTUAL, "textual 필요")
+class InlineFlowGrowthTests(unittest.IsolatedAsyncioTestCase):
+    async def test_flow_grows_with_output_and_composer_stays_pinned(self) -> None:
+        from forgekit_console.tui.session_flow import SessionFlow
+
+        app = _inline_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            flow = app.query_one(SessionFlow)
+            comp = app.query_one("#composer-input-shell")
+            empty_h = flow.region.height
+            comp_bottom = comp.region.bottom
+            self.assertLess(empty_h, 14)                       # compact when empty (no 14-box)
+            # a long /doctor-style output
+            for i in range(40):
+                app._transcript.write(f"doctor {i:02d} ......................................")
+            app._follow_tail()
+            for _ in range(4):
+                await pilot.pause()
+            grown = flow.region.height
+            self.assertGreater(grown, empty_h)                 # flow accumulated (grew)
+            self.assertGreater(grown, 14)                      # past the old hard cap
+            self.assertEqual(comp.region.bottom, comp_bottom)  # composer stayed pinned
+            self.assertLessEqual(comp.region.bottom, 30)       # ... and on-screen
+            # once it exceeds the viewport it stays scrollable (older output not lost)
+            self.assertTrue(flow.allow_vertical_scroll)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_tui_inline_mode.py
+++ b/tests/forgekit/test_tui_inline_mode.py
@@ -101,19 +101,27 @@ class InlineLayoutTests(unittest.IsolatedAsyncioTestCase):
         ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
         return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, inline=inline)
 
-    async def test_inline_bounds_flow_full_uses_1fr(self):
+    async def test_inline_flow_is_content_driven_not_a_fixed_box(self):
         from forgekit_console.tui.session_flow import SessionFlow
         from forgekit_console.tui.header import IntroHeader
         from forgekit_console.tui import intro_state
 
-        # inline → bounded flow + compact intro
+        # inline → CONTENT-DRIVEN flow (compact when empty, grows with content; no 14-cap)
         app = self._app(True)
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             self.assertTrue(app.screen.has_class("-inline"))
-            self.assertEqual(app.query_one(SessionFlow).region.height, 14)   # bounded
-            self.assertEqual(app.query_one(IntroHeader).mode, intro_state.INTRO_COMPACT)  # no hero
-        # full → flow fills (much taller than the inline cap)
+            empty_h = app.query_one(SessionFlow).region.height
+            self.assertLess(empty_h, 14)   # empty session is COMPACT, not a fixed 14-row box
+            self.assertEqual(app.query_one(IntroHeader).mode, intro_state.INTRO_COMPACT)
+            for _ in range(30):
+                app._execute("/status")
+            for _ in range(4):
+                await pilot.pause()
+            grown_h = app.query_one(SessionFlow).region.height
+            self.assertGreater(grown_h, empty_h)   # flow GREW with content (accumulates)
+            self.assertGreater(grown_h, 14)         # blew past the old hard cap
+        # full → flow fills the alt-screen (1fr)
         app2 = self._app(False)
         async with app2.run_test(size=(100, 40)) as pilot:
             await pilot.pause()

--- a/tests/forgekit/test_tui_palette_below.py
+++ b/tests/forgekit/test_tui_palette_below.py
@@ -29,14 +29,14 @@ def _app(config=None):
 
 @unittest.skipUnless(_TEXTUAL, "textual 필요")
 class PaletteBelowGeometryTests(unittest.IsolatedAsyncioTestCase):
-    async def test_input_inline_near_top_before_slash(self):
+    async def test_input_docked_at_bottom_before_slash(self):
         from forgekit_console.tui.composer import Composer
         app = _app()
         async with app.run_test(size=(100, 28)) as pilot:
             await pilot.pause()
             comp = app.query_one(Composer).region
-            # INLINE: empty session → composer near the TOP, not docked at the bottom
-            self.assertLess(comp.bottom, app.size.height - 2)
+            # the composer is the chat bar pinned at the bottom; the flow grows above it
+            self.assertGreaterEqual(comp.bottom, app.size.height - 1)
 
     async def test_palette_flush_below_input_and_visible(self):
         from forgekit_console.tui.palette import CommandPalette

--- a/tests/forgekit/test_tui_parity_hotfix2.py
+++ b/tests/forgekit/test_tui_parity_hotfix2.py
@@ -83,8 +83,8 @@ class DockedLayoutTests(unittest.IsolatedAsyncioTestCase):
             H = app.size.height
             comp = app.query_one(Composer)
             bar = app.query_one("#composer-input-shell")
-            # INLINE: empty session → composer near the top, NOT docked at the bottom
-            self.assertLess(comp.region.bottom, H - 2)
+            # composer is the chat bar pinned at the bottom; the reading flow grows above it
+            self.assertGreaterEqual(comp.region.bottom, H - 1)
             # open palette → it opens DIRECTLY BELOW the input bar (flush, gap ≈ 0)
             await pilot.press("slash", "h", "e")
             await pilot.pause()

--- a/tests/forgekit/test_tui_scroll_model.py
+++ b/tests/forgekit/test_tui_scroll_model.py
@@ -58,12 +58,16 @@ class ScrollModelTests(unittest.IsolatedAsyncioTestCase):
                 w = app.query_one(cls)
                 visible_gutter = _gutter(w) > 0 and w.show_vertical_scrollbar
                 self.assertFalse(visible_gutter, f"{cls.__name__} draws a visible gutter (inline={inline})")
-            # content panes never own scroll — only SessionFlow (reading) + input may scroll
+            # content panes never own scroll — only SessionFlow (the reading flow) may.
             self.assertFalse(app.query_one(Transcript).allow_vertical_scroll)
             self.assertFalse(app.query_one(HelpPanel).allow_vertical_scroll)
             self.assertFalse(app.query_one(CommandPalette).allow_vertical_scroll)
             self.assertFalse(app.query_one(Composer).allow_vertical_scroll)
-            self.assertTrue(app.query_one(SessionFlow).allow_vertical_scroll)   # the one owner
+            # SessionFlow is the SOLE scroll-owning container (a VerticalScroll). It is now
+            # content-driven (height auto, max-height 100%), so it only *engages* scroll when
+            # content exceeds the viewport — but it is structurally the one and only owner.
+            from textual.containers import VerticalScroll
+            self.assertIsInstance(app.query_one(SessionFlow), VerticalScroll)
 
     async def test_full_mode_clean(self):
         await self._assert_clean_scroll(False)

--- a/tests/forgekit/test_tui_smoke.py
+++ b/tests/forgekit/test_tui_smoke.py
@@ -87,10 +87,11 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             # Claude-style idle: the mode pill is hidden (no `● operator` row)
             self.assertFalse(app.query_one("#modepill", Static).display)
 
-    async def test_composer_inline_near_top_when_idle(self) -> None:
-        """Composer is INLINE (Claude): on an EMPTY session the input sits near the TOP
-        (just under the intro/issue) with empty space below — NOT docked at the bottom,
-        NOT floating mid-screen. (Parity correction: reverted the dock.)"""
+    async def test_composer_docked_at_bottom_when_idle(self) -> None:
+        """Composer is DOCKED at the bottom (Claude-Code cadence): the chat bar is pinned
+        to the viewport bottom and the reading flow grows ABOVE it. On an empty session the
+        flow is compact (content-driven) and the composer sits at the bottom — NOT trapped
+        in a fixed bounded box."""
         from forgekit_console.tui.prompt_area import PromptArea
         from forgekit_console.tui.composer import Composer
 
@@ -100,26 +101,27 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             composer = app.query_one("#composer", Composer)
             self.assertTrue(composer.display)
             self.assertTrue(app.query_one("#prompt", PromptArea).display)
-            # empty session → composer near the TOP, empty space BELOW it (not docked)
-            self.assertLess(composer.region.y, app.size.height // 2)
-            self.assertLess(composer.region.bottom, app.size.height - 2)
+            # composer is pinned to the bottom of the viewport (docked)
+            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
 
-    async def test_composer_follows_content_down_as_transcript_grows(self) -> None:
-        """As the transcript grows, the inline composer is pushed DOWN (tail-follow) and
-        stays visible — it does not stay pinned near the top."""
+    async def test_composer_stays_pinned_at_bottom_as_transcript_grows(self) -> None:
+        """As the transcript grows, the reading flow accumulates ABOVE the composer while
+        the composer stays pinned at the viewport bottom — the chat bar never scrolls away
+        (content-driven inline growth is covered by test_tui_inline_mode)."""
         from forgekit_console.tui.composer import Composer
 
         app = self._app(config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
         async with app.run_test(size=(100, 40)) as pilot:
             await pilot.pause()
             composer = app.query_one("#composer", Composer)
-            short_y = composer.region.y
+            bottom_before = composer.region.bottom
             for _ in range(30):
                 app._execute("/status")
             for _ in range(4):
                 await pilot.pause()
-            # the composer moved DOWN with the content (inline tail-follow), still visible
-            self.assertGreater(composer.region.y, short_y)
+            # the composer stayed pinned at the bottom (still visible), content above it
+            self.assertEqual(composer.region.bottom, bottom_before)
+            self.assertGreaterEqual(composer.region.bottom, app.size.height - 1)
             self.assertTrue(composer.display)
 
     async def test_help_tabs_first_with_cyan_divider_no_branding(self) -> None:
@@ -294,12 +296,12 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(app.mode, "operator")
 
     async def test_topdown_order_intro_issue_content_composer_hint(self) -> None:
-        """Geometry smoke: TOP-ALIGNED inline flow intro → issue → main → composer → hint.
+        """Geometry smoke: intro → issue → main (reading flow) → DOCKED composer → hint.
 
         Stands in for an SVG snapshot (the CI sweep runs unittest, not the
-        textual-snapshot pytest plugin): it asserts the y-order of the regions.
-        The composer is INLINE in the top-aligned flow: intro · issue · content ·
-        composer · hint, near the top on an empty session (NOT docked at the bottom).
+        textual-snapshot pytest plugin): it asserts the y-order of the regions. The
+        reading flow stacks top→down; the composer is docked at the bottom (content
+        accumulates above it) with the hint as its foot.
         """
         from textual.widgets import Static
         from forgekit_console.tui.composer import Composer
@@ -314,15 +316,15 @@ class TuiSmokeTests(unittest.IsolatedAsyncioTestCase):
             log = app.query_one("#main", MainPanel).region
             composer = app.query_one("#composer", Composer).region
             hint = app.query_one("#hint", Static).region
-            # top → down: intro · issue · content · (inline) composer-bar
+            # top → down: intro · issue · content (reading flow) · composer-bar (bottom)
             self.assertLessEqual(intro.y, issue.y)
             self.assertLessEqual(issue.y, log.y)
             self.assertLessEqual(log.bottom, composer.y)
             # the hint is the FOOT of the composer bar (inside it), not a stray line
             self.assertGreaterEqual(hint.y, composer.y)
             self.assertLessEqual(hint.bottom, composer.bottom)
-            # composer is INLINE near the top (empty session) — NOT pinned to the bottom
-            self.assertLess(composer.bottom, app.size.height - 2)
+            # composer is the LAST element, pinned at the bottom of the viewport
+            self.assertGreaterEqual(composer.bottom, app.size.height - 1)
 
     async def test_intro_avatar_renderer_selected(self) -> None:
         from forgekit_console.tui.header import IntroHeader


### PR DESCRIPTION
## 목적
inline UI가 "고정 높이 박스 안에서 이전 내용이 밀려 사라지는" 느낌을 없애고, Claude Code처럼 터미널 본문에 누적되는 흐름에 더 가깝게 만든다.

## 원인 (인정)
- `Screen.-inline #flow { height: 14 }` — reading flow를 14줄 고정 박스로 잘라, 출력이 길어지면 이전 내용이 작은 창 밖으로 밀려남.
- composer가 `#flow` 안에 있어 `follow_tail`이 tail(composer)을 보이려 위쪽(옛 내용)을 밀어냄.

## 변경
- **14-cap 제거** → `Screen.-inline #flow { height: auto; max-height: 100% }` (content-driven: 짧으면 compact, 길면 viewport까지 누적, 넘으면 단일 SessionFlow 스크롤 — 이전 내용 손실 없음). full은 1fr 유지.
- **composer를 flow 밖으로** (`compose()`): inline=`dock:bottom`, full=1fr flow 뒤 마지막 child → 항상 하단 고정.
- **print-flow seam** `tui/transcript_sink.py`: TranscriptSink/WidgetSink(현재)/PrintFlowSink(미연결 seam, NotImplemented 정직).
- palette: 입력 bar 바로 아래(flush) 유지, composer가 위로 자람(command area).

## 검증 (실측 render evidence)
inline 100×30, flow empty=2: `/doctor`→10, `/provider`→16, `/usage`(31줄)→25 scrollable(max_scroll_y=8), 긴 paste→25(12), 긴 응답(45줄)→25(22). composer 항상 하단 on-screen. evidence: `examples/inline-accumulating-flow/render-evidence.txt`.
- root CI **OK (skipped=112)**, console TUI 서브셋 **OK**. 신규 guard `test_inline_accumulating_flow` + parity 테스트 5개 갱신(idle-near-top → docked-bottom).

## 정직한 한계
viewport까지 누적+단일 스크롤이지 **진짜 terminal-native scrollback 누적은 아직 아님**(Textual inline 한계). 다음 단계 = PrintFlowSink 연결(region 위 write 프리미티브 필요 — Textual 미지원이 blocker).

---
### Audit
- base: main @ c007bb1
- commits: 3 (layout / seam / 회귀+evidence+docs)
- self-merge: CI green 시