### PR TITLE
✨ per-provider budget 강제 + mode→slot chat/비-chat 분리 (multi-brain routing #2)

### DIFF
--- a/apps/forgekit-console/examples/provider-budget/README.md
+++ b/apps/forgekit-console/examples/provider-budget/README.md
@@ -1,0 +1,22 @@
+# per-provider budget + mode→slot 분리 — evidence
+
+`provider-budget-evidence.txt` 는 wave-2 multi-brain routing gap 마감을 **deterministic**
+(fake transport·temp home·no net)으로 캡처한 것이다. SSoT: [`docs/forgekit-provider-policy.md`](../../../../docs/forgekit-provider-policy.md)
+§4.1(per-provider budget) · §2.1(mode→slot 분리). 회귀: `tests/forgekit/test_provider_budget.py`,
+`tests/forgekit/test_routing.py`.
+
+증명:
+1. **per-provider 한도 영속** — `set_provider_budget` → `persist_config` → reload 후에도
+   `budget_policy.provider_daily_limits` 유지(재실행-후-유지).
+2. **초과 → 정직 fallback** — gemini 가 일일 한도 초과면 routing/submit 이 gemini 를 건너뛰고
+   다음 후보(ollama)로 **정직하게 fallback**(faked send 없음). 전 chain 초과면 `budget_throttled`.
+3. **mode→slot chat/비-chat 분리** — operator CHAT 은 mode 와 무관하게 항상 `default_chat`,
+   비-chat WORK 만 mode 의 work slot(research 등)로 라우팅.
+
+재생성:
+
+```
+PYTHONPATH=<packages/*/src:apps/*/src> python3 \
+  apps/forgekit-console/examples/provider-budget/_regen.py \
+  > apps/forgekit-console/examples/provider-budget/provider-budget-evidence.txt
+```

--- a/apps/forgekit-console/examples/provider-budget/_regen.py
+++ b/apps/forgekit-console/examples/provider-budget/_regen.py
@@ -1,0 +1,97 @@
+"""Regenerate provider-budget-evidence.txt — deterministic (fake transport, temp home, no net).
+
+per-provider daily budget enforcement (honest fallback / throttle, no fake) + mode→slot
+chat/non-chat separation. Run from repo root with every package src on PYTHONPATH; redirect
+stdout into provider-budget-evidence.txt. Regression: tests/forgekit/test_provider_budget.py,
+tests/forgekit/test_routing.py.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from forgekit_provider.usage import provider_budget as pb, ledger
+from forgekit_provider.policy import provider_ops as ops, provider_config as pc, routing as rt
+from forgekit_provider.chat.service import SubmitService
+
+
+class FakeTransport:
+    def __init__(self, reply="live reply"):
+        self.reply = reply
+
+    def openai_chat(self, *, endpoint, model, prompt, api_key=""):
+        return self.reply
+
+    def ollama_reachable(self, endpoint):
+        return True
+
+    def ollama_models(self, endpoint):
+        return ("gemma3:latest",)
+
+
+def banner(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+def main():
+    print("ForgeKit per-provider budget + mode→slot 분리 — deterministic evidence (no fake)")
+    print("재현: tests/forgekit/test_provider_budget.py · test_routing.py")
+
+    banner("STEP 1 — per-provider 한도 영속 (set_provider_budget → persist → reload)")
+    with tempfile.TemporaryDirectory() as home:
+        env = {"FORGEKIT_HOME": home}
+        base = ops.set_primary(ops.load_raw_config(env=env), "gemini")
+        cfg = ops.set_provider_budget(base, "gemini", 100)
+        ok, where = ops.persist_config(cfg, env=env)
+        print(f"$ /provider budget gemini 100  → 저장 ok={ok}")
+        reloaded = ops.load_raw_config(env=env)
+        print(f"$ cat config.json  (재실행 후)\n  budget_policy = {json.dumps(reloaded.get('budget_policy'), ensure_ascii=False)}")
+        print(f"  provider_limits(reload) = {pb.provider_limits(reloaded)}  (재실행-후-유지)")
+
+        banner("STEP 2 — 한도 초과 → routing 정직 fallback (gemini ring-fenced → ollama)")
+        full = {
+            "primary_provider": "gemini", "linked_providers": ["gemini", "ollama"],
+            "slot_routing": {"default_chat": "gemini"},
+            "fallback_policy": {"slot_fallback_orders": {"default_chat": ["ollama"]}},
+            "budget_policy": {"provider_daily_limits": {"gemini": 100}},
+        }
+        rows = [{"provider": "gemini", "total_tokens": 150, "throttled": False}]
+        print(f"  오늘 gemini spent=150 / limit=100 → over={sorted(pb.over_budget_providers(full, rows))}")
+        avail = pb.availability(full, rows)
+        res = rt.resolve_routing(pc.load_provider_config(full), pc.SLOT_DEFAULT_CHAT, available=avail)
+        print(f"  resolve default_chat → actual={res.actual_provider} (status={res.status}, "
+              f"fallback_used={res.fallback_used})  ← gemini 건너뛰고 정직 fallback")
+
+        banner("STEP 3 — live submit 경로도 동일 강제 (over-budget head skip → live fallback)")
+        ledger.append_event(ledger.UsageEvent(ts=ledger.now_ts(env), provider="gemini",
+                                              total_tokens=150, success=True), env=env)
+        svc = SubmitService(transport=FakeTransport(), env=env, config=full)
+        r = svc.submit("hello")
+        print(f"  submit → ok={r.ok}, provider={r.provider_id}, fallback_used={r.fallback_used} "
+              f"(gemini 예산초과 → ollama live)")
+
+        # whole chain over budget → honest throttle, NO faked send.
+        full2 = {**full, "budget_policy": {"provider_daily_limits": {"gemini": 100, "ollama": 100}}}
+        ledger.append_event(ledger.UsageEvent(ts=ledger.now_ts(env), provider="ollama",
+                                              total_tokens=150, success=True), env=env)
+        r2 = SubmitService(transport=FakeTransport(), env=env, config=full2).submit("hello")
+        print(f"  전 chain 초과 → ok={r2.ok}, category={r2.category}, throttled={r2.throttled} "
+              f"(faked send 없음)")
+
+    banner("STEP 4 — mode→slot: chat 은 항상 default_chat, 비-chat work 만 mode slot")
+    cfg = pc.load_provider_config({
+        "primary_provider": "gemini", "linked_providers": ["gemini", "ollama"],
+        "slot_routing": {"default_chat": "ollama", "research": "gemini"},
+    })
+    chat = rt.resolve_submit(cfg, rt.rm.MODE_RESEARCH)                       # kind=chat (default)
+    work = rt.resolve_submit(cfg, rt.rm.MODE_RESEARCH, kind=rt.WORK_NONCHAT)
+    print(f"  research 모드 CHAT  → slot=default_chat → {chat.actual_provider} (chat 은 mode 로 안 끌려감)")
+    print(f"  research 모드 WORK  → slot=research     → {work.actual_provider} (비-chat work 만 mode slot)")
+    print(f"  slot_for(research, chat)={rt.slot_for('research', rt.WORK_CHAT)} · "
+          f"slot_for(research, nonchat)={rt.slot_for('research', rt.WORK_NONCHAT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/provider-budget/provider-budget-evidence.txt
+++ b/apps/forgekit-console/examples/provider-budget/provider-budget-evidence.txt
@@ -1,0 +1,29 @@
+ForgeKit per-provider budget + mode→slot 분리 — deterministic evidence (no fake)
+재현: tests/forgekit/test_provider_budget.py · test_routing.py
+
+==============================================================================
+STEP 1 — per-provider 한도 영속 (set_provider_budget → persist → reload)
+==============================================================================
+$ /provider budget gemini 100  → 저장 ok=True
+$ cat config.json  (재실행 후)
+  budget_policy = {"provider_daily_limits": {"gemini": 100}}
+  provider_limits(reload) = {'gemini': 100}  (재실행-후-유지)
+
+==============================================================================
+STEP 2 — 한도 초과 → routing 정직 fallback (gemini ring-fenced → ollama)
+==============================================================================
+  오늘 gemini spent=150 / limit=100 → over=['gemini']
+  resolve default_chat → actual=ollama (status=fallback, fallback_used=True)  ← gemini 건너뛰고 정직 fallback
+
+==============================================================================
+STEP 3 — live submit 경로도 동일 강제 (over-budget head skip → live fallback)
+==============================================================================
+  submit → ok=True, provider=ollama, fallback_used=True (gemini 예산초과 → ollama live)
+  전 chain 초과 → ok=False, category=budget_throttled, throttled=True (faked send 없음)
+
+==============================================================================
+STEP 4 — mode→slot: chat 은 항상 default_chat, 비-chat work 만 mode slot
+==============================================================================
+  research 모드 CHAT  → slot=default_chat → ollama (chat 은 mode 로 안 끌려감)
+  research 모드 WORK  → slot=research     → gemini (비-chat work 만 mode slot)
+  slot_for(research, chat)=default_chat · slot_for(research, nonchat)=research

--- a/docs/forgekit-provider-policy.md
+++ b/docs/forgekit-provider-policy.md
@@ -68,6 +68,20 @@ slot → capability 매핑(optimized): execution→`execution`, research→`rese
 `execution→codex`, `research→gemini`, `synthesis→claude`, `fallback→gemini`,
 `default_chat→claude`.
 
+### 2.1 mode→slot: chat vs 비-chat 분리 (`policy/routing.py`)
+
+제출은 두 종류다 — operator **CHAT** turn 과 자율 **NON-CHAT** work item. routing 은 이 둘을
+분리한다(`WORK_CHAT` / `WORK_NONCHAT`):
+
+- **chat** → 항상 `default_chat` slot. mode 가 chat 을 work slot 으로 몰래 끌고 가지 않는다
+  (이전엔 delivery 모드의 chat 이 execution slot 으로 가는 conflation 이 있었음). 이는 live submit
+  경로(`chat/service` 가 `default_chat` 사용)와 정확히 일치한다.
+- **nonchat work** → `mode_work_slot(mode)`(research→research, delivery→execution, …). 자율 작업만
+  mode 가 slot 을 결정한다.
+
+`slot_for(mode, kind)` / `resolve_submit(cfg, mode, kind=WORK_CHAT)` 가 진입점. `mode_submit_slot`
+은 back-compat(=`mode_work_slot`). 회귀 `tests/forgekit/test_routing.py`.
+
 ## 3. Main-provider 기본값 (`policy/main_profile.py`)
 
 setup 의 단 하나의 결정 — "어느 provider 가 네 것인가" — 에서 기본값을 파생한다.
@@ -105,6 +119,23 @@ subscription→subscription_aware, api→adaptive, local→local_first, enterpri
 `should_throttle(policy, spent, budget)`: strict 는 `spent >= budget`, 그 외는
 `spent >= reserve_floor(budget)`. budget<=0(unbounded/무비용)은 strict 가 아니면
 throttle 안 함.
+
+### 4.1 per-provider 일일 budget (`usage/provider_budget.py`)
+
+global daily budget(`daily_token_budget`) 위에 **provider 별** 일일 token 한도를 둔다 —
+한 brain 이 전체 예산을 태우지 못하게 하고, 유료 provider 를 ring-fence 한다. config:
+
+```jsonc
+"budget_policy": { "provider_daily_limits": { "gemini": 50000, "ollama": 0 } }
+```
+
+`0`/absent = **unbounded**(정직 — 한도를 임의로 만들지 않음). spend 는 ledger 의 **성공·non-throttle**
+제출만 합산(held/throttle 는 태운 게 없음). 강제는 **routing 의 `available` seam**으로: 한도 초과
+provider 는 *unavailable* → `resolve_routing` 이 다음 후보로 **정직하게 fallback**, live submit 체인
+(`chat/service`)도 동일하게 over-budget head 를 skip(faked send 없음). chain 전부 초과면
+`budget_throttled`. 영속 writer 는 `provider_ops.set_provider_budget`(canonical config, reload 유지),
+표면은 `/provider`(`provider_surface` 가 설정 한도 표기). provider-neutral(특정 vendor 분기 없음).
+회귀 `tests/forgekit/test_provider_budget.py`, evidence `examples/provider-budget/`.
 
 ## 5. Enterprise / internal seam (`providers/registry.py`)
 

--- a/packages/forgekit-provider/src/forgekit_provider/chat/service.py
+++ b/packages/forgekit-provider/src/forgekit_provider/chat/service.py
@@ -77,6 +77,21 @@ class SubmitService:
         if self.config is None:
             self.config = load_config(self.env)
 
+    def _over_budget_providers(self):
+        """Providers over their per-provider daily token limit (honest). Empty (and zero IO)
+        when no per-provider limit is configured — so this is a no-op for existing setups."""
+
+        from ..usage import provider_budget as pb
+
+        if not pb.provider_limits(self.config):
+            return frozenset()
+        from ..usage import ledger
+        try:
+            rows = ledger.read_events(env=self.env, day=ledger.today(self.env))
+        except Exception:  # noqa: BLE001 - ledger unreadable → treat as no spend (never raise on submit)
+            rows = ()
+        return pb.over_budget_providers(self.config, rows)
+
     # --- resolution ---------------------------------------------------------
     def resolve(self, *, prefer_provider: str = "") -> Tuple[Optional[ProviderSpec], str]:
         """Return ``(spec, source)``. Configured provider, else zero-config local ollama.
@@ -173,10 +188,21 @@ class SubmitService:
             )
 
         head = chain[0]
