### PR TITLE
✨ /setup 을 컨트롤플레인 부트스트랩으로 통합 (provider·knowledge·toolchain)

### DIFF
--- a/apps/forgekit-console/examples/bootstrap/README.md
+++ b/apps/forgekit-console/examples/bootstrap/README.md
@@ -18,6 +18,11 @@
    단일 canonical `~/.forgekit/config.json` 에 persist 되고, STEP 3 의 *restart 시뮬레이션*
    (in-memory state 없이 disk 재독)에서 그대로 살아남아 STEP 4 verdict 가 `ready` 로 뒤집힌다.
    같은 config 에 `slot_routing` + `fallback_policy`(routing/fallback)도 함께 보존된다.
+5. **provider 5-state taxonomy** — STEP 1/4 의 `[provider 상태 — 정직 taxonomy]` 줄이 각 provider 를
+   setup-required / configured / linked / live / unsupported 중 하나로 정직하게 표면화한다
+   (`live` 는 검증된 probe 일 때만).
+6. **always-on daemon resume** — STEP 5 가 직전 heartbeat tick=5 에서 재시작해 tick 6,7 로 **이어지는**
+   것을(cold-start 아님) `resumed_from`/`/daemon` 상태로 증명한다.
 
 재생성:
 

--- a/apps/forgekit-console/examples/bootstrap/README.md
+++ b/apps/forgekit-console/examples/bootstrap/README.md
@@ -1,0 +1,30 @@
+# `/setup` 컨트롤플레인 부트스트랩 — evidence
+
+`setup-bootstrap-evidence.txt` 는 통합 `/setup` 부트스트랩(provider · knowledge(nexus/vault)
+· toolchain)을 **deterministic fake probe**(real IO 없음 — CI 재현 가능)로 처음부터 끝까지
+캡처한 것이다. SSoT 문서: [`docs/forgekit-setup-bootstrap.md`](../../../../docs/forgekit-setup-bootstrap.md).
+
+증명하는 완료 조건:
+
+1. **한 화면 정직 집계** — provider/knowledge/toolchain 세 lane 이 각자 패키지의 정직한
+   assessor 에 위임되어 한 화면에 표면화된다. 어떤 lane 도 green 으로 위장하지 않는다
+   (STEP 1: provider `setup-required`, knowledge `not_connected`, toolchain `detected`).
+2. **no fake provider** — claude/codex 는 CLI attach 라 `connected · routing only`(live 아님),
+   live lane 은 실제 검증된 gemini/ollama 뿐. live 전송 provider 가 없으면 verdict 는
+   정직하게 `setup-required`.
+3. **live / unsupported / setup-required 정직 표면** — verdict 와 lane 상태가 실제 검증
+   결과만 반영.
+4. **재실행 후 설정 유지** — STEP 2 에서 `apply`(provider preset)와 `/nexus set`(nexus_root)이
+   단일 canonical `~/.forgekit/config.json` 에 persist 되고, STEP 3 의 *restart 시뮬레이션*
+   (in-memory state 없이 disk 재독)에서 그대로 살아남아 STEP 4 verdict 가 `ready` 로 뒤집힌다.
+   같은 config 에 `slot_routing` + `fallback_policy`(routing/fallback)도 함께 보존된다.
+
+재생성:
+
+```
+PYTHONPATH=<packages/*/src:apps/*/src> python3 \
+  apps/forgekit-console/examples/bootstrap/_regen.py \
+  > apps/forgekit-console/examples/bootstrap/setup-bootstrap-evidence.txt
+```
+
+(회귀 테스트: `python3 -m unittest tests.forgekit.test_bootstrap`.)

--- a/apps/forgekit-console/examples/bootstrap/_regen.py
+++ b/apps/forgekit-console/examples/bootstrap/_regen.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from forgekit_console import bootstrap as b
 from forgekit_provider.policy import provider_ops as ops
 from forgekit_provider_connect import wizard
+from forgekit_runtime.runtime import heartbeat as HB
+from forgekit_runtime.runtime.daemon import BoundedDaemon, TickOutcome
+from forgekit_runtime.runtime import surface as daemon_surface
 from hephaistos import nexus_ops as nops
 
 
@@ -76,8 +79,21 @@ def main() -> None:
             print(ln)
 
         bs = b.assess_bootstrap(env=env, probe=live, repo_root=Path(repo))
-        banner("HONEST AGGREGATE (machine-readable)")
+        banner("HONEST AGGREGATE (machine-readable, incl. 5-state provider taxonomy)")
         print(json.dumps(bs.to_dict(), ensure_ascii=False, indent=2))
+
+        banner("STEP 5 — always-on daemon RESUME (restart continues tick numbering, not cold-start)")
+        # a prior run left off at tick 5; a restart (e.g. launchd KeepAlive) resumes continuity.
+        HB.write_heartbeat(HB.Heartbeat(status=HB.STATUS_STOPPED, tick=5, ts="(prev run)", pid=111,
+                                        note="prev run stopped"), env=env)
+        d = BoundedDaemon(max_ticks=2, env=env, sleep_fn=lambda s: None, pid=222, resume=True)
+        r = d.serve(lambda t: TickOutcome(summary=f"tick {t}"))
+        print(f"$ forgekit runtime serve --max-ticks 2   (prior heartbeat tick=5)")
+        print(f"  resumed_from = {r.resumed_from} · 이 run tick = {r.resumed_from+1}..{r.ticks} "
+              f"(this-run {r.ticks - r.resumed_from}, heartbeat tick 연속)")
+        print("$ /daemon  (status surface)")
+        for ln in daemon_surface.daemon_status_lines(env=env):
+            print(f"  {ln}")
 
 
 if __name__ == "__main__":

