### PR TITLE
콘솔: Shift+Tab transcript flood 제거 + intro scroll-away + internal-scroll 회귀 구조 제거

### DIFF
--- a/apps/forgekit-console/examples/mode-intro-scroll/before-after-evidence.txt
+++ b/apps/forgekit-console/examples/mode-intro-scroll/before-after-evidence.txt
@@ -1,0 +1,26 @@
+ForgeKit 콘솔 — mode 전환 / intro / internal-scroll : BEFORE → AFTER (실측, inline 100x30)
+====================================================================================
+
+[A] Shift+Tab 모드 전환 — transcript flood
+  BEFORE: _cycle_runtime_mode 가 매 키프레스마다 self._transcript.write(runtime_mode_line)
+          → Shift+Tab N번 = transcript 에 N줄 append (대화 로그 도배)
+  AFTER : 8x Shift+Tab → transcript lines 0→0  (flood 제거: True)
+          live indicator 만 갱신 — issue: '◆ Idea-discovery · routing optimized · usage ada'
+                                hint : '▶▶ Idea-discovery mode · /help · / palette · ^C quit'
+
+[D] 하단 hint — 실제 runtime mode 반영
+  BEFORE: 항상 '▶▶ operator · /help · / palette · ^C quit' (고정 'operator')
+  AFTER : '▶▶ <현재mode> mode · /help …'  ← Shift+Tab 으로 바뀐 mode 반영
+
+[B] intro/hero lifecycle
+  BEFORE: IntroHeader 가 SessionFlow 밖 '고정 top chrome' — 대화가 쌓여도 상단에 영구 점유
+  AFTER : IntroHeader 가 SessionFlow 안(첫 child). in_flow=True
+          empty 일 때 intro.y=0 → 40줄 후 intro.y=-25 (위로 스크롤되어 사라짐)
+
+[C] internal scroll / gutter
+  BEFORE: mode flood + 고정 intro 로 내부 pane 처럼 보이고, 긴 출력에서 내부 세로 스크롤 체감
+  AFTER : visible gutter — SessionFlow=False MainPanel=False IntroHeader=False (전부 False)
+          MainPanel/IntroHeader owns_scroll=False/False → SessionFlow 만 scroll(gutter 0)
+
+정직한 한계: SessionFlow 가 viewport 초과 시 스크롤하는 건 여전(단일 owner, gutter 0). 진짜
+terminal-native scrollback 누적은 print-flow seam(tui/transcript_sink.py) 다음 단계.

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -160,22 +160,22 @@ class ForgekitConsoleApp(App):
     # --- layout -------------------------------------------------------------
 
     def compose(self) -> ComposeResult:
-        # top (fixed banner): small real-image avatar + brand/version/provider/...
-        yield IntroHeader(
-            repo=str(self.repo_root),
-            version=__version__,
-            profile=self.context.profile,
-            id="intro",
-        )
-        # THE SESSION FLOW — the SINGLE scroll owner of the READING flow only:
-        #   issue line → transcript/help → process feed.
-        # It is CONTENT-DRIVEN in inline mode (height: auto — see styles.SCREEN_CSS): the
-        # block grows with the conversation and the terminal renders that many rows, so
-        # output ACCUMULATES downward instead of being trapped in a fixed bounded box. The
-        # composer is NOT inside it — it is DOCKED at the bottom (below), so the chat bar
-        # stays pinned while the conversation grows above it (Claude-Code cadence).
+        # THE SESSION FLOW — the SINGLE scroll owner of the whole READING flow:
+        #   intro (hero/compact) → issue line → transcript/help → process feed.
+        # The intro is the FIRST child of the flow (NOT fixed top chrome), so it is a
+        # first-impression element that scrolls UP and away as the conversation grows —
+        # Claude-Code style — instead of a permanent panel pinned at the top eating space.
+        # The flow is CONTENT-DRIVEN in inline mode (height: auto — see styles.SCREEN_CSS):
+        # it grows with the conversation so output accumulates downward. The composer is NOT
+        # inside it — it is DOCKED at the bottom (below), pinned while content grows above.
         with SessionFlow(id="flow"):