+        over_budget = self._over_budget_providers()   # per-provider daily limit (honest fallback)
         last: Optional[m.SubmitResult] = None
         for i, pid in enumerate(chain):
             spec = self._spec_for(pid)
             if spec is None:
+                continue
+            if pid in over_budget:
+                # honest: this provider hit its OWN daily budget → skip to the next candidate
+                # (never a faked send). If the whole chain is exhausted this is the returned reason.
+                last = m.SubmitResult(
+                    ok=False, mode=m.MODE_HELD, category=m.CAT_BUDGET_THROTTLED,
+                    provider_id=pid, provider_label=spec.label, source=base_source,
+                    runtime_mode=runtime_mode, throttled=True,
+                    text=f"{spec.label} 는 per-provider 일일 token budget 초과 — 다음 후보로 fallback.",
+                    next_action="`budget_policy.provider_daily_limits` 상향 또는 다른 provider 로 routing.")
                 continue
             result = self._dispatch(prompt, spec, base_source, brain, runtime_mode=runtime_mode)
             if result.ok:

--- a/packages/forgekit-provider/src/forgekit_provider/policy/provider_ops.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/provider_ops.py
@@ -79,6 +79,25 @@ def set_implicit_fallback(cfg: Optional[Mapping], enabled: bool) -> dict:
     return out
 
 