--- a/apps/forgekit-console/examples/bootstrap/_regen.py
+++ b/apps/forgekit-console/examples/bootstrap/_regen.py
@@ -1,0 +1,84 @@
+"""Regenerate setup-bootstrap-evidence.txt — deterministic (fake probe, no real IO).
+
+Run from the repo root with every package src on PYTHONPATH (see README). Prints to stdout;
+redirect into ``setup-bootstrap-evidence.txt``. The companion regression test is
+``tests/forgekit/test_bootstrap.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from forgekit_console import bootstrap as b
+from forgekit_provider.policy import provider_ops as ops
+from forgekit_provider_connect import wizard
+from hephaistos import nexus_ops as nops
+
+
+class FakeProbe:
+    """Deterministic probe (no real IO) so this evidence is reproducible in CI."""
+
+    def __init__(self, *, claude=None, codex=None, gemini_key=False, ollama_up=False, models=()):
+        self._c, self._x, self._g, self._o, self._m = claude, codex, gemini_key, ollama_up, models
+
+    def cli_authenticated(self, pid):
+        return {"claude": self._c, "codex": self._x}.get(pid)
+
+    def api_key(self, pid, env=None):
+        return "key" if (pid == "gemini" and self._g) else ""
+
+    def daemon_reachable(self, ep):
+        return self._o
+
+    def installed_models(self, ep):
+        return self._m
+
+
+def banner(t: str) -> None:
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+def main() -> None:
+    print("ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (deterministic fake probe)")
+    print("provider · knowledge(nexus/vault) · toolchain → 단일 canonical ~/.forgekit/config.json")
+    print("재현: tests/forgekit/test_bootstrap.py / 이 스크립트(fake probe, no real IO)")
+
+    with tempfile.TemporaryDirectory() as home, \
+            tempfile.TemporaryDirectory() as vault, \
+            tempfile.TemporaryDirectory() as repo:
+        env = {"FORGEKIT_HOME": home}
+        # repo with a real repo-local manifest (no guess) so the toolchain lane is honest.
+        (Path(repo) / ".tool-versions").write_text("python 3.13.1\nnodejs 20.11.0\n", encoding="utf-8")
+        # before any connection: only claude/codex CLI attached (routing-only) → NO live lane.
+        pre = FakeProbe(claude=True, codex=True, gemini_key=False, ollama_up=False)
+
+        banner("STEP 1 — `/setup` (fresh: no provider live lane, no nexus, manifest present)")
+        for ln in b.bootstrap_lines(env=env, probe=pre, repo_root=Path(repo)):
+            print(ln)
+
+        banner("STEP 2 — `/setup apply` (persist recommended four-brain preset) + `/nexus set <vault>`")
+        # now the operator also has a gemini key + ollama model (live lane appears) — honest, verified.
+        live = FakeProbe(claude=True, codex=True, gemini_key=True, ollama_up=True, models=("llama3",))
+        ok, msg, _ = wizard.apply_recommended(env=env, probe=live)
+        print(f"$ /setup apply\n{msg}")
+        okv, msgv = nops.apply_set_root(vault, env=env)
+        print(f"\n$ /nexus set {vault}\n  {msgv}")
+
+        banner("STEP 3 — RESTART SIMULATION: re-read canonical config from disk (no in-memory state)")
+        reloaded = ops.load_raw_config(env=env)
+        print(f"$ cat {home}/config.json")
+        print(json.dumps(reloaded, ensure_ascii=False, indent=2))
+
+        banner("STEP 4 — `/setup` after restart (settings persisted → verdict ready)")
+        for ln in b.bootstrap_lines(env=env, probe=live, repo_root=Path(repo)):
+            print(ln)
+
+        bs = b.assess_bootstrap(env=env, probe=live, repo_root=Path(repo))
+        banner("HONEST AGGREGATE (machine-readable)")
+        print(json.dumps(bs.to_dict(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/bootstrap/setup-bootstrap-evidence.txt
+++ b/apps/forgekit-console/examples/bootstrap/setup-bootstrap-evidence.txt
@@ -6,7 +6,7 @@ provider · knowledge(nexus/vault) · toolchain → 단일 canonical ~/.forgekit
 STEP 1 — `/setup` (fresh: no provider live lane, no nexus, manifest present)
 ==============================================================================
 ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provider · knowledge · toolchain)
-  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json  (재실행 후에도 유지)
+  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp5dx6b6gy/config.json  (재실행 후에도 유지)
 
   ○ provider   setup-required — live 전송 가능한 provider 없음 — CLI(claude/codex)는 routing-only
       다음: `/setup apply` 로 추천 4-provider preset 저장 · `/provider connect <id>`
@@ -14,6 +14,9 @@ ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provid
       다음: `/nexus set <vault/repo 경로>` 로 지식 source 연결
   ◐ toolchain  detected       — 2 tool (repo-local manifest, 추측 없음): python@3.13.1, nodejs@20.11.0
       다음: `/toolchain verify` 로 mise 기반 검증(설치 시)
+
+[provider 상태 — 정직 taxonomy]
+  claude=setup-required · codex=setup-required · gemini=setup-required · ollama=setup-required
 
 [provider 상세]
   [b]/setup[/b] — provider onboarding  ·  verdict: [b]setup-required[/b]
@@ -37,13 +40,13 @@ setup 적용 — primary brain = claude, default_chat actual live = gemini.
   실제 live lane(검증됨): gemini. claude/codex 는 routing/brain participant.
   verdict: ready. `/provider` 로 declared→actual, `/setup` 로 연결 재점검.
 
-$ /nexus set /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4
-  nexus_root = /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4 (저장됨) · 상태: [exists] 연결됨
+$ /nexus set /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp281f9m1t
+  nexus_root = /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp281f9m1t (저장됨) · 상태: [exists] 연결됨
 
 ==============================================================================
 STEP 3 — RESTART SIMULATION: re-read canonical config from disk (no in-memory state)
 ==============================================================================
-$ cat /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json
+$ cat /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp5dx6b6gy/config.json
 {
   "primary_provider": "claude",
   "linked_providers": [
@@ -97,19 +100,22 @@ $ cat /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json
       ]
     }
   },
-  "nexus_root": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4"
+  "nexus_root": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp281f9m1t"
 }
 
 ==============================================================================
 STEP 4 — `/setup` after restart (settings persisted → verdict ready)
 ==============================================================================
 ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provider · knowledge · toolchain)
-  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json  (재실행 후에도 유지)
+  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp5dx6b6gy/config.json  (재실행 후에도 유지)
 
   ● provider   live           — live lane(검증됨): gemini · claude/codex 는 routing/brain participant
-  ◐ knowledge  connected      — /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4
+  ◐ knowledge  connected      — /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp281f9m1t
   ◐ toolchain  detected       — 2 tool (repo-local manifest, 추측 없음): python@3.13.1, nodejs@20.11.0
       다음: `/toolchain verify` 로 mise 기반 검증(설치 시)
+
+[provider 상태 — 정직 taxonomy]
+  claude=unsupported · codex=unsupported · gemini=live · ollama=linked
 
 [provider 상세]
   [b]/setup[/b] — provider onboarding  ·  verdict: [b]ready[/b]
@@ -127,14 +133,32 @@ verdict: ready — provider live lane 있음. `/daemon` always-on · `/goal` 연
   지식/toolchain 은 non-blocking 정직 표면 — 미연결도 console 은 동작.
 
 ==============================================================================
-HONEST AGGREGATE (machine-readable)
+HONEST AGGREGATE (machine-readable, incl. 5-state provider taxonomy)
 ==============================================================================
 {
   "verdict": "ready",
   "ready": true,
-  "config_path": "/private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json",
+  "config_path": "/private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp5dx6b6gy/config.json",
   "live_lane": [
     "gemini"
+  ],
+  "provider_states": [
+    {
+      "provider": "claude",
+      "state": "unsupported"
+    },
+    {
+      "provider": "codex",
+      "state": "unsupported"
+    },
+    {
+      "provider": "gemini",
+      "state": "live"
+    },
+    {
+      "provider": "ollama",
+      "state": "linked"
+    }
   ],
   "stages": [
     {
@@ -152,7 +176,7 @@ HONEST AGGREGATE (machine-readable)
       "status": "connected",
       "connected": true,
       "blocking": false,
-      "detail": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4",
+      "detail": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp281f9m1t",
       "next_action": ""
     },
     {
@@ -166,3 +190,17 @@ HONEST AGGREGATE (machine-readable)
     }
   ]
 }
+
+==============================================================================
+STEP 5 — always-on daemon RESUME (restart continues tick numbering, not cold-start)
+==============================================================================
+$ forgekit runtime serve --max-ticks 2   (prior heartbeat tick=5)
+  resumed_from = 5 · 이 run tick = 6..7 (this-run 2, heartbeat tick 연속)
+$ /daemon  (status surface)
+  forgekit always-on daemon — stopped
+    status    : stopped · tick 7 · pid 222
+    last tick : 2026-06-22T11:43:51
+    last note : max_ticks(2)
+    kill-switch: clear
+    resume    : 다음 serve 는 tick 8 부터 이어집니다 (resume on; cooldown 연속성 유지)
+    [dim]제어: CLI `forgekit runtime serve|once|status|stop` · 콘솔 `/daemon stop`(kill-switch)[/dim]

--- a/apps/forgekit-console/examples/bootstrap/setup-bootstrap-evidence.txt
+++ b/apps/forgekit-console/examples/bootstrap/setup-bootstrap-evidence.txt
@@ -1,0 +1,168 @@
+ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (deterministic fake probe)
+provider · knowledge(nexus/vault) · toolchain → 단일 canonical ~/.forgekit/config.json
+재현: tests/forgekit/test_bootstrap.py / 이 스크립트(fake probe, no real IO)
+
+==============================================================================
+STEP 1 — `/setup` (fresh: no provider live lane, no nexus, manifest present)
+==============================================================================
+ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provider · knowledge · toolchain)
+  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json  (재실행 후에도 유지)
+
+  ○ provider   setup-required — live 전송 가능한 provider 없음 — CLI(claude/codex)는 routing-only
+      다음: `/setup apply` 로 추천 4-provider preset 저장 · `/provider connect <id>`
+  ○ knowledge  not_connected  — FORGEKIT_NEXUS_ROOT (env) / nexus_root (config) 미설정
+      다음: `/nexus set <vault/repo 경로>` 로 지식 source 연결
+  ◐ toolchain  detected       — 2 tool (repo-local manifest, 추측 없음): python@3.13.1, nodejs@20.11.0
+      다음: `/toolchain verify` 로 mise 기반 검증(설치 시)
+
+[provider 상세]
+  [b]/setup[/b] — provider onboarding  ·  verdict: [b]setup-required[/b]
+    연결 상태 (brain participant vs live transport 분리):
+    ◐ claude  connected · routing only  [dim]— Claude Code CLI 세션 attach(heuristic) — routing/brain participant[/dim]
+    ◐ codex   connected · routing only  [dim]— Codex CLI 세션 attach(heuristic) — routing/brain participant[/dim]
+    ○ gemini  missing_key  [dim]— Gemini API 키 미설정 (GEMINI_API_KEY)[/dim]
+    ○ ollama  daemon_down  [dim]— Ollama 데몬 미응답 (http://localhost:11434)[/dim]
+    live lane(검증됨): (없음)   ·   추천 preset: [b]four-brain[/b]
+    다음: gemini API 키 또는 ollama 데몬을 연결한 뒤 `/setup apply` — claude/codex 만으로는 live 불가.
+    명령: `/setup apply` · `/provider connect <id>` · `/provider test <id>` · `/provider recommended`
+
+verdict: setup-required — provider live lane 없음(필수). `/setup apply` 로 추천 preset 저장 후 재점검.
+  지식/toolchain 은 non-blocking 정직 표면 — 미연결도 console 은 동작.
+
+==============================================================================
+STEP 2 — `/setup apply` (persist recommended four-brain preset) + `/nexus set <vault>`
+==============================================================================
+$ /setup apply
+setup 적용 — primary brain = claude, default_chat actual live = gemini.
+  실제 live lane(검증됨): gemini. claude/codex 는 routing/brain participant.
+  verdict: ready. `/provider` 로 declared→actual, `/setup` 로 연결 재점검.
+
+$ /nexus set /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4
+  nexus_root = /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4 (저장됨) · 상태: [exists] 연결됨
+
+==============================================================================
+STEP 3 — RESTART SIMULATION: re-read canonical config from disk (no in-memory state)
+==============================================================================
+$ cat /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json
+{
+  "primary_provider": "claude",
+  "linked_providers": [
+    "claude",
+    "codex",
+    "gemini",
+    "ollama"
+  ],
+  "model_overrides": {
+    "ollama": "gemma3:latest"
+  },
+  "slot_routing": {
+    "default_chat": "gemini",
+    "research": "gemini",
+    "execution": "codex",
+    "compression": "ollama",
+    "classification": "ollama",
+    "safety": "claude",
+    "synthesis": "claude"
+  },
+  "fallback_policy": {
+    "implicit_local_fallback": false,
+    "slot_fallback_orders": {
+      "default_chat": [
+        "gemini",
+        "ollama"
+      ],
+      "research": [
+        "gemini",
+        "ollama"
+      ],
+      "execution": [
+        "codex",
+        "gemini",
+        "ollama"
+      ],
+      "compression": [
+        "ollama"
+      ],
+      "classification": [
+        "ollama"
+      ],
+      "safety": [
+        "claude",
+        "gemini"
+      ],
+      "synthesis": [
+        "claude",
+        "gemini",
+        "ollama"
+      ]
+    }
+  },
+  "nexus_root": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4"
+}
+
+==============================================================================
+STEP 4 — `/setup` after restart (settings persisted → verdict ready)
+==============================================================================
+ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provider · knowledge · toolchain)
+  canonical config: /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json  (재실행 후에도 유지)
+
+  ● provider   live           — live lane(검증됨): gemini · claude/codex 는 routing/brain participant
+  ◐ knowledge  connected      — /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4
+  ◐ toolchain  detected       — 2 tool (repo-local manifest, 추측 없음): python@3.13.1, nodejs@20.11.0
+      다음: `/toolchain verify` 로 mise 기반 검증(설치 시)
+
+[provider 상세]
+  [b]/setup[/b] — provider onboarding  ·  verdict: [b]ready[/b]
+    primary brain: claude
+    연결 상태 (brain participant vs live transport 분리):
+    ◐ claude  connected · routing only  [dim]— Claude Code CLI 세션 attach(heuristic) — routing/brain participant[/dim]
+    ◐ codex   connected · routing only  [dim]— Codex CLI 세션 attach(heuristic) — routing/brain participant[/dim]
+    ● gemini  live  [dim]— Gemini API 키 감지 — console live-submit 가능[/dim]
+    ○ ollama  model_missing  [dim]— 선택 모델 'gemma3:latest' 가 설치 목록에 없음 (설치: llama3)[/dim]
+    live lane(검증됨): gemini   ·   추천 preset: [b]four-brain[/b]
+    다음: `/setup apply` 로 추천 4-provider 브레인 저장 + 검증 (또는 `/provider preset four-brain`).
+    명령: `/setup apply` · `/provider connect <id>` · `/provider test <id>` · `/provider recommended`
+
+verdict: ready — provider live lane 있음. `/daemon` always-on · `/goal` 연속 작업으로 진행.
+  지식/toolchain 은 non-blocking 정직 표면 — 미연결도 console 은 동작.
+
+==============================================================================
+HONEST AGGREGATE (machine-readable)
+==============================================================================
+{
+  "verdict": "ready",
+  "ready": true,
+  "config_path": "/private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpoarrg4yl/config.json",
+  "live_lane": [
+    "gemini"
+  ],
+  "stages": [
+    {
+      "id": "provider",
+      "label": "provider",
+      "status": "live",
+      "connected": true,
+      "blocking": true,
+      "detail": "live lane(검증됨): gemini · claude/codex 는 routing/brain participant",
+      "next_action": ""
+    },
+    {
+      "id": "knowledge",
+      "label": "knowledge",
+      "status": "connected",
+      "connected": true,
+      "blocking": false,
+      "detail": "/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpph26jja4",
+      "next_action": ""
+    },
+    {
+      "id": "toolchain",
+      "label": "toolchain",
+      "status": "detected",
+      "connected": true,
+      "blocking": false,
+      "detail": "2 tool (repo-local manifest, 추측 없음): python@3.13.1, nodejs@20.11.0",
+      "next_action": "`/toolchain verify` 로 mise 기반 검증(설치 시)"
+    }
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/bootstrap.py
+++ b/apps/forgekit-console/src/forgekit_console/bootstrap.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Mapping, Optional, Tuple
 
 from forgekit_provider.policy import provider_ops as ops
+from forgekit_provider.policy import provider_surface as psurf
 from forgekit_provider_connect import surface, wizard
 from forgekit_provider_connect.probe import ConnectionProbe
 
@@ -72,6 +73,8 @@ class ControlPlaneBootstrap:
     provider: wizard.BootstrapStatus
     config_path: str = ""                       # where the canonical config persists
     live_lane: Tuple[str, ...] = field(default_factory=tuple)
+    # honest per-provider 5-state taxonomy (setup-required/configured/linked/live/unsupported).
+    provider_states: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
 
     @property
     def ready(self) -> bool:
@@ -89,6 +92,7 @@ class ControlPlaneBootstrap:
         return {
             "verdict": self.verdict, "ready": self.ready,
             "config_path": self.config_path, "live_lane": list(self.live_lane),
+            "provider_states": [{"provider": p, "state": s} for p, s in self.provider_states],
             "stages": [s.to_dict() for s in self.stages],
         }
 
@@ -183,10 +187,14 @@ def assess_bootstrap(config: Optional[Mapping] = None, *,
         _knowledge_stage(env, cfg),
         _toolchain_stage(repo_root),
     )
+    # honest per-provider taxonomy — live asserted only from the VERIFIED probe (no fake).
+    live_map = {s.provider_id: bool(s.live_capable) for s in prov.statuses}
+    provider_states = psurf.provider_state_map(cfg, live_map=live_map)
     from forgekit_config.paths import config_path
     return ControlPlaneBootstrap(
         stages=stages, provider=prov,
         config_path=str(config_path(env)), live_lane=tuple(prov.live_lane),
+        provider_states=provider_states,
     )
 
 
@@ -211,6 +219,11 @@ def bootstrap_lines(config: Optional[Mapping] = None, *,
         out.append(f"  {st.glyph} {st.label:<10} {st.status:<14} — {st.detail}")
         if st.next_action:
             out.append(f"      다음: {st.next_action}")
+    out.append("")
+
+    # honest per-provider state taxonomy (setup-required / configured / linked / live / unsupported).
+    out.append("[provider 상태 — 정직 taxonomy]")
+    out.append("  " + " · ".join(f"{pid}={state}" for pid, state in bs.provider_states))
     out.append("")
 
     # the authoritative per-provider connection rows (brain vs live transport, no greenwash).

--- a/apps/forgekit-console/src/forgekit_console/bootstrap.py
+++ b/apps/forgekit-console/src/forgekit_console/bootstrap.py
@@ -1,0 +1,235 @@
+"""Unified control-plane bootstrap — composes the onboarding lanes into ONE honest /setup.
+
+``docs/control-plane-architecture.md`` §4 describes ForgeKit setup as a *control-plane
+bootstrap* (not a single provider wizard): provider + toolchain + nexus/vault each
+"감지 → 검증 → 저장 → 정직한 상태" with the same shape, converging on the single canonical
+``~/.forgekit/config.json``. The individual lanes already exist and persist —
+``forgekit-provider-connect`` (provider), ``hephaistos.nexus_read`` (knowledge/vault),
+``forgekit-toolchain`` (language runtime) — but ``/setup`` only ever showed the provider
+lane. This module is the operator-facing COMPOSITION that the doc calls for.
+
+It owns NO core logic: every stage delegates to its package's honest assessor and never
+green-washes. Only the **provider live lane** flips overall readiness (a console live-submit
+needs a real transport; claude/codex stay routing-only). Knowledge and toolchain are
+surfaced as honest, *non-blocking* lanes — ``connected`` / ``not_connected`` / ``detected``
+/ ``not_configured`` / ``unavailable`` — so the operator sees the whole control plane in one
+screen without any lane being faked into green.
+
+Pure given (config, env, probe, repo_root) so it is fully unit-testable with fakes — the
+console (surface) renders :func:`bootstrap_lines`; the data lives in
+:class:`ControlPlaneBootstrap`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from forgekit_provider.policy import provider_ops as ops
+from forgekit_provider_connect import surface, wizard
+from forgekit_provider_connect.probe import ConnectionProbe
+
+# stage ids — the control-plane bootstrap lanes (§4) we currently compose.
+STAGE_PROVIDER = "provider"
+STAGE_KNOWLEDGE = "knowledge"
+STAGE_TOOLCHAIN = "toolchain"
+
+
+@dataclass(frozen=True)
+class BootstrapStage:
+    """One onboarding lane's honest verdict. ``connected`` is the verified truth for the
+    lane; ``blocking`` says whether it gates overall readiness (only provider does)."""
+
+    id: str
+    label: str
+    status: str            # honest status word (live / not_connected / detected / ...)
+    connected: bool        # verified connected/live for this lane (never faked)
+    blocking: bool         # gates overall readiness?
+    detail: str = ""
+    next_action: str = ""
+
+    @property
+    def glyph(self) -> str:
+        # ● verified-and-counts · ◐ present-but-not-live/optional · ○ not connected
+        if self.connected:
+            return "●" if self.blocking else "◐"
+        return "○"
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id, "label": self.label, "status": self.status,
+            "connected": self.connected, "blocking": self.blocking,
+            "detail": self.detail, "next_action": self.next_action,
+        }
+
+
+@dataclass(frozen=True)
+class ControlPlaneBootstrap:
+    """The composed control-plane bootstrap report across every onboarding lane."""
+
+    stages: Tuple[BootstrapStage, ...]
+    provider: wizard.BootstrapStatus
+    config_path: str = ""                       # where the canonical config persists
+    live_lane: Tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def ready(self) -> bool:
+        """Ready = every BLOCKING lane is connected (today only the provider lane)."""
+        return all(s.connected for s in self.stages if s.blocking)
+
+    @property
+    def verdict(self) -> str:
+        return "ready" if self.ready else "setup-required"
+
+    def stage(self, sid: str) -> Optional[BootstrapStage]:
+        return next((s for s in self.stages if s.id == sid), None)
+
+    def to_dict(self) -> dict:
+        return {
+            "verdict": self.verdict, "ready": self.ready,
+            "config_path": self.config_path, "live_lane": list(self.live_lane),
+            "stages": [s.to_dict() for s in self.stages],
+        }
+
+
+# ── per-lane assessors (each delegates to its package; none fakes a connection) ──────
+
+
+def _provider_stage(prov: wizard.BootstrapStatus) -> BootstrapStage:
+    live = tuple(prov.live_lane)
+    if live:
+        detail = f"live lane(검증됨): {', '.join(live)} · claude/codex 는 routing/brain participant"
+        nxt = ""
+    else:
+        detail = "live 전송 가능한 provider 없음 — CLI(claude/codex)는 routing-only"
+        nxt = "`/setup apply` 로 추천 4-provider preset 저장 · `/provider connect <id>`"
+    return BootstrapStage(
+        id=STAGE_PROVIDER, label="provider",
+        status="live" if live else "setup-required",
+        connected=bool(live), blocking=True, detail=detail, next_action=nxt,
+    )
+
+
+def _knowledge_stage(env: Optional[Mapping[str, str]], config: Mapping) -> BootstrapStage:
+    # delegate to the honest nexus connection status (connected only when root set AND readable).
+    from hephaistos import nexus_read as nx
+
+    cs = nx.connection_status(env, config)
+    status = cs["status"]            # not_connected / missing / blocked / exists
+    connected = bool(cs["connected"])
+    detail = cs["reason"]
+    if connected:
+        # honest "is this actually an Obsidian vault?" hint — never fakes connection state.
+        root = Path(cs["root"])
+        try:
+            obsidian = (root / ".obsidian").is_dir()
+        except OSError:
+            obsidian = False
+        detail = f"{cs['root']}" + (" · Obsidian vault 감지(.obsidian)" if obsidian else "")
+        nxt = ""
+    else:
+        nxt = "`/nexus set <vault/repo 경로>` 로 지식 source 연결"
+    return BootstrapStage(
+        id=STAGE_KNOWLEDGE, label="knowledge",
+        # "connected" word only when verified; else surface the real status verbatim.
+        status="connected" if connected else status,
+        connected=connected, blocking=False, detail=detail, next_action=nxt,
+    )
+
+
+def _toolchain_stage(repo_root: Optional[Path]) -> BootstrapStage:
+    # lazy: forgekit-toolchain is optional infra — the console must boot without it.
+    try:
+        from forgekit_toolchain.detect import detect_requirements
+    except ImportError:
+        return BootstrapStage(
+            id=STAGE_TOOLCHAIN, label="toolchain", status="unavailable",
+            connected=False, blocking=False,
+            detail="forgekit-toolchain 미설치",
+            next_action="`pip install -e packages/forgekit-toolchain`",
+        )
+    root = repo_root or Path(".")
+    reqs = detect_requirements(root)
+    if reqs:
+        tools = ", ".join(f"{r.tool}{('@' + r.version) if r.version else ''}" for r in reqs)
+        return BootstrapStage(
+            id=STAGE_TOOLCHAIN, label="toolchain", status="detected",
+            connected=True, blocking=False,
+            detail=f"{len(reqs)} tool (repo-local manifest, 추측 없음): {tools}",
+            next_action="`/toolchain verify` 로 mise 기반 검증(설치 시)",
+        )
+    return BootstrapStage(
+        id=STAGE_TOOLCHAIN, label="toolchain", status="not_configured",
+        connected=False, blocking=False,
+        detail="repo-local 버전 manifest 없음 (.tool-versions/.mise.toml/.nvmrc/...)",
+        next_action="`/toolchain recommend <loadout>` 로 loadout 기반 프로파일 제안",
+    )
+
+
+def assess_bootstrap(config: Optional[Mapping] = None, *,
+                     env: Optional[Mapping[str, str]] = None,
+                     probe: Optional[ConnectionProbe] = None,
+                     repo_root: Optional[Path] = None) -> ControlPlaneBootstrap:
+    """Compose every onboarding lane into one honest control-plane bootstrap report.
+
+    Reads the same canonical config the lanes persist to (``provider_ops.load_raw_config``)
+    so the report reflects what survives an operator restart — no separate state."""
+
+    cfg = dict(config) if config is not None else ops.load_raw_config(env=env)
+    prov = wizard.assess(cfg, probe=probe, env=env)
+    stages = (
+        _provider_stage(prov),
+        _knowledge_stage(env, cfg),
+        _toolchain_stage(repo_root),
+    )
+    from forgekit_config.paths import config_path
+    return ControlPlaneBootstrap(
+        stages=stages, provider=prov,
+        config_path=str(config_path(env)), live_lane=tuple(prov.live_lane),
+    )
+
+
+# ── operator surface (the console renders these; logic stays here) ───────────────────
+
+
+def bootstrap_lines(config: Optional[Mapping] = None, *,
+                    env: Optional[Mapping[str, str]] = None,
+                    probe: Optional[ConnectionProbe] = None,
+                    repo_root: Optional[Path] = None) -> Tuple[str, ...]:
+    """`/setup` — the unified control-plane bootstrap: one honest screen across every lane."""
+
+    cfg = dict(config) if config is not None else ops.load_raw_config(env=env)
+    bs = assess_bootstrap(cfg, env=env, probe=probe, repo_root=repo_root)
+
+    out = [
+        "ForgeKit 컨트롤플레인 부트스트랩 — 한 화면 정직 집계 (provider · knowledge · toolchain)",
+        f"  canonical config: {bs.config_path}  (재실행 후에도 유지)",
+        "",
+    ]
+    for st in bs.stages:
+        out.append(f"  {st.glyph} {st.label:<10} {st.status:<14} — {st.detail}")
+        if st.next_action:
+            out.append(f"      다음: {st.next_action}")
+    out.append("")
+
+    # the authoritative per-provider connection rows (brain vs live transport, no greenwash).
+    out.append("[provider 상세]")
+    out.extend("  " + ln for ln in surface.setup_status_lines(cfg, probe=probe, env=env))
+    out.append("")
+
+    if bs.ready:
+        out.append(f"verdict: {bs.verdict} — provider live lane 있음. "
+                   "`/daemon` always-on · `/goal` 연속 작업으로 진행.")
+    else:
+        out.append(f"verdict: {bs.verdict} — provider live lane 없음(필수). "
+                   "`/setup apply` 로 추천 preset 저장 후 재점검.")
+    out.append("  지식/toolchain 은 non-blocking 정직 표면 — 미연결도 console 은 동작.")
+    return tuple(out)
+
+
+__all__ = (
+    "STAGE_PROVIDER", "STAGE_KNOWLEDGE", "STAGE_TOOLCHAIN",
+    "BootstrapStage", "ControlPlaneBootstrap",
+    "assess_bootstrap", "bootstrap_lines",
+)

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -102,7 +102,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
     SlashCommand("provider", "provider 설정/연결 — `/provider [set|link|unlink|connect <id>|disconnect <id>|test <id>|recommended|preset four-brain|route show|route set <slot> <id>|list|doctor]`", H_PROVIDER, "status"),
