### PR TITLE
✨ Nexus root / Obsidian vault bootstrap (honest validate + scaffold)

### DIFF
--- a/apps/forgekit-console/examples/nexus-vault-bootstrap/README.md
+++ b/apps/forgekit-console/examples/nexus-vault-bootstrap/README.md
@@ -1,0 +1,22 @@
+# Nexus root / Obsidian vault bootstrap — evidence
+
+`nexus-vault-bootstrap-evidence.txt` 는 honest vault 검증 + opt-in scaffold 를 **deterministic**
+(tempdir vault)으로 캡처. SSoT: [`docs/nexus-read-path.md`](../../../../docs/nexus-read-path.md)
+"Vault bootstrap" 절. 코드 `packages/hephaistos/src/hephaistos/nexus_vault.py`, 회귀
+`tests/forgekit/test_nexus_vault.py`.
+
+증명:
+1. **honest inspect** — not_connected/missing/empty/connected, 실제 `.obsidian/` 만 Obsidian 으로
+   인정(위조 없음), bounded note count, KB layout present/missing.
+2. **opt-in scaffold** — `create=False` 보고만, `create=True` 만 KB dir 생성. `.obsidian` 은 절대
+   생성하지 않음(가짜 vault 금지). missing root 면 정직 실패.
+3. **persistence** — `apply_bootstrap` 가 nexus_root 를 canonical config 에 영속 → 재실행(config 재로드)
+   후에도 연결 + vault-aware status 유지.
+
+재생성:
+
+```
+PYTHONPATH=<packages/*/src> python3 \
+  apps/forgekit-console/examples/nexus-vault-bootstrap/_regen.py \
+  > apps/forgekit-console/examples/nexus-vault-bootstrap/nexus-vault-bootstrap-evidence.txt
+```