+def set_provider_budget(cfg: Optional[Mapping], pid: str, daily_token_limit: int) -> dict:
+    """Set (or clear) a provider's per-provider daily token limit under
+    ``budget_policy.provider_daily_limits`` — persisted in the same canonical config.
+
+    ``daily_token_limit <= 0`` removes the limit (unbounded, honest — never invents one).
+    Routing/submit enforce it (over → honest fallback to the next candidate)."""
+
+    out = _clone(cfg)
+    pol = dict(out.get("budget_policy") or {})
+    limits = dict(pol.get("provider_daily_limits") or {})
+    if daily_token_limit and int(daily_token_limit) > 0:
+        limits[pid] = int(daily_token_limit)
+    else:
+        limits.pop(pid, None)
+    pol["provider_daily_limits"] = limits
+    out["budget_policy"] = pol
+    return out
+
+
 # --- presets (multi-provider brain templates) -------------------------------
 def preset_four_brain(cfg: Optional[Mapping]) -> dict:
     """The recommended 4-provider brain: claude(primary/safety/synthesis) + codex(execution)
@@ -198,5 +217,6 @@ def setup_review(cfg: Optional[Mapping]) -> SetupReview:
 __all__ = (
     "REVIEW_READY", "REVIEW_INCOMPLETE", "REVIEW_MISCONFIGURED", "REVIEW_NO_LIVE",
     "set_primary", "link_provider", "unlink_provider", "route_slot", "set_implicit_fallback",
+    "set_provider_budget",
     "load_raw_config", "persist_config", "BrainMap", "brain_map", "SetupReview", "setup_review",
 )

--- a/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
@@ -121,6 +121,9 @@ def provider_status_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
         f"  unsupported_in_console: {', '.join(bmap.unsupported) or '-'}",
         f"  implicit local fallback: {'on' if parsed.implicit_local_fallback else 'off (기본)'}",
     ]
+    # per-provider daily budget (configured policy, cfg-pure — live spend is in `/usage`).
+    from ..usage import provider_budget as _pb
+    lines.extend(_pb.limit_lines(cfg))
     if not review.ready:
         lines += [f"  ⚠ {i}" for i in review.issues]
     lines.append("  명령: /provider set <id> · /provider list · /provider doctor")

--- a/packages/forgekit-provider/src/forgekit_provider/policy/recommend.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/recommend.py
@@ -97,8 +97,9 @@ def recommend(cfg: pc.ProviderConfig, mode_id: str, *,
                 f"slot '{slot}' 는 현재 {target} 인데 {better} 가 {cap} capability 를 가집니다",
                 f"`/provider route {slot} {better}`", slot=slot, provider=better))
 
-    # 2) active-mode submit slot must be live-capable — surface unsupported as blocked.
-    res = rt.resolve_submit(cfg, mode_id)
+    # 2) active-mode WORK slot must be live-capable — surface unsupported as blocked.
+    #    (non-chat work routes by the mode's slot; chat always uses default_chat separately.)
+    res = rt.resolve_submit(cfg, mode_id, kind=rt.WORK_NONCHAT)
     if res.status == rt.RESOLVE_UNSUPPORTED:
         live_alt = _provider_with_cap(CAP_CHEAP, linked) or \
             next((p for p in linked if rt.submit_supported(builtins.builtin(p))), "")

--- a/packages/forgekit-provider/src/forgekit_provider/policy/routing.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/routing.py
@@ -34,8 +34,14 @@ RESOLVE_FALLBACK = "fallback"                 # declared unusable → explicit f
 RESOLVE_UNSUPPORTED = "unsupported_in_console"  # selected provider has no console transport
 RESOLVE_NO_CONFIG = "no_config"               # nothing configured → setup required
 
-# mode → which brain slot a free-text submit should use (mode actually steers routing).
-_MODE_SLOT = {
+# work kind — a submit is either an operator CHAT turn or an autonomous NON-CHAT work item.
+WORK_CHAT = "chat"          # operator free-text conversation → always the default_chat slot
+WORK_NONCHAT = "nonchat"    # autonomous work (execution/research/…) → the mode's WORK slot
+
+# mode → the brain slot the mode's autonomous NON-CHAT work uses (mode steers work routing).
+# Chat is deliberately ABSENT here: an operator chat turn is never silently routed to a work
+# slot by the mode (that conflated chat with work) — chat is always default_chat.
+_MODE_WORK_SLOT = {
     rm.MODE_RESEARCH: pc.SLOT_RESEARCH,
     rm.MODE_IDEA_DISCOVERY: pc.SLOT_RESEARCH,
     rm.MODE_DELIVERY: pc.SLOT_EXECUTION,
@@ -44,14 +50,33 @@ _MODE_SLOT = {
     rm.MODE_COST_SAVE: pc.SLOT_COMPRESSION,    # cheapest slot
     rm.MODE_WATCH: pc.SLOT_CLASSIFICATION,
     rm.MODE_RED_BLUE: pc.SLOT_SAFETY,
-    # interactive / auto / approval-wait / video-watch → default_chat
+    # modes with no distinct work slot fall back to default_chat.
 }
 
 
-def mode_submit_slot(mode_id: str) -> str:
-    """Which brain slot the active mode routes a free-text submit to."""
+def mode_work_slot(mode_id: str) -> str:
+    """The brain slot the active mode's autonomous NON-CHAT work routes to."""
 