-            yield Static(id="issue")               # one quiet status line at the top
+            yield IntroHeader(                     # first impression — scrolls away with content
+                repo=str(self.repo_root),
+                version=__version__,
+                profile=self.context.profile,
+                id="intro",
+            )
+            yield Static(id="issue")               # one quiet status line under the intro
             yield MainPanel(id="main")             # transcript XOR help (height: auto)
             # process event feed (route/submit/generate/…); empty → collapses to 0 rows.
             yield Static(id="livestatus")
@@ -1231,6 +1231,28 @@ class ForgekitConsoleApp(App):
             return
         w.update("\n".join(render.process_feed_lines(self._feed.recent(6))))
 
+    def _flash_mode_switch(self) -> None:
+        """A SHORT transient '▶▶ <mode> mode on' confirmation in the live status zone —
+        NEVER the transcript. Replaces in place and clears after a brief dwell, so cycling
+        Shift+Tab many times leaves the reading log untouched."""
+
+        pol = self._effective_policy
+        if pol is None or not self._feed.empty:
+            return  # a real process feed is active → don't clobber it (issue/hint still update)
+        try:
+            w = self.query_one("#livestatus", Static)
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return
+        w.update(render.mode_switch_flash(pol.mode_label))
+        self._mode_flash = token = object()
+
+        def _restore() -> None:
+            if getattr(self, "_mode_flash", None) is token:
+                self._mode_flash = None
+                self._render_feed()   # idle → collapses to 0 rows; active submit → real feed
+
+        self.set_timer(1.6, _restore)
+
     def _refocus_prompt(self) -> None:
         try:
             self.query_one("#prompt", PromptArea).focus()
@@ -1485,14 +1507,12 @@ class ForgekitConsoleApp(App):
         self._runtime_mode = rm.cycle_mode(self._runtime_mode, direction)
         self._mode_pinned = True  # explicit operator action → auto won't override
         self._recompute_policy()
-        pol = self._effective_policy
-        if pol is not None:
-            self._transcript.write(
-                render.runtime_mode_line(
-                    pol.mode_label, pol.provider_policy_mode, pol.usage.usage_mode,
-                    pol.approval, loop=pol.background_loop,
-                )
-            )
+        # Shift+Tab is an EPHEMERAL mode switch — it must NOT append to the transcript
+        # (that floods the reading log with a mode line on every keypress). The current
+        # mode is shown in the LIVE surfaces that REPLACE in place: the issue line
+        # (`◆ <mode> · routing …`) and the bottom hint (`▶▶ <mode> mode …`). A short
+        # transient "▶▶ <mode> mode on" flash confirms the switch, then clears.
+        self._flash_mode_switch()
         self._refresh_issue()
         self._refresh_chrome()
         self._sync_intro()
@@ -1545,12 +1565,15 @@ class ForgekitConsoleApp(App):
         if show_mode:
             modepill.update(render.mode_pill(self.mode, self.context.agents))
         typing = bool((self._prompt_value() or "").strip())
+        pol = self._effective_policy
+        mode_label = getattr(pol, "mode_label", "") if pol is not None else ""
         self.query_one("#hint", Static).update(
             render.hint_line(
                 palette_open=self._palette.is_open,
                 help_open=self._main.help_open,
                 in_agent=self.mode != MODE_OPERATOR,
                 typing=typing,
+                mode_label=mode_label,   # bottom hint reflects the actual runtime mode (D)
             )
         )
 

--- a/apps/forgekit-console/src/forgekit_console/tui/header.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/header.py
@@ -33,6 +33,10 @@ class IntroHeader(Vertical):
     IntroHeader {
         height: auto;
         padding: 0 1 0 1;   /* no top padding — a tight product header */
+        /* the intro now lives INSIDE the SessionFlow (it scrolls away) — it must never own
+           a scroll/gutter of its own (SessionFlow is the sole scroll owner). */
+        scrollbar-size-vertical: 0;
+        overflow-y: hidden;
     }
     IntroHeader #intro-hero {
         height: auto;

