### PR TITLE
✨ operator cockpit completion — approve 실행 표면 정합 + /provider budget + runtime install-unit

### DIFF
--- a/apps/forgekit-console/examples/goal/approval.txt
+++ b/apps/forgekit-console/examples/goal/approval.txt
@@ -1,33 +1,31 @@
-ForgeKit operator cockpit — in-console approve/deny (real router + goal store)
+ForgeKit operator cockpit — approve/deny + GW4-B 실행 연결 (real router+store+bridge)
 ==============================================================================
-Method: 실 router(route) + 실 GoalStore(tmp FORGEKIT_HOME). no mock, no fake execute.
-승인=awaiting_approval→active+decision evidence, 거부=→blocked+decision evidence.
-GW4-B 실행 bridge 미연결 → approve 는 '실행 대기' 정직 표기(execution evidence 없음).
+Method: 실 route + 실 GoalStore + 실 GW4-B execute_approved_packet. mock/fake 없음.
+approve = awaiting_approval→active + decision evidence, 그 뒤 GW4-B 실행 bridge 호출.
+bridge 가 execution+verification evidence 를 직접 persist → surface 는 RELOAD(덮어쓰기 금지).
+safe packet → 실행됨, risky packet → 실행 거부(가짜 실행 없음). 실제 outcome 을 콘솔에 표면.
 
 $ /goal awaiting  [info]
   2 goal 승인 대기:
-    goal-5a7a0763ab2a  스키마 마이그레이션
-      linked packets: packet-migrate-1
-      승인: `/goal approve goal-5a7a0763ab2a [메모]`   거부: `/goal deny goal-5a7a0763ab2a [메모]`
-    goal-bc4df3a6e234  배포 파이프라인 구성
-      linked packets: packet-deploy-1, packet-deploy-2
-      승인: `/goal approve goal-bc4df3a6e234 [메모]`   거부: `/goal deny goal-bc4df3a6e234 [메모]`
+    goal-7d92df0edc26  auth 대규모 변경
+      linked packets: packet-b204066fabee
+      승인: `/goal approve goal-7d92df0edc26 [메모]`   거부: `/goal deny goal-7d92df0edc26 [메모]`
+    goal-08921ea58a7c  self-manage ForgeKit
+      linked packets: packet-e0191b811b01
+      승인: `/goal approve goal-08921ea58a7c [메모]`   거부: `/goal deny goal-08921ea58a7c [메모]`
 
-$ /goal approve goal-bc4df3a6e234 운영자 승인  [info]
-  goal-bc4df3a6e234 승인 -> active  · 승인됨(실행 대기 — GW4-B 실행 bridge 미연결)
+$ /goal approve goal-08921ea58a7c 운영자 승인  (safe packet)  [info]
+  goal-08921ea58a7c 승인 -> active  · 실행됨(safe·게이트 통과 · execution+verification 기록 · executor=backend-engineer)
 
-$ /goal deny goal-5a7a0763ab2a 마이그레이션 범위 밖  [info]
-  goal-5a7a0763ab2a 거부 -> blocked  · 거부됨(blocked, 재검토 가능)
+$ /goal evidence goal-08921ea58a7c  (decision+execution+verification 보존)  [info]
+  goal-08921ea58a7c evidence (4):
+    - 2026-06-22T04:27:17.604726+00:00  [proposal] [safe] 콘솔 도움말 문구 개선 -> safe → tech-lead ready (승인 체계 내 자동 가능)  (packet-e0191b811b01)
+    - 2026-06-22T04:27:17.605897+00:00  [decision] operator 승인: 운영자 승인
+    - 2026-06-22T04:27:17.606184+00:00  [execution] safe-class 실행 인가 — packet packet-e0191b811b01: 콘솔 도움말 문구 개선 [executor=backend-engineer author=Forgekit Backend <be@forgekit.local> approver=operator approval=decision=콘솔 도움말 문구 개선;level=L2_internal_approve;signoff=tech-lead] (실제 파일 mutation 은 BoundedMutator 게이트 — 본 단계는 인가+검증 기록)  (packet-e0191b811b01)
+    - 2026-06-22T04:27:17.606193+00:00  [verification] 실행 게이트 재검증 통과 — chain(can_execute)+decision-lane(authorize)+validate_execution 모두 통과, action_class=safe, approval=decision=콘솔 도움말 문구 개선;level=L2_internal_approve;signoff=tech-lead  (packet-e0191b811b01)
 
-$ /goal awaiting  (결정 후)  [info]
-  승인 대기 goal 없음 — runtime 이 risky/restricted packet 을 만들면 awaiting_approval 로 여기 모입니다.
+$ /goal approve goal-7d92df0edc26 위험 검토  (risky packet → 게이트 거부)  [info]
+  goal-7d92df0edc26 승인 -> active  · 실행 거부(게이트: risky(L3) — operator 승인 없음, tech-lead 내부 승인(can_execute) 없음, safe class 아님(risky) — 자동 실행 금지, 내부 chain 승인(can_execute) 없음) — decision 기록, 가짜 실행 없음
 
-$ /goal evidence goal-bc4df3a6e234  [info]
-  goal-bc4df3a6e234 evidence (1):
-    - 2026-06-22T03:16:20.119796+00:00  [decision] operator 승인: 운영자 승인
-
-$ /goal approve goal-nope  [error]
-  goal 'goal-nope' 없음 — `/goal awaiting` 로 확인
-
-$ /goal approve goal-c78582c701c7  (draft, 승인 대상 아님)  [error]
-  goal-c78582c701c7 는 승인 대기 아님(현재 draft) — approve 는 awaiting_approval goal 만 대상
+$ /goal approve goal-d5d0428b1925  (draft, 승인 대상 아님)  [error]
+  goal-d5d0428b1925 는 승인 대기 아님(현재 draft) — approve 는 awaiting_approval goal 만 대상