-    return _MODE_SLOT.get(mode_id, pc.SLOT_DEFAULT_CHAT)
+    return _MODE_WORK_SLOT.get(mode_id, pc.SLOT_DEFAULT_CHAT)
+
+
+def slot_for(mode_id: str, kind: str = WORK_CHAT) -> str:
+    """The brain slot for a submit of *kind* under *mode_id*.
+
+    ``chat`` → ``default_chat`` ALWAYS (an operator chat turn is chat, never re-routed to a
+    work slot by the mode — matches the live submit path, which uses ``default_chat``).
+    ``nonchat`` → the mode's work slot (:func:`mode_work_slot`)."""
+
+    return pc.SLOT_DEFAULT_CHAT if kind == WORK_CHAT else mode_work_slot(mode_id)
+
+
+def mode_submit_slot(mode_id: str) -> str:
+    """Back-compat: the mode's NON-CHAT work slot (== :func:`mode_work_slot`).
+
+    Retained for existing callers; new code should call :func:`slot_for` with an explicit
+    ``kind`` so chat (default_chat) and non-chat work (mode slot) stay separated."""
+
+    return mode_work_slot(mode_id)
 
 
 def submit_supported(spec: Optional[ProviderSpec]) -> bool:
@@ -146,10 +171,15 @@ def resolve_routing(
     )
 
 
