### PR TITLE
✨ evidence → Nexus/vault 누적 (최종완성 축4, lane D)

### DIFF
--- a/apps/forgekit-console/examples/evidence-vault/README.md
+++ b/apps/forgekit-console/examples/evidence-vault/README.md
@@ -1,0 +1,20 @@
+# evidence → Nexus/vault 누적 — evidence
+
+`evidence-vault-evidence.txt` 는 final-completion 축4 "evidence 가 Nexus/vault 에 누적"의 lane-D
+브리지를 **deterministic**(tempdir goal store + tempdir vault)으로 캡처한 것이다. SSoT:
+[`docs/nexus-read-path.md`](../../../../docs/nexus-read-path.md) "Write path" 절. 코드
+`packages/nexus/src/nexus/vault/evidence.py`, 회귀 `tests/forgekit/test_evidence_vault.py`.
+
+증명:
+1. **goal store → vault** — `forgekit_goal` 의 append-only `EvidenceRecord` 가 연결된 Nexus root
+   아래 인증 vault note(frontmatter + 5섹션)로 누적된다.
+2. **no fake nexus connection** — vault 미연결이면 `not_connected`(노트 0개), goal 미해결이면 `no_goal`.
+3. **append-only / idempotent** — 재실행(restart)에도 기존 note 를 덮어쓰지 않고 skip, 파일은 disk 영속.
+
+재생성:
+
+```
+PYTHONPATH=<packages/*/src:apps/*/src> python3 \
+  apps/forgekit-console/examples/evidence-vault/_regen.py \
+  > apps/forgekit-console/examples/evidence-vault/evidence-vault-evidence.txt
+```

