### PR TITLE
✨ Hephaistos forge governance — forge plan→승인 게이트 + execution receipt ledger + /resolve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ docs/
 | git write 안전 (HOME/모호 경로·broad add 금지) | `docs/git-write-safety.md` (+ `agents/governance/git_path_safety.py`) |
 | engineering-agent role council / tech-lead signoff / execution review | `docs/engineering-role-council-runtime.md` (+ council contract SSoT `apps/engineering-agent/src/yule_engineering/agents/council.py`) |
 | 설계 결정 레인 / PM→gateway→tech-lead→engineer handoff / stack 비교·권고 / fake meeting·signoff 금지 | `docs/pm-techlead-lane.md` (+ 코드 SSoT `packages/forgekit-runtime/src/forgekit_runtime/decision_lane/`) |
+| Hephaistos forge plan → 실제 승인 게이트 → execution receipt / forge governance | `docs/hephaistos-governance.md` (+ 코드 SSoT `packages/forgekit-runtime/src/forgekit_runtime/forge/`) |
 | 모노레포 구조 / packages·apps / compat shim / 코드 이전 | `docs/monorepo-structure.md` (달성 구조 · 의존 hard rail · shim 카탈로그 · 남은 로드맵 SSoT) |
 | ForgeKit 플랫폼 경계 / console=operator app / 코어 packages 분리 | `docs/forgekit-architecture-ownership.md` (owner 매트릭스 · import 경계 · 이전 우선순위 SSoT) |
 | packages/* 분류 / 네이밍 충돌 / 새 기능 위치 / transitional debt | `docs/package-topology.md` (18 package 분류표 · migration matrix · 결정 트리 SSoT) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@
 | plugin/hook/skill/MCP/backend 분리 / provider 배치 | + `docs/plugin-taxonomy.md` + `docs/provider-capability-matrix.md` |
 | engineering role council / tech-lead signoff / execution review | + `docs/engineering-role-council-runtime.md` (SSoT — same-role peer review 통과 후에만 cross-role synthesis, tech-lead = technical approval, gateway = operator approval surface. 코드 contract: `apps/engineering-agent/src/yule_engineering/agents/council.py`) |
 | 설계 결정 레인 / PM brief·meeting·stack 비교 / PM→gateway→tech-lead→engineer handoff / fake meeting·signoff 금지 | + `docs/pm-techlead-lane.md` (SSoT — design system+coding convention+stack+tradeoff+approval 5필수, single executor gate `can_engineer_start`. 코드: `packages/forgekit-runtime/src/forgekit_runtime/decision_lane/`) |
+| Hephaistos forge plan governance / forge→승인게이트→execution receipt / weapon safety 분류 / fake receipt 금지 | + `docs/hephaistos-governance.md` (SSoT — forge plan 을 동일 승인 게이트(run_internal_chain→authorize_runtime_execution→validate_execution)에 연결, 코드: `packages/forgekit-runtime/src/forgekit_runtime/forge/`) |
 | 모노레포 구조 / packages·apps 추가 / compat shim | + `docs/monorepo-structure.md` (현황·의존 규칙·shim 카탈로그·로드맵 SSoT) |
 | ForgeKit 플랫폼 경계 / console=operator app / 코어 packages 분리(WT1~4) | + `docs/forgekit-architecture-ownership.md` (owner 매트릭스·import 경계·이전 우선순위 SSoT) |
 | packages/* 분류 / 네이밍 충돌 / 어디에 새 기능 추가 / transitional debt | + `docs/package-topology.md` (18 package 분류표·migration matrix·결정 트리 SSoT) |

--- a/apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-governance.json
+++ b/apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-governance.json
@@ -1,0 +1,158 @@
+{
+  "note": "Hephaistos forge plan → real approval gate(run_internal_chain→authorize_runtime_execution→validate_execution) → execution receipt",
+  "safe_authorized": {
+    "receipt": {
+      "request": "java spring boot 백엔드 REST API 추가",
+      "selected_agent": "backend-engineer",
+      "selected_loadout": "backend-java-local",
+      "selected_skills": [
+        "java-spring",
+        "auth-jwt",
+        "docker",
+        "mysql",
+        "oauth2",
+        "postgres",
+        "redis",
+        "openai-api"
+      ],
+      "required_weapons": [
+        "openjdk",
+        "gradle",
+        "docker",
+        "mysql",
+        "postgres",
+        "redis"
+      ],
+      "action_class": "safe",
+      "approval_level": "L2_internal_approve",
+      "authorized": true,
+      "outcome": "executed",
+      "approval_metadata": "decision=java spring boot 백엔드 REST API 추가;level=L2_internal_approve;signoff=tech-lead",
+      "chain_trace": [
+        "pm:structure",
+        "gateway:route→be",
+        "tech-lead:safe/L2_internal_approve"
+      ],
+      "commit_trailers": [
+        "Forgekit-Agent: backend-engineer",
+        "Forgekit-Role: Backend",
+        "Forgekit-Dept: engineering",
+        "Forgekit-GitHub-App: missing",
+        "Forgekit-Vault-Class: fk-be",
+        "Forgekit-Flow: hephaistos-forge",
+        "Forgekit-Mode: safe",
+        "Forgekit-Handoff-From: tech-lead",
+        "Forgekit-Handoff-To: backend-engineer",
+        "Forgekit-Approval: decision=java spring boot 백엔드 REST API 추가;level=L2_internal_approve;signoff=tech-lead"
+      ],
+      "verification": [
+        "java -version",
+        "gradle -v",
+        "docker --version",
+        "./gradlew test",
+        "./gradlew check",
+        "./gradlew test --tests '*Jwt*'",
+        "docker compose config",
+        "mysql --version",
+        "mysql -u root -e 'SELECT 1'",
+        "(흐름 수동 검증)",
+        "psql --version",
+        "redis-cli ping",
+        "(연결 smoke)"
+      ],
+      "risky_weapons": [],
+      "blocking_reasons": [],
+      "evidence_path": "runs/forgekit/hephaistos/"
+    },
+    "receipt_validation": []
+  },
+  "destructive_blocked": {
+    "receipt": {
+      "request": "프로덕션 배포 deploy 및 secret 회전",
+      "selected_agent": "security-engineer",
+      "selected_loadout": "devops-cloud-local",
+      "selected_skills": [
+        "secrets-management",
+        "terraform",
+        "aws-ecs",
+        "kubernetes"
+      ],
+      "required_weapons": [
+        "docker",
+        "terraform",
+        "awscli",
+        "kubectl"
+      ],
+      "action_class": "destructive",
+      "approval_level": "L4_restricted",
+      "authorized": false,
+      "outcome": "blocked",
+      "approval_metadata": "",
+      "chain_trace": [
+        "pm:structure",
+        "gateway:route→be",
+        "tech-lead:blocked/L4_restricted"
+      ],
+      "commit_trailers": [],
+      "verification": [
+        "terraform version",
+        "docker --version",
+        "git grep -nE '(secret|password|api[_-]?key)\\s*=' || true",
+        "terraform validate",
+        "terraform plan",
+        "aws --version",
+        "kubectl version --client"
+      ],
+      "risky_weapons": [],
+      "blocking_reasons": [
+        "destructive(L4) — 자동 실행 금지, operator + runbook 전용",
+        "tech-lead 내부 승인(can_execute) 없음",
+        "safe class 아님(blocked) — 자동 실행 금지",
+        "내부 chain 승인(can_execute) 없음 — safe-class 자동 실행만"
+      ],
+      "evidence_path": "runs/forgekit/hephaistos/"
+    },
+    "receipt_validation": []
+  },
+  "risky_weapon_blocked": {
+    "receipt": {
+      "request": "docker 컨테이너 구성",
+      "selected_agent": "backend-engineer",
+      "selected_loadout": "devops-cloud-local",
+      "selected_skills": [
+        "docker"
+      ],
+      "required_weapons": [
+        "docker",
+        "terraform"
+      ],
+      "action_class": "risky",
+      "approval_level": "L3_user_approve",
+      "authorized": false,
+      "outcome": "blocked",
+      "approval_metadata": "",
+      "chain_trace": [
+        "pm:structure",
+        "gateway:route→be",
+        "tech-lead:risky/L3_user_approve"
+      ],
+      "commit_trailers": [],
+      "verification": [
+        "terraform version",
+        "docker --version",
+        "docker compose config"
+      ],
+      "risky_weapons": [
+        "docker"
+      ],
+      "blocking_reasons": [
+        "risky(L3) — operator 승인 없음",
+        "tech-lead 내부 승인(can_execute) 없음",
+        "safe class 아님(risky) — 자동 실행 금지",
+        "내부 chain 승인(can_execute) 없음 — safe-class 자동 실행만"
+      ],
+      "evidence_path": "runs/forgekit/hephaistos/"
+    },
+    "receipt_validation": []
+  }
+}

--- a/apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-ledger.json
+++ b/apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-ledger.json
@@ -1,0 +1,119 @@
+{
+  "note": "append-only forge governance decision log (영속); fake receipts refused at persistence",
+  "entries": [
+    {
+      "receipt": {
+        "request": "java spring boot REST API",
+        "selected_agent": "backend-engineer",
+        "selected_loadout": "backend-java-local",
+        "selected_skills": [
+          "java-spring",
+          "auth-jwt",
+          "docker",
+          "mysql",
+          "oauth2",
+          "postgres",
+          "redis",
+          "openai-api"
+        ],
+        "required_weapons": [
+          "openjdk",
+          "gradle",
+          "docker",
+          "mysql",
+          "postgres",
+          "redis"
+        ],
+        "action_class": "safe",
+        "approval_level": "L2_internal_approve",
+        "authorized": true,
+        "outcome": "executed",
+        "approval_metadata": "decision=java spring boot REST API;level=L2_internal_approve;signoff=tech-lead",
+        "chain_trace": [
+          "pm:structure",
+          "gateway:route→be",
+          "tech-lead:safe/L2_internal_approve"
+        ],
+        "commit_trailers": [
+          "Forgekit-Agent: backend-engineer",
+          "Forgekit-Role: Backend",
+          "Forgekit-Dept: engineering",
+          "Forgekit-GitHub-App: missing",
+          "Forgekit-Vault-Class: fk-be",
+          "Forgekit-Flow: hephaistos-forge",
+          "Forgekit-Mode: safe",
+          "Forgekit-Handoff-From: tech-lead",
+          "Forgekit-Handoff-To: backend-engineer",
+          "Forgekit-Approval: decision=java spring boot REST API;level=L2_internal_approve;signoff=tech-lead"
+        ],
+        "verification": [
+          "java -version",
+          "gradle -v",
+          "docker --version",
+          "./gradlew test",
+          "./gradlew check",
+          "./gradlew test --tests '*Jwt*'",
+          "docker compose config",
+          "mysql --version",
+          "mysql -u root -e 'SELECT 1'",
+          "(흐름 수동 검증)",
+          "psql --version",
+          "redis-cli ping",
+          "(연결 smoke)"
+        ],
+        "risky_weapons": [],
+        "blocking_reasons": [],
+        "evidence_path": "runs/forgekit/hephaistos/"
+      },
+      "recorded_at": "2026-06-22"
+    },
+    {
+      "receipt": {
+        "request": "프로덕션 배포 deploy secret",
+        "selected_agent": "security-engineer",
+        "selected_loadout": "devops-cloud-local",
+        "selected_skills": [
+          "secrets-management",
+          "terraform",
+          "aws-ecs",
+          "kubernetes"
+        ],
+        "required_weapons": [
+          "docker",
+          "terraform",
+          "awscli",
+          "kubectl"
+        ],
+        "action_class": "destructive",
+        "approval_level": "L4_restricted",
+        "authorized": false,
+        "outcome": "blocked",
+        "approval_metadata": "",
+        "chain_trace": [
+          "pm:structure",
+          "gateway:route→be",
+          "tech-lead:blocked/L4_restricted"
+        ],
+        "commit_trailers": [],
+        "verification": [
+          "terraform version",
+          "docker --version",
+          "git grep -nE '(secret|password|api[_-]?key)\\s*=' || true",
+          "terraform validate",
+          "terraform plan",
+          "aws --version",
+          "kubectl version --client"
+        ],
+        "risky_weapons": [],
+        "blocking_reasons": [
+          "destructive(L4) — 자동 실행 금지, operator + runbook 전용",
+          "tech-lead 내부 승인(can_execute) 없음",
+          "safe class 아님(blocked) — 자동 실행 금지",
+          "내부 chain 승인(can_execute) 없음 — safe-class 자동 실행만"
+        ],
+        "evidence_path": "runs/forgekit/hephaistos/"
+      },
+      "recorded_at": "2026-06-22"
+    }
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -414,8 +414,26 @@ def _hephaistos_result(handler, parsed, ctx=None) -> CommandResult:
                                             "(예: `/resolve Spring Boot JWT refresh token`).",))
     plan, read = proj.resolve_with_sources(request, env=env, config=config, role=role)
     if handler == H_RESOLVE:
-        return CommandResult.info("resolve", proj.resolve_summary_lines(plan, read))
+        lines = list(proj.resolve_summary_lines(plan, read)) + list(_forge_governance_lines(request, env=env))
+        return CommandResult.info("resolve", tuple(lines))
     return CommandResult.info("skills", proj.skills_lines(plan, read))
+
+
+def _forge_governance_lines(request: str, *, env=None) -> tuple:
+    """Append the forge GOVERNANCE verdict to /resolve — the operator sees whether the
+    forged plan would be authorized (safe→인가), needs the operator (risky), or is blocked
+    (destructive), bound to the same approval gate the runtime enforces. Lazy + best-effort:
+    if forgekit_runtime is unavailable the resolve summary is returned unchanged."""
+
+    try:
+        from forgekit_runtime.forge import forge_execute
+    except Exception:  # noqa: BLE001
+        return ()
+    try:
+        receipt = forge_execute(request, env=env)
+    except Exception:  # noqa: BLE001 — a render must never break /resolve
+        return ()
+    return ("", "── governance ──") + receipt.lines()
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/docs/hephaistos-governance.md
+++ b/docs/hephaistos-governance.md
@@ -1,0 +1,137 @@
+# Hephaistos Governance — forge plan → 실제 실행 게이트 → execution receipt (SSoT)
+
+> 본 문서는 Hephaistos forging core 를 governance backbone 에 연결하는 단일
+> SSoT 다. 코드 SSoT 는
+> [`packages/forgekit-runtime/src/forgekit_runtime/forge/`](../packages/forgekit-runtime/src/forgekit_runtime/forge/)
+> (`classify.py` / `receipt.py` / `bridge.py`), 회귀는
+> [`tests/forgekit/test_hephaistos_governance.py`](../tests/forgekit/test_hephaistos_governance.py),
+> evidence 는
+> [`apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-governance.json`](../apps/forgekit-console/examples/pm-techlead-lane/hephaistos-forge-governance.json).
+>
+> 승인 게이트는 **재구현하지 않는다** — 자가개선 경로
+> ([`selfimprove/execute_bridge.py`](../packages/forgekit-runtime/src/forgekit_runtime/selfimprove/execute_bridge.py))
+> 와 **동일한** `run_internal_chain` → `decision_lane.authorize_runtime_execution`
+> → `autopilot.validate_execution` 를 재사용한다.
+
+## 0. 한 줄 요약
+
+- Hephaistos `resolve(request)` = forge plan(specialist + skills + loadout +
+  weapons + work packet). 지금까지 이 plan 은 **governance/실행 경로에 미연결**
+  이었다 (execute_bridge 는 self-improvement packet 만 다룸).
+- 본 레인은 forge plan 을 **분류 → 실제 승인 체인 → execution receipt** 로
+  묶어 "회사처럼 움직이는 에이전트 조직" 의 governance backbone 을 forging
+  표면에서 닫는다.
+- **fake 금지:** 차단된 plan 은 trailer 도, executed 도 없다. receipt validator
+  가 위조(미승인 trailer / 승인인데 metadata 없음 / 미인가 executed)를 거부.
+
+## 1. 흐름
+
+```text
+hephaistos.resolve(request)            ← forge: agent+skills+loadout+weapons+packet
+  → classify_forge_plan                ← safe/risky/destructive (packet level + weapon safety + goal wording)
+  → run_internal_chain                 ← PM → gateway → tech-lead (기존)
+  → authorize_runtime_execution        ← decision-lane 런타임 게이트 (executor = forge 가 고른 specialist)
+  → validate_execution                 ← autopilot 재검증
+  → ForgeExecutionReceipt              ← verdict + identity + weapon class + commit trailer + outcome
+```
+
+코드 진입점: `forge_execute(request, *, operator_approval=None, weapon_safety=None)`.
+
+## 2. 분류 — safe / risky / destructive (`classify.py`)
+
+`classify_forge_plan` 은 다음 **가장 엄격한** 값을 취한다.
+
+1. work packet 의 `approval_level` (L2/L3/L4),
+2. **weapon safety** — `required_weapons` 중 armory `risky` 무기가 있으면 최소
+   risky 로 승격. **unknown 무기도 safe 아님**(safe-by-rejection → risky),
+3. **goal wording** — goal 텍스트의 deploy/secret/schema/auth → destructive
+   (`autopilot.approval.classify_level` 재사용).
+
+> **주의:** `forbidden_scope` 는 분류 입력에서 **제외**한다. 그 필드는 "deploy/
+> schema/auth 를 건드리지 말라" 는 가드레일을 *명시* 하므로, 분류에 넣으면 모든
+> plan 이 destructive 로 오분류된다. 작업이 *무엇을 하는가* 는 goal 이 말한다.
+
+weapon safety resolver 는 주입 가능(기본 = armory 카탈로그 lazy 조회) — 순수/
+테스트 가능.
+
+## 3. 실제 실행 게이트 적용 (`bridge.py`)
+
+- executor = forge 의 `selected_agent`(registry 식별자). 미상이면 chain 의
+  routed owner, 그래도 미상이면 `backend-engineer` fallback(항상 `is_known`).
+- `authorize_runtime_execution` 가 gateway + tech-lead + (risky 면) operator +
+  실행시점 재분류를 강제.
+- **honest boundary (execute_bridge 와 동일):** `authorized` 는 **safe-class +
+  chain(can_execute) + decision-lane + validate_execution 전부 통과** 일 때만
+  True. risky/destructive(위험/미상 무기 포함)는 `blocked` — 실행 안 됨, trailer
+  없음. risky + operator 승인이어도 autopilot 체인은 safe 만 자동 실행하므로
+  honest 하게 `blocked`(propose) 로 기록된다.
+- 실제 파일 mutation 은 여전히 `BoundedMutator` 게이트 — 본 단계는 **승인을
+  forged 작업에 묶고 그 증거(receipt)를 발급**.
+
+## 4. Execution Receipt (`receipt.py`)
+
+`ForgeExecutionReceipt` = forge plan 한 건이 어떤 승인 아래 실행됐는지의 증거.
+
+| 필드 | 의미 |
+|---|---|
+| request / selected_agent / selected_loadout / selected_skills / required_weapons | 무엇을 누구에게 equip 했나 |
+| action_class / approval_level / risky_weapons | 어떻게 분류됐나 |
+| authorized / outcome | 인가 여부 + executed/blocked/awaiting/error |
+| approval_metadata / chain_trace / commit_trailers | 누가 승인했나 + commit 이 무엇을 달고 나가나 |
+| blocking_reasons | 차단 사유(미인가 시) |
+
+### 4.1 anti-fake (`validate_forge_receipt`)
+
+- `authorized` → approval_metadata 必, executor `is_known` 必, commit_trailers 必,
+  destructive 면 authorized 불가.
+- 미인가 → blocking_reasons 必, commit_trailers **금지**(있으면 fake approval),
+  outcome=executed **금지**.
+- outcome=executed → authorized 必.
+
+→ 승인/실행이 실제로 일어나지 않은 receipt 는 **만들 수 없다**.
+
+## 4.2 operator surface — `/resolve`
+
+governance 는 라이브러리 함수에 그치지 않고 **operator 가 실제로 본다**.
+`/resolve <요청>` 출력 끝에 `── governance ──` 섹션이 붙어 forged plan 의
+class(safe/risky/destructive) · 인가 여부 · approval metadata 를 보여준다
+(코드: `forgekit_console.commands.router._forge_governance_lines`, best-effort —
+forgekit_runtime 부재 시 resolve 요약만 그대로). 이로써 forging 표면이 동일
+승인 게이트에 **런타임에서** 연결된다.
+
+## 4.3 decision log 영속 (`ledger.py`)
+
+receipt 가 콘솔 출력으로 끝나면 "decision log" 가 아니다. `forge/ledger.py` 가
+append-only JSONL(`state_dir/forge_receipts.jsonl`, **vault 아님** — 별도 트랙)에
+receipt 를 누적해 결정 로그를 **영속** 시킨다.
+
+- `forge_execute(..., persist=True)` → 발급된 receipt 를 ledger 에 1줄 append.
+  `/resolve` 미리보기는 `persist=False`(읽기 전용).
+- `record_forge_receipt` 는 persistence 경계에서 `validate_forge_receipt` 를 다시
+  돌려 **fake receipt 를 거부**(`FakeReceiptRefused`) — 위조 승인/실행은 durable
+  로그에 절대 못 들어간다. I/O 실패는 best-effort(결정 유실 없음), fake 는 hard 거부.
+- `read_forge_receipts(env=, limit=)` 로 audit 재생.
+
+## 5. 무엇을 닫았나 (axis2/axis3)
+
+- PM→gateway→tech-lead→**specialist** chain 을 forge plan 의 실제 specialist
+  (`selected_agent`)로 runtime 에 연결.
+- meeting/decision/handoff/approval(decision-lane) + safe/risky/destructive +
+  approval chain 을 forging 실행 경로에 적용.
+- commit trailer / agent identity / approval metadata / **execution receipt** 를
+  forged 작업에 바인딩.
+- ForgeKit 내부 축 정렬: Hephaistos = execution core 가 governance 게이트 아래에
+  정렬됨(별도 경로 아님 — 동일 게이트 재사용).
+
+## 6. 한계 / 비목표
+
+- 실제 파일 mutation 은 BoundedMutator 경로(별도). 본 레인은 승인+receipt.
+- risky 의 autonomous 실행은 열지 않는다(autopilot safe-only hard rail 유지).
+- self-improvement 자동 promote 금지(기존 hard rail).
+
+## 7. 동기화
+
+- [`AGENTS.md`](../AGENTS.md) §2 — Hephaistos governance 행.
+- [`CLAUDE.md`](../CLAUDE.md) — runtime governance hard rails cross-link.
+- 승인 게이트 SSoT 는 [`pm-techlead-lane.md`](pm-techlead-lane.md), 본 문서는
+  forging 표면 적용으로 cross-link.

--- a/packages/forgekit-runtime/pyproject.toml
+++ b/packages/forgekit-runtime/pyproject.toml
@@ -7,7 +7,7 @@ name = "forgekit-runtime"
 version = "0.1.0"
 description = "ForgeKit runtime core — bounded always-on loop / daemon / approval-notify / lifecycle escalation / autopilot / self-improvement. Operator-gated, never an app import."
 requires-python = ">=3.9"
-dependencies = ["forgekit-config", "forgekit-provider", "forgekit-contracts", "nexus", "forgekit-goal"]
+dependencies = ["forgekit-config", "forgekit-provider", "forgekit-contracts", "nexus", "forgekit-goal", "hephaistos", "armory"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/__init__.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/__init__.py
@@ -1,0 +1,44 @@
+"""Hephaistos forge → governance execution binding (the "execution core" gated).
+
+Closes the org governance backbone for the forging path: a Hephaistos forge plan is
+classified (safe/risky/destructive, incl. weapon safety), run through the SAME real
+approval gate as every other execution (PM→gateway→tech-lead → decision-lane runtime gate
+→ validate_execution), and proven by a :class:`ForgeExecutionReceipt`. No fake approval /
+no fake receipt: a blocked plan is never trailer-stamped and never "executed".
+
+Docs SSoT: ``docs/hephaistos-governance.md``.
+"""
+
+from __future__ import annotations
+
+from .classify import (
+    DESTRUCTIVE,
+    RISKY,
+    SAFE,
+    ForgeClassification,
+    classify_forge_plan,
+)
+from .receipt import (
+    OUTCOME_AWAITING,
+    OUTCOME_BLOCKED,
+    OUTCOME_ERROR,
+    OUTCOME_EXECUTED,
+    ForgeExecutionReceipt,
+    validate_forge_receipt,
+)
+from .bridge import authorize_forge_plan, forge_execute
+from .ledger import (
+    FakeReceiptRefused,
+    forge_receipt_ledger_path,
+    read_forge_receipts,
+    record_forge_receipt,
+)
+
+__all__ = (
+    "SAFE", "RISKY", "DESTRUCTIVE", "ForgeClassification", "classify_forge_plan",
+    "OUTCOME_EXECUTED", "OUTCOME_BLOCKED", "OUTCOME_AWAITING", "OUTCOME_ERROR",
+    "ForgeExecutionReceipt", "validate_forge_receipt",
+    "authorize_forge_plan", "forge_execute",
+    "FakeReceiptRefused", "forge_receipt_ledger_path",
+    "record_forge_receipt", "read_forge_receipts",
+)

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/bridge.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/bridge.py
@@ -1,0 +1,168 @@
+"""Hephaistos forge → governance execution bridge (no re-implementation, real gates).
+
+Connects the forging core to the governance backbone: a Hephaistos
+:class:`ResolvedForgePlan` (request → specialist + skills + loadout + weapons + work
+packet) is run through the EXACT SAME approval path the self-improvement bridge uses —
+
+    forge(resolve) → classify(safe/risky/destructive)
+      → run_internal_chain (PM → gateway → tech-lead)
+      → authorize_runtime_execution (decision-lane runtime gate, the executor is the
+        forge's selected specialist)
+      → validate_execution (autopilot re-check)
+      → ForgeExecutionReceipt (bound to the verdict + identity + commit trailers)
+
+Honest boundary (same as ``selfimprove.execute_bridge``): ``authorized`` is True ONLY for
+a safe-class plan that cleared the full gate; risky/destructive (incl. a risky/unknown
+weapon) → ``blocked``, never executed, never trailer-stamped. The physical file mutation
+stays BoundedMutator-gated — this binds approval to the forged work and issues the proof.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+from forgekit_config.identity.registry import canonical_id, is_known
+
+from ..autopilot import (
+    AutopilotLimits,
+    ExecutionTaskSplit,
+    RepoFinding,
+    can_specialist_execute,
+    run_internal_chain,
+    validate_execution,
+)
+from ..decision_lane import (
+    ActionRequest,
+    authorize_runtime_execution,
+    execution_commit_trailers,
+)
+from .classify import DESTRUCTIVE, RISKY, SAFE, classify_forge_plan
+from .receipt import (
+    OUTCOME_AWAITING,
+    OUTCOME_BLOCKED,
+    OUTCOME_ERROR,
+    OUTCOME_EXECUTED,
+    ForgeExecutionReceipt,
+)
+
+# action class → the chain/classifier risk_class wording (safe→"", reuse approval ladder)
+_RISK_FLAG = {SAFE: "", RISKY: "risky", DESTRUCTIVE: "blocked"}
+# safe-class kind so an authorized safe plan is not re-bumped to risky at exec time
+_SAFE_KIND = "note"
+_EXECUTOR_FALLBACK = "backend-engineer"
+
+
+def _executor_for(plan, route_owner: str) -> str:
+    """The forge already selected a specialist — use it if registry-known, else the
+    chain's routed owner, else the fallback engineer (always ``is_known``)."""
+
+    for cand in (getattr(plan, "selected_agent", ""), route_owner, _EXECUTOR_FALLBACK):
+        cid = canonical_id(cand)
+        if cid and is_known(cid):
+            return cid
+    return canonical_id(_EXECUTOR_FALLBACK) or _EXECUTOR_FALLBACK
+
+
+def authorize_forge_plan(plan, *, weapon_safety=None, operator_approval=None):
+    """Run *plan* through the full real gate. Returns ``(receipt-fields dict)`` pieces via
+    a tuple ``(classification, verdict, chain_ok, val_ok, val_reasons, executor, trace)``."""
+
+    classification = classify_forge_plan(plan, weapon_safety=weapon_safety)
+    risk_flag = _RISK_FLAG.get(classification.action_class, "risky")
+
+    goal = getattr(plan, "request", "") or getattr(getattr(plan, "packet_draft", None), "goal", "")
+    finding = RepoFinding(repo="forgekit", finding=goal, kind="gap",
+                          evidence="hephaistos forge plan")
+    _pkt, route, decision, trace = run_internal_chain(finding, risk_class=risk_flag)
+    executor = _executor_for(plan, route.owner_role)
+
+    request = ActionRequest(kind=_SAFE_KIND if classification.action_class == SAFE else "",
+                            summary=goal, risk_flag=risk_flag)
+    verdict = authorize_runtime_execution(
+        decision, request, executor_role=executor, gateway_ok=True,
+        operator_approval=operator_approval)
+
+    chain_ok = can_specialist_execute(decision)
+    split = ExecutionTaskSplit(decision_summary=goal, executor=executor, tasks=(goal,))
+    val_ok, val_reasons = validate_execution(decision, split, AutopilotLimits())
+    return classification, verdict, chain_ok, val_ok, val_reasons, executor, trace
+
+
+def forge_execute(
+    request: str,
+    *,
+    preferred_role: str = "",
+    operator_approval=None,
+    weapon_safety=None,
+    env: Optional[Mapping[str, str]] = None,
+    persist: bool = False,
+    recorded_at: str = "",
+) -> ForgeExecutionReceipt:
+    """Forge a plan for *request* and issue its governance execution receipt.
+
+    Honest: ``authorized`` (and thus a trailer-stamped, executed receipt) only for a
+    safe-class plan that cleared chain + decision-lane + validate_execution. risky /
+    destructive / risky-weapon → blocked receipt with reasons and NO trailers.
+
+    ``persist=True`` appends the receipt to the append-only decision log (only a
+    validation-passing receipt is recorded — the ledger refuses fakes). A read-only
+    preview (e.g. the /resolve surface) keeps the default ``persist=False``."""
+
+    if not (request or "").strip():
+        return ForgeExecutionReceipt(request="", outcome=OUTCOME_AWAITING,
+                                     blocking_reasons=("빈 요청 — forge 할 작업 없음",))
+
+    # forge the plan (lazy import keeps the module importable without hephaistos installed)
+    try:
+        from hephaistos import resolve
+    except Exception as e:  # noqa: BLE001
+        return ForgeExecutionReceipt(request=request, outcome=OUTCOME_ERROR,
+                                     blocking_reasons=(f"hephaistos 미가용: {e}",))
+    plan = resolve(request, preferred_role=preferred_role)
+
+    classification, verdict, chain_ok, val_ok, val_reasons, executor, trace = \
+        authorize_forge_plan(plan, weapon_safety=weapon_safety, operator_approval=operator_approval)
+
+    authorized = bool(verdict.allowed and chain_ok and val_ok)
+
+    reasons = []
+    if not authorized:
+        reasons = list(verdict.blocking_reasons) + list(val_reasons)
+        if not chain_ok:
+            reasons.append("내부 chain 승인(can_execute) 없음 — safe-class 자동 실행만")
+
+    # trailers bind to the AUTHORIZED verdict only (no fake approval on a blocked path)
+    trailers = execution_commit_trailers(verdict, flow="hephaistos-forge", env=env) if authorized else ()
+    outcome = OUTCOME_EXECUTED if authorized else OUTCOME_BLOCKED
+    packet = getattr(plan, "packet_draft", None)
+
+    receipt = ForgeExecutionReceipt(
+        request=request,
+        selected_agent=executor,
+        selected_loadout=getattr(plan, "selected_loadout", ""),
+        selected_skills=tuple(getattr(plan, "selected_skills", ()) or ()),
+        required_weapons=tuple(getattr(plan, "required_weapons", ()) or ()),
+        action_class=classification.action_class,
+        approval_level=classification.approval_level,
+        authorized=authorized,
+        outcome=outcome,
+        approval_metadata=verdict.approval_metadata if authorized else "",
+        chain_trace=tuple(trace),
+        commit_trailers=tuple(trailers),
+        verification=tuple(getattr(plan, "verification_commands", ()) or ()),
+        risky_weapons=classification.risky_weapons,
+        blocking_reasons=tuple(reasons),
+        evidence_path=getattr(packet, "evidence_path", "") if packet else "",
+    )
+
+    if persist:
+        # append-only decision log; refuses to persist a fake receipt (best-effort I/O).
+        from .ledger import record_forge_receipt
+        try:
+            record_forge_receipt(receipt, env=env, recorded_at=recorded_at)
+        except Exception:  # noqa: BLE001 — a store/validation issue must not lose the verdict
+            pass
+    return receipt
+
+
+__all__ = ("authorize_forge_plan", "forge_execute")

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/classify.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/classify.py
@@ -1,0 +1,118 @@
+"""Forge-plan risk classification — safe / risky / destructive (governance backbone).
+
+A Hephaistos :class:`ResolvedForgePlan` is "what to equip + the work packet". Before it
+can run through the execution gate, its risk has to be derived from the SAME inputs an
+operator would weigh — and from MORE than the packet's own ``approval_level`` (which the
+resolver currently hardcodes to L2). We take the STRICTEST of:
+
+* the work packet's declared ``approval_level`` (L2/L3/L4),
+* the **weapon safety** of every required weapon (an armory ``risky`` weapon bumps the
+  plan to at least risky — installing/using a risky tool is not a safe-class act),
+* the goal/forbidden-scope **wording** (deploy/secret/schema/auth → destructive), reusing
+  the one classifier ladder (:mod:`forgekit_runtime.autopilot.approval`).
+
+Safe-by-rejection: an unknown weapon is treated as risky, not silently safe. The weapon
+safety resolver is injectable so the classifier stays pure + testable; the default reads
+the armory catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+from ..autopilot import approval as A
+
+# action classes (mirror decision_lane.enforcement)
+SAFE = "safe"
+RISKY = "risky"
+DESTRUCTIVE = "destructive"
+
+_LEVEL_ORDER = {A.L2_INTERNAL_APPROVE: 0, A.L3_USER_APPROVE: 1, A.L4_RESTRICTED: 2}
+_CLASS_BY_LEVEL = {A.L2_INTERNAL_APPROVE: SAFE, A.L3_USER_APPROVE: RISKY,
+                   A.L4_RESTRICTED: DESTRUCTIVE}
+
+# armory weapon safety values (kept local to avoid a hard armory import at module load)
+_WEAPON_RISKY = "risky"
+
+
+@dataclass(frozen=True)
+class ForgeClassification:
+    """The derived risk of a forge plan + WHY (explainable, evidence-able)."""
+
+    action_class: str                       # safe / risky / destructive
+    approval_level: str                     # autopilot.approval L*
+    risky_weapons: Tuple[str, ...] = ()
+    unknown_weapons: Tuple[str, ...] = ()
+    reasons: Tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"action_class": self.action_class, "approval_level": self.approval_level,
+                "risky_weapons": list(self.risky_weapons),
+                "unknown_weapons": list(self.unknown_weapons), "reasons": list(self.reasons)}
+
+
+def _default_weapon_safety(weapon_id: str) -> Optional[str]:
+    """Look a weapon's safety up in the armory catalog (lazy import). None if unknown."""
+
+    try:
+        from armory import weapon as _weapon
+    except Exception:  # noqa: BLE001 — armory absent → caller treats as unknown (risky)
+        return None
+    spec = _weapon(weapon_id)
+    return spec.safety if spec is not None else None
+
+
+def _max_level(a: str, b: str) -> str:
+    return a if _LEVEL_ORDER.get(a, 1) >= _LEVEL_ORDER.get(b, 1) else b
+
+
+def classify_forge_plan(
+    plan,
+    *,
+    weapon_safety: Optional[Callable[[str], Optional[str]]] = None,
+) -> ForgeClassification:
+    """Derive the strictest risk class for *plan* from packet level + weapons + wording."""
+
+    resolve_safety = weapon_safety or _default_weapon_safety
+    reasons = []
+
+    packet = getattr(plan, "packet_draft", None)
+    level = getattr(packet, "approval_level", "") or A.L2_INTERNAL_APPROVE
+    if level not in _LEVEL_ORDER:
+        level = A.L2_INTERNAL_APPROVE
+    reasons.append(f"packet approval_level={level}")
+
+    # wording: the GOAL drives the restricted/risky ladder. We deliberately do NOT feed
+    # ``forbidden_scope`` in — that field NAMES deploy/schema/auth as the guardrail the
+    # executor must not cross, so including it would misclassify every plan as destructive.
+    goal = getattr(plan, "request", "") or getattr(packet, "goal", "")
+    text_level = A.classify_level(goal)
+    if _LEVEL_ORDER.get(text_level, 0) > _LEVEL_ORDER.get(level, 0):
+        reasons.append(f"goal wording → {text_level}")
+    level = _max_level(level, text_level)
+
+    # weapon safety: a risky/unknown weapon bumps the plan to at least risky
+    risky_weapons = []
+    unknown_weapons = []
+    for w in getattr(plan, "required_weapons", ()) or ():
+        safety = resolve_safety(w)
+        if safety is None:
+            unknown_weapons.append(w)
+        elif safety == _WEAPON_RISKY:
+            risky_weapons.append(w)
+    if risky_weapons:
+        reasons.append(f"risky weapons: {', '.join(risky_weapons)}")
+        level = _max_level(level, A.L3_USER_APPROVE)
+    if unknown_weapons:
+        # safe-by-rejection: an unknown weapon is not auto-safe
+        reasons.append(f"unknown weapons(보수적 risky): {', '.join(unknown_weapons)}")
+        level = _max_level(level, A.L3_USER_APPROVE)
+
+    return ForgeClassification(
+        action_class=_CLASS_BY_LEVEL.get(level, RISKY), approval_level=level,
+        risky_weapons=tuple(risky_weapons), unknown_weapons=tuple(unknown_weapons),
+        reasons=tuple(reasons))
+
+
+__all__ = ("SAFE", "RISKY", "DESTRUCTIVE", "ForgeClassification", "classify_forge_plan")

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/ledger.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/ledger.py
@@ -1,0 +1,93 @@
+"""Forge governance decision log — append-only receipt ledger (the "영속" seam).
+
+A receipt proves one forge plan's trip through the gate; the LEDGER makes that proof
+**accumulate** so the decision log is real and durable, not ephemeral console output. It
+is an append-only JSONL under the local runtime state dir (NOT the vault — that's a
+separate evidence track), one line per recorded receipt.
+
+Anti-fake at the persistence boundary: :func:`record_forge_receipt` re-runs
+:func:`validate_forge_receipt` and REFUSES to persist a receipt that fails — so a fake
+approval/execution can never enter the durable log. Best-effort on I/O (a store failure
+never corrupts the decision), but a fake receipt is a hard refusal, not a silent skip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+from forgekit_config.paths import state_dir
+
+from .receipt import ForgeExecutionReceipt, validate_forge_receipt
+
+_LEDGER_NAME = "forge_receipts.jsonl"
+
+
+class FakeReceiptRefused(ValueError):
+    """Raised when a caller tries to persist a receipt that fails validation."""
+
+
+def forge_receipt_ledger_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    """The append-only forge-receipt decision log (JSONL) under the runtime state dir."""
+
+    return state_dir(env) / _LEDGER_NAME
+
+
+def record_forge_receipt(
+    receipt: ForgeExecutionReceipt,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    recorded_at: str = "",
+) -> Optional[Path]:
+    """Append *receipt* to the decision log. Refuses a fake (validation-failing) receipt.
+
+    Returns the ledger path on success, ``None`` on a best-effort I/O failure (so the
+    decision is never corrupted by a store problem). A FAKE receipt is a hard refusal."""
+
+    violations = validate_forge_receipt(receipt)
+    if violations:
+        raise FakeReceiptRefused("; ".join(violations))
+
+    entry = {"receipt": receipt.to_dict()}
+    if recorded_at:
+        entry["recorded_at"] = recorded_at
+    line = json.dumps(entry, ensure_ascii=False)
+    try:
+        path = forge_receipt_ledger_path(env)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        return path
+    except OSError:
+        return None
+
+
+def read_forge_receipts(
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    limit: int = 0,
+) -> List[dict]:
+    """Read recorded receipt entries (newest last). ``limit>0`` returns the last N."""
+
+    path = forge_receipt_ledger_path(env)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    entries: List[dict] = []
+    for ln in raw.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            entries.append(json.loads(ln))
+        except ValueError:
+            continue
+    return entries[-limit:] if limit > 0 else entries
+
+
+__all__ = (
+    "FakeReceiptRefused", "forge_receipt_ledger_path",
+    "record_forge_receipt", "read_forge_receipts",
+)

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/receipt.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/receipt.py
@@ -1,0 +1,120 @@
+"""Forge execution receipt — proof that a forged work packet ran under a real approval.
+
+The harness already has a per-run :class:`ExecutionReceipt` (context/grants/runner). This
+is the GOVERNANCE receipt for the **forge → execution** path: it binds one Hephaistos
+forge plan to the approval chain that authorized it. A receipt is the artifact an operator
+(or an audit) reads to answer "who was equipped, to do what, classified how, approved by
+whom, and what did the commit carry".
+
+Anti-fake is the whole point (:func:`validate_forge_receipt`):
+
+* a receipt may be ``authorized`` ONLY with real approval metadata, a registry-known
+  executor, and commit trailers (a blocked verdict produces NO trailers);
+* ``outcome == "executed"`` REQUIRES ``authorized`` (no fabricated execution);
+* a non-authorized receipt MUST carry blocking reasons and MUST NOT carry trailers or an
+  executed outcome.
+
+So there is no way to mint a receipt that claims approval/execution that did not happen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from forgekit_config.identity.registry import is_known
+
+# outcome states (mirror selfimprove.execute_bridge — honest)
+OUTCOME_EXECUTED = "executed"
+OUTCOME_BLOCKED = "blocked"
+OUTCOME_AWAITING = "awaiting"
+OUTCOME_ERROR = "error"
+OUTCOMES: Tuple[str, ...] = (OUTCOME_EXECUTED, OUTCOME_BLOCKED, OUTCOME_AWAITING, OUTCOME_ERROR)
+
+
+@dataclass(frozen=True)
+class ForgeExecutionReceipt:
+    """Governance proof for one forge plan's trip through the execution gate."""
+
+    request: str
+    selected_agent: str = ""                  # the specialist (executor) — canonical id
+    selected_loadout: str = ""
+    selected_skills: Tuple[str, ...] = ()
+    required_weapons: Tuple[str, ...] = ()
+    action_class: str = ""                    # safe / risky / destructive
+    approval_level: str = ""                  # autopilot.approval L*
+    authorized: bool = False
+    outcome: str = OUTCOME_AWAITING
+    approval_metadata: str = ""               # decision/level/signoff(+operator)
+    chain_trace: Tuple[str, ...] = ()         # PM→gateway→tech-lead trace
+    commit_trailers: Tuple[str, ...] = ()     # Forgekit-Agent/Approval/... (authorized only)
+    verification: Tuple[str, ...] = ()        # the plan's verification commands
+    risky_weapons: Tuple[str, ...] = ()
+    blocking_reasons: Tuple[str, ...] = ()
+    evidence_path: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "request": self.request, "selected_agent": self.selected_agent,
+            "selected_loadout": self.selected_loadout, "selected_skills": list(self.selected_skills),
+            "required_weapons": list(self.required_weapons), "action_class": self.action_class,
+            "approval_level": self.approval_level, "authorized": self.authorized,
+            "outcome": self.outcome, "approval_metadata": self.approval_metadata,
+            "chain_trace": list(self.chain_trace), "commit_trailers": list(self.commit_trailers),
+            "verification": list(self.verification), "risky_weapons": list(self.risky_weapons),
+            "blocking_reasons": list(self.blocking_reasons), "evidence_path": self.evidence_path,
+        }
+
+    def lines(self) -> Tuple[str, ...]:
+        head = "forge execution receipt"
+        status = ("인가됨" if self.authorized else "차단됨") + f" / {self.outcome}"
+        out = [
+            f"{head} — {status}",
+            f"- request : {self.request[:70]}",
+            f"- equip   : agent={self.selected_agent} loadout={self.selected_loadout}",
+            f"- class   : {self.action_class} ({self.approval_level})",
+            f"- approval: {self.approval_metadata or '-'}",
+        ]
+        if self.risky_weapons:
+            out.append(f"- risky weapons: {', '.join(self.risky_weapons)}")
+        if not self.authorized and self.blocking_reasons:
+            out.append(f"- blocked : {'; '.join(self.blocking_reasons)}")
+        return tuple(out)
+
+
+def validate_forge_receipt(receipt: ForgeExecutionReceipt) -> Tuple[str, ...]:
+    """Reject a fake receipt. ``()`` = the receipt's claims match a real authorization."""
+
+    v = []
+    if receipt.outcome not in OUTCOMES:
+        v.append(f"receipt: outcome '{receipt.outcome}' 알 수 없음")
+    # a real-plan outcome must name its request; AWAITING is the honest "nothing to forge".
+    if receipt.outcome != OUTCOME_AWAITING and not (receipt.request or "").strip():
+        v.append("receipt: request 비어 있음")
+
+    if receipt.authorized:
+        if not (receipt.approval_metadata or "").strip():
+            v.append("receipt: authorized 인데 approval_metadata 없음 — fake 승인")
+        if not is_known(receipt.selected_agent):
+            v.append(f"receipt: executor '{receipt.selected_agent}' 레지스트리에 없음")
+        if not receipt.commit_trailers:
+            v.append("receipt: authorized 인데 commit trailer 없음 — 승인 메타데이터 미바인딩")
+        if receipt.action_class == "destructive":
+            v.append("receipt: destructive 가 authorized 일 수 없음")
+    else:
+        if not receipt.blocking_reasons:
+            v.append("receipt: 미인가인데 blocking_reasons 없음 — 침묵 거부")
+        if receipt.commit_trailers:
+            v.append("receipt: 미인가인데 commit trailer 존재 — fake approval metadata")
+        if receipt.outcome == OUTCOME_EXECUTED:
+            v.append("receipt: 미인가인데 outcome=executed — fake 실행")
+
+    if receipt.outcome == OUTCOME_EXECUTED and not receipt.authorized:
+        v.append("receipt: executed 는 authorized 를 요구")
+    return tuple(v)
+
+
+__all__ = (
+    "OUTCOME_EXECUTED", "OUTCOME_BLOCKED", "OUTCOME_AWAITING", "OUTCOME_ERROR", "OUTCOMES",
+    "ForgeExecutionReceipt", "validate_forge_receipt",
+)

--- a/tests/forgekit/test_hephaistos_governance.py
+++ b/tests/forgekit/test_hephaistos_governance.py
@@ -1,0 +1,198 @@
+"""Hephaistos governance completion — forge plan → real execution gate → receipt.
+
+Proves the forging core is bound to the org governance backbone (not a separate path):
+- ``classify_forge_plan`` derives safe/risky/destructive from packet level + weapon
+  safety + goal wording (forbidden-scope is a guardrail, NOT a destructive signal);
+- ``forge_execute`` runs a SAFE plan through the SAME real gate the self-improvement
+  bridge uses (run_internal_chain → authorize_runtime_execution → validate_execution) and
+  issues an authorized, trailer-stamped :class:`ForgeExecutionReceipt`;
+- destructive wording / a risky (or unknown) weapon → blocked receipt, NO trailers, never
+  "executed";
+- the receipt validator rejects fakes: authorized-without-trailers, blocked-with-trailers,
+  executed-without-authorization;
+- the executor on the receipt is the forge's selected specialist, a registry identity.
+
+Hermetic + pure: forge resolves from the Armory catalog; no network, no file writes.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _rel in (
+    "packages/forgekit-runtime/src",
+    "packages/forgekit-config/src",
+    "packages/forgekit-provider/src",
+    "packages/forgekit-contracts/src",
+    "packages/forgekit-goal/src",
+    "packages/hephaistos/src",
+    "packages/armory/src",
+    "packages/nexus/src",
+    "apps/forgekit-console/src",
+):
+    _p = str(_ROOT / _rel)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from forgekit_runtime import forge as F
+from forgekit_runtime.decision_lane import OperatorApproval
+from hephaistos import resolve
+
+_SAFE_REQUEST = "java spring boot 백엔드 REST API 추가"
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_plain_backend_request_is_safe(self) -> None:
+        c = F.classify_forge_plan(resolve(_SAFE_REQUEST), weapon_safety=lambda w: "safe")
+        self.assertEqual(c.action_class, F.SAFE)
+        self.assertEqual(c.approval_level, "L2_internal_approve")
+
+    def test_destructive_wording_bumps_to_destructive(self) -> None:
+        c = F.classify_forge_plan(resolve("프로덕션 배포 deploy 및 secret 회전"),
+                                  weapon_safety=lambda w: "safe")
+        self.assertEqual(c.action_class, F.DESTRUCTIVE)
+
+    def test_risky_weapon_bumps_to_risky(self) -> None:
+        c = F.classify_forge_plan(resolve("docker 컨테이너 구성"),
+                                  weapon_safety=lambda w: "risky" if w == "docker" else "safe")
+        self.assertEqual(c.action_class, F.RISKY)
+        self.assertIn("docker", c.risky_weapons)
+
+    def test_unknown_weapon_is_not_auto_safe(self) -> None:
+        c = F.classify_forge_plan(resolve(_SAFE_REQUEST), weapon_safety=lambda w: None)
+        self.assertEqual(c.action_class, F.RISKY)
+        self.assertTrue(c.unknown_weapons)
+
+
+class ReceiptValidatorTests(unittest.TestCase):
+    def _base(self, **kw):
+        d = dict(request="x", selected_agent="backend-engineer", action_class="safe",
+                 authorized=True, outcome=F.OUTCOME_EXECUTED,
+                 approval_metadata="decision=x;level=L2;signoff=tech-lead",
+                 commit_trailers=("Forgekit-Agent: backend-engineer",))
+        d.update(kw)
+        return F.ForgeExecutionReceipt(**d)
+
+    def test_real_authorized_receipt_passes(self) -> None:
+        self.assertEqual(F.validate_forge_receipt(self._base()), ())
+
+    def test_authorized_without_trailers_rejected(self) -> None:
+        self.assertTrue(F.validate_forge_receipt(self._base(commit_trailers=())))
+
+    def test_authorized_without_metadata_rejected(self) -> None:
+        self.assertTrue(F.validate_forge_receipt(self._base(approval_metadata="")))
+
+    def test_blocked_with_trailers_rejected(self) -> None:
+        r = self._base(authorized=False, outcome=F.OUTCOME_BLOCKED,
+                       blocking_reasons=("x",))  # but still carries trailers
+        self.assertTrue(any("fake approval" in x for x in F.validate_forge_receipt(r)))
+
+    def test_executed_without_authorization_rejected(self) -> None:
+        r = self._base(authorized=False, outcome=F.OUTCOME_EXECUTED,
+                       commit_trailers=(), blocking_reasons=("x",))
+        self.assertTrue(F.validate_forge_receipt(r))
+
+    def test_unknown_executor_rejected(self) -> None:
+        self.assertTrue(F.validate_forge_receipt(self._base(selected_agent="not-a-role")))
+
+
+class ForgeExecuteTests(unittest.TestCase):
+    def test_safe_forge_authorized_and_stamped(self) -> None:
+        r = F.forge_execute(_SAFE_REQUEST, weapon_safety=lambda w: "safe")
+        self.assertTrue(r.authorized)
+        self.assertEqual(r.outcome, F.OUTCOME_EXECUTED)
+        self.assertEqual(r.action_class, F.SAFE)
+        self.assertTrue(r.commit_trailers)
+        self.assertIn("signoff=tech-lead", r.approval_metadata)
+        self.assertEqual(r.selected_agent, "backend-engineer")
+        self.assertEqual(F.validate_forge_receipt(r), ())
+        # the chain actually ran PM→gateway→tech-lead
+        self.assertEqual(len(r.chain_trace), 3)
+
+    def test_destructive_forge_blocked_no_trailers(self) -> None:
+        r = F.forge_execute("프로덕션 배포 deploy 및 secret 회전", weapon_safety=lambda w: "safe")
+        self.assertFalse(r.authorized)
+        self.assertEqual(r.outcome, F.OUTCOME_BLOCKED)
+        self.assertEqual(r.action_class, F.DESTRUCTIVE)
+        self.assertEqual(r.commit_trailers, ())
+        self.assertTrue(r.blocking_reasons)
+        self.assertEqual(F.validate_forge_receipt(r), ())
+
+    def test_risky_weapon_forge_blocked(self) -> None:
+        r = F.forge_execute("docker 컨테이너 구성",
+                            weapon_safety=lambda w: "risky" if w == "docker" else "safe")
+        self.assertFalse(r.authorized)
+        self.assertEqual(r.action_class, F.RISKY)
+        self.assertIn("docker", r.risky_weapons)
+        self.assertEqual(r.commit_trailers, ())
+        self.assertEqual(F.validate_forge_receipt(r), ())
+
+    def test_risky_with_operator_still_chain_gated(self) -> None:
+        # operator approval satisfies decision-lane, but the autopilot chain only auto-runs
+        # safe — so a risky forge stays blocked (honest, not fake-executed)
+        op = OperatorApproval(approver="operator", decision_ref="x", approved=True)
+        r = F.forge_execute("docker 구성", weapon_safety=lambda w: "risky" if w == "docker" else "safe",
+                            operator_approval=op)
+        self.assertFalse(r.authorized)
+        self.assertEqual(F.validate_forge_receipt(r), ())
+
+    def test_empty_request_awaiting(self) -> None:
+        r = F.forge_execute("")
+        self.assertEqual(r.outcome, F.OUTCOME_AWAITING)
+        self.assertFalse(r.authorized)
+        self.assertEqual(F.validate_forge_receipt(r), ())
+
+
+class LedgerTests(unittest.TestCase):
+    """The forge governance decision log accumulates (영속) and refuses fakes."""
+
+    def _env(self):
+        import tempfile
+        return {"FORGEKIT_HOME": tempfile.mkdtemp()}
+
+    def test_persist_and_read_back(self) -> None:
+        env = self._env()
+        F.forge_execute(_SAFE_REQUEST, weapon_safety=lambda w: "safe",
+                        env=env, persist=True, recorded_at="2026-06-22")
+        F.forge_execute("프로덕션 배포 deploy secret", env=env, persist=True, recorded_at="2026-06-22")
+        entries = F.read_forge_receipts(env=env)
+        self.assertEqual(len(entries), 2)                      # append-only accumulation
+        self.assertEqual(entries[0]["receipt"]["outcome"], F.OUTCOME_EXECUTED)
+        self.assertEqual(entries[1]["receipt"]["outcome"], F.OUTCOME_BLOCKED)
+        self.assertEqual(entries[0]["recorded_at"], "2026-06-22")
+
+    def test_preview_does_not_persist(self) -> None:
+        env = self._env()
+        F.forge_execute(_SAFE_REQUEST, weapon_safety=lambda w: "safe", env=env)  # persist=False
+        self.assertEqual(F.read_forge_receipts(env=env), [])
+
+    def test_fake_receipt_refused_at_persistence(self) -> None:
+        env = self._env()
+        fake = F.ForgeExecutionReceipt(request="x", authorized=True, outcome=F.OUTCOME_EXECUTED,
+                                       approval_metadata="", selected_agent="backend-engineer")
+        with self.assertRaises(F.FakeReceiptRefused):
+            F.record_forge_receipt(fake, env=env)
+        self.assertEqual(F.read_forge_receipts(env=env), [])   # nothing persisted
+
+
+class ResolveSurfaceTests(unittest.TestCase):
+    """The governance verdict is reachable at runtime — /resolve surfaces it."""
+
+    def test_resolve_surfaces_governance_receipt(self) -> None:
+        from pathlib import Path as _P
+
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+
+        r = route(parse_input("/resolve java spring boot REST API"), build_default_context(_P(".")))
+        joined = "\n".join(r.lines)
+        self.assertIn("governance", joined)            # the section is rendered
+        self.assertIn("forge execution receipt", joined)
+        self.assertIn("class", joined)                 # safe/risky/destructive surfaced
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
axis3 Hephaistos(execution core) 강화: forge plan 을 실제 승인 게이트에 연결 + append-only execution receipt ledger + /resolve governance 표면.

## 범위
- packages/forgekit-runtime/forge/{__init__,bridge,classify,ledger,receipt}.py(신규): forge_execute→run_internal_chain→authorize_runtime_execution→validate_execution→ForgeExecutionReceipt + ledger 영속.
- /resolve 출력에 forge governance receipt 표면(router). pyproject hephaistos/armory dep. docs/hephaistos-governance.md + AGENTS/CLAUDE cross-link.

## 리스크
- /resolve·/provider budget 양립(router 수동 머지로 둘 다 동작 확인). 머지된 기능(execute_bridge/budget/unit) 미접촉.

## 테스트
- test_hephaistos_governance 19 green(forge round-trip+ledger 영속). 전체 forgekit 1062 OK. governance 3 OK. coordinator 직접 검증.

## 이슈 linkage
Closes https://github.com/yule-studio/forgekit/issues/357. umbrella #238.

## 감사(audit)
gw1 lane 작업을 현 main 위로 salvage(구 브랜치는 머지된 feature 와 충돌→unique forge 부분만 clean replay). 파일 disjoint(forge/* 신규 + router 양립 머지).