-    SlashCommand("setup", "provider onboarding wizard — 연결 점검 + 추천 4-provider 브레인 저장/검증 (`/setup [apply]`)", H_SETUP, "status"),
+    SlashCommand("setup", "컨트롤플레인 부트스트랩 — provider · knowledge(nexus/vault) · toolchain 한 화면 정직 집계 + 추천 preset 저장/검증 (`/setup [apply [preset]]`)", H_SETUP, "status"),
     SlashCommand("toolchain", "language/runtime 버전 전환 — `/toolchain [detect|recommend <loadout>|switch [global] [--approve]|verify|drift]` (repo-local 감지·mise 기반, global/install 은 승인 게이트)", H_TOOLCHAIN, "status"),
     SlashCommand("nexus", "Nexus 지식 source — `/nexus [set <path>|clear]` 연결/해제 + live 상태(connected/not_connected/missing/blocked/restricted)", H_NEXUS, "status"),
     SlashCommand("daemon", "always-on 데몬 heartbeat — state/tick/last_tick/pid/kill-switch (`/daemon [stop]`); CLI `forgekit runtime serve|status|stop`", H_DAEMON, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -176,7 +176,7 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
     if handler == H_PROVIDER:
         return _provider_result(parsed)
     if handler == H_SETUP:
-        return _setup_result(parsed)
+        return _setup_result(parsed, ctx)
     if handler == H_TOOLCHAIN:
         return _toolchain_result(parsed, ctx)
     if handler == H_NEXUS:
@@ -279,17 +279,24 @@ def _provider_result(parsed) -> CommandResult:
     return CommandResult.info("provider", ps.provider_status_lines(cfg))
 
 
-def _setup_result(parsed) -> CommandResult:
-    # /setup [apply] — provider onboarding wizard (connect checks → recommended preset → save+verify).
-    from forgekit_provider_connect import surface as cs
-
+def _setup_result(parsed, ctx) -> CommandResult:
+    # /setup [apply [preset]] — unified control-plane bootstrap (docs/forgekit-setup-bootstrap.md):
+    # composes provider + knowledge(nexus/vault) + toolchain into ONE honest screen, persisted in
+    # the single canonical ~/.forgekit/config.json. `apply` writes the recommended provider preset
+    # (the only lane with a one-shot recommended default) then re-verifies; knowledge/toolchain are
+    # connected per-lane (`/nexus set`, `/toolchain`). No lane is ever faked into green.
     args = list(getattr(parsed, "args", ()) or ())
     sub = args[0].lower() if args else ""
     if sub == "apply":
+        from forgekit_provider_connect import surface as cs
+
         ok, msg = cs.apply_setup(args[1] if len(args) > 1 else "four-brain")
         return (CommandResult.info if ok else CommandResult.error)("setup", msg.split("\n"))
-    from ..policy import provider_ops as ops
-    return CommandResult.info("setup", cs.setup_status_lines(ops.load_raw_config()))
+    from .. import bootstrap as bs
+
+    env = getattr(ctx, "env", None) or None
+    repo_root = getattr(ctx, "repo_root", None)
+    return CommandResult.info("setup", bs.bootstrap_lines(env=env, repo_root=repo_root))
 
 
 def _toolchain_result(parsed, ctx) -> CommandResult:

--- a/docs/control-plane-architecture.md
+++ b/docs/control-plane-architecture.md
@@ -110,6 +110,14 @@ flowchart LR
 | **github app / git attribution** | GitHub App env / git author identity | configured / missing | P1 |
 | **notification** | inbox / opt-in desktop / channel | on / off | P1 |
 
+> **통합 표면 상태 (구현됨):** provider · knowledge(nexus/vault) · toolchain 세 lane 은 이제
+> `/setup` 한 화면으로 **합성**된다(`forgekit_console.bootstrap` — core 로직 없이 각 lane 의
+> 정직한 assessor 에 위임, no fake). provider live lane 만 readiness 를 결정하고 나머지는
+> non-blocking 정직 표면. 모두 단일 canonical config 에 persist → 재실행 후 유지. 구현 SSoT 는
+> [`forgekit-setup-bootstrap.md`](forgekit-setup-bootstrap.md), 회귀 `tests/forgekit/test_bootstrap.py`,
+> evidence `apps/forgekit-console/examples/bootstrap/`. github app / notification lane 의 부트스트랩
+> 합류는 후속(P1 잔여).
+
 ## 5. 실행 우선순위 로드맵 (고정)
 
 ### P0 — control plane 의 뼈대

--- a/docs/forgekit-setup-bootstrap.md
+++ b/docs/forgekit-setup-bootstrap.md
@@ -34,6 +34,23 @@ provider 하나뿐 — 콘솔 live-submit 은 실제 live 전송(gemini API / ol
 가능하고, claude/codex 는 CLI attach = `connected · routing only`(brain participant)이지 live
 전송이 아니다. **no fake-live**: 검증 못 한 lane 은 `connected` 로 표기하지 않는다.
 
+### 2.1 provider 5-state taxonomy (정직)
+
+`/setup` provider lane 은 각 built-in provider 를 **정확히 한 상태**로 표면화한다 — SSoT 는
+`forgekit_provider.policy.provider_surface.classify_provider_state`(코드), 코드는 config role +
+**검증된 probe 결과**만으로 판정한다(추측 금지).
+
+| state | 의미 |
+| --- | --- |
+| `setup-required` | brain 에 미포함(primary 도 linked 도 아님) — 쓰려면 설정 필요 |
+| `configured` | primary brain, console 전송 가능 타입, 아직 live 검증 안 됨 |
+| `linked` | linked participant, console 전송 가능 타입, 아직 live 검증 안 됨 |
+| `live` | **probe 로 검증된** console live 전송 (gemini key / ollama daemon+model) |
+| `unsupported` | brain 에 있으나 console live-submit 불가(CLI claude/codex = routing only) |
+
+판정 우선순위: 검증-live → not-in-brain → CLI-unsupported → primary(configured) → linked.
+`live` 는 **probe 가 True 일 때만** — 키/데몬 없이는 절대 live 로 위장하지 않는다.
+
 knowledge/toolchain 은 **non-blocking 정직 표면** — 미연결이어도 콘솔은 동작하지만 상태는
 숨기지 않는다(green-wash 금지).
 
@@ -64,6 +81,16 @@ fallback_policy · nexus_root)이 그대로 반영된다.
 
 evidence(`examples/bootstrap/setup-bootstrap-evidence.txt`)의 STEP 3 가 *restart 시뮬레이션*으로
 이를 증명한다 — in-memory state 없이 disk config 를 재독했을 때 verdict 가 `ready` 로 유지.
+
+### 4.1 always-on daemon resume (재시작 후 tick 연속)
+
+설정뿐 아니라 **always-on 런타임**도 재시작 후 이어진다. `BoundedDaemon.serve(resume=True)`(기본)
+는 시작 시 직전 heartbeat(`runtime-heartbeat.json`)를 읽어 tick 번호를 **이어서** 매긴다 — launchd
+`KeepAlive`/재부팅으로 프로세스가 재기동돼도 cooldown(`next_eligible_tick`) 연속성이 유지되고
+`DaemonResult.resumed_from` 으로 어디서 이어졌는지 정직하게 보고한다. **liveness 를 위조하지 않는다**:
+직전 프로세스가 살아있다고 가정하지 않고 tick 카운터 연속성만 복구한다. `max_ticks` 는 이 run 의
+tick 수만 제한(resume offset 과 무관). `/daemon` 상태 표면이 "다음 serve 는 tick N+1 부터" 를 보여준다.
+evidence STEP 5 참조. 코드 SSoT `forgekit_runtime.runtime.daemon`, 회귀 `test_runtime_daemon.py`.
 
 ## 5. routing / fallback / actual-live 표시
 

--- a/docs/forgekit-setup-bootstrap.md
+++ b/docs/forgekit-setup-bootstrap.md
@@ -1,0 +1,80 @@
+# ForgeKit `/setup` 컨트롤플레인 부트스트랩 (SSoT)
+
+> `/setup` 은 단일 provider wizard 가 아니라 **여러 onboarding lane 을 한 화면으로 묶는
+> control-plane bootstrap** 이다. [`control-plane-architecture.md`](control-plane-architecture.md) §4
+> 가 방향(provider + toolchain + nexus/vault + … → save → verify)의 SSoT 이고, 본 문서는 그
+> 통합 표면의 **구현 SSoT** 다.
+>
+> 코드 SSoT:
+> - 합성/표면: `apps/forgekit-console/src/forgekit_console/bootstrap.py`
+> - lane core: `forgekit-provider-connect`(provider) · `hephaistos.nexus_read`(knowledge) ·
+>   `forgekit-toolchain`(toolchain)
+> - 회귀: `tests/forgekit/test_bootstrap.py` · evidence: `apps/forgekit-console/examples/bootstrap/`
+
+## 1. 왜 통합 표면인가
+
+각 onboarding lane(provider / knowledge / toolchain)은 이미 독립적으로 존재하고 **각자
+정직하게** 상태를 보고하며 같은 canonical `~/.forgekit/config.json` 에 persist 한다. 그러나
+`/setup` 은 provider lane 만 보여줬다 — 운영자는 "내 컨트롤플레인이 지금 어떤 상태인가"를
+한 화면에서 볼 수 없었다.
+
+`bootstrap.py` 는 그 **합성(composition)** 이다. core 로직을 새로 갖지 않고 각 lane 의 정직한
+assessor 에 위임만 한다. 따라서 거짓 표면이 생길 여지가 없다 — 각 lane 의 진실을 그대로 모은다.
+
+## 2. lane 과 정직 상태
+
+| lane | core | 상태(정직) | blocking? |
+| --- | --- | --- | --- |
+| **provider** | `forgekit-provider-connect` (`wizard.assess`) | `live`(검증된 live 전송 lane 존재) / `setup-required`(없음) | **예** — readiness 를 결정 |
+| **knowledge** (nexus/vault) | `hephaistos.nexus_read.connection_status` | `connected` / `not_connected` / `missing` / `blocked` (+`.obsidian` 감지 시 vault 표기) | 아니오 |
+| **toolchain** | `forgekit-toolchain.detect_requirements` | `detected`(repo-local manifest) / `not_configured`(manifest 없음) / `unavailable`(미설치) | 아니오 |
+
+**readiness 규칙:** `verdict = ready` ⟺ 모든 *blocking* lane 이 connected. 현재 blocking 은
+provider 하나뿐 — 콘솔 live-submit 은 실제 live 전송(gemini API / ollama daemon)이 있어야
+가능하고, claude/codex 는 CLI attach = `connected · routing only`(brain participant)이지 live
+전송이 아니다. **no fake-live**: 검증 못 한 lane 은 `connected` 로 표기하지 않는다.
+
+knowledge/toolchain 은 **non-blocking 정직 표면** — 미연결이어도 콘솔은 동작하지만 상태는
+숨기지 않는다(green-wash 금지).
+
+## 3. 명령 표면
+
+```
+/setup                 # 통합 부트스트랩 — 세 lane 한 화면 + verdict + 다음 액션
+/setup apply [preset]  # 추천 provider preset(기본 four-brain)을 canonical config 에 저장 후 재검증
+```
+
+lane 별 연결/전환은 기존 명령이 그대로 담당한다(통합 표면은 그 상태를 모아 보여줄 뿐):
+
+- provider: `/provider connect|disconnect|test|recommended|preset|route ...`
+- knowledge: `/nexus set <vault/repo 경로>` · `/nexus clear`
+- toolchain: `/toolchain detect|recommend|verify|drift|switch`
+
+`/setup apply` 가 provider lane 만 one-shot 으로 쓰는 이유: provider 는 "추천 4-provider"
+라는 단일 합리적 기본값(`four-brain` preset)이 있지만, nexus_root(운영자별 vault 경로)와
+toolchain(repo 마다 다름)은 운영자 입력이 필요하므로 자동 추측하지 않는다(거짓 기본값 금지).
+
+## 4. 영속성 (재실행 후 유지)
+
+모든 lane 은 단일 canonical config(`forgekit_config.paths.config_path` → `~/.forgekit/config.json`,
+`$FORGEKIT_HOME` 로 override)에 쓴다. `provider_ops`(provider preset/routing/fallback)와
+`nexus_ops`(nexus_root)가 그 writer 다. `assess_bootstrap` 은 **별도 state 없이** 같은 config 를
+읽으므로, 운영자가 콘솔을 재실행해도 저장된 설정(primary provider · slot_routing ·
+fallback_policy · nexus_root)이 그대로 반영된다.
+
+evidence(`examples/bootstrap/setup-bootstrap-evidence.txt`)의 STEP 3 가 *restart 시뮬레이션*으로
+이를 증명한다 — in-memory state 없이 disk config 를 재독했을 때 verdict 가 `ready` 로 유지.
+
+## 5. routing / fallback / actual-live 표시
+
+`/setup apply` 가 저장하는 config 는 `slot_routing`(slot→provider)과 `fallback_policy`
+(`slot_fallback_orders`)를 포함한다 — routing 과 fallback 의 SSoT 는
+[`forgekit-provider-policy.md`](forgekit-provider-policy.md). 통합 표면은 provider lane 의
+**declared(primary/brain) vs actual-live(검증된 전송)** 분리를 그대로 보여준다(`provider 상세`
+블록): claude/codex 는 routing-only, gemini/ollama 만 live lane 으로 표기.
+
+## 6. 테스트 / evidence
+
+- 회귀: `python3 -m unittest tests.forgekit.test_bootstrap` — lane 별 정직 상태, no-fake,
+  non-blocking, **재실행-후-유지**, 콘솔 라우팅을 fake probe + tempdir 로 검증.
+- evidence: `apps/forgekit-console/examples/bootstrap/`(`_regen.py` 로 재생성, deterministic).

--- a/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
@@ -26,6 +26,57 @@ def _live_word(pid: str) -> str:
     return "live" if spec.submit_compat == SUBMIT_OPENAI else "unsupported_in_console"
 
 
+# ── honest per-provider state taxonomy (single SSoT for the 5 operator-facing states) ──
+# A provider is reported as exactly ONE state. `live` is asserted ONLY from a VERIFIED probe
+# result (no fake-live): without a probe we never claim live, we fall back to the config role
+# (configured/linked) or its console transport capability (unsupported for CLI brains).
+STATE_SETUP_REQUIRED = "setup-required"   # not part of the configured brain (primary nor linked)
+STATE_CONFIGURED = "configured"           # the primary brain, console-capable, not verified live yet
+STATE_LINKED = "linked"                   # a linked participant, console-capable, not verified live yet
+STATE_LIVE = "live"                       # verified live console transport right now
+STATE_UNSUPPORTED = "unsupported"         # in brain but console live-submit unsupported (CLI claude/codex)
+
+PROVIDER_STATES = (
+    STATE_SETUP_REQUIRED, STATE_CONFIGURED, STATE_LINKED, STATE_LIVE, STATE_UNSUPPORTED,
+)
+
+
+def classify_provider_state(pid: str, parsed, *, live_capable: Optional[bool] = None) -> str:
+    """Honest single-state verdict for *pid* given the parsed brain config.
+
+    ``live_capable`` is the VERIFIED probe result (True/False) or ``None`` when not probed.
+    Precedence (most decision-relevant first): verified-live → not-in-brain → CLI-unsupported →
+    primary(configured) → linked. ``live`` is never inferred — only a True probe yields it."""
+
+    in_brain = (pid == parsed.primary_provider) or (pid in parsed.linked_providers)
+    if live_capable is True:
+        return STATE_LIVE
+    if not in_brain:
+        return STATE_SETUP_REQUIRED
+    spec = builtins.builtin(pid)
+    if spec is not None and spec.submit_compat != SUBMIT_OPENAI:
+        # in the brain but its console transport can never live-submit (CLI attach = routing only).
+        return STATE_UNSUPPORTED
+    if pid == parsed.primary_provider:
+        return STATE_CONFIGURED
+    return STATE_LINKED
+
+
+def provider_state_map(cfg: Optional[Mapping], *,
+                       live_map: Optional[Mapping[str, bool]] = None) -> Tuple[Tuple[str, str], ...]:
+    """`(pid, state)` for every built-in provider, honest per :func:`classify_provider_state`.
+
+    ``live_map`` maps pid→verified live_capable (from a connect probe); absent entries are
+    treated as unprobed (``None``) so no provider is faked into ``live``."""
+
+    parsed = pc.load_provider_config(cfg)
+    lm = dict(live_map or {})
+    return tuple(
+        (pid, classify_provider_state(pid, parsed, live_capable=lm.get(pid)))
+        for pid in builtins.BUILTIN_PROVIDERS
+    )
+
+
 def _route_word(res) -> str:
     """Honest one-word verdict for a slot resolution (declared → actual)."""
 
@@ -236,4 +287,6 @@ __all__ = (
     "provider_status_lines", "provider_list_lines", "provider_doctor_lines", "apply_set_primary",
     "apply_preset", "apply_link", "apply_unlink", "route_show_lines", "apply_route_set",
     "apply_route_clear",
+    "STATE_SETUP_REQUIRED", "STATE_CONFIGURED", "STATE_LINKED", "STATE_LIVE", "STATE_UNSUPPORTED",
+    "PROVIDER_STATES", "classify_provider_state", "provider_state_map",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/runtime/daemon.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/runtime/daemon.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 from . import heartbeat as HB
 
@@ -45,11 +45,13 @@ class DaemonResult:
     notified: int = 0
     heartbeats: int = 0
     executed: int = 0              # total safe-class mutations across the run (WT2 #241)
+    resumed_from: int = 0          # prior heartbeat tick this run resumed from (0 = cold start)
 
     def to_dict(self) -> dict:
         return {"ticks": self.ticks, "stopped_reason": self.stopped_reason,
                 "waits": self.waits, "notified": self.notified,
-                "heartbeats": self.heartbeats, "executed": self.executed}
+                "heartbeats": self.heartbeats, "executed": self.executed,
+                "resumed_from": self.resumed_from}
 
 
 @dataclass
@@ -64,10 +66,23 @@ class BoundedDaemon:
     notifier: Optional[object] = None
     sleep_fn: Optional[Callable[[float], None]] = None
     pid: int = 0
+    resume: bool = True            # on serve start, continue tick numbering from the last heartbeat
     _stop: bool = False
 
     def request_stop(self) -> None:
         self._stop = True
+
+    def _resume_tick(self) -> Tuple[int, str]:
+        """Read the prior heartbeat and return (start_tick, note). Honest continuity only — we
+        resume the tick counter (so cooldown/next_eligible_tick stay monotonic across a restart,
+        e.g. launchd ``KeepAlive``), we do NOT fake that the prior process is still alive."""
+
+        if not self.resume:
+            return 0, ""
+        prior = HB.read_heartbeat(path=self.heartbeat_path, env=self.env)
+        if prior.tick <= 0:
+            return 0, ""
+        return prior.tick, f"resumed from tick {prior.tick} (prev status={prior.status})"
 
     def _heartbeat(self, status: str, tick: int, note: str = "") -> bool:
         from .heartbeat import Heartbeat
@@ -110,15 +125,21 @@ class BoundedDaemon:
         res = DaemonResult()
         sleep = self.sleep_fn or _real_sleep
         self._install_signals()
-        tick = 0
+        tick, resume_note = self._resume_tick()
+        res.resumed_from = tick
+        if tick:
+            # honest startup heartbeat so `forgekit runtime status` shows the resume immediately.
+            self._heartbeat(HB.STATUS_IDLE, tick, resume_note)
+        run_ticks = 0          # ticks executed THIS serve (max_ticks bounds this, not the resumed offset)
         while not self._stop:
             if self._killed():
                 res.stopped_reason = "kill switch"
                 break
-            if self.max_ticks and tick >= self.max_ticks:
+            if self.max_ticks and run_ticks >= self.max_ticks:
                 res.stopped_reason = f"max_ticks({self.max_ticks})"
                 break
             tick += 1
+            run_ticks += 1
             outcome = tick_fn(tick)
             res.ticks = tick
             res.executed += outcome.executed

--- a/packages/forgekit-runtime/src/forgekit_runtime/runtime/surface.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/runtime/surface.py
@@ -42,6 +42,9 @@ def daemon_status_lines(*, env: Optional[Mapping[str, str]] = None) -> Tuple[str
     ]
     if beat.status == hb.STATUS_STOPPED and not beat.ts:
         lines.append("  (데몬 미가동 — `forgekit runtime serve --interval 300 --max-ticks N` 로 bounded 시작)")
+    elif beat.tick > 0:
+        # honest resume hint: the next serve continues tick numbering from here (launchd KeepAlive 등).
+        lines.append(f"  resume    : 다음 serve 는 tick {beat.tick + 1} 부터 이어집니다 (resume on; cooldown 연속성 유지)")
     lines.append("  [dim]제어: CLI `forgekit runtime serve|once|status|stop` · 콘솔 `/daemon stop`(kill-switch)[/dim]")
     return tuple(lines)
 

--- a/tests/forgekit/test_bootstrap.py
+++ b/tests/forgekit/test_bootstrap.py
@@ -181,5 +181,25 @@ class SurfaceAndRouterTests(unittest.TestCase):
             self.assertIn("knowledge", joined)
 
 
+class ProviderTaxonomyInBootstrapTests(unittest.TestCase):
+    """The bootstrap surfaces the honest per-provider 5-state taxonomy (no fake-live)."""
+
+    def test_states_reflect_config_and_verified_probe(self) -> None:
+        from forgekit_provider.policy import provider_surface as ps
+
+        cfg = {"primary_provider": "claude", "linked_providers": ["claude", "gemini"]}
+        # gemini key present (verified live); claude is CLI (unsupported); ollama not in brain.
+        bs = b.assess_bootstrap(cfg, env={}, probe=FakeProbe(claude=True, gemini_key=True))
+        states = dict(bs.provider_states)
+        self.assertEqual(states["gemini"], ps.STATE_LIVE)            # verified
+        self.assertEqual(states["claude"], ps.STATE_UNSUPPORTED)     # CLI brain
+        self.assertEqual(states["ollama"], ps.STATE_SETUP_REQUIRED)  # not in brain
+        # surfaced in the lines + machine-readable dict.
+        text = "\n".join(b.bootstrap_lines(cfg, env={}, probe=FakeProbe(claude=True, gemini_key=True)))
+        self.assertIn("정직 taxonomy", text)
+        self.assertIn("gemini=live", text)
+        self.assertIn("provider_states", bs.to_dict())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/forgekit/test_bootstrap.py
+++ b/tests/forgekit/test_bootstrap.py
@@ -1,0 +1,185 @@
+"""Unified control-plane bootstrap guard — honest composition of every onboarding lane.
+
+Proves ``forgekit_console.bootstrap`` (the ``/setup`` capstone described in
+``docs/forgekit-setup-bootstrap.md`` / ``docs/control-plane-architecture.md`` §4):
+
+- composes provider + knowledge(nexus/vault) + toolchain into ONE report, delegating to each
+  package's honest assessor — NO lane is faked into green;
+- only the provider live lane is *blocking*: readiness flips with it, knowledge/toolchain are
+  surfaced as honest non-blocking lanes (connected / not_connected / missing / detected / ...);
+- the report reads the single canonical ``~/.forgekit/config.json`` the lanes persist to, so an
+  operator re-run after restart reflects what was saved (provider preset + nexus_root survive);
+- the console routes ``/setup`` to the unified bootstrap and ``/setup apply`` still persists+verifies.
+
+Pure / CI-safe — every probe is faked, every path is a tempdir.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console import bootstrap as b
+
+
+class FakeProbe:
+    """Deterministic provider probe — mirrors test_provider_connect.FakeProbe (no real IO)."""
+
+    def __init__(self, *, claude=None, codex=None, gemini_key=False, ollama_up=False, models=()):
+        self._c, self._x, self._g, self._o, self._m = claude, codex, gemini_key, ollama_up, models
+
+    def cli_authenticated(self, pid):
+        return {"claude": self._c, "codex": self._x}.get(pid)
+
+    def api_key(self, pid, env=None):
+        return "key" if (pid == "gemini" and self._g) else ""
+
+    def daemon_reachable(self, ep):
+        return self._o
+
+    def installed_models(self, ep):
+        return self._m
+
+
+class ProviderLaneTests(unittest.TestCase):
+    """The provider lane is the only thing that flips overall readiness."""
+
+    def test_no_live_provider_is_setup_required_blocking(self) -> None:
+        # claude/codex attached = routing-only (connected, NOT live) → no live lane.
+        bs = b.assess_bootstrap({}, env={}, probe=FakeProbe(claude=True, codex=True))
+        prov = bs.stage(b.STAGE_PROVIDER)
+        self.assertTrue(prov.blocking)
+        self.assertFalse(prov.connected)
+        self.assertEqual(prov.status, "setup-required")
+        self.assertEqual(bs.verdict, "setup-required")
+        self.assertFalse(bs.ready)
+
+    def test_live_provider_flips_ready(self) -> None:
+        bs = b.assess_bootstrap({}, env={}, probe=FakeProbe(gemini_key=True))
+        prov = bs.stage(b.STAGE_PROVIDER)
+        self.assertTrue(prov.connected)
+        self.assertEqual(prov.status, "live")
+        self.assertIn("gemini", bs.live_lane)
+        self.assertEqual(bs.verdict, "ready")
+        self.assertTrue(bs.ready)
+
+
+class KnowledgeLaneTests(unittest.TestCase):
+    """Knowledge(nexus/vault) is honest + non-blocking — never faked, never gates readiness."""
+
+    def _probe_live(self):
+        return FakeProbe(gemini_key=True)   # keep provider ready so we isolate the knowledge lane
+
+    def test_no_root_is_not_connected(self) -> None:
+        bs = b.assess_bootstrap({}, env={}, probe=self._probe_live())
+        k = bs.stage(b.STAGE_KNOWLEDGE)
+        self.assertFalse(k.connected)
+        self.assertEqual(k.status, "not_connected")
+        self.assertFalse(k.blocking)
+        self.assertTrue(k.next_action)               # offers /nexus set
+        self.assertTrue(bs.ready)                     # knowledge does NOT block readiness
+
+    def test_missing_path_stays_missing_not_faked(self) -> None:
+        cfg = {"nexus_root": "/no/such/forgekit/nexus/root"}
+        bs = b.assess_bootstrap(cfg, env={}, probe=self._probe_live())
+        k = bs.stage(b.STAGE_KNOWLEDGE)
+        self.assertFalse(k.connected)               # NO fake connection for an absent path
+        self.assertEqual(k.status, "missing")
+
+    def test_existing_root_is_connected(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            bs = b.assess_bootstrap({"nexus_root": root}, env={}, probe=self._probe_live())
+            k = bs.stage(b.STAGE_KNOWLEDGE)
+            self.assertTrue(k.connected)
+            self.assertEqual(k.status, "connected")
+
+    def test_obsidian_vault_detected_in_detail(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / ".obsidian").mkdir()
+            bs = b.assess_bootstrap({"nexus_root": root}, env={}, probe=self._probe_live())
+            k = bs.stage(b.STAGE_KNOWLEDGE)
+            self.assertTrue(k.connected)
+            self.assertIn("Obsidian", k.detail)
+
+
+class ToolchainLaneTests(unittest.TestCase):
+    """Toolchain is repo-local detection only (no guess, no fake switch) and non-blocking."""
+
+    def test_no_manifest_is_not_configured(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            bs = b.assess_bootstrap({}, env={}, probe=FakeProbe(gemini_key=True), repo_root=Path(repo))
+            t = bs.stage(b.STAGE_TOOLCHAIN)
+            self.assertFalse(t.connected)
+            self.assertEqual(t.status, "not_configured")
+            self.assertFalse(t.blocking)
+
+    def test_repo_manifest_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            (Path(repo) / ".tool-versions").write_text("python 3.13.1\nnodejs 20.11.0\n", encoding="utf-8")
+            bs = b.assess_bootstrap({}, env={}, probe=FakeProbe(gemini_key=True), repo_root=Path(repo))
+            t = bs.stage(b.STAGE_TOOLCHAIN)
+            self.assertTrue(t.connected)
+            self.assertEqual(t.status, "detected")
+            self.assertIn("python", t.detail)
+
+
+class PersistenceTests(unittest.TestCase):
+    """Completion criterion: operator settings survive a restart (single canonical config)."""
+
+    def test_nexus_root_and_provider_preset_survive_reload(self) -> None:
+        from forgekit_provider.policy import provider_ops as ops
+        from forgekit_provider_connect import wizard
+        from hephaistos import nexus_ops as nops
+
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as vault:
+            env = {"FORGEKIT_HOME": home}
+            probe = FakeProbe(gemini_key=True, claude=True, codex=True, ollama_up=True, models=("llama3",))
+
+            # 1) persist the provider preset (real writer) + 2) connect a nexus root (real writer).
+            ok, _msg, _post = wizard.apply_recommended(env=env, probe=probe)
+            self.assertTrue(ok)
+            ok2, _m2 = nops.apply_set_root(vault, env=env)
+            self.assertTrue(ok2)
+
+            # 3) re-run the bootstrap with NO in-memory config — it must read what was saved on disk.
+            reloaded = ops.load_raw_config(env=env)
+            self.assertEqual(reloaded.get("nexus_root"), vault)     # survived
+            self.assertTrue(reloaded.get("primary_provider"))       # preset survived
+
+            bs = b.assess_bootstrap(env=env, probe=probe)
+            self.assertEqual(bs.stage(b.STAGE_KNOWLEDGE).status, "connected")
+            self.assertEqual(bs.stage(b.STAGE_PROVIDER).status, "live")
+            self.assertEqual(bs.verdict, "ready")
+            # the report points at the real canonical path under the operator's home.
+            self.assertTrue(bs.config_path.endswith("config.json"))
+            self.assertIn(home, bs.config_path)
+
+
+class SurfaceAndRouterTests(unittest.TestCase):
+    def test_bootstrap_lines_cover_every_lane_and_verdict(self) -> None:
+        text = "\n".join(b.bootstrap_lines({}, env={}, probe=FakeProbe(gemini_key=True)))
+        self.assertIn("컨트롤플레인 부트스트랩", text)
+        self.assertIn("provider", text)
+        self.assertIn("knowledge", text)
+        self.assertIn("toolchain", text)
+        self.assertIn("verdict:", text)
+        self.assertIn("canonical config", text)     # persistence is surfaced
+
+    def test_console_routes_setup_to_unified_bootstrap(self) -> None:
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import ConsoleContext, route
+
+        with tempfile.TemporaryDirectory() as repo:
+            ctx = ConsoleContext(repo_root=Path(repo), env={}, config={})
+            res = route(parse_input("/setup"), ctx)
+            self.assertEqual(res.title, "setup")
+            joined = "\n".join(res.lines)
+            self.assertIn("컨트롤플레인 부트스트랩", joined)   # the unified screen, not the provider-only wizard
+            self.assertIn("knowledge", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_provider_surface.py
+++ b/tests/forgekit/test_provider_surface.py
@@ -122,5 +122,43 @@ class RoutingTests(unittest.TestCase):
         self.assertIn("slot routing", "\n".join(route(parse_input("/provider route show"), ctx).lines))
 
 
+class ProviderStateTaxonomyTests(unittest.TestCase):
+    """The honest 5-state taxonomy (setup-required / configured / linked / live / unsupported).
+
+    ``live`` is asserted ONLY from a verified probe (no fake-live); CLI brains (claude/codex)
+    are ``unsupported`` for console live-submit even as configured participants."""
+
+    def test_not_in_brain_is_setup_required(self) -> None:
+        states = dict(ps.provider_state_map({}))               # empty config → every provider needs setup
+        self.assertEqual(set(states.values()), {ps.STATE_SETUP_REQUIRED})
+
+    def test_cli_primary_is_unsupported_not_faked_live(self) -> None:
+        cfg = {"primary_provider": "claude", "linked_providers": ["claude"]}
+        states = dict(ps.provider_state_map(cfg))
+        self.assertEqual(states["claude"], ps.STATE_UNSUPPORTED)   # CLI brain, no console live — honest
+
+    def test_openai_primary_without_probe_is_configured(self) -> None:
+        cfg = {"primary_provider": "gemini", "linked_providers": ["gemini"]}
+        states = dict(ps.provider_state_map(cfg))                  # unprobed → never "live"
+        self.assertEqual(states["gemini"], ps.STATE_CONFIGURED)
+
+    def test_linked_participant_is_linked(self) -> None:
+        cfg = {"primary_provider": "gemini", "linked_providers": ["gemini", "ollama"]}
+        states = dict(ps.provider_state_map(cfg))
+        self.assertEqual(states["ollama"], ps.STATE_LINKED)
+
+    def test_live_only_from_verified_probe(self) -> None:
+        cfg = {"primary_provider": "gemini", "linked_providers": ["gemini", "ollama"]}
+        states = dict(ps.provider_state_map(cfg, live_map={"ollama": True, "gemini": False}))
+        self.assertEqual(states["ollama"], ps.STATE_LIVE)         # verified → live
+        self.assertEqual(states["gemini"], ps.STATE_CONFIGURED)   # not verified → no fake-live
+
+    def test_every_state_is_one_of_five(self) -> None:
+        cfg = {"primary_provider": "claude", "linked_providers": ["claude", "gemini", "ollama"]}
+        states = dict(ps.provider_state_map(cfg, live_map={"ollama": True}))
+        for pid, state in states.items():
+            self.assertIn(state, ps.PROVIDER_STATES, f"{pid} → {state} not a known state")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/forgekit/test_runtime_daemon.py
+++ b/tests/forgekit/test_runtime_daemon.py
@@ -86,6 +86,28 @@ class DaemonTests(unittest.TestCase):
         self.assertEqual(hb.tick, 1)
         self.assertEqual(hb.status, HB.STATUS_IDLE)
 
+    def test_resume_continues_tick_numbering_from_prior_heartbeat(self) -> None:
+        # a previous run left off at tick 5 (e.g. process restarted under launchd KeepAlive).
+        HB.write_heartbeat(HB.Heartbeat(status=HB.STATUS_STOPPED, tick=5, ts="t0", pid=99), path=self.hb)
+        d = self._daemon(max_ticks=2, resume=True)
+        res = d.serve(lambda n: TickOutcome(summary=f"t{n}"))
+        self.assertEqual(res.resumed_from, 5)                 # honest: picked up the prior tick
+        self.assertEqual(res.ticks, 7)                        # continued 6, 7 (heartbeat tick continuous)
+        self.assertEqual(res.ticks - res.resumed_from, 2)     # max_ticks bounds ticks THIS run, not the offset
+        self.assertEqual(HB.read_heartbeat(path=self.hb).tick, 7)
+
+    def test_resume_disabled_is_cold_start(self) -> None:
+        HB.write_heartbeat(HB.Heartbeat(status=HB.STATUS_STOPPED, tick=9, ts="t0"), path=self.hb)
+        d = self._daemon(max_ticks=2, resume=False)
+        res = d.serve(lambda n: TickOutcome())
+        self.assertEqual(res.resumed_from, 0)                 # ignored the prior heartbeat
+        self.assertEqual(res.ticks, 2)
+
+    def test_resume_with_no_prior_heartbeat_is_cold_start(self) -> None:
+        d = self._daemon(max_ticks=1, resume=True)            # no heartbeat file written yet
+        res = d.serve(lambda n: TickOutcome())
+        self.assertEqual(res.resumed_from, 0)                 # nothing to resume → honest cold start
+
 
 class HeartbeatTests(unittest.TestCase):
     def test_roundtrip_and_kill(self) -> None:


### PR DESCRIPTION
## 목적
ForgeKit **provider/runtime/setup lane completion**. `/setup` 을 단일 provider wizard 에서
**컨트롤플레인 부트스트랩**으로 통합하고(provider · knowledge(nexus/vault) · toolchain), 완료에
필요한 정직 표면(5-state taxonomy)과 always-on 런타임 resume 경로까지 닫는다.

## 범위
- **통합 부트스트랩** `forgekit_console/bootstrap.py` — 세 lane 을 `ControlPlaneBootstrap` 으로
  합성(core 로직 없음, 각 lane 의 정직 assessor 위임). provider live lane 만 blocking.
- **provider 5-state taxonomy** `provider_surface.classify_provider_state`/`provider_state_map`
  (단일 SSoT) — setup-required / configured / linked / live / unsupported. `live` 는 검증된
  probe 일 때만(no fake-live), CLI 브레인은 unsupported. `/setup` 에 표면화.
- **operator 제어**(기존 + 검증): `/provider set|link|unlink|route set|route clear|preset` →
  primary/linked/slot routing/actual-live, 단일 canonical config 에 persist.
- **always-on daemon resume** `BoundedDaemon.serve(resume=True)` — 재시작 시 직전 heartbeat tick
  에서 이어서(cold-start 아님), `resumed_from` 보고, liveness 위조 없음. `/daemon` 에 resume 힌트.
- **Nexus root / Obsidian vault** — 기존 `/nexus set` persist + bootstrap knowledge lane(.obsidian 감지).
- docs SSoT `docs/forgekit-setup-bootstrap.md`(2.1 taxonomy / 4.1 resume) + control-plane §4.
- evidence `apps/forgekit-console/examples/bootstrap/`(deterministic `_regen.py`, STEP 1~5).
- 범위 밖: github app / notification lane 부트스트랩 합류(P1), claude/codex CLI live 전송(unsupported 유지).

## 리스크
- 낮음. taxonomy 분류기는 입력만 받는 순수 함수(거짓 기본값 없음), daemon resume 은 tick 연속성만
  복구(생존 가정 없음). app→package 단방향, core 패키지 호출만. no fake-live 전반 보존.

## 테스트
- 신규: `test_bootstrap.py`(+taxonomy surfacing), `test_provider_surface.py`(ProviderStateTaxonomyTests),
  `test_runtime_daemon.py`(resume 3종). forgekit **908 OK**, 전체 repo **6720 OK**.
- 커밋 governance guard 8 commit OK. PR CI(run 27926490467): test/commit-governance/notify 전부 success.
- evidence: fresh setup-required → apply+`/nexus set` → restart → ready, +5-state taxonomy(STEP 4) +
  daemon resume tick 5→6,7(STEP 5).

## 이슈 linkage
- 방향 SSoT: `docs/control-plane-architecture.md` §4(control-plane bootstrap)·§5 P0(provider/toolchain/
  daemon)·P1(nexus/vault). ForgeKit umbrella #238 계열 setup lane completion(전용 이슈 없음).

---
audit: 브랜치 `feat/forgekit-setup-bootstrap`, base `main`(0e4062e), 8 commit. draft PR — 자동 머지 금지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