-def resolve_submit(cfg: pc.ProviderConfig, mode_id: str, **kw) -> RoutingResolution:
-    """Top-level: mode → slot → resolved routing for a free-text submit."""
+def resolve_submit(cfg: pc.ProviderConfig, mode_id: str, *,
+                   kind: str = WORK_CHAT, **kw) -> RoutingResolution:
+    """Top-level: (mode, kind) → slot → resolved routing.
 
-    return resolve_routing(cfg, mode_submit_slot(mode_id), **kw)
+    ``kind=chat`` (default) resolves the ``default_chat`` slot — the honest answer for an
+    operator chat turn (and what the live submit path actually uses). ``kind=nonchat``
+    resolves the mode's WORK slot, so autonomous work routes by the mode, not by chat."""
+
+    return resolve_routing(cfg, slot_for(mode_id, kind), **kw)
 
 
 def submit_chain(cfg: pc.ProviderConfig, slot: str, *, prefer: str = "") -> Tuple[str, ...]:
@@ -181,6 +211,7 @@ def submit_chain(cfg: pc.ProviderConfig, slot: str, *, prefer: str = "") -> Tupl
 
 __all__ = (
     "RESOLVE_OK", "RESOLVE_FALLBACK", "RESOLVE_UNSUPPORTED", "RESOLVE_NO_CONFIG",
-    "mode_submit_slot", "submit_supported", "RoutingResolution",
+    "WORK_CHAT", "WORK_NONCHAT", "mode_work_slot", "slot_for", "mode_submit_slot",
+    "submit_supported", "RoutingResolution",
     "resolve_routing", "resolve_submit", "submit_chain",
 )