--- a/apps/forgekit-console/src/forgekit_console/tui/main_panel.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/main_panel.py
@@ -45,6 +45,11 @@ class MainPanel(ContentSwitcher):
     MainPanel {
         width: 1fr;
         height: auto;
+        /* never own a scroll/gutter — SessionFlow is the sole scroll owner. height:auto
+           means this should never overflow, but zero the gutter so it can NEVER draw an
+           internal-pane scrollbar even transiently (structural, not a CSS cover-up). */
+        scrollbar-size-vertical: 0;
+        overflow-y: hidden;
     }
     """
 

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -223,20 +223,29 @@ def mode_pill(mode: str, agents: Sequence[AgentInfo] = ()) -> str:
     return f"[dim]●[/dim] {mode}"
 
 
+def mode_switch_flash(label: str) -> str:
+    """The transient '▶▶ <mode> mode on' confirmation shown in the live status zone on a
+    Shift+Tab switch (ephemeral — replaces in place, never appended to the transcript)."""
+
+    return f"[{_ACCENT}]▶▶[/{_ACCENT}] [b]{label}[/b] mode on"
+
+
 def hint_line(
     *,
     palette_open: bool = False,
     help_open: bool = False,
     in_agent: bool = False,
     typing: bool = False,
+    mode_label: str = "",
 ) -> str:
     """The secondary mode/shortcut line shown BELOW the input bar (Claude-style).
 