--- a/apps/forgekit-console/examples/evidence-vault/_regen.py
+++ b/apps/forgekit-console/examples/evidence-vault/_regen.py
@@ -1,0 +1,58 @@
+"""Regenerate evidence-vault-evidence.txt — deterministic (tempdir goal store + tempdir vault).
+
+goal store append-only evidence → curated authored Nexus vault notes (final-completion 축4).
+Run from repo root with every package src on PYTHONPATH; redirect stdout into the .txt.
+Regression: tests/forgekit/test_evidence_vault.py.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from nexus.vault import evidence as ev
+from forgekit_goal.store import GoalStore
+from forgekit_goal.models import Goal
+
+
+def banner(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+def main():
+    print("ForgeKit evidence → Nexus/vault 누적 — deterministic evidence (no fake)")
+    print("goal store(append-only EvidenceRecord) → 인증 vault note. 재현: tests/forgekit/test_evidence_vault.py")
+
+    with tempfile.TemporaryDirectory() as gstore, tempfile.TemporaryDirectory() as vault:
+        env = {"FORGEKIT_HOME": gstore}
+        st = GoalStore(env=env)
+        g = Goal.create("Nexus provider runtime completion", intent="close axis 4 evidence accumulation")
+        g = g.add_evidence("observation", "per-provider budget + mode/slot 분리 merged", ref="PR#343")
+        g = g.add_evidence("execution", "evidence→vault bridge 구현", ref="nexus.vault.evidence")
+        g = g.add_evidence("verification", "회귀 9 + 전체 1007 OK", ref="test_evidence_vault")
+        st.save(g)
+        print(f"\ngoal `{g.id}` — append-only evidence {len(g.evidence)}건 (goal store 영속)")
+
+        banner("STEP 1 — vault 미연결 → not_connected (노트 위조 없음)")
+        r0 = ev.accumulate_goal_evidence(g.id, vault_root="", env=env)
+        print(f"  accumulate(vault_root='') → status={r0.status}, written={len(r0.written)}")
+
+        banner("STEP 2 — vault 연결 → evidence 가 인증 vault note 로 누적")
+        r1 = ev.accumulate_goal_evidence(g.id, vault_root=vault, env=env)
+        print(f"  status={r1.status}, written={len(r1.written)}, skipped={len(r1.skipped)}")
+        for sub in r1.written:
+            print(f"    + {sub}")
+
+        banner("STEP 3 — 재실행(restart) → append-only idempotent (덮어쓰지 않음)")
+        fresh = GoalStore(env=env)   # 새 핸들 = 프로세스 재시작
+        r2 = ev.accumulate_goal_evidence(g.id, vault_root=vault, env=env, store=fresh)
+        print(f"  status={r2.status}, written={len(r2.written)}, skipped={len(r2.skipped)} (기존 노트 보존)")
+
+        banner("STEP 4 — 누적된 vault note 내용 (인증 frontmatter + 5섹션, 실 evidence)")
+        first = sorted(Path(vault).rglob("*.md"))[0]
+        print(f"$ cat {first.relative_to(vault)}")
+        print(first.read_text(encoding="utf-8").rstrip())
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/evidence-vault/evidence-vault-evidence.txt
+++ b/apps/forgekit-console/examples/evidence-vault/evidence-vault-evidence.txt
@@ -1,0 +1,54 @@
+ForgeKit evidence → Nexus/vault 누적 — deterministic evidence (no fake)
+goal store(append-only EvidenceRecord) → 인증 vault note. 재현: tests/forgekit/test_evidence_vault.py
+
+goal `goal-9d5ff93da4d6` — append-only evidence 3건 (goal store 영속)
+
+==============================================================================
+STEP 1 — vault 미연결 → not_connected (노트 위조 없음)
+==============================================================================
+  accumulate(vault_root='') → status=not_connected, written=0
+
+==============================================================================
+STEP 2 — vault 연결 → evidence 가 인증 vault note 로 누적
+==============================================================================
+  status=connected, written=3, skipped=0
+    + 10-projects/forgekit/evidence/goal-9d5ff93da4d6/001-observation.md
+    + 10-projects/forgekit/evidence/goal-9d5ff93da4d6/002-execution.md
+    + 10-projects/forgekit/evidence/goal-9d5ff93da4d6/003-verification.md
+
+==============================================================================
+STEP 3 — 재실행(restart) → append-only idempotent (덮어쓰지 않음)
+==============================================================================
+  status=connected, written=0, skipped=3 (기존 노트 보존)
+
+==============================================================================
+STEP 4 — 누적된 vault note 내용 (인증 frontmatter + 5섹션, 실 evidence)
+==============================================================================
+$ cat 10-projects/forgekit/evidence/goal-9d5ff93da4d6/001-observation.md
+---
+title: "evidence — Nexus provider runtime completion #1 (observation)"
+kind: evidence
+status: recorded
+created_at: "2026-06-22T04:30:51.793451+00:00"
+tags: [forgekit, evidence, observation]
+related: [goal-9d5ff93da4d6]
+agent_author: knowledge-engineer
+agent_role: Knowledge Engineer
+cssclasses: [fk-knowledge]
+agent_color: "#f59e0b"
+---
+
+> [!fk-knowledge] Knowledge Engineer
+
+## 핵심 요약
+- per-provider budget + mode/slot 분리 merged
+
+## 적용 맥락
+- goal: Nexus provider runtime completion (`goal-9d5ff93da4d6`)
+- evidence #1 · kind: observation · ts: 2026-06-22T04:30:51.793451+00:00
+
+## 참고 (ref)
+- PR#343
+
+## 관련 노트
+- [[goal-9d5ff93da4d6]] (goal evidence 누적)

--- a/docs/nexus-read-path.md
+++ b/docs/nexus-read-path.md
@@ -47,3 +47,23 @@ so the surfaces now reflect the REAL root:
 
 Evidence: [`examples/nexus-live-read/`](../apps/forgekit-console/examples/nexus-live-read/),
 tests `test_nexus_live_read` + `test_nexus_read`.
+
+## Write path — evidence → vault 누적 (`nexus/vault/evidence.py`)
+
+Nexus 는 read-only 가 아니다 — ForgeKit 의 **evidence 가 knowledge plane 에 누적**돼야 한다
+(최종 완성 축4). `forgekit_goal` 의 append-only `EvidenceRecord`(ts/kind/summary/ref)를 **인증
+vault note**(frontmatter + 5섹션, `nexus.vault.note` writer 재사용)로 써서 연결된 Nexus root 아래
+`10-projects/forgekit/evidence/<goal>/NNN-<kind>.md` 에 누적한다.
+
+honesty rails:
+- **no fake nexus connection** — `vault_root` 없으면 `not_connected`(노트 0개, 위조 없음).
+  goal/스토어 미해결이면 `no_goal`.
+- **append-only / idempotent** — note 경로는 (goal, index) 결정적. 기존 note 는 재실행에도
+  덮어쓰지 않고 skip(goal evidence 의 append-only 계약과 일치). 파일은 disk 에 영속(restart 유지).
+- `forgekit_goal` 은 **lazy best-effort import** — nexus 의 단일 `forgekit-config` 의존 유지.
+
+API: `accumulate_goal_evidence(goal_id, vault_root=, env=)`(goal store → vault) ·
+`accumulate_records(goal_id, title, records, vault_root=)`(pure) · `write_evidence_note(...)`.
+live 루프에서 evidence append 시 자동 누적하는 wiring 은 runtime seam(후속). 코드 SSoT
+`packages/nexus/src/nexus/vault/evidence.py`, 회귀 `tests/forgekit/test_evidence_vault.py`,
+evidence [`examples/evidence-vault/`](../apps/forgekit-console/examples/evidence-vault/).

--- a/packages/nexus/src/nexus/vault/__init__.py
+++ b/packages/nexus/src/nexus/vault/__init__.py
@@ -10,6 +10,12 @@ from .authorship import (
     vault_css_snippet,
 )
 from .note import build_authored_note, note_from_handoff, write_note
+from .evidence import (
+    AccumulationResult,
+    accumulate_goal_evidence,
+    accumulate_records,
+    write_evidence_note,
+)
 
 __all__ = (
     "AGENT_IDENTITIES",
@@ -20,4 +26,8 @@ __all__ = (
     "build_authored_note",
     "note_from_handoff",
     "write_note",
+    "AccumulationResult",
+    "accumulate_goal_evidence",
+    "accumulate_records",
+    "write_evidence_note",
 )

--- a/packages/nexus/src/nexus/vault/evidence.py
+++ b/packages/nexus/src/nexus/vault/evidence.py
@@ -1,0 +1,165 @@
+"""Goal evidence → Nexus vault accumulation (final-completion 축4 — "evidence 가 Nexus/vault 누적").
+
+`forgekit_goal` keeps append-only :class:`EvidenceRecord` entries in the goal store; this bridge
+writes each as a **curated, authored vault note** under the connected Nexus root, so evidence
+accumulates in the knowledge plane (Obsidian-readable), not only in the goal store. It reuses the
+existing authored-note writer (:mod:`nexus.vault.note`) — no new vault format.
+
+Honesty rails (no fake):
+- **no fake nexus connection** — with no ``vault_root`` it returns ``not_connected`` and writes
+  nothing; a write that fails returns the failure, never a pretended note.
+- **append-only / idempotent** — an evidence note path is deterministic from (goal, index); an
+  existing note is left untouched (skipped), mirroring the append-only evidence contract.
+- ``forgekit_goal`` is imported **lazily / best-effort** so ``nexus`` keeps its single
+  ``forgekit-config`` dependency; if the goal package is absent the bridge degrades honestly.
+
+Pure given (records, vault_root) → unit-testable; the goal-store adapter is exercised end-to-end
+with a tempdir store + tempdir vault.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Mapping, Optional, Sequence, Tuple
+
+from . import note
+
+# evidence notes live under one project subtree (Obsidian-friendly, one folder per goal).
+EVIDENCE_DIR = "10-projects/forgekit/evidence"
+DEFAULT_AGENT = "knowledge-engineer"   # vault authorship identity for accumulated evidence
+
+# honest connection verdicts for an accumulation run.
+STATUS_CONNECTED = "connected"
+STATUS_NOT_CONNECTED = "not_connected"   # no vault root → nothing written (no fake)
+STATUS_NO_GOAL = "no_goal"               # goal store / goal id unresolved (best-effort)
+
+
+def _slug(text: str, *, limit: int = 32) -> str:
+    s = re.sub(r"[^0-9a-zA-Z가-힣]+", "-", (text or "").strip()).strip("-").lower()
+    return (s[:limit] or "x")
+
+
+def evidence_subpath(goal_id: str, index: int, record) -> str:
+    """Deterministic, stable note path for one evidence record (goal folder + zero-padded index)."""
+
+    kind = _slug(getattr(record, "kind", "") or "note", limit=16)
+    return f"{EVIDENCE_DIR}/{_slug(goal_id, limit=24)}/{index:03d}-{kind}.md"
+
+
+def evidence_note_content(goal_id: str, goal_title: str, index: int, record,
+                          *, agent_id: str = DEFAULT_AGENT) -> str:
+    """Render one :class:`EvidenceRecord` (or any obj with ts/kind/summary/ref) as an authored note."""
+
+    ts = getattr(record, "ts", "") or ""
+    kind = getattr(record, "kind", "") or "note"
+    summary = getattr(record, "summary", "") or ""
+    ref = getattr(record, "ref", None)
+    body = "\n".join((
+        "## 핵심 요약",
+        f"- {summary}",
+        "",
+        "## 적용 맥락",
+        f"- goal: {goal_title} (`{goal_id}`)",
+        f"- evidence #{index} · kind: {kind} · ts: {ts or '(미기록)'}",
+        "",
+        "## 참고 (ref)",
+        f"- {ref}" if ref else "- (외부 artifact ref 없음)",
+        "",
+        "## 관련 노트",
+        f"- [[{_slug(goal_id, limit=24)}]] (goal evidence 누적)",
+    ))
+    return note.build_authored_note(
+        agent_id,
+        title=f"evidence — {goal_title[:40]} #{index} ({kind})",
+        body=body, kind="evidence", status="recorded", created_at=ts,
+        tags=("forgekit", "evidence", _slug(kind, limit=16)),
+        related=(_slug(goal_id, limit=24),),
+    )
+
+
+def write_evidence_note(goal_id: str, goal_title: str, index: int, record,
+                        *, vault_root, agent_id: str = DEFAULT_AGENT,
+                        overwrite: bool = False) -> Optional[Path]:
+    """Write ONE evidence record as a vault note. Idempotent: an existing note is skipped
+    (append-only) unless *overwrite*. Returns the path, or None when no vault / write failed."""
+
+    if not vault_root:
+        return None
+    subpath = evidence_subpath(goal_id, index, record)
+    target = Path(vault_root) / subpath
+    if target.exists() and not overwrite:
+        return target                       # already accumulated — append-only, no rewrite
+    return note.write_note(evidence_note_content(goal_id, goal_title, index, record,
+                                                 agent_id=agent_id), vault_root, subpath)
+
+
+@dataclass(frozen=True)
+class AccumulationResult:
+    """Honest summary of one evidence→vault accumulation run."""
+
+    goal_id: str
+    status: str
+    vault_root: str = ""
+    written: Tuple[str, ...] = ()          # newly written note subpaths
+    skipped: Tuple[str, ...] = ()          # already-present (append-only) subpaths
+    evidence_count: int = 0
+
+    @property
+    def connected(self) -> bool:
+        return self.status == STATUS_CONNECTED
+
+    def to_dict(self) -> dict:
+        return {"goal_id": self.goal_id, "status": self.status, "vault_root": self.vault_root,
+                "written": list(self.written), "skipped": list(self.skipped),
+                "evidence_count": self.evidence_count}
+
+
+def accumulate_records(goal_id: str, goal_title: str, records: Sequence,
+                       *, vault_root, agent_id: str = DEFAULT_AGENT) -> AccumulationResult:
+    """Accumulate a sequence of evidence records into the vault. Pure given the records —
+    no goal-store dependency. Honest ``not_connected`` (writes nothing) when no vault root."""
+
+    if not vault_root:
+        return AccumulationResult(goal_id, STATUS_NOT_CONNECTED, evidence_count=len(records))
+    written: List[str] = []
+    skipped: List[str] = []
+    for i, rec in enumerate(records, start=1):
+        sub = evidence_subpath(goal_id, i, rec)
+        existed = (Path(vault_root) / sub).exists()
+        p = write_evidence_note(goal_id, goal_title, i, rec, vault_root=vault_root, agent_id=agent_id)
+        if p is None:
+            continue                         # write failed → honest omission (not counted as written)
+        (skipped if existed else written).append(sub)
+    return AccumulationResult(goal_id, STATUS_CONNECTED, str(vault_root),
+                              tuple(written), tuple(skipped), len(records))
+
+
+def accumulate_goal_evidence(goal_id: str, *, vault_root, env: Optional[Mapping[str, str]] = None,
+                             agent_id: str = DEFAULT_AGENT, store=None) -> AccumulationResult:
+    """Read a goal's append-only evidence from the goal store and accumulate it into the vault.
+
+    ``forgekit_goal`` is imported lazily (nexus keeps its lone forgekit-config dep). Honest:
+    ``not_connected`` when no vault, ``no_goal`` when the goal/store can't be resolved."""
+
+    if not vault_root:
+        return AccumulationResult(goal_id, STATUS_NOT_CONNECTED)
+    if store is None:
+        try:
+            from forgekit_goal.store import GoalStore  # lazy / best-effort
+        except Exception:  # noqa: BLE001 - goal package absent → honest degrade
+            return AccumulationResult(goal_id, STATUS_NO_GOAL, str(vault_root))
+        store = GoalStore(env=env)
+    goal = store.get(goal_id)
+    if goal is None:
+        return AccumulationResult(goal_id, STATUS_NO_GOAL, str(vault_root))
+    return accumulate_records(goal.id, goal.title, goal.evidence,
+                              vault_root=vault_root, agent_id=agent_id)
+
+
+__all__ = (
+    "EVIDENCE_DIR", "DEFAULT_AGENT", "STATUS_CONNECTED", "STATUS_NOT_CONNECTED", "STATUS_NO_GOAL",
+    "evidence_subpath", "evidence_note_content", "write_evidence_note",
+    "AccumulationResult", "accumulate_records", "accumulate_goal_evidence",
+)