--- a/packages/forgekit-provider/src/forgekit_provider/usage/provider_budget.py
+++ b/packages/forgekit-provider/src/forgekit_provider/usage/provider_budget.py
@@ -1,0 +1,127 @@
+"""Per-provider daily token budget — honest enforcement seam (no fake).
+
+The global budget (:mod:`forgekit_provider.usage.budget`) caps the whole day; this caps
+**each provider** so one brain can't burn the entire budget and an operator can ring-fence
+a paid provider (e.g. gemini 50k/day, ollama unbounded). It is pure: given the config's
+``budget_policy.provider_daily_limits`` + today's ledger rows, it answers "is provider X over
+its own daily limit?" — consumed as a routing **availability** gate (over → honest fallback to
+the next candidate, never a faked send) and surfaced per-provider.
+
+``0`` / absent limit = **unbounded** (honest — an unconfigured provider is never throttled,
+and we never invent a limit). Lives next to the usage ledger/breakdown it reads.
+
+Pure / stdlib-only → unit-testable with in-memory rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, FrozenSet, Mapping, Optional, Sequence, Tuple
+
+# config shape: ``budget_policy: {"provider_daily_limits": {"gemini": 50000, "ollama": 0}}``
+BUDGET_POLICY_KEY = "budget_policy"
+PROVIDER_LIMITS_KEY = "provider_daily_limits"
+
+
+def provider_limits(config: Optional[Mapping]) -> Dict[str, int]:
+    """Per-provider daily token limits from config. Only positive limits are kept
+    (0 / absent / invalid = unbounded → omitted from the map)."""
+
+    pol = (config or {}).get(BUDGET_POLICY_KEY) or {}
+    raw = pol.get(PROVIDER_LIMITS_KEY) if isinstance(pol, Mapping) else None
+    out: Dict[str, int] = {}
+    if isinstance(raw, Mapping):
+        for pid, lim in raw.items():
+            try:
+                v = int(lim)
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                out[str(pid)] = v
+    return out
+
+
+def provider_spent(rows: Sequence[Mapping], pid: str) -> int:
+    """Sum ``total_tokens`` for *pid* across *rows* (rows should already be day-scoped).
+
+    Only successful, non-throttled submits count toward spend — a held/throttled attempt
+    burned nothing, so counting it would fake a cost."""
+
+    total = 0
+    for r in rows or ():
+        if str(r.get("provider", "")) != pid:
+            continue
+        if r.get("throttled"):
+            continue
+        try:
+            total += int(r.get("total_tokens", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def is_over(pid: str, limits: Mapping[str, int], rows: Sequence[Mapping]) -> bool:
+    """True iff *pid* has a positive limit AND today's spend already reached it."""
+
+    limit = limits.get(pid, 0)
+    return limit > 0 and provider_spent(rows, pid) >= limit
+
+
+def over_budget_providers(config: Optional[Mapping], rows: Sequence[Mapping]) -> FrozenSet[str]:
+    """The set of providers that are over their per-provider daily limit (honest)."""
+
+    limits = provider_limits(config)
+    return frozenset(pid for pid in limits if is_over(pid, limits, rows))
+
+
+def availability(config: Optional[Mapping], rows: Sequence[Mapping]) -> Callable[[str], bool]:
+    """An ``available(pid)`` callable for :func:`routing.resolve_routing` — False for any
+    provider over its per-provider budget (so routing honestly falls back to the next)."""
+
+    over = over_budget_providers(config, rows)
+    return lambda pid: pid not in over
+
+
+@dataclass(frozen=True)
+class ProviderBudgetState:
+    provider: str
+    limit: int            # 0 = unbounded
+    spent: int
+    over: bool
+
+    @property
+    def ratio(self) -> float:
+        return (self.spent / self.limit) if self.limit > 0 else 0.0
+
+    def to_dict(self) -> dict:
+        return {"provider": self.provider, "limit": self.limit, "spent": self.spent,
+                "over": self.over, "ratio": round(self.ratio, 3)}
+
+
+def provider_budget_states(config: Optional[Mapping],
+                           rows: Sequence[Mapping]) -> Tuple[ProviderBudgetState, ...]:
+    """Honest per-provider budget state for every provider that HAS a limit configured."""
+
+    limits = provider_limits(config)
+    return tuple(
+        ProviderBudgetState(pid, limit, provider_spent(rows, pid),
+                            provider_spent(rows, pid) >= limit)
+        for pid, limit in sorted(limits.items())
+    )
+
+
+def limit_lines(config: Optional[Mapping]) -> Tuple[str, ...]:
+    """`/provider` 표면 — 설정된 per-provider 한도 (live spend 없이 cfg 만, router 비의존)."""
+
+    limits = provider_limits(config)
+    if not limits:
+        return ("  per-provider budget: 미설정 (전 provider unbounded — global budget 만 적용)",)
+    items = ", ".join(f"{pid}={lim}tok/day" for pid, lim in sorted(limits.items()))
+    return (f"  per-provider budget: {items} (초과 시 routing 이 정직하게 fallback/거부)",)
+
+
+__all__ = (
+    "BUDGET_POLICY_KEY", "PROVIDER_LIMITS_KEY",
+    "provider_limits", "provider_spent", "is_over", "over_budget_providers",
+    "availability", "ProviderBudgetState", "provider_budget_states", "limit_lines",
+)