--- a/apps/forgekit-console/examples/provider-budget/surface.txt
+++ b/apps/forgekit-console/examples/provider-budget/surface.txt
@@ -1,0 +1,23 @@
+ForgeKit operator cockpit — /provider budget (per-provider 일일 token budget, gw2 #343)
+==============================================================================
+Method: 실 route + 실 provider_ops(config writer) + provider_budget(policy). mock 없음.
+set=budget_policy.provider_daily_limits 영속(정책이 routing fallback 으로 강제), 0=해제.
+show=설정 한도 + 오늘 ledger 사용량(live). 미설정=unbounded 정직 표기.
+
+$ /provider budget  [info]
+  per-provider budget: 미설정 — 전 provider unbounded (global `/usage` budget 만 적용).
+    설정: `/provider budget set <provider> <일일토큰>`  (0 = 해제/unbounded)
+
+$ /provider budget set gemini 50000  [info]
+  gemini per-provider budget = 50000tok/day 설정
+
+$ /provider budget set ollama 0  [info]
+  ollama per-provider budget 해제 (unbounded)
+
+$ /provider budget show  [info]
+  per-provider 일일 token budget (live spend / limit):
+    gemini     0/50000tok (0%)
+    set: `/provider budget set <provider> <일일토큰>`  (0 = 해제)
+
+$ /provider budget set gemini lots  [error]
+  토큰 한도는 정수여야 합니다 — 'lots'

--- a/apps/forgekit-console/examples/runtime-daemon/install-unit.txt
+++ b/apps/forgekit-console/examples/runtime-daemon/install-unit.txt
@@ -1,0 +1,24 @@
+ForgeKit operator cockpit — `forgekit runtime install-unit` (launchd 자동설치, lane B)
+==============================================================================
+Method: 실 deploy_unit.install + 실 템플릿(deploy/launchd) 렌더. launchctl 은 미실행(파일만).
+수동 sed flow 대체: placeholder 4개 자동 치환 → ~/Library/LaunchAgents 배치. daemon 시작은
+operator 결정(--load opt-in). macOS 전용·lid-close suspend 한계 정직 표기.
+
+$ forgekit runtime install-unit --repo-root <checkout>   [ok=True]
+  ✓ LaunchAgent 작성됨: /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpwx57x1fm/LaunchAgents/com.forgekit.runtime.plist
+    bin=/Users/op/.venvs/forgekit/bin/forgekit  repo=/Users/masterway/local-dev/yule-studio-agent/.claude/worktrees/gw3-console-parity
+    FORGEKIT_HOME=/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpwx57x1fm/.forgekit
+    load(operator 승인 후): launchctl bootstrap gui/$(id -u) /var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmpwx57x1fm/LaunchAgents/com.forgekit.runtime.plist
+    자동 load 안 함 — daemon 시작은 operator 결정입니다 (`--load` 로 지금 로드).
+    honest: macOS lid-close 는 host 를 suspend — 24h 는 caffeinate/pmset 또는 systemd 경로.
+
+rendered plist (발췌 — placeholder 전부 치환됨):
+  ForgeKit control-plane daemon LaunchAgent (GW7).
+  Runs `forgekit runtime serve` as a per-USER LaunchAgent on a Mac mini host
+  (docs/control-plane-architecture.md §3: Mac mini = 1차 ForgeKit host). This is
+  Reproducible config: the daemon reads the SAME ~/.forgekit/config.json as the
+  /Users/op/.venvs/forgekit/bin/forgekit   absolute path to the installed `forgekit` entrypoint
+  (e.g. /Users/<you>/.venvs/forgekit/bin/forgekit)
+
+$ (Linux) forgekit runtime install-unit   [ok=False]
+  launchd 자동설치는 macOS 전용입니다 — Linux 는 systemd 경로(`deploy/systemd/`, 수동)를 쓰세요.

--- a/apps/forgekit-console/src/forgekit_console/cli/runtime_cmd.py
+++ b/apps/forgekit-console/src/forgekit_console/cli/runtime_cmd.py
@@ -31,6 +31,12 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     once.add_argument("--repo-root", default="")
     rsub.add_parser("status", help="heartbeat 상태 출력")
     rsub.add_parser("stop", help="kill switch 설정 (running serve 가 다음 tick 에 종료)")
+    inst = rsub.add_parser("install-unit",
+                           help="launchd LaunchAgent 자동 설치 (템플릿 치환+배치; macOS)")
+    inst.add_argument("--repo-root", default="", help="daemon 이 운영할 체크아웃 경로")
+    inst.add_argument("--bin", default="", help="forgekit 실행파일 경로 (기본 자동 감지)")
+    inst.add_argument("--load", action="store_true",
+                      help="작성 후 launchctl 로 즉시 로드 (operator 승인 — 기본은 파일만)")
 
 
 def _repo_root(args) -> str:
@@ -73,6 +79,16 @@ def handle(args: argparse.Namespace) -> int:
         HB.request_kill()
         print("kill switch 설정됨 — running serve 가 다음 tick 에 종료합니다.")
         return EXIT_OK
+
+    if cmd == "install-unit":
+        from .. import deploy_unit as du
+
+        ok, lines = du.install(
+            repo_root=_repo_root(args), env=dict(os.environ),
+            bin_path=getattr(args, "bin", "") or None, load=getattr(args, "load", False))
+        for ln in lines:
+            print(ln)
+        return EXIT_OK if ok else EXIT_ERROR
 
     repo = _repo_root(args)
     notifier = _build_notifier()

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -101,7 +101,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
-    SlashCommand("provider", "provider 설정/연결 — `/provider [set|link|unlink|connect <id>|disconnect <id>|test <id>|recommended|preset four-brain|route show|route set <slot> <id>|list|doctor]`", H_PROVIDER, "status"),
+    SlashCommand("provider", "provider 설정/연결 — `/provider [set|link|unlink|connect <id>|disconnect <id>|test <id>|recommended|preset four-brain|route show|route set <slot> <id>|budget [show|set <id> <토큰>]|list|doctor]`", H_PROVIDER, "status"),
     SlashCommand("setup", "컨트롤플레인 부트스트랩 — provider · knowledge(nexus/vault) · toolchain 한 화면 정직 집계 + 추천 preset 저장/검증 (`/setup [apply [preset]]`)", H_SETUP, "status"),
     SlashCommand("toolchain", "language/runtime 버전 전환 — `/toolchain [detect|recommend <loadout>|switch [global] [--approve]|verify|drift]` (repo-local 감지·mise 기반, global/install 은 승인 게이트)", H_TOOLCHAIN, "status"),
     SlashCommand("nexus", "Nexus 지식 source — `/nexus [set <path>|clear]` 연결/해제 + live 상태(connected/not_connected/missing/blocked/restricted)", H_NEXUS, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -174,7 +174,7 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
     if handler in (H_RESOLVE, H_HEPHAISTOS, H_SKILLS, H_LOADOUT):
         return _hephaistos_result(handler, parsed, ctx)
     if handler == H_PROVIDER:
-        return _provider_result(parsed)
+        return _provider_result(parsed, ctx)
     if handler == H_SETUP:
         return _setup_result(parsed, ctx)
     if handler == H_TOOLCHAIN:
@@ -242,7 +242,7 @@ def _goal_result(parsed, ctx: ConsoleContext) -> CommandResult:
     return CommandResult.info("goal", gs.usage_lines())
 
 
-def _provider_result(parsed) -> CommandResult:
+def _provider_result(parsed, ctx=None) -> CommandResult:
     # /provider operator surface over policy.provider_surface (read) + provider_ops (persist).
     from ..policy import provider_ops as ops
     from ..policy import provider_surface as ps
@@ -284,6 +284,18 @@ def _provider_result(parsed) -> CommandResult:
             ok, msg = ps.apply_route_clear(args[2] if len(args) > 2 else "")
             return (CommandResult.info if ok else CommandResult.error)("provider route", (msg,))
         return CommandResult.info("provider route", ps.route_show_lines(cfg))
+    if sub == "budget":
+        from .. import provider_budget_surface as pbs
+
+        env = getattr(ctx, "env", None) or None
+        op = args[1].lower() if len(args) > 1 else "show"
+        if op == "set":
+            ok, msg = pbs.apply_set_budget(args[2] if len(args) > 2 else "",
+                                           args[3] if len(args) > 3 else "", env=env)
+            return (CommandResult.info if ok else CommandResult.error)("provider budget", (msg,))
+        if op in ("show", ""):
+            return CommandResult.info("provider budget", pbs.budget_lines(env=env))
+        return CommandResult.info("provider budget", pbs.usage_lines())
     return CommandResult.info("provider", ps.provider_status_lines(cfg))
 
 

--- a/apps/forgekit-console/src/forgekit_console/deploy_unit.py
+++ b/apps/forgekit-console/src/forgekit_console/deploy_unit.py
@@ -1,0 +1,155 @@
+"""launchd LaunchAgent auto-install (final-completion lane B) — render + place, honest.
+
+Replaces the manual ``sed`` flow in ``deploy/launchd/README.md``: resolve the four
+template placeholders from the live environment, render the COMMITTED template (single
+source — no embedded duplicate that could drift), write it to the per-user
+``~/Library/LaunchAgents`` dir, and emit the EXACT ``launchctl`` command.
+
+Honest boundaries:
+- The daemon START stays operator-gated. By default this installs the FILE ONLY and
+  prints the load command — it does NOT run ``launchctl`` (no unapproved background
+  start). ``load=True`` is the operator opt-in that runs + verifies it.
+- Never a fake "installed": an unsubstituted placeholder aborts, a write error is
+  surfaced, and a load is confirmed via ``launchctl`` (not assumed).
+- macOS only (the placeholder template is launchd); the Linux/systemd path stays the
+  existing manual template. The macOS lid-close suspend limit is restated, not hidden.
+
+Pure-ish: rendering / resolution / path logic is unit-testable; the file write + the
+optional ``launchctl`` run are injectable (``dest_path`` / ``runner``).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Tuple
+
+LABEL = "com.forgekit.runtime"
+_PLIST_REL = ("deploy", "launchd", "com.forgekit.runtime.plist")
+_PLACEHOLDER_RE = re.compile(r"__[A-Z_]+__")
+
+
+def template_path(repo_root) -> Path:
+    """The committed launchd template (single source of truth)."""
+
+    return Path(repo_root).joinpath(*_PLIST_REL)
+
+
+def resolve_bin(bin_path: Optional[str] = None) -> str:
+    """Absolute path to the ``forgekit`` entrypoint — explicit, else PATH, else venv bin."""
+
+    if bin_path:
+        return str(bin_path)
+    found = shutil.which("forgekit")
+    if found:
+        return found
+    return str(Path(sys.executable).parent / "forgekit")
+
+
+def resolve_values(*, repo_root, env: Optional[Mapping[str, str]] = None,
+                   bin_path: Optional[str] = None, user_home: Optional[str] = None) -> dict:
+    """Resolve the four template placeholders from the live environment (honest paths)."""
+
+    env = env or {}
+    home = str(user_home or env.get("HOME") or Path.home())
+    fk_home = str(env.get("FORGEKIT_HOME") or (Path(home) / ".forgekit"))
+    return {
+        "__FORGEKIT_BIN__": resolve_bin(bin_path),
+        "__REPO_ROOT__": str(Path(repo_root).resolve()),
+        "__FORGEKIT_HOME__": fk_home,
+        "__USER_HOME__": home,
+    }
+
+
+def render(template_text: str, values: Mapping[str, str]) -> Tuple[str, Tuple[str, ...]]:
+    """Substitute placeholders → ``(rendered, leftover_placeholders)``. Leftovers are an
+    error signal (never ship a half-rendered unit)."""
+
+    out = template_text
+    for key, val in values.items():
+        out = out.replace(key, val)
+    missing = tuple(sorted(set(_PLACEHOLDER_RE.findall(out))))
+    return out, missing
+
+
+def target_path(user_home: str) -> Path:
+    return Path(user_home) / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def load_command(plist_path) -> str:
+    return f"launchctl bootstrap gui/$(id -u) {plist_path}"
+
+
+def _default_runner(argv) -> Tuple[bool, str]:
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=20)
+        return p.returncode == 0, (p.stderr or p.stdout or "").strip()
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def install(*, repo_root, env: Optional[Mapping[str, str]] = None,
+            user_home: Optional[str] = None, bin_path: Optional[str] = None,
+            dest_path: Optional[str] = None, load: bool = False,
+            runner: Optional[Callable[[list], Tuple[bool, str]]] = None,
+            platform: Optional[str] = None) -> Tuple[bool, Tuple[str, ...]]:
+    """Render + place the LaunchAgent. ``load=True`` also runs + verifies launchctl.
+
+    Returns ``(ok, lines)``. ``ok`` is False on any honest failure (non-macOS, missing
+    template, leftover placeholder, write error, launchctl failure) — never a fake success.
+    """
+
+    platform = platform or sys.platform
+    env = dict(env or {})
+    home = str(user_home or env.get("HOME") or Path.home())
+    if platform != "darwin":
+        return False, (
+            "launchd 자동설치는 macOS 전용입니다 — Linux 는 systemd 경로(`deploy/systemd/`, 수동)를 쓰세요.",
+        )
+    tpl = template_path(repo_root)
+    if not tpl.exists():
+        return False, (f"launchd 템플릿 없음: {tpl} — `--repo-root` 를 ForgeKit 체크아웃으로 지정하세요.",)
+    values = resolve_values(repo_root=repo_root, env=env, bin_path=bin_path, user_home=home)
+    rendered, missing = render(tpl.read_text(encoding="utf-8"), values)
+    if missing:
+        return False, (f"치환되지 않은 placeholder: {', '.join(missing)} — 설치 중단(가짜 설치 금지).",)
+    dest = Path(dest_path) if dest_path else target_path(home)
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(rendered, encoding="utf-8")
+    except OSError as exc:
+        return False, (f"unit 파일 쓰기 실패: {exc}",)
+
+    lines = [
+        f"✓ LaunchAgent 작성됨: {dest}",
+        f"  bin={values['__FORGEKIT_BIN__']}  repo={values['__REPO_ROOT__']}",
+        f"  FORGEKIT_HOME={values['__FORGEKIT_HOME__']}",
+    ]
+    cmd = load_command(dest)
+    if not load:
+        lines.append(f"  load(operator 승인 후): {cmd}")
+        lines.append("  자동 load 안 함 — daemon 시작은 operator 결정입니다 (`--load` 로 지금 로드).")
+        lines.append("  honest: macOS lid-close 는 host 를 suspend — 24h 는 caffeinate/pmset 또는 systemd 경로.")
+        return True, tuple(lines)
+
+    run = runner or _default_runner
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    ok, out = run(["launchctl", "bootstrap", f"gui/{uid}", str(dest)])
+    if not ok:
+        lines.append(f"  ⚠ launchctl bootstrap 실패: {out or '(no output)'} — 수동: {cmd}")
+        return False, tuple(lines)
+    verified, _ = run(["launchctl", "print", f"gui/{uid}/{LABEL}"])
+    lines.append("✓ launchctl bootstrap 완료" + (" · 등록 확인됨" if verified
+                 else " · (print 확인 실패 — `launchctl list | grep forgekit` 로 점검)"))
+    lines.append("  honest: macOS lid-close suspend 한계는 동일합니다.")
+    return True, tuple(lines)
+
+
+__all__ = (
+    "LABEL", "template_path", "resolve_bin", "resolve_values", "render",
+    "target_path", "load_command", "install",
+)

--- a/apps/forgekit-console/src/forgekit_console/goal_surface.py
+++ b/apps/forgekit-console/src/forgekit_console/goal_surface.py
@@ -96,10 +96,13 @@ def apply_activate(env: Optional[Mapping[str, str]], gid: str) -> Tuple[bool, st
 # cockpit parity gap. The decision is a LEGAL status transition + an append-only
 # ``decision`` evidence record; the surface owns no goal logic (ownership §3.1).
 #
-# Honest execution boundary: approving records the operator decision and (if the GW4-B
-# execution bridge from gw1 is merged) triggers it. Until that bridge exists, approve is
-# "승인됨(실행 대기)" — never a fake "executed". The bridge is looked up lazily so it lights
-# up automatically once gw1 lands it, with no change here.
+# Honest execution boundary: approving records the operator decision, then runs the GW4-B
+# execution bridge (``forgekit_runtime.selfimprove.execute_approved_packet``, now merged).
+# The bridge runs the REAL gate (chain + decision-lane + validate_execution) and persists
+# execution+verification evidence ITSELF — so this surface RELOADS the authoritative goal
+# afterward rather than overwriting it, and renders the bridge's real outcome (executed /
+# blocked / awaiting / error). Never a fabricated "executed". The bridge is still looked up
+# lazily so the surface also works if it is ever absent (honest "실행 대기").
 
 def awaiting_lines(env: Optional[Mapping[str, str]]) -> Tuple[str, ...]:
     """List goals in ``awaiting_approval`` + their linked packets + the action hint."""
@@ -122,14 +125,23 @@ def _decision_summary(decision: str, note: str) -> str:
     return f"operator {decision}" + (f": {note}" if note else "")
 
 
-def _try_execute_bridge(goal, env) -> Tuple[bool, str]:
-    """Call the GW4-B execution bridge (gw1) if it is merged; else honest no-op.
+_BRIDGE_ABSENT = "absent"     # GW4-B not deployed
+_BRIDGE_FAILED = "failed"     # bridge raised (must not corrupt the decision)
 
-    Lazy, defensive import so this surface works before the bridge exists AND lights up
-    automatically once it lands — without owning any execution logic itself."""
+
+def _run_execute_bridge(goal, env):
+    """Run the GW4-B execution bridge if merged. Returns ``(state, payload)``:
+
+    * ``(_BRIDGE_ABSENT, None)`` — bridge not deployed (pre-GW4-B);
+    * ``(_BRIDGE_FAILED, "<msg>")`` — bridge raised;
+    * ``("ok", ExecuteOutcome)`` — bridge ran (it persisted its own decision/execution/
+      verification evidence on executed/blocked — the caller must RELOAD, not overwrite).
+
+    Lazy, defensive import: the surface owns no execution logic and works whether or not
+    the bridge exists, lighting up automatically once it lands."""
 
     fn = None
-    try:  # canonical home once gw1 GW4-B merges
+    try:  # canonical home (gw1 GW4-B)
         from forgekit_runtime.selfimprove import execute_approved_packet as fn  # type: ignore
     except Exception:  # noqa: BLE001
         try:
@@ -137,18 +149,44 @@ def _try_execute_bridge(goal, env) -> Tuple[bool, str]:
         except Exception:  # noqa: BLE001
             fn = None
     if fn is None:
-        return False, ""
+        return _BRIDGE_ABSENT, None
     try:
-        result = fn(goal, env=env)
-        return True, f"실행 bridge 호출됨: {result}"
+        return "ok", fn(goal, env=env)
     except Exception as exc:  # noqa: BLE001 - bridge failure must not corrupt the decision
-        return False, f"실행 bridge 오류: {exc}"
+        return _BRIDGE_FAILED, str(exc)
+
+
+def _outcome_tail(state: str, payload) -> str:
+    """Render the REAL execution state for the operator — never a fake "executed"."""
+
+    if state == _BRIDGE_ABSENT:
+        return "승인됨(실행 대기 — GW4-B 실행 bridge 미배포)"
+    if state == _BRIDGE_FAILED:
+        return f"승인됨(실행 bridge 오류: {payload} — 실행 미수행)"
+    o = payload  # ExecuteOutcome
+    kind = getattr(o, "outcome", "")
+    if kind == "executed":
+        who = getattr(o, "executor_id", "") or "executor"
+        return f"실행됨(safe·게이트 통과 · execution+verification 기록 · executor={who})"
+    if kind == "blocked":
+        reasons = ", ".join(getattr(o, "reasons", ()) or ()) or getattr(o, "action_class", "gate")
+        return f"실행 거부(게이트: {reasons}) — decision 기록, 가짜 실행 없음"
+    if kind == "awaiting":
+        return "승인됨(실행 가능한 packet 없음 — 실행 대기)"
+    # error / unknown
+    detail = getattr(o, "detail", "") or "실행 불가"
+    return f"승인됨(실행 불가: {detail})"
 
 
 def apply_approve(env: Optional[Mapping[str, str]], gid: str, note: str = "") -> Tuple[bool, str]:
-    """Approve an awaiting goal: ``awaiting_approval -> active`` + decision evidence.
+    """Approve an awaiting goal: ``awaiting_approval -> active`` + decision evidence,
+    then run the GW4-B execution bridge and surface its REAL outcome.
 
-    Attempts the GW4-B execution bridge; if absent, returns "승인됨(실행 대기)" honestly."""
+    Persist order matters: the decision is saved FIRST (so it survives even when the
+    bridge is absent / errors / writes nothing), then the bridge runs and persists its
+    own execution+verification evidence. We RELOAD the authoritative goal afterward
+    instead of re-saving a stale copy — otherwise the bridge's real execution evidence
+    would be overwritten (a "fake status"). No fabricated execution, ever."""
 
     st = _store(env)
     g = st.get((gid or "").strip())
@@ -162,12 +200,10 @@ def apply_approve(env: Optional[Mapping[str, str]], gid: str, note: str = "") ->
     except transitions.InvalidTransition as exc:
         return False, str(exc)
     g2 = g2.add_evidence("decision", _decision_summary("승인", note))
-    executed, bridge_note = _try_execute_bridge(g2, env)
-    if executed:
-        g2 = g2.add_evidence("execution", bridge_note)
-    st.save(g2)
-    tail = bridge_note if executed else "승인됨(실행 대기 — GW4-B 실행 bridge 미연결)"
-    return True, f"{g2.id} 승인 -> {g2.status.value}  · {tail}"
+    st.save(g2)                                  # decision persisted unconditionally
+    state, payload = _run_execute_bridge(g2, env)
+    final = st.get(g2.id) or g2                  # bridge may have written richer evidence
+    return True, f"{final.id} 승인 -> {final.status.value}  · {_outcome_tail(state, payload)}"
 
 
 def apply_deny(env: Optional[Mapping[str, str]], gid: str, note: str = "") -> Tuple[bool, str]:

--- a/apps/forgekit-console/src/forgekit_console/provider_budget_surface.py
+++ b/apps/forgekit-console/src/forgekit_console/provider_budget_surface.py
@@ -1,0 +1,81 @@
+"""/provider budget operator surface (next-wave P1 #3) — thin show/set over the
+per-provider daily token budget that gw2 enforces (#343).
+
+Console stays a *surface* (ownership §3.1): the policy lives in
+``forgekit_provider.usage.provider_budget`` (which providers are over their own daily
+limit → routing fallback) and the config writer in
+``forgekit_provider.policy.provider_ops.set_provider_budget`` (persists
+``budget_policy.provider_daily_limits`` in the canonical config). This module only:
+
+* ``budget_lines`` — render each configured provider's LIVE state (today's spend from the
+  usage ledger vs its limit, over-budget flagged honestly);
+* ``apply_set_budget`` — validate operator input and apply via the package writer
+  (``0`` clears the limit → unbounded; never invents a limit).
+
+No fake numbers: spend comes from the real ledger; "no limit configured" is stated
+plainly rather than shown as a fake cap.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Tuple
+
+
+def budget_lines(env: Optional[Mapping[str, str]] = None) -> Tuple[str, ...]:
+    """Per-provider daily budget + LIVE today's spend (honest; unconfigured = unbounded)."""
+
+    from forgekit_provider.policy import provider_ops as ops
+    from forgekit_provider.usage import provider_budget as pb, read_events, today
+
+    cfg = ops.load_raw_config(env=env)
+    try:
+        rows = read_events(env=env, day=today(env))   # today's ledger rows → real spend
+    except Exception:  # noqa: BLE001 - ledger read must never break the surface
+        rows = []
+    states = pb.provider_budget_states(cfg, rows)
+    if not states:
+        return (
+            "per-provider budget: 미설정 — 전 provider unbounded (global `/usage` budget 만 적용).",
+            "  설정: `/provider budget set <provider> <일일토큰>`  (0 = 해제/unbounded)",
+        )
+    out = ["per-provider 일일 token budget (live spend / limit):"]
+    for s in states:
+        flag = "  ⚠ 초과(routing fallback)" if s.over else ""
+        out.append(f"  {s.provider:<10} {s.spent}/{s.limit}tok ({int(s.ratio * 100)}%){flag}")
+    out.append("  set: `/provider budget set <provider> <일일토큰>`  (0 = 해제)")
+    return tuple(out)
+
+
+def apply_set_budget(pid: str, tokens: str, *, env: Optional[Mapping[str, str]] = None) -> Tuple[bool, str]:
+    """Set (or clear with 0) a provider's per-provider daily token limit via the package
+    writer, then persist. Validation is honest: non-int / negative is rejected, not coerced."""
+
+    from forgekit_provider.policy import provider_ops as ops
+
+    pid = (pid or "").strip()
+    if not pid:
+        return False, "provider id 필요 — `/provider budget set <provider> <일일토큰>`"
+    try:
+        limit = int(tokens)
+    except (TypeError, ValueError):
+        return False, f"토큰 한도는 정수여야 합니다 — {tokens!r}"
+    if limit < 0:
+        return False, "토큰 한도는 0 이상 (0 = 해제/unbounded)"
+    new_cfg = ops.set_provider_budget(ops.load_raw_config(env=env), pid, limit)
+    ok, msg = ops.persist_config(new_cfg, env=env)
+    if not ok:
+        return False, f"저장 실패: {msg}"
+    if limit == 0:
+        return True, f"{pid} per-provider budget 해제 (unbounded)"
+    return True, f"{pid} per-provider budget = {limit}tok/day 설정"
+
+
+def usage_lines() -> Tuple[str, ...]:
+    return (
+        "`/provider budget` — per-provider 일일 token budget (gw2 enforcement #343)",
+        "  /provider budget [show]            provider 별 한도 + 오늘 사용량(live)",
+        "  /provider budget set <id> <토큰>   한도 설정 (0 = 해제/unbounded)",
+    )
+
+
+__all__ = ("budget_lines", "apply_set_budget", "usage_lines")

--- a/deploy/launchd/README.md
+++ b/deploy/launchd/README.md
@@ -23,7 +23,21 @@ sleep, so "24h always-on" on a laptop/lid-closed Mac mini is not real without:
 
 This template does not pretend the daemon runs through sleep.
 
-## Install
+## Install — automated (recommended)
+
+```bash
+# Resolves the 4 placeholders from your environment, writes the rendered plist to
+# ~/Library/LaunchAgents, and prints the exact load command. Daemon START stays
+# operator-gated — it does NOT launchctl-load by default.
+forgekit runtime install-unit --repo-root /path/to/checkout
+forgekit runtime install-unit --repo-root /path/to/checkout --load   # also bootstrap now (opt-in)
+```
+
+`--load` runs `launchctl bootstrap` and verifies it; a non-macOS host, an unresolved
+placeholder, or a launchctl failure all report an honest error (never a fake "installed").
+Code: `forgekit_console.deploy_unit` (rendering/placement) + `cli/runtime_cmd.py`.
+
+## Install — manual (equivalent)
 
 ```bash
 # 1) Substitute placeholders into a real plist:

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -31,7 +31,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | toolchain verify/drift (required vs ACTIVE, mise; no manager→honest) | working (needs mise to verify; manager-missing surfaced) | `/toolchain verify\|drift [<loadout>]` | `test_toolchain` |
 | toolchain switch (mise; global/install **approval-gated**, no fake switch) | working (local 적용; gated 액션은 `--approve`) | `/toolchain switch [global] [--approve]` | `test_toolchain` |
 | goal control plane (장기 목표 model/transition/append-only evidence/packet·child linkage, 영속) | working (surface CRUD; tick=runtime/GW4) | `/goal [list\|new <제목>\|show <id>\|activate <id>\|evidence <id>]` | `examples/goal/`, `test_goal_core`·`test_goal_surface`·`test_goal_tick` |
-| in-console approve/deny (awaiting_approval goal + linked packets → operator 결정) | working (legal transition + decision evidence; 실행=GW4-B 머지 시, 미연결이면 "실행 대기" 정직) | `/goal awaiting` · `/goal approve <id> [메모]` · `/goal deny <id> [메모]` | `examples/goal/approval.txt`, `test_goal_approval` |
+| in-console approve/deny + GW4-B 실행 연결 (awaiting_approval goal → operator 결정 → 실제 게이트 실행) | working (legal transition + decision evidence → GW4-B execute_approved_packet 호출: safe=실행됨(execution+verification 보존, surface 는 reload·비덮어쓰기), risky/blocked=실행 거부, 가짜 실행 0) | `/goal awaiting` · `/goal approve <id> [메모]` · `/goal deny <id> [메모]` | `examples/goal/approval.txt`, `test_goal_approval`·`test_execute_bridge` |
 
 ## Provider reality matrix
 | provider | connection | live submit | usage basis | mode influence |

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -24,6 +24,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | `/provider` console config (set primary / list / doctor) | working | `/provider [set <id>\|list\|doctor]` | `test_provider_surface` |
 | provider link / unlink / slot route | working | `/provider [link\|unlink\|route show\|route set <slot> <id>]` | `test_provider_surface` |
 | 4-provider brain preset (real config writer) | working | `/provider preset four-brain` | `test_four_brain_preset_and_routing` |
+| per-provider 일일 token budget (gw2 #343 enforcement 의 operator 표면) | working (show=설정한도+오늘 live spend, set/0-clear=canonical config 영속; 정책이 routing fallback 으로 강제) | `/provider budget [show\|set <id> <토큰>]` | `examples/provider-budget/surface.txt`, `test_provider_budget_surface` |
 | `/provider` declared→actual per slot (brain vs live transport) | working | `/provider` (default_chat/execution: declared X → actual Y) | `test_four_brain_preset_and_routing` |
 | provider onboarding wizard (connect 점검 → 추천 preset → save+verify) | working | `/setup` · `/setup apply` | `test_provider_connect` |
 | provider connect 진단 (CLI attach·API key·daemon, no fake-live) | working | `/provider connect\|disconnect\|test\|recommended <id>` | `test_provider_connect` |

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -17,6 +17,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | runtime modes (real routing/budget/approval) | working | `/mode`, Shift+Tab | `examples/runtime-teeth/` |
 | always-on daemon + safe-class autopilot | working (bounded) | `forgekit runtime serve`, `/autopilot` | `examples/runtime/`, `examples/autopilot/` |
 | daemon heartbeat in console (state/tick/pid/kill-switch) | working | `/daemon` · `/daemon stop` | `examples/runtime-daemon/`, `test_runtime_daemon_surface` |
+| launchd unit 자동설치 (수동 sed flow 대체, macOS) | working (템플릿 4-placeholder 자동 치환 + ~/Library/LaunchAgents 배치 + load 명령 emit; `--load` 는 operator opt-in, 비-macOS/누락 placeholder/load 실패는 정직 실패) | `forgekit runtime install-unit [--repo-root P] [--bin P] [--load]` | `examples/runtime-daemon/install-unit.txt`, `test_deploy_unit` |
 | agent identity (git author / app status) | working | `/whoami` | `test_identity_attribution` |
 | discovery collectors (free-first) | working; YouTube/IG/Google planned | `/sources` | `examples/sources/` |
 | design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |

--- a/tests/forgekit/test_deploy_unit.py
+++ b/tests/forgekit/test_deploy_unit.py
@@ -1,0 +1,111 @@
+"""launchd unit auto-install (final-completion lane B) — render + place, honest.
+
+Replaces the manual sed flow. Verified WITHOUT touching the real ~/Library/LaunchAgents
+or running launchctl: rendering/resolution are pure, the file write targets a tmp dest,
+and the launchctl run is an injected fake. Asserts no fake success (non-macOS / missing
+template / leftover placeholder / launchctl failure all return ok=False) and that the
+written plist is fully substituted (no __PLACEHOLDER__ leftovers).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console import deploy_unit as du
+
+_REPO = Path(__file__).resolve().parents[2]   # the real checkout (has deploy/launchd/)
+
+
+class RenderResolveTests(unittest.TestCase):
+    def test_resolve_values_uses_env_and_repo(self) -> None:
+        vals = du.resolve_values(
+            repo_root="/tmp/checkout",
+            env={"HOME": "/Users/me", "FORGEKIT_HOME": "/Users/me/.fk"},
+            bin_path="/venv/bin/forgekit", user_home="/Users/me")
+        self.assertEqual(vals["__FORGEKIT_BIN__"], "/venv/bin/forgekit")
+        self.assertEqual(vals["__FORGEKIT_HOME__"], "/Users/me/.fk")
+        self.assertEqual(vals["__USER_HOME__"], "/Users/me")
+        self.assertTrue(vals["__REPO_ROOT__"].endswith("checkout"))
+
+    def test_render_substitutes_all_placeholders(self) -> None:
+        tpl = du.template_path(_REPO).read_text(encoding="utf-8")
+        vals = du.resolve_values(repo_root=str(_REPO), env={"HOME": "/Users/me"},
+                                 bin_path="/venv/bin/forgekit", user_home="/Users/me")
+        rendered, missing = du.render(tpl, vals)
+        self.assertEqual(missing, ())                       # nothing left unsubstituted
+        self.assertNotIn("__", rendered.replace("<!--", ""))  # no leftover placeholder token
+        self.assertIn("/venv/bin/forgekit", rendered)
+
+    def test_render_reports_leftover_placeholder(self) -> None:
+        rendered, missing = du.render("X __FORGEKIT_BIN__ __REPO_ROOT__", {"__FORGEKIT_BIN__": "b"})
+        self.assertIn("__REPO_ROOT__", missing)
+
+
+class InstallTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = self._tmp.name
+        self.dest = str(Path(self.home) / "LaunchAgents" / "com.forgekit.runtime.plist")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_file_only_writes_rendered_plist_and_prints_load_cmd(self) -> None:
+        ok, lines = du.install(
+            repo_root=str(_REPO), env={"HOME": self.home}, user_home=self.home,
+            bin_path="/venv/bin/forgekit", dest_path=self.dest, platform="darwin", load=False)
+        self.assertTrue(ok)
+        blob = "\n".join(lines)
+        self.assertIn("launchctl bootstrap", blob)          # exact load command emitted
+        self.assertIn("자동 load 안 함", blob)               # default does NOT start the daemon
+        self.assertIn("lid-close", blob)                    # honest macOS limit restated
+        written = Path(self.dest).read_text(encoding="utf-8")
+        self.assertIn("/venv/bin/forgekit", written)
+        self.assertNotIn("__FORGEKIT_BIN__", written)       # fully rendered, no fake
+
+    def test_non_macos_is_honest_no_write(self) -> None:
+        ok, lines = du.install(repo_root=str(_REPO), env={"HOME": self.home},
+                               user_home=self.home, dest_path=self.dest, platform="linux")
+        self.assertFalse(ok)
+        self.assertIn("systemd", "\n".join(lines))
+        self.assertFalse(Path(self.dest).exists())          # nothing written on the wrong OS
+
+    def test_missing_template_is_honest_failure(self) -> None:
+        ok, lines = du.install(repo_root=self._tmp.name, env={"HOME": self.home},
+                               user_home=self.home, dest_path=self.dest, platform="darwin")
+        self.assertFalse(ok)
+        self.assertIn("템플릿 없음", lines[0])
+
+    def test_load_runs_launchctl_via_injected_runner(self) -> None:
+        calls = []
+
+        def fake_runner(argv):
+            calls.append(argv)
+            return True, ""                                  # bootstrap + print both succeed
+
+        ok, lines = du.install(
+            repo_root=str(_REPO), env={"HOME": self.home}, user_home=self.home,
+            bin_path="/venv/bin/forgekit", dest_path=self.dest, platform="darwin",
+            load=True, runner=fake_runner)
+        self.assertTrue(ok)
+        self.assertTrue(any("bootstrap" in a for a in calls[0]))   # real launchctl invoked
+        self.assertIn("bootstrap 완료", "\n".join(lines))
+
+    def test_load_failure_is_honest_no_fake_success(self) -> None:
+        def fail_runner(argv):
+            return False, "Bootstrap failed: 5: Input/output error"
+
+        ok, lines = du.install(
+            repo_root=str(_REPO), env={"HOME": self.home}, user_home=self.home,
+            bin_path="/venv/bin/forgekit", dest_path=self.dest, platform="darwin",
+            load=True, runner=fail_runner)
+        self.assertFalse(ok)                                 # NOT a fake success
+        self.assertIn("실패", "\n".join(lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_goal_approval.py
+++ b/tests/forgekit/test_goal_approval.py
@@ -105,6 +105,36 @@ class GoalApprovalTest(unittest.TestCase):
             self.assertNotIn("safe·게이트 통과", e.summary)
             self.assertNotIn("실행 인가", e.summary)
 
+    def test_approve_executed_packet_preserves_bridge_evidence(self) -> None:
+        # A safe, executable packet → GW4-B runs the real gate and writes
+        # execution+verification evidence + persists. The surface must RELOAD that
+        # authoritative goal, NOT overwrite it with a stale copy (the integration bug
+        # this guards). Reload must show the bridge's real evidence + the operator decision.
+        import tempfile
+
+        from forgekit_runtime.selfimprove import goal_tick
+
+        class _Sig:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        repo = tempfile.mkdtemp()
+        g = Goal.create("self-manage ForgeKit", mode="auto")
+        g = transitions.apply(g, GoalStatus.ACTIVE)
+        res = goal_tick.tick_goal(g, repo, signals=[_Sig("콘솔 도움말 문구 개선")])
+        self.assertEqual(len(res.goal.packets), 1)               # a real linked packet
+        parked = transitions.apply(res.goal, GoalStatus.AWAITING_APPROVAL)
+        GoalStore(env=self.env).save(parked)
+
+        out = _route(f"/goal approve {parked.id}", self.env)
+        self.assertEqual(out.kind, KIND_INFO)
+        self.assertIn("실행됨", out.lines[0])                     # REAL executed outcome surfaced
+        reloaded = self._get(parked.id)
+        kinds = [e.kind for e in reloaded.evidence]
+        self.assertIn("execution", kinds)                        # bridge evidence PRESERVED
+        self.assertIn("verification", kinds)                     # (not overwritten by surface)
+        self.assertIn("decision", kinds)                         # operator decision also kept
+
     def test_approve_missing_goal_is_error(self) -> None:
         res = _route("/goal approve goal-nope", self.env)
         self.assertEqual(res.kind, KIND_ERROR)

--- a/tests/forgekit/test_provider_budget_surface.py
+++ b/tests/forgekit/test_provider_budget_surface.py
@@ -1,0 +1,98 @@
+"""/provider budget console surface (next-wave P1 #3, gw3 console wiring).
+
+The operator surface for gw2's per-provider daily budget enforcement (#343). Proven via
+the REAL router + real config writer (tmp FORGEKIT_HOME), not mocks:
+
+- ``/provider budget`` (show) with NO limits configured → honest "미설정/unbounded";
+- ``/provider budget set <id> <tokens>`` → persists ``budget_policy.provider_daily_limits``
+  in the canonical config (re-readable by the enforcement policy);
+- ``/provider budget set <id> 0`` → clears the limit (unbounded, never invents one);
+- after a set, ``/provider budget`` show lists the provider + its limit;
+- non-int / negative input is rejected honestly (no coercion).
+
+Surface stays thin: it renders state + applies via the package writer
+(``forgekit_provider.policy.provider_ops.set_provider_budget``) — it owns no policy.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.commands.parser import parse_input
+from forgekit_console.commands.router import ConsoleContext, route
+from forgekit_contracts.models import KIND_ERROR, KIND_INFO
+
+
+def _route(raw: str, env):
+    return route(parse_input(raw), ConsoleContext(repo_root=Path("."), env=env))
+
+
+class ProviderBudgetSurfaceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.env = {"FORGEKIT_HOME": self._tmp.name}
+        # seed a minimal valid brain config in THIS env (the budget surface is
+        # env-isolated; persist_config validation needs primary + linked providers)
+        from forgekit_provider.policy import provider_ops as ops
+        ok, msg = ops.persist_config(
+            {"primary_provider": "ollama", "linked_providers": ["ollama"]}, env=self.env)
+        assert ok, msg
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_show_unset_is_honest_unbounded(self) -> None:
+        res = _route("/provider budget", self.env)
+        self.assertEqual(res.kind, KIND_INFO)
+        blob = "\n".join(res.lines)
+        self.assertIn("미설정", blob)
+        self.assertIn("unbounded", blob)
+
+    def test_set_persists_limit_and_show_lists_it(self) -> None:
+        res = _route("/provider budget set gemini 50000", self.env)
+        self.assertEqual(res.kind, KIND_INFO)
+        self.assertIn("50000", res.lines[0])
+        # persisted under budget_policy.provider_daily_limits (real config writer)
+        from forgekit_provider.policy import provider_ops as ops
+        from forgekit_provider.usage import provider_budget as pb
+        cfg = ops.load_raw_config(env=self.env)
+        self.assertEqual(pb.provider_limits(cfg).get("gemini"), 50000)
+        # show now lists gemini + its limit
+        show = _route("/provider budget show", self.env)
+        self.assertTrue(any("gemini" in ln and "50000" in ln for ln in show.lines))
+
+    def test_set_zero_clears_limit(self) -> None:
+        _route("/provider budget set gemini 50000", self.env)
+        res = _route("/provider budget set gemini 0", self.env)
+        self.assertEqual(res.kind, KIND_INFO)
+        self.assertIn("해제", res.lines[0])
+        from forgekit_provider.policy import provider_ops as ops
+        from forgekit_provider.usage import provider_budget as pb
+        self.assertNotIn("gemini", pb.provider_limits(ops.load_raw_config(env=self.env)))
+
+    def test_set_non_integer_rejected(self) -> None:
+        res = _route("/provider budget set gemini lots", self.env)
+        self.assertEqual(res.kind, KIND_ERROR)
+        self.assertIn("정수", res.lines[0])
+
+    def test_set_negative_rejected(self) -> None:
+        res = _route("/provider budget set gemini -5", self.env)
+        self.assertEqual(res.kind, KIND_ERROR)
+
+    def test_set_missing_provider_rejected(self) -> None:
+        res = _route("/provider budget set", self.env)
+        self.assertEqual(res.kind, KIND_ERROR)
+        self.assertIn("provider id", res.lines[0])
+
+    def test_registry_lists_budget(self) -> None:
+        from forgekit_console.commands.registry import find_command
+        cmd = find_command("provider")
+        self.assertIn("budget", cmd.summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
operator cockpit / console parity 축의 final-completion — 콘솔에서 ForgeKit control plane 을
실제 구조로(=fake parity 아님) 다룰 수 있게 마감. 이미 머지된 parity 표면(#337) 위에 operator-visible
실행/예산/배포 표면 3개를 닫는다.

## 범위 (gw3 OWN: apps/forgekit-console/** + tests + docs + deploy)
- **approve→GW4-B 실행 결과 operator 표면 정합**: `/goal approve` 가 GW4-B(#348) 실행 결과를 잃지
  않고(권위본 reload, stale 재저장 제거) executed/blocked/awaiting/error 실제 outcome 을 표면.
- **`/provider budget [show|set <id> <토큰>]`**: per-provider 일일 budget 의 operator 콘솔 표면
  (정책/영속은 forgekit-provider 소유 — surface 는 호출만).
- **`forgekit runtime install-unit`**: launchd LaunchAgent 자동설치(수동 sed 대체), `--load` opt-in.
- 비범위(타 lane): provider runtime deep execution(gw2), PM/Tech-Lead governance(gw1),
  BoundedMutator 물리 실행(C), evidence→vault(D/gw2 #349).

## 리스크
- 콘솔 표면이 패키지 정책 함수만 호출 → 로직 중복/우회 없음. router 순수성 유지.
- install-unit 은 기본 파일만 작성(daemon 시작 operator-gated), 비-macOS/launchctl 실패 정직.
- 머지 순서: gw0 merge-order 가 C→D→A→B → 본 PR(A/B)은 C/D 이후. 파일 disjoint(충돌 0 예상).
- 알려진 flaky: `test_tui_ingest_attach::test_placeholder_paste_rehydrates_and_submits_full`
  (full-suite 동시 실행 시 간헐, isolation green — 기존 pilot 타이밍, 본 변경 무관).

## 테스트
- 신규: `test_goal_approval`(executed evidence 보존 가드 포함), `test_provider_budget_surface`(7),
  `test_deploy_unit`(8). 회귀: parity 96 tests green(palette-below/scroll-owner/copy round-trip/
  paste·multiline·attach/process feed/mode-no-pollution).
- 전체 forgekit **1013 passed / 1 skipped**(flaky 1 isolation green). commit-governance 9/9 OK.
- evidence: `examples/goal/approval.txt`, `examples/provider-budget/surface.txt`,
  `examples/runtime-daemon/install-unit.txt`.

## 이슈 linkage
- final-completion wave gw3 lane (A + B) — gw0 `.claude/shared/forgekit-master/` acceptance.
- 선행 관련: #337(parity), #348(GW4-B execute bridge), #343(per-provider budget enforcement).

---
audit:
- no fake: 실행은 GW4-B 실제 게이트 경유(safe=실행됨/risky=거부), budget 은 실 ledger live spend,
  install-unit 은 실 템플릿 렌더(미치환 placeholder 중단). fake typing/status 0.
- operator-visible: `/goal approve|show`(execution+verification evidence), `/provider budget`,
  `forgekit runtime install-unit`, operator-surfaces.md 3 행.
- geometry/runtime/clipboard/payload 기준 검증(parity lane harness).