--- a/tests/forgekit/test_evidence_vault.py
+++ b/tests/forgekit/test_evidence_vault.py
@@ -1,0 +1,119 @@
+"""Goal evidence → Nexus vault accumulation (final-completion 축4). Pure / stdlib.
+
+Proves the lane-D bridge:
+- an append-only goal :class:`EvidenceRecord` becomes a curated, authored vault note
+  (frontmatter + 5 sections) under a deterministic per-goal path;
+- **no fake nexus connection** — no vault root → ``not_connected`` and nothing written;
+- **append-only / idempotent** — re-running skips existing notes (no rewrite);
+- end-to-end from the real goal store (tempdir) into a tempdir vault, surviving a fresh read
+  (restart): the notes persist on disk.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from nexus.vault import evidence as ev
+from forgekit_goal.store import GoalStore
+from forgekit_goal.models import Goal
+
+
+class _Rec:
+    """A minimal evidence record (ts/kind/summary/ref) for the pure-path tests."""
+
+    def __init__(self, ts="2026-06-22T10:00:00", kind="observation", summary="did a thing", ref=None):
+        self.ts, self.kind, self.summary, self.ref = ts, kind, summary, ref
+
+
+class NoteFormatTests(unittest.TestCase):
+    def test_subpath_is_deterministic_and_per_goal(self) -> None:
+        rec = _Rec(kind="execution")
+        sub = ev.evidence_subpath("goal-abc123", 2, rec)
+        self.assertEqual(sub, "10-projects/forgekit/evidence/goal-abc123/002-execution.md")
+        self.assertEqual(sub, ev.evidence_subpath("goal-abc123", 2, rec))   # stable
+
+    def test_note_content_is_authored_and_honest_about_missing_ref(self) -> None:
+        content = ev.evidence_note_content("goal-x", "My Goal", 1, _Rec(ref=None))
+        self.assertIn("kind: evidence", content)                 # authored frontmatter
+        self.assertIn("## 핵심 요약", content)
+        self.assertIn("ref 없음", content)                        # honest, not a fabricated ref
+        with_ref = ev.evidence_note_content("goal-x", "My Goal", 1, _Rec(ref="PR#343"))
+        self.assertIn("PR#343", with_ref)
+
+
+class AccumulateRecordsTests(unittest.TestCase):
+    def test_no_vault_is_not_connected_and_writes_nothing(self) -> None:
+        res = ev.accumulate_records("goal-x", "G", [_Rec()], vault_root="")
+        self.assertEqual(res.status, ev.STATUS_NOT_CONNECTED)
+        self.assertFalse(res.connected)
+        self.assertEqual(res.written, ())
+
+    def test_write_evidence_note_no_vault_returns_none(self) -> None:
+        self.assertIsNone(ev.write_evidence_note("g", "G", 1, _Rec(), vault_root=""))
+
+    def test_connected_writes_then_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as vault:
+            recs = [_Rec(kind="observation"), _Rec(kind="execution")]
+            r1 = ev.accumulate_records("goal-x", "Axis 4", recs, vault_root=vault)
+            self.assertEqual(r1.status, ev.STATUS_CONNECTED)
+            self.assertEqual(len(r1.written), 2)
+            self.assertEqual(len(r1.skipped), 0)
+            self.assertEqual(len(list(Path(vault).rglob("*.md"))), 2)
+            # re-run = append-only: existing notes skipped, none rewritten.
+            r2 = ev.accumulate_records("goal-x", "Axis 4", recs, vault_root=vault)
+            self.assertEqual(len(r2.written), 0)
+            self.assertEqual(len(r2.skipped), 2)
+
+
+class GoalStoreEndToEndTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gstore = Path(tempfile.mkdtemp())
+        self.vault = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.gstore, ignore_errors=True))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.vault, ignore_errors=True))
+        self.env = {"FORGEKIT_HOME": str(self.gstore)}
+
+    def _goal_with_evidence(self) -> str:
+        st = GoalStore(env=self.env)
+        g = Goal.create("Nexus runtime completion", intent="close axis 4")
+        g = g.add_evidence("observation", "per-provider budget merged", ref="PR#343")
+        g = g.add_evidence("execution", "evidence→vault bridge built", ref="nexus.vault.evidence")
+        st.save(g)
+        return g.id
+
+    def test_goal_evidence_accumulates_to_vault(self) -> None:
+        gid = self._goal_with_evidence()
+        res = ev.accumulate_goal_evidence(gid, vault_root=str(self.vault), env=self.env)
+        self.assertEqual(res.status, ev.STATUS_CONNECTED)
+        self.assertEqual(res.evidence_count, 2)
+        self.assertEqual(len(res.written), 2)
+        # the real evidence summary made it into a real note (no fabrication).
+        notes = sorted(self.vault.rglob("*.md"))
+        self.assertEqual(len(notes), 2)
+        self.assertIn("per-provider budget merged", notes[0].read_text(encoding="utf-8"))
+
+    def test_unknown_goal_is_no_goal(self) -> None:
+        res = ev.accumulate_goal_evidence("goal-nope", vault_root=str(self.vault), env=self.env)
+        self.assertEqual(res.status, ev.STATUS_NO_GOAL)
+
+    def test_no_vault_is_not_connected(self) -> None:
+        gid = self._goal_with_evidence()
+        self.assertEqual(ev.accumulate_goal_evidence(gid, vault_root="", env=self.env).status,
+                         ev.STATUS_NOT_CONNECTED)
+
+    def test_notes_persist_across_fresh_reaccumulate(self) -> None:
+        # restart simulation: a brand-new store handle reads the same persisted goal + vault.
+        gid = self._goal_with_evidence()
+        ev.accumulate_goal_evidence(gid, vault_root=str(self.vault), env=self.env)
+        fresh = GoalStore(env=self.env)                 # fresh handle == process restart
+        res = ev.accumulate_goal_evidence(gid, vault_root=str(self.vault), env=self.env, store=fresh)
+        self.assertEqual(res.status, ev.STATUS_CONNECTED)
+        self.assertEqual(len(res.skipped), 2)           # prior notes survived on disk (append-only)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
ForgeKit 최종 완성 **축4 "evidence 가 Nexus/vault 에 누적"**(lane D) 마감 — `forgekit_goal` 의
append-only evidence 가 goal store 에만 머무르지 않고 연결된 Nexus root 에 인증 vault note 로
누적되게 한다. (Nexus provider runtime completion 축의 evidence accumulation 부분)

## 범위
- `packages/nexus/src/nexus/vault/evidence.py` (신규) — EvidenceRecord → 인증 vault note(frontmatter
  +5섹션, 기존 `nexus.vault.note` writer 재사용), 결정적 per-goal 경로, idempotent.
  `accumulate_goal_evidence`(goal store→vault, lazy forgekit_goal import) · `accumulate_records`(pure)
  · `write_evidence_note`.
- 비범위: forgekit-runtime(lane C execute_bridge→BoundedMutator), console(lane A/B). live 루프 자동
  누적 wiring 은 runtime seam(후속 M2, coordinator 확인). nexus 하드 dep 무변경(goal import=lazy).

## 리스크
- 낮음. 전부 `packages/nexus/**`(C/A/B lane 과 파일 교집합 0). nexus 단일 forgekit-config 의존 유지.
  no fake: vault 미연결=not_connected(0 note), goal 미해결=no_goal. append-only: 기존 note skip(덮어쓰기 없음).

## 테스트
- `tests/forgekit/test_evidence_vault.py` (신규 9): 결정적 subpath, 인증 note(ref 없음 정직),
  not_connected, connected+idempotent, goal store end-to-end, no_goal, restart 후 누적 유지.
- forgekit **1007 OK**, 전체 repo **6819 OK**. commit-governance 3 commit OK.
- evidence: `examples/evidence-vault/`(deterministic, 미연결→연결→idempotent→note 내용).

## 이슈 linkage
- acceptance.md 축4 "evidence 가 Nexus/vault 에 누적"(현재 ⬜) → lane D. master-goal completion #4.
  merge-order C→D(disjoint package, 병렬 개발). ForgeKit 최종 완성 wave(전용 이슈 없음).

---
audit: 브랜치 `feat/forgekit-evidence-vault`, base `main`(de622f7), 3 commit. draft PR — 머지는 gw0 coordinator(자율 머지 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