-    Claude shows a quiet mode line under the input (``▶▶ auto mode on …``) only at
-    idle. So: while TYPING (non-empty input) this line is empty — the input is the
-    star and clutter drops. When the palette is open the palette owns the space
-    (also empty here). At idle it shows the mode + key shortcuts with a small accent
-    ``▶▶`` marker, like Claude's bottom mode line.
+    Claude shows a quiet mode line under the input (``▶▶ auto mode on …``) only at idle.
+    So: while TYPING (non-empty input) this line is empty — the input is the star and
+    clutter drops. When the palette is open the palette owns the space (also empty here).
+    At idle it shows the CURRENT runtime mode + key shortcuts with a small accent ``▶▶``
+    marker — so Shift+Tab is reflected HERE (not a fixed "operator" string), and this line
+    doubles as the persistent live mode indicator.
     """
 
     if typing or palette_open:
@@ -246,7 +255,8 @@ def hint_line(
         return f"{marker} [dim]Tab 탭 전환 · Esc 로 닫기[/dim]"
     if in_agent:
         return f"{marker} [dim]Esc 로 operator · /help · ^C quit[/dim]"
-    return f"{marker} [dim]operator · /help · / palette · ^C quit[/dim]"
+    mode = (mode_label or "operator").strip()
+    return f"{marker} [b]{mode}[/b] [dim]mode · /help · / palette · ^C quit[/dim]"
 
 
 def default_help_tab(sections: Sequence[HelpSection]) -> int:

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -14,14 +14,23 @@ composer + 입력창 바로 아래 열리는 palette), `tui/transcript_store.py`
 
 ## 1. Layout — content-driven reading flow + 하단 고정 composer
 ```
-IntroHeader              (fixed top banner)
-SessionFlow              ← 유일한 vertical scroll owner. issue + transcript/help 만 (composer 제외).
-  #issue                   inline: height auto, max-height 100% (content-driven)
+SessionFlow              ← 유일한 vertical scroll owner. intro+issue+transcript/help (composer 제외).
+  #intro (IntroHeader)     첫 인상 요소 — flow 의 첫 child 라 대화가 쌓이면 위로 스크롤되어 사라짐
+  #issue                   inline: height auto, max-height 100% (content-driven). 현재 mode 라이브 표시
   #main (transcript XOR help, height auto)   full : height 1fr (alt-screen 채움)
-  #livestatus            (thinking→generating 마커)
+  #livestatus            (thinking→generating 마커 · mode 전환 flash)
 Composer                 ← inline 에서 dock:bottom. full 에서는 1fr flow 뒤 마지막 child(자연히 하단).
-                           입력 bar + palette(입력 바로 아래) + hint.
+                           입력 bar + palette(입력 바로 아래) + hint(현재 runtime mode 반영).
 ```
+**intro lifecycle:** IntroHeader 는 더 이상 flow 밖 고정 top chrome 가 아니라 **SessionFlow 의 첫
+child** 다. 첫 진입엔 보이고(첫 인상), 대화가 쌓여 viewport 를 넘으면 자연히 **위로 스크롤되어
+사라진다**(고정 panel 로 공간을 영구 점유하지 않음). inline 은 compact, full 은 hero→compact.
+
+**mode 전환(Shift+Tab)은 ephemeral:** 예전엔 `_cycle_runtime_mode` 가 매 키프레스마다
+`transcript.write(runtime_mode_line)` 해서 대화 로그를 mode 줄로 도배했다. 이제 **transcript append
+0** — 현재 mode 는 **교체형 live surface** 에만: `#issue`(`◆ <mode> · routing …`) + 하단 `#hint`
+(`▶▶ <mode> mode · …` — 고정 'operator' 아님) + 짧은 `▶▶ <mode> mode on` flash(#livestatus, dwell 후
+소멸). `/mode` 명령은 전체 표 유지용으로 남는다. 측정: `test_mode_intro_scroll`.
 **inline 누적 흐름(이번 라운드 핵심):** 예전엔 `Screen.-inline #flow { height: 14 }` 로 reading
 flow 를 **14줄 고정 박스**로 잘라, 출력이 길어지면 이전 내용이 그 작은 창 밖으로 밀려나 "내용이
 날아간다"는 느낌을 줬다. 이제 inline flow 는 **content-driven**(`height: auto; max-height: 100%`):

--- a/tests/forgekit/test_mode_intro_scroll.py
+++ b/tests/forgekit/test_mode_intro_scroll.py
@@ -1,0 +1,127 @@
+"""Mode-switch UX / intro lifecycle / internal-scroll guard (Claude parity round).
+
+Real render checks via the Textual pilot:
+- A: Shift+Tab cycling NEVER appends to the transcript (no mode-table flood) — the mode
+     shows only in live surfaces (issue line + bottom hint) that replace in place.
+- D: the bottom hint reflects the CURRENT runtime mode, not a fixed "operator" string.
+- B: the IntroHeader lives INSIDE the SessionFlow and scrolls away as content accumulates
+     (first-impression element, not permanent top chrome).
+- C: only SessionFlow can scroll; no widget draws a visible vertical gutter.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+def _inline_app():
+    from forgekit_console.commands.registry import load_agents, load_commands
+    from forgekit_console.commands.router import ConsoleContext
+    from forgekit_console.tui.app import ForgekitConsoleApp
+    ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
+    return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx,
+                              config={"primary_provider": "ollama", "linked_providers": ["ollama"]},
+                              inline=True)
+
+
+# --------------------------------------------------------------------------- #
+# pure: hint + flash reflect the mode
+# --------------------------------------------------------------------------- #
+class HintReflectsModeTests(unittest.TestCase):
+    def test_hint_line_shows_the_runtime_mode_not_fixed_operator(self) -> None:
+        from forgekit_console.tui import render
+
+        line = render.hint_line(mode_label="research")
+        self.assertIn("research", line)
+        self.assertNotIn("operator · /help", line)   # the old fixed string is gone
+        # falls back to 'operator' only when no mode is resolved
+        self.assertIn("operator", render.hint_line(mode_label=""))
+
+    def test_mode_switch_flash_is_ephemeral_marker(self) -> None:
+        from forgekit_console.tui import render
+
+        flash = render.mode_switch_flash("repo-autopilot")
+        self.assertIn("repo-autopilot", flash)
+        self.assertIn("mode on", flash)
+
+
+# --------------------------------------------------------------------------- #
+# real render
+# --------------------------------------------------------------------------- #
+@unittest.skipUnless(_TEXTUAL, "textual 필요")
+class ModeIntroScrollRenderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_shift_tab_does_not_flood_the_transcript(self) -> None:
+        app = _inline_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            before = len(app._transcript.lines)
+            for _ in range(8):
+                await pilot.press("shift+tab")
+                await pilot.pause()
+            self.assertEqual(len(app._transcript.lines), before)   # NO append on cycle
+
+    async def test_issue_and_hint_reflect_the_current_mode(self) -> None:
+        from textual.widgets import Static
+        app = _inline_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            issue = str(app.query_one("#issue", Static).render())
+            hint = str(app.query_one("#hint", Static).render())
+            # both surfaces carry the live mode marker (◆ on issue, ▶▶ mode on hint)
+            self.assertIn("◆", issue)
+            self.assertIn("mode", hint)
+
+    async def test_intro_is_inside_flow_and_scrolls_away(self) -> None:
+        from forgekit_console.tui.session_flow import SessionFlow
+        from forgekit_console.tui.header import IntroHeader
+        app = _inline_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            intro = app.query_one(IntroHeader)
+            flow = app.query_one(SessionFlow)
+            self.assertIn(intro, list(flow.walk_children()))    # intro is INSIDE the flow
+            top_y = intro.region.y
+            for i in range(40):
+                app._transcript.write(f"line {i}")
+            app._follow_tail()
+            for _ in range(4):
+                await pilot.pause()
+            # the intro scrolled UP and out of the viewport (first impression, not chrome)
+            self.assertLess(intro.region.y, top_y)
+            self.assertLess(intro.region.bottom, 1)             # above the visible top
+
+    async def test_only_sessionflow_scrolls_no_visible_gutter(self) -> None:
+        from forgekit_console.tui.session_flow import SessionFlow
+        from forgekit_console.tui.main_panel import MainPanel
+        from forgekit_console.tui.header import IntroHeader
+        app = _inline_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            for i in range(50):
+                app._transcript.write(f"line {i}")
+            app._follow_tail()
+            for _ in range(4):
+                await pilot.pause()
+
+            def visible_gutter(w):
+                size = int(w.styles.scrollbar_size_vertical or 0)
+                return size > 0 and w.show_vertical_scrollbar
+
+            self.assertFalse(visible_gutter(app.query_one(SessionFlow)))
+            self.assertFalse(visible_gutter(app.query_one(MainPanel)))
+            self.assertFalse(visible_gutter(app.query_one(IntroHeader)))
+            # MainPanel / IntroHeader never own scroll at all
+            self.assertFalse(app.query_one(MainPanel).allow_vertical_scroll)
+            self.assertFalse(app.query_one(IntroHeader).allow_vertical_scroll)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
Claude parity: mode 전환이 transcript를 도배하지 않고, intro/hero가 고정 panel로 남지 않으며, ForgeKit 내부 scroll/pane 느낌을 구조적으로 줄인다.