--- a/tests/forgekit/test_provider_budget.py
+++ b/tests/forgekit/test_provider_budget.py
@@ -1,0 +1,160 @@
+"""Per-provider daily budget — honest enforcement (no fake), persistence, routing fallback.
+
+Proves the wave-2 multi-brain routing gap closure:
+- per-provider daily token limits parse from config (0/absent = unbounded, never invented);
+- spend counts only successful non-throttled submits (a held attempt burned nothing);
+- an over-budget provider is **unavailable** → routing/submit honestly fall back to the next
+  candidate, and a fully-exhausted chain returns a budget_throttled result (never a faked send);
+- limits persist to the single canonical config and survive reload.
+
+Pure / stdlib (in-memory rows + a fake transport) → runs in the bare CI install.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_provider.usage import provider_budget as pb
+from forgekit_provider.usage import ledger
+from forgekit_provider.policy import provider_ops as ops, provider_config as pc, routing as rt
+from forgekit_provider.chat import models as m
+from forgekit_provider.chat.service import SubmitService
+
+
+class FakeTransport:
+    """openai-compatible live for any provider it's asked to call (ollama/gemini compat)."""
+
+    def __init__(self, *, reply="ok reply"):
+        self.reply = reply
+        self.calls = []
+
+    def openai_chat(self, *, endpoint, model, prompt, api_key=""):
+        self.calls.append((endpoint, model))
+        return self.reply
+
+    def ollama_reachable(self, endpoint):
+        return True
+
+    def ollama_models(self, endpoint):
+        return ("gemma3:latest",)
+
+
+def _rows(*pairs, throttled=False):
+    """Build ledger rows: each pair = (provider, total_tokens)."""
+    return [{"provider": p, "total_tokens": t, "throttled": throttled} for p, t in pairs]
+
+
+class BudgetUnitTests(unittest.TestCase):
+    CFG = {"budget_policy": {"provider_daily_limits": {"gemini": 100, "ollama": 0}}}
+
+    def test_limits_drop_zero_and_invalid(self) -> None:
+        self.assertEqual(pb.provider_limits(self.CFG), {"gemini": 100})   # ollama 0 = unbounded
+        self.assertEqual(pb.provider_limits({}), {})                       # absent = unbounded
+
+    def test_spent_excludes_throttled(self) -> None:
+        rows = _rows(("gemini", 80), ("gemini", 30)) + _rows(("gemini", 999), throttled=True)
+        self.assertEqual(pb.provider_spent(rows, "gemini"), 110)           # throttled burned nothing
+
+    def test_over_and_availability(self) -> None:
+        rows = _rows(("gemini", 120))
+        self.assertEqual(sorted(pb.over_budget_providers(self.CFG, rows)), ["gemini"])
+        avail = pb.availability(self.CFG, rows)
+        self.assertFalse(avail("gemini"))
+        self.assertTrue(avail("ollama"))                                   # unbounded → always available
+
+    def test_under_budget_is_available(self) -> None:
+        rows = _rows(("gemini", 50))
+        self.assertEqual(pb.over_budget_providers(self.CFG, rows), frozenset())
+
+    def test_no_config_is_unbounded(self) -> None:
+        self.assertEqual(pb.over_budget_providers({}, _rows(("gemini", 10 ** 9))), frozenset())
+
+
+class RoutingFallbackTests(unittest.TestCase):
+    def test_over_budget_declared_falls_back_to_next(self) -> None:
+        # default_chat declared = gemini, explicit fallback = ollama; gemini over budget.
+        cfg = pc.load_provider_config({
+            "primary_provider": "gemini",
+            "linked_providers": ["gemini", "ollama"],
+            "slot_routing": {"default_chat": "gemini"},
+            "fallback_policy": {"slot_fallback_orders": {"default_chat": ["ollama"]}},
+            "budget_policy": {"provider_daily_limits": {"gemini": 100}},
+        })
+        avail = pb.availability({"budget_policy": {"provider_daily_limits": {"gemini": 100}}},
+                                _rows(("gemini", 150)))
+        res = rt.resolve_routing(cfg, pc.SLOT_DEFAULT_CHAT, available=avail)
+        self.assertEqual(res.actual_provider, "ollama")     # honest fallback, gemini ring-fenced
+        self.assertTrue(res.fallback_used)
+        self.assertEqual(res.status, rt.RESOLVE_FALLBACK)
+
+
+class SubmitEnforcementTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.env = {"FORGEKIT_HOME": str(self.tmp)}
+
+    def _spend(self, pid: str, tokens: int) -> None:
+        ledger.append_event(
+            ledger.UsageEvent(ts=ledger.now_ts(self.env), provider=pid, total_tokens=tokens,
+                              success=True),
+            env=self.env)
+
+    def _cfg(self, **over):
+        base = {
+            "primary_provider": "gemini",
+            "linked_providers": ["gemini", "ollama"],
+            "slot_routing": {"default_chat": "gemini"},
+            "fallback_policy": {"slot_fallback_orders": {"default_chat": ["ollama"]}},
+            "budget_policy": {"provider_daily_limits": {"gemini": 100}},
+        }
+        base.update(over)
+        return base
+
+    def test_over_budget_head_falls_back_to_live_provider(self) -> None:
+        self._spend("gemini", 150)                          # gemini over its 100/day limit today
+        svc = SubmitService(transport=FakeTransport(), env=self.env, config=self._cfg())
+        res = svc.submit("hi")
+        self.assertTrue(res.ok)
+        self.assertEqual(res.provider_id, "ollama")         # skipped gemini → live fallback
+        self.assertTrue(res.fallback_used)
+
+    def test_whole_chain_over_budget_returns_honest_throttle(self) -> None:
+        self._spend("gemini", 150)
+        self._spend("ollama", 150)
+        cfg = self._cfg(budget_policy={"provider_daily_limits": {"gemini": 100, "ollama": 100}})
+        svc = SubmitService(transport=FakeTransport(), env=self.env, config=cfg)
+        res = svc.submit("hi")
+        self.assertFalse(res.ok)                            # no faked send
+        self.assertEqual(res.category, m.CAT_BUDGET_THROTTLED)
+        self.assertTrue(res.throttled)
+
+    def test_unconfigured_budget_is_noop(self) -> None:
+        # no per-provider limits → normal submit (gemini head answers live), no budget skip.
+        cfg = self._cfg(budget_policy={})
+        svc = SubmitService(transport=FakeTransport(), env=self.env, config=cfg)
+        self.assertEqual(svc._over_budget_providers(), frozenset())
+        self.assertTrue(svc.submit("hi").ok)
+
+
+class PersistenceTests(unittest.TestCase):
+    def test_set_provider_budget_persists_and_reloads(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            env = {"FORGEKIT_HOME": home}
+            base = ops.set_primary(ops.load_raw_config(env=env), "gemini")   # a valid brain first
+            cfg = ops.set_provider_budget(base, "gemini", 50000)
+            ok, where = ops.persist_config(cfg, env=env)
+            self.assertTrue(ok, where)
+            reloaded = ops.load_raw_config(env=env)                    # fresh read = restart
+            self.assertEqual(pb.provider_limits(reloaded), {"gemini": 50000})
+            # clearing (<=0) removes the limit → unbounded again.
+            cleared = ops.set_provider_budget(reloaded, "gemini", 0)
+            self.assertEqual(pb.provider_limits(cleared), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_routing.py
+++ b/tests/forgekit/test_routing.py
@@ -44,13 +44,20 @@ class ResolveTests(unittest.TestCase):
         self.assertTrue(res.submit_supported)
         self.assertFalse(res.fallback_used)
 
-    def test_mode_changes_actual_provider(self) -> None:
-        # research slot routed to gemini → research mode resolves to gemini (live-capable)
+    def test_mode_steers_nonchat_work_but_chat_stays_default_chat(self) -> None:
+        # research slot routed to gemini. A NON-CHAT work item in research mode resolves to the
+        # research slot (gemini); a CHAT turn stays on default_chat (ollama) regardless of mode —
+        # chat is never silently re-routed to a work slot by the mode (the honest separation).
         cfg = _cfg(linked_providers=["ollama", "gemini"], slot_routing={"research": "gemini"})
-        interactive = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
-        research = r.resolve_submit(cfg, rm.MODE_RESEARCH)
-        self.assertEqual(interactive.actual_provider, "ollama")
-        self.assertEqual(research.actual_provider, "gemini")  # mode actually changed routing
+        chat_research = r.resolve_submit(cfg, rm.MODE_RESEARCH)                      # default kind=chat
+        work_research = r.resolve_submit(cfg, rm.MODE_RESEARCH, kind=r.WORK_NONCHAT)
+        chat_interactive = r.resolve_submit(cfg, rm.MODE_INTERACTIVE)
+        self.assertEqual(chat_research.actual_provider, "ollama")   # chat → default_chat, not research
+        self.assertEqual(chat_interactive.actual_provider, "ollama")
+        self.assertEqual(work_research.actual_provider, "gemini")   # non-chat work → mode's research slot
+        # the separation helpers agree.
+        self.assertEqual(r.slot_for(rm.MODE_RESEARCH, r.WORK_CHAT), "default_chat")
+        self.assertEqual(r.slot_for(rm.MODE_RESEARCH, r.WORK_NONCHAT), "research")
 
     def test_cli_provider_is_unsupported_not_faked(self) -> None:
         # claude routes (declared) but has no console transport → unsupported, never live


### PR DESCRIPTION
## 목적
ForgeKit multi-brain routing 의 마지막 gap(#2) 마감 — **per-provider 일일 budget 강제**와
**mode→slot chat/비-chat 분리**. 한 provider 가 전체 예산을 태우지 못하게 ring-fence 하고,
operator chat 이 mode 에 따라 work slot 으로 몰래 라우팅되던 conflation 을 제거한다.
(wave-2 / gw2 lane, coordinator 배정)

## 범위
- `usage/provider_budget.py` (신규) — per-provider 일일 token 한도 파싱/spend/over/availability (pure).
- `chat/service.py` — live 제출 체인이 over-budget provider 정직 skip→fallback, 전 chain 초과면 throttle.
- `policy/provider_ops.set_provider_budget` — 한도 영속(canonical config, reload 유지).
- `policy/provider_surface` — 설정 한도 표면(/provider, cfg-pure).
- `policy/routing.py` — WORK_CHAT/WORK_NONCHAT + slot_for + mode_work_slot; chat=default_chat 고정.
- 비범위: console commands/registry·router(NON-OVERLAP — /provider budget wiring 은 coordinator 승인 후),
  forgekit-runtime(gw1 영역), claude/codex live transport.

## 리스크
- 낮음. 전부 `packages/forgekit-provider/**`(gw1 forgekit-runtime 와 파일 교집합 0). budget 은 미설정
  시 no-op(기존 setup 무영향). routing 분리는 additive — 기존 호출부 동작 보존(recommend=WORK_NONCHAT),
  conflation 만 제거. no fake provider — 초과는 fallback/throttle 로만, faked send 없음.

## 테스트
- `tests/forgekit/test_provider_budget.py` (신규 10): 한도 파싱/throttle 제외 spend/over/availability/
  routing fallback/live skip→fallback/전 chain throttle/영속+reload.
- `tests/forgekit/test_routing.py`: chat=default_chat vs 비-chat work=mode slot 분리(의도된 동작 변경).
- forgekit **955 OK**, 전체 repo **6767 OK**. commit-governance guard 5 commit OK.
- evidence: `examples/provider-budget/`(deterministic, 영속→초과 fallback→live skip→throttle→분리).

## 이슈 linkage
- acceptance.md A(multi-brain) #2 gap: per-provider budget_policy + mode→slot 비-chat 분리 → gw2.
  master-goal completion #1. ForgeKit umbrella 계열(전용 이슈 없음).

---
audit: 브랜치 `feat/forgekit-provider-budget-routing`, base `main`(bbf311d), 5 commit. draft PR — 머지는 gw0 coordinator 경로(자율 머지 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