--- a/apps/forgekit-console/examples/nexus-vault-bootstrap/_regen.py
+++ b/apps/forgekit-console/examples/nexus-vault-bootstrap/_regen.py
@@ -1,0 +1,62 @@
+"""Regenerate nexus-vault-bootstrap-evidence.txt — deterministic (tempdir vault, no net).
+
+honest Obsidian vault inspect (not a fake) + opt-in KB scaffold + apply_bootstrap persistence.
+Run from repo root with packages on PYTHONPATH; redirect stdout into the .txt.
+Regression: tests/forgekit/test_nexus_vault.py.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from hephaistos import nexus_vault as nv
+from hephaistos import nexus_ops as nops
+from hephaistos import nexus_read as nx
+from forgekit_config.paths import config_path
+
+
+def banner(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+def main():
+    print("ForgeKit Nexus root / Obsidian vault bootstrap — deterministic evidence (no fake)")
+    print("재현: tests/forgekit/test_nexus_vault.py")
+
+    banner("STEP 1 — inspect: 미연결 / 없음 / 빈 root (정직 상태, Obsidian 위조 없음)")
+    print(f"  none      → {nv.inspect_vault(None).state}")
+    print(f"  missing   → {nv.inspect_vault(Path('/no/such/vault')).state}")
+    with tempfile.TemporaryDirectory() as empty:
+        i = nv.inspect_vault(Path(empty))
+        print(f"  empty dir → state={i.state} · is_obsidian={i.is_obsidian} · notes={i.note_count}")
+
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as vault:
+        env = {"FORGEKIT_HOME": home}
+        v = Path(vault)
+        (v / ".obsidian").mkdir()                       # a REAL Obsidian vault marker
+        (v / "10-projects").mkdir()
+        (v / "note.md").write_text("# n", encoding="utf-8")
+
+        banner("STEP 2 — inspect 연결된 Obsidian vault (실 .obsidian + notes + KB layout)")
+        i = nv.inspect_vault(v)
+        print(f"  state={i.state} · is_obsidian={i.is_obsidian} · notes={i.note_count} · "
+              f"KB present={list(i.present_dirs)} missing={list(i.missing_dirs)}")
+
+        banner("STEP 3 — /nexus bootstrap <vault> --create (영속 + scaffold, .obsidian 미생성)")
+        ok, msg = nops.apply_bootstrap(vault, create=True, env=env)
+        print(f"  ok={ok}\n" + "\n".join("  " + ln for ln in msg.splitlines()))
+        print(f"  KB dirs on disk: {[d for d in nv.KB_LAYOUT if (v / d).is_dir()]}")
+        print(f"  .obsidian 그대로(부트스트랩이 만들지 않음): {(v / '.obsidian').is_dir()}")
+
+        banner("STEP 4 — 재실행(restart): 저장된 config.json 로드 → 연결 유지 + vault-aware status")
+        saved = json.loads(config_path(env).read_text(encoding="utf-8"))
+        print(f"  config.json nexus_root = {saved.get('nexus_root')}")
+        cs = nx.connection_status(env, saved)
+        print(f"  connection_status: status={cs['status']} connected={cs['connected']} "
+              f"is_vault={cs.get('is_vault')} note_count={cs.get('note_count')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/nexus-vault-bootstrap/nexus-vault-bootstrap-evidence.txt
+++ b/apps/forgekit-console/examples/nexus-vault-bootstrap/nexus-vault-bootstrap-evidence.txt
@@ -1,0 +1,31 @@
+ForgeKit Nexus root / Obsidian vault bootstrap — deterministic evidence (no fake)
+재현: tests/forgekit/test_nexus_vault.py
+
+==============================================================================
+STEP 1 — inspect: 미연결 / 없음 / 빈 root (정직 상태, Obsidian 위조 없음)
+==============================================================================
+  none      → not_connected
+  missing   → missing
+  empty dir → state=empty · is_obsidian=False · notes=0
+
+==============================================================================
+STEP 2 — inspect 연결된 Obsidian vault (실 .obsidian + notes + KB layout)
+==============================================================================
+  state=connected · is_obsidian=True · notes=1 · KB present=['10-projects'] missing=['00-inbox', '20-areas', '30-resources']
+
+==============================================================================
+STEP 3 — /nexus bootstrap <vault> --create (영속 + scaffold, .obsidian 미생성)
+==============================================================================
+  ok=True
+  nexus_root = /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpgbm2ckw6 (저장됨)
+    vault: [connected] Obsidian vault · notes 1 · KB layout 1/4
+    Obsidian(.obsidian): 예 · notes 1
+    scaffold: 생성 [00-inbox, 20-areas, 30-resources] · 기존 [10-projects]
+  KB dirs on disk: ['00-inbox', '10-projects', '20-areas', '30-resources']
+  .obsidian 그대로(부트스트랩이 만들지 않음): True
+
+==============================================================================
+STEP 4 — 재실행(restart): 저장된 config.json 로드 → 연결 유지 + vault-aware status
+==============================================================================
+  config.json nexus_root = /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpgbm2ckw6
+  connection_status: status=exists connected=True is_vault=True note_count=1

--- a/docs/nexus-read-path.md
+++ b/docs/nexus-read-path.md
@@ -22,6 +22,26 @@ bounded normalize → attach`.
 Evidence: [`examples/hephaistos/nexus-read-foundation/`](../apps/forgekit-console/examples/hephaistos/nexus-read-foundation/)
 (connected / not_connected / restricted projection). Surfaced via the `nexus` line in `/resolve`.
 
+## Vault bootstrap — honest Obsidian validation + opt-in scaffold (`nexus_vault.py`)
+
+`connection_status` 는 "root 가 set·readable 인가"만 답한다. **vault bootstrap**(`hephaistos/nexus_vault.py`)
+는 운영자가 알아야 할 더 풍부한 질문에 정직하게 답한다 — 연결된 root 가 실제 **Obsidian vault**(진짜
+`.obsidian/`)인가, 비었는가, note 가 몇 개인가, ForgeKit KB layout(`00-inbox/10-projects/20-areas/
+30-resources`)이 있는가 — 그리고 **opt-in 으로 누락 KB dir 를 scaffold** 한다.
+
+honesty rails:
+- `is_obsidian` 은 실제 `.obsidian/` 검사 — 없으면 `markdown root`(Obsidian 으로 위조 안 함).
+- `inspect_vault` 상태: `not_connected/missing/blocked/empty/connected`(빈 readable root 는 `empty`이되
+  connected). note count 는 bounded(대형 vault 는 `N+`).
+- `scaffold_vault(create=False)` 는 gap **보고만**, `create=True` 만 KB dir 생성하고 created/existing 을
+  정직 보고. **`.obsidian` 은 절대 만들지 않음**(가짜 vault 금지). missing root 면 정직 실패.
+- `connection_status` 는 connected 일 때만 `is_vault`/`note_count`/`empty` 키를 **추가**(기존 키 불변, back-compat).
+
+`/nexus set <path>`(persist) 위에 `nexus_ops.apply_bootstrap(path, create=)` 가 연결+검사+scaffold 를
+한 번에 — 영속(canonical config) 후 재실행에도 유지. 코드 SSoT `packages/hephaistos/src/hephaistos/
+nexus_vault.py`, 회귀 `tests/forgekit/test_nexus_vault.py`, evidence
+[`examples/nexus-vault-bootstrap/`](../apps/forgekit-console/examples/nexus-vault-bootstrap/).
+
 ## Live surface wiring (WT2)
 The read path was real but the surfaces called it with no env/config, so `/nexus`·`/resolve`·
 `/hephaistos` showed a static `not_connected`. WT2 threads the live env + config through

--- a/packages/hephaistos/src/hephaistos/nexus_ops.py
+++ b/packages/hephaistos/src/hephaistos/nexus_ops.py
@@ -50,6 +50,41 @@ def apply_set_root(path_str: str, *, env: Optional[Mapping[str, str]] = None,
     return True, f"nexus_root = {raw} (저장됨) · 상태: [{cs['status']}] {cs['reason']}"
 
 
+def apply_bootstrap(path_str: str, *, create: bool = False,
+                    env: Optional[Mapping[str, str]] = None,
+                    config_file: Optional[Path] = None) -> Tuple[bool, str]:
+    """`/nexus bootstrap <path> [--create]` — connect a vault root AND report/scaffold the KB layout.
+
+    Persists ``nexus_root`` (same canonical config as ``apply_set_root``), then inspects the vault
+    honestly (Obsidian? notes? KB layout?) and — only with ``create=True`` — makes the missing KB
+    dirs (never ``.obsidian``; no fake vault). The message reports the REAL resulting state."""
+
+    raw = (path_str or "").strip()
+    if not raw:
+        return False, "경로를 입력하세요 — `/nexus bootstrap <vault 경로> [--create]`"
+    ok, msg = apply_set_root(raw, env=env, config_file=config_file)
+    if not ok:
+        return False, msg
+    from . import nexus_vault as nv
+
+    insp = nv.inspect_vault(Path(raw))
+    lines = [
+        f"nexus_root = {raw} (저장됨)",
+        f"  vault: [{insp.state}] {insp.reason}",
+        f"  Obsidian(.obsidian): {'예' if insp.is_obsidian else '아니오(markdown root)'} · "
+        f"notes {insp.note_count}{'+' if insp.note_capped else ''}",
+    ]
+    if insp.connected:
+        scaf = nv.scaffold_vault(Path(raw), create=create)
+        if create:
+            lines.append(f"  scaffold: 생성 [{', '.join(scaf.created) or '없음'}] · "
+                         f"기존 [{', '.join(scaf.existing) or '없음'}]"
+                         + ("" if scaf.ok else f" — ⚠ {scaf.reason}"))
+        else:
+            lines.append(f"  KB layout: {scaf.reason} (생성하려면 `--create`)")
+    return True, "\n".join(lines)
+
+
 def apply_clear_root(*, env: Optional[Mapping[str, str]] = None,
                      config_file: Optional[Path] = None) -> Tuple[bool, str]:
     """Remove ``nexus_root`` from config → back to not_connected."""
@@ -66,4 +101,4 @@ def apply_clear_root(*, env: Optional[Mapping[str, str]] = None,
     return True, "nexus_root 해제됨 — not_connected (지식 source 미연결)"
 
 
-__all__ = ("apply_set_root", "apply_clear_root")
+__all__ = ("apply_set_root", "apply_clear_root", "apply_bootstrap")

--- a/packages/hephaistos/src/hephaistos/nexus_read.py
+++ b/packages/hephaistos/src/hephaistos/nexus_read.py
@@ -256,7 +256,13 @@ def connection_status(env: Optional[Mapping[str, str]] = None,
     if not readable:
         return {"status": SRC_BLOCKED, "root": str(root), "connected": False,
                 "reason": "root 읽기 불가(permission/TCC)"}
-    return {"status": SRC_EXISTS, "root": str(root), "connected": True, "reason": "연결됨"}
+    # connected — enrich with honest vault awareness (is it an Obsidian vault? how many notes?).
+    # Back-compat: status/root/connected/reason keys unchanged; is_vault/note_count are additive.
+    from . import nexus_vault as _vault
+    insp = _vault.inspect_vault(root)
+    return {"status": SRC_EXISTS, "root": str(root), "connected": True, "reason": "연결됨",
+            "is_vault": insp.is_obsidian, "note_count": insp.note_count,
+            "empty": insp.note_count == 0, "kb_present": list(insp.present_dirs)}
 
 
 __all__ = (

--- a/packages/hephaistos/src/hephaistos/nexus_vault.py
+++ b/packages/hephaistos/src/hephaistos/nexus_vault.py
@@ -1,0 +1,154 @@
+"""Nexus root / Obsidian vault bootstrap — honest inspection + opt-in scaffold (no fake).
+
+`connection_status` (in :mod:`hephaistos.nexus_read`) answers "is a root set and readable?". This
+module answers the richer **vault** questions an operator bootstrap needs: is the connected root an
+actual Obsidian vault (a real ``.obsidian/`` dir), is it empty, how many notes does it hold, and does
+it have the ForgeKit KB layout — then optionally **scaffolds** the missing layout dirs.
+
+Honesty rails:
+- never claims Obsidian where there's no ``.obsidian/`` (``is_obsidian`` is the real check, not assumed);
+- ``scaffold`` with ``create=False`` only *reports* the gap; ``create=True`` makes the missing KB dirs
+  and reports exactly what it created vs found — it NEVER creates ``.obsidian`` (won't fake a vault);
+- bounded note count (won't walk an unbounded tree).
+
+Pure stdlib (Path only). Lives beside the nexus reader (package-topology: nexus_read/ops are the
+hephaistos-side reader); no new cross-package dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# vault states (honest superset of the connection states, vault-aware).
+VAULT_NOT_CONNECTED = "not_connected"   # no root configured
+VAULT_MISSING = "missing"               # root set but path absent
+VAULT_BLOCKED = "blocked"               # present but unreadable (permission/TCC)
+VAULT_EMPTY = "empty"                    # readable but no markdown notes yet
+VAULT_CONNECTED = "connected"            # readable with notes
+
+# the ForgeKit knowledge-base layout (the vault folders curated notes live under).
+KB_LAYOUT: Tuple[str, ...] = ("00-inbox", "10-projects", "20-areas", "30-resources")
+
+_NOTE_SCAN_CAP = 2000   # bound the note count walk — large vaults report "<cap>+" honestly
+
+
+@dataclass(frozen=True)
+class VaultInspection:
+    """Honest verdict for a (maybe-absent) Nexus vault root."""
+
+    state: str
+    root: str = ""
+    is_obsidian: bool = False           # a real ``.obsidian/`` dir is present
+    note_count: int = 0                 # markdown notes found (bounded; see note_capped)
+    note_capped: bool = False           # True if the walk hit the scan cap
+    present_dirs: Tuple[str, ...] = ()  # KB_LAYOUT dirs that exist
+    missing_dirs: Tuple[str, ...] = ()  # KB_LAYOUT dirs absent
+    reason: str = ""
+
+    @property
+    def connected(self) -> bool:
+        return self.state in (VAULT_EMPTY, VAULT_CONNECTED)
+
+    def to_dict(self) -> dict:
+        return {
+            "state": self.state, "root": self.root, "is_obsidian": self.is_obsidian,
+            "note_count": self.note_count, "note_capped": self.note_capped,
+            "present_dirs": list(self.present_dirs), "missing_dirs": list(self.missing_dirs),
+            "reason": self.reason,
+        }
+
+
+def _count_notes(root: Path) -> Tuple[int, bool]:
+    """Bounded count of ``*.md`` files under *root*. (count, capped)."""
+
+    n = 0
+    try:
+        for _dirpath, _dirs, files in os.walk(root):
+            for f in files:
+                if f.endswith(".md"):
+                    n += 1
+                    if n >= _NOTE_SCAN_CAP:
+                        return n, True
+    except OSError:
+        return n, False
+    return n, False
+
+
+def inspect_vault(root: Optional[Path]) -> VaultInspection:
+    """Inspect a Nexus vault root honestly. ``root=None`` → not_connected (no fake)."""
+
+    if root is None:
+        return VaultInspection(VAULT_NOT_CONNECTED, reason="nexus_root 미설정")
+    root = Path(root)
+    try:
+        exists = root.exists()
+        readable = exists and os.access(root, os.R_OK)
+    except OSError:
+        exists = readable = False
+    if not exists:
+        return VaultInspection(VAULT_MISSING, str(root), reason="설정된 root 경로가 존재하지 않음")
+    if not readable:
+        return VaultInspection(VAULT_BLOCKED, str(root), reason="root 읽기 불가(permission/TCC)")
+    is_obsidian = (root / ".obsidian").is_dir()
+    present = tuple(d for d in KB_LAYOUT if (root / d).is_dir())
+    missing = tuple(d for d in KB_LAYOUT if d not in present)
+    count, capped = _count_notes(root)
+    state = VAULT_CONNECTED if count > 0 else VAULT_EMPTY
+    vault_word = "Obsidian vault" if is_obsidian else "markdown root"
+    reason = (f"{vault_word} · notes {count}{'+' if capped else ''} · "
+              f"KB layout {len(present)}/{len(KB_LAYOUT)}")
+    return VaultInspection(state, str(root), is_obsidian, count, capped, present, missing, reason)
+
+
+@dataclass(frozen=True)
+class ScaffoldResult:
+    """What a scaffold pass found/created. ``created`` is empty when ``create=False``."""
+
+    root: str
+    created: Tuple[str, ...] = ()
+    existing: Tuple[str, ...] = ()
+    ok: bool = True
+    reason: str = ""
+
+    def to_dict(self) -> dict:
+        return {"root": self.root, "created": list(self.created),
+                "existing": list(self.existing), "ok": self.ok, "reason": self.reason}
+
+
+def scaffold_vault(root: Optional[Path], *, create: bool = False) -> ScaffoldResult:
+    """Report (and optionally create) the ForgeKit KB layout dirs under *root*.
+
+    ``create=False`` → report only (created stays empty). ``create=True`` → mkdir the missing
+    KB dirs, reporting created vs existing. NEVER touches ``.obsidian`` (won't fake a vault).
+    Honest failure on a missing/unwritable root."""
+
+    if root is None:
+        return ScaffoldResult("", ok=False, reason="nexus_root 미설정 — 먼저 연결하세요")
+    root = Path(root)
+    if not root.exists():
+        return ScaffoldResult(str(root), ok=False, reason="root 경로 없음 — scaffold 불가(위조 안 함)")
+    existing = [d for d in KB_LAYOUT if (root / d).is_dir()]
+    missing = [d for d in KB_LAYOUT if d not in existing]
+    if not create:
+        return ScaffoldResult(str(root), existing=tuple(existing),
+                              reason=f"미생성 {len(missing)}개: {', '.join(missing) or '없음'} "
+                                     f"(`create=True` 로 생성)")
+    created: List[str] = []
+    for d in missing:
+        try:
+            (root / d).mkdir(parents=True, exist_ok=True)
+            created.append(d)
+        except OSError:
+            return ScaffoldResult(str(root), tuple(created), tuple(existing), ok=False,
+                                  reason=f"{d} 생성 실패(권한 확인)")
+    return ScaffoldResult(str(root), tuple(created), tuple(existing),
+                          reason=f"생성 {len(created)} · 기존 {len(existing)} (.obsidian 미생성)")
+
+
+__all__ = (
+    "VAULT_NOT_CONNECTED", "VAULT_MISSING", "VAULT_BLOCKED", "VAULT_EMPTY", "VAULT_CONNECTED",
+    "KB_LAYOUT", "VaultInspection", "inspect_vault", "ScaffoldResult", "scaffold_vault",
+)

--- a/tests/forgekit/test_nexus_vault.py
+++ b/tests/forgekit/test_nexus_vault.py
@@ -1,0 +1,122 @@
+"""Nexus root / Obsidian vault bootstrap — honest inspect + opt-in scaffold (no fake). Pure.
+
+Proves the lane M2 completion:
+- inspect_vault is honest across not_connected/missing/blocked/empty/connected, detects a REAL
+  ``.obsidian/`` (never assumes Obsidian), counts notes (bounded), reports KB layout;
+- scaffold reports the gap (create=False) and only creates KB dirs with create=True — NEVER
+  fabricates ``.obsidian``;
+- nexus_ops.apply_bootstrap persists the root (canonical config) + reports the real vault state,
+  surviving reload;
+- connection_status is enriched (is_vault / note_count) WITHOUT breaking its existing keys.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from hephaistos import nexus_vault as nv
+from hephaistos import nexus_ops as nops
+from hephaistos import nexus_read as nx
+
+
+class InspectTests(unittest.TestCase):
+    def test_none_root_is_not_connected(self) -> None:
+        self.assertEqual(nv.inspect_vault(None).state, nv.VAULT_NOT_CONNECTED)
+
+    def test_missing_path(self) -> None:
+        self.assertEqual(nv.inspect_vault(Path("/no/such/forgekit/vault")).state, nv.VAULT_MISSING)
+
+    def test_empty_readable_root_is_empty_not_connected_word(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            insp = nv.inspect_vault(Path(root))
+            self.assertEqual(insp.state, nv.VAULT_EMPTY)   # readable but no notes
+            self.assertTrue(insp.connected)                # empty still counts as a live root
+            self.assertFalse(insp.is_obsidian)
+            self.assertEqual(insp.note_count, 0)
+
+    def test_notes_and_obsidian_and_kb_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            r = Path(root)
+            (r / ".obsidian").mkdir()
+            (r / "10-projects").mkdir()
+            (r / "note.md").write_text("# hi", encoding="utf-8")
+            (r / "10-projects" / "p.md").write_text("# p", encoding="utf-8")
+            insp = nv.inspect_vault(r)
+            self.assertEqual(insp.state, nv.VAULT_CONNECTED)
+            self.assertTrue(insp.is_obsidian)              # REAL .obsidian, not assumed
+            self.assertEqual(insp.note_count, 2)
+            self.assertIn("10-projects", insp.present_dirs)
+
+
+class ScaffoldTests(unittest.TestCase):
+    def test_report_only_when_create_false(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            res = nv.scaffold_vault(Path(root), create=False)
+            self.assertEqual(res.created, ())              # report-only
+            self.assertEqual(len(list(Path(root).iterdir())), 0)   # nothing created
+
+    def test_create_makes_kb_dirs_but_never_obsidian(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            res = nv.scaffold_vault(Path(root), create=True)
+            self.assertEqual(set(res.created), set(nv.KB_LAYOUT))
+            for d in nv.KB_LAYOUT:
+                self.assertTrue((Path(root) / d).is_dir())
+            self.assertFalse((Path(root) / ".obsidian").exists())   # no fake Obsidian vault
+
+    def test_create_missing_root_is_honest_failure(self) -> None:
+        res = nv.scaffold_vault(Path("/no/such/root"), create=True)
+        self.assertFalse(res.ok)                            # no fabrication on a missing root
+
+
+class ApplyBootstrapTests(unittest.TestCase):
+    def test_persists_and_reports_and_survives_reload(self) -> None:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as vault:
+            env = {"FORGEKIT_HOME": home}
+            (Path(vault) / "seed.md").write_text("# seed", encoding="utf-8")
+            ok, msg = nops.apply_bootstrap(vault, create=True, env=env)
+            self.assertTrue(ok, msg)
+            self.assertIn("nexus_root", msg)
+            self.assertIn("scaffold", msg)
+            # persisted to canonical config → survives a fresh read (restart): load the saved
+            # config.json (what the console threads in as ctx.config) and confirm it's connected.
+            import json
+            from forgekit_config.paths import config_path
+            saved = json.loads(config_path(env).read_text(encoding="utf-8"))
+            self.assertEqual(saved["nexus_root"], vault)            # persisted
+            cs = nx.connection_status(env, saved)
+            self.assertTrue(cs["connected"])
+            self.assertEqual(cs["root"], vault)
+            # KB dirs really created.
+            for d in nv.KB_LAYOUT:
+                self.assertTrue((Path(vault) / d).is_dir())
+
+    def test_empty_path_refused(self) -> None:
+        self.assertFalse(nops.apply_bootstrap("", env={})[0])
+
+
+class ConnectionStatusEnrichmentTests(unittest.TestCase):
+    def test_enriched_keys_are_additive_and_backcompat(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / ".obsidian").mkdir()
+            (Path(root) / "a.md").write_text("# a", encoding="utf-8")
+            cs = nx.connection_status(env={"FORGEKIT_NEXUS_ROOT": root}, config={})
+            # back-compat keys unchanged
+            self.assertEqual(cs["status"], "exists")
+            self.assertTrue(cs["connected"])
+            # additive vault awareness
+            self.assertTrue(cs["is_vault"])
+            self.assertEqual(cs["note_count"], 1)
+            self.assertFalse(cs["empty"])
+
+    def test_not_connected_has_no_false_vault(self) -> None:
+        cs = nx.connection_status(env={}, config={})
+        self.assertFalse(cs["connected"])
+        self.assertNotIn("is_vault", cs)        # only enriched when actually connected (no fake)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
ForgeKit 최종 완성 Nexus 축 — **Nexus root / Obsidian vault bootstrap** 완성. connect(`/nexus set`,
5-way status)는 있었으나 "실제 Obsidian vault 인가 · note 유무 · KB layout"을 정직하게 검증·scaffold
하는 경로가 없었다. (operator goal "Nexus root/Obsidian vault bootstrap")

## 범위
- `packages/hephaistos/src/hephaistos/nexus_vault.py` (신규) — `inspect_vault`(not_connected/missing/
  blocked/empty/connected + 실 `.obsidian/` 검사 + bounded note_count + KB layout) + `scaffold_vault`
  (opt-in create, `.obsidian` 위조 안 함).
- `nexus_read.connection_status` — connected 일 때 `is_vault`/`note_count`/`empty` 추가(기존 키 불변, back-compat).
- `nexus_ops.apply_bootstrap(path, create=)` — 연결+검사+scaffold 영속(canonical config, reload 유지).
- 비범위: console registry/router, forgekit-runtime. lazy/새 dep 없음(hephaistos-side, 기존 nexus reader 옆).

## 리스크
- 낮음. 전부 `packages/hephaistos/**`(+docs/examples) — A/B/C/D lane 과 파일 교집합 0. additive(connection_status
  키 추가만, 기존 4 status/connected/reason 불변). no fake: 미연결/missing 정직, `.obsidian` 절대 생성 안 함.
- base de622f7(머지 후 origin/main 진행) — additive 라 3-dot diff = 내 8파일만, 충돌 없음.

## 테스트
- `tests/forgekit/test_nexus_vault.py` (신규 11): inspect 5상태+실 .obsidian/note_count, scaffold report/create
  (.obsidian 미생성), apply_bootstrap 영속+reload, connection_status enrich back-compat.
- forgekit **1009 OK**. commit-governance 4 commit OK.
- evidence: `examples/nexus-vault-bootstrap/`(deterministic: inspect→bootstrap+scaffold→restart 유지).

## 이슈 linkage
- master-goal 축3 "Nexus=read path/vault/obsidian" + operator goal "Nexus root/Obsidian vault bootstrap".
  ForgeKit 최종완성 wave(전용 이슈 없음). lane D(evidence→vault, #349)와 별개 nexus 작업.

---
audit: 브랜치 `feat/forgekit-nexus-vault-bootstrap`, base `main`(de622f7), 4 commit. draft PR — 머지는 gw0 coordinator(자율 머지 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