## 원인 (구조)
- **A flood**: `_cycle_runtime_mode`가 매 Shift+Tab마다 `transcript.write(runtime_mode_line)` → 대화 로그 도배(이미 `#issue`가 라이브 표시하던 것과 중복).
- **B intro**: `IntroHeader`가 `SessionFlow` 밖 고정 top chrome → 대화가 쌓여도 상단 영구 점유.
- **C scroll**: mode flood→overflow + 고정 intro→boxed 느낌. `MainPanel`/`IntroHeader`가 기본 gutter(size 2) 보유.
- **D hint**: 하단 hint가 고정 'operator' 문구.

## 변경
- **A**: transcript.write 제거(키보드 전환 append 0). `_flash_mode_switch`(`▶▶ <mode> mode on`, #livestatus, dwell 후 소멸, idle만). `/mode` 표는 유지.
- **D**: `hint_line(mode_label=…)` → `▶▶ <mode> mode · …`. `#issue`는 `◆ <mode> · routing …`.
- **B**: `IntroHeader`를 `SessionFlow` 첫 child로 → 내용 쌓이면 위로 scroll-away.
- **C**: `MainPanel`/`IntroHeader`에 `scrollbar-size-vertical:0` + `overflow-y:hidden` → SessionFlow만 단일 scroll owner(gutter 0). CSS 가림 아니라 소유 단일화.

## 검증 (before→after 실측, inline 100×30)
- A: 8× Shift+Tab → transcript **0→0**. D: hint `▶▶ <mode> mode`. B: intro y=0→**−25**(사라짐). C: visible gutter **전부 False**.
- 회귀 가드 `test_mode_intro_scroll`(6), root CI **OK(skipped=116)**, console 서브셋 **OK**. evidence: `examples/mode-intro-scroll/before-after-evidence.txt`.

## 남은 한계 (정직)
SessionFlow가 viewport 초과 시 스크롤하는 건 여전(단일 owner) — 진짜 native scrollback 누적은 print-flow seam(`tui/transcript_sink.py`) 다음 단계.

---
### Audit
- base: main @ 4b689d2
- commits: 3 (A/D · B/C · E)
- self-merge: CI green 시