### PR TITLE
♻️ approve→GW4-B 실행 evidence 보존 정합 (operator cockpit acceptance #2)

### DIFF
--- a/apps/forgekit-console/examples/goal/approval.txt
+++ b/apps/forgekit-console/examples/goal/approval.txt
@@ -1,33 +1,31 @@
-ForgeKit operator cockpit — in-console approve/deny (real router + goal store)
+ForgeKit operator cockpit — approve/deny + GW4-B 실행 연결 (real router+store+bridge)
 ==============================================================================
-Method: 실 router(route) + 실 GoalStore(tmp FORGEKIT_HOME). no mock, no fake execute.
-승인=awaiting_approval→active+decision evidence, 거부=→blocked+decision evidence.
-GW4-B 실행 bridge 미연결 → approve 는 '실행 대기' 정직 표기(execution evidence 없음).
+Method: 실 route + 실 GoalStore + 실 GW4-B execute_approved_packet. mock/fake 없음.
+approve = awaiting_approval→active + decision evidence, 그 뒤 GW4-B 실행 bridge 호출.
+bridge 가 execution+verification evidence 를 직접 persist → surface 는 RELOAD(덮어쓰기 금지).
+safe packet → 실행됨, risky packet → 실행 거부(가짜 실행 없음). 실제 outcome 을 콘솔에 표면.
 
 $ /goal awaiting  [info]
   2 goal 승인 대기:
-    goal-5a7a0763ab2a  스키마 마이그레이션
-      linked packets: packet-migrate-1
-      승인: `/goal approve goal-5a7a0763ab2a [메모]`   거부: `/goal deny goal-5a7a0763ab2a [메모]`
-    goal-bc4df3a6e234  배포 파이프라인 구성
-      linked packets: packet-deploy-1, packet-deploy-2
-      승인: `/goal approve goal-bc4df3a6e234 [메모]`   거부: `/goal deny goal-bc4df3a6e234 [메모]`
+    goal-7d92df0edc26  auth 대규모 변경
+      linked packets: packet-b204066fabee
+      승인: `/goal approve goal-7d92df0edc26 [메모]`   거부: `/goal deny goal-7d92df0edc26 [메모]`
+    goal-08921ea58a7c  self-manage ForgeKit
+      linked packets: packet-e0191b811b01
+      승인: `/goal approve goal-08921ea58a7c [메모]`   거부: `/goal deny goal-08921ea58a7c [메모]`
 
-$ /goal approve goal-bc4df3a6e234 운영자 승인  [info]
-  goal-bc4df3a6e234 승인 -> active  · 승인됨(실행 대기 — GW4-B 실행 bridge 미연결)
+$ /goal approve goal-08921ea58a7c 운영자 승인  (safe packet)  [info]
+  goal-08921ea58a7c 승인 -> active  · 실행됨(safe·게이트 통과 · execution+verification 기록 · executor=backend-engineer)
 
-$ /goal deny goal-5a7a0763ab2a 마이그레이션 범위 밖  [info]
-  goal-5a7a0763ab2a 거부 -> blocked  · 거부됨(blocked, 재검토 가능)
+$ /goal evidence goal-08921ea58a7c  (decision+execution+verification 보존)  [info]
+  goal-08921ea58a7c evidence (4):
+    - 2026-06-22T04:27:17.604726+00:00  [proposal] [safe] 콘솔 도움말 문구 개선 -> safe → tech-lead ready (승인 체계 내 자동 가능)  (packet-e0191b811b01)
+    - 2026-06-22T04:27:17.605897+00:00  [decision] operator 승인: 운영자 승인
+    - 2026-06-22T04:27:17.606184+00:00  [execution] safe-class 실행 인가 — packet packet-e0191b811b01: 콘솔 도움말 문구 개선 [executor=backend-engineer author=Forgekit Backend <be@forgekit.local> approver=operator approval=decision=콘솔 도움말 문구 개선;level=L2_internal_approve;signoff=tech-lead] (실제 파일 mutation 은 BoundedMutator 게이트 — 본 단계는 인가+검증 기록)  (packet-e0191b811b01)
+    - 2026-06-22T04:27:17.606193+00:00  [verification] 실행 게이트 재검증 통과 — chain(can_execute)+decision-lane(authorize)+validate_execution 모두 통과, action_class=safe, approval=decision=콘솔 도움말 문구 개선;level=L2_internal_approve;signoff=tech-lead  (packet-e0191b811b01)
 
-$ /goal awaiting  (결정 후)  [info]
-  승인 대기 goal 없음 — runtime 이 risky/restricted packet 을 만들면 awaiting_approval 로 여기 모입니다.
+$ /goal approve goal-7d92df0edc26 위험 검토  (risky packet → 게이트 거부)  [info]
+  goal-7d92df0edc26 승인 -> active  · 실행 거부(게이트: risky(L3) — operator 승인 없음, tech-lead 내부 승인(can_execute) 없음, safe class 아님(risky) — 자동 실행 금지, 내부 chain 승인(can_execute) 없음) — decision 기록, 가짜 실행 없음
 
-$ /goal evidence goal-bc4df3a6e234  [info]
-  goal-bc4df3a6e234 evidence (1):
-    - 2026-06-22T03:16:20.119796+00:00  [decision] operator 승인: 운영자 승인
-
-$ /goal approve goal-nope  [error]
-  goal 'goal-nope' 없음 — `/goal awaiting` 로 확인
-
-$ /goal approve goal-c78582c701c7  (draft, 승인 대상 아님)  [error]
-  goal-c78582c701c7 는 승인 대기 아님(현재 draft) — approve 는 awaiting_approval goal 만 대상
+$ /goal approve goal-d5d0428b1925  (draft, 승인 대상 아님)  [error]
+  goal-d5d0428b1925 는 승인 대기 아님(현재 draft) — approve 는 awaiting_approval goal 만 대상

--- a/apps/forgekit-console/src/forgekit_console/goal_surface.py
+++ b/apps/forgekit-console/src/forgekit_console/goal_surface.py
@@ -96,10 +96,13 @@ def apply_activate(env: Optional[Mapping[str, str]], gid: str) -> Tuple[bool, st
 # cockpit parity gap. The decision is a LEGAL status transition + an append-only
 # ``decision`` evidence record; the surface owns no goal logic (ownership §3.1).
 #
-# Honest execution boundary: approving records the operator decision and (if the GW4-B
-# execution bridge from gw1 is merged) triggers it. Until that bridge exists, approve is
-# "승인됨(실행 대기)" — never a fake "executed". The bridge is looked up lazily so it lights
-# up automatically once gw1 lands it, with no change here.
+# Honest execution boundary: approving records the operator decision, then runs the GW4-B
+# execution bridge (``forgekit_runtime.selfimprove.execute_approved_packet``, now merged).
+# The bridge runs the REAL gate (chain + decision-lane + validate_execution) and persists
+# execution+verification evidence ITSELF — so this surface RELOADS the authoritative goal
+# afterward rather than overwriting it, and renders the bridge's real outcome (executed /
+# blocked / awaiting / error). Never a fabricated "executed". The bridge is still looked up
+# lazily so the surface also works if it is ever absent (honest "실행 대기").
 
 def awaiting_lines(env: Optional[Mapping[str, str]]) -> Tuple[str, ...]:
     """List goals in ``awaiting_approval`` + their linked packets + the action hint."""
@@ -122,14 +125,23 @@ def _decision_summary(decision: str, note: str) -> str:
     return f"operator {decision}" + (f": {note}" if note else "")
 
 
-def _try_execute_bridge(goal, env) -> Tuple[bool, str]:
-    """Call the GW4-B execution bridge (gw1) if it is merged; else honest no-op.
+_BRIDGE_ABSENT = "absent"     # GW4-B not deployed
+_BRIDGE_FAILED = "failed"     # bridge raised (must not corrupt the decision)
 
-    Lazy, defensive import so this surface works before the bridge exists AND lights up
-    automatically once it lands — without owning any execution logic itself."""
+
+def _run_execute_bridge(goal, env):
+    """Run the GW4-B execution bridge if merged. Returns ``(state, payload)``:
+
+    * ``(_BRIDGE_ABSENT, None)`` — bridge not deployed (pre-GW4-B);
+    * ``(_BRIDGE_FAILED, "<msg>")`` — bridge raised;
+    * ``("ok", ExecuteOutcome)`` — bridge ran (it persisted its own decision/execution/
+      verification evidence on executed/blocked — the caller must RELOAD, not overwrite).
+
+    Lazy, defensive import: the surface owns no execution logic and works whether or not
+    the bridge exists, lighting up automatically once it lands."""
 
     fn = None
-    try:  # canonical home once gw1 GW4-B merges
+    try:  # canonical home (gw1 GW4-B)
         from forgekit_runtime.selfimprove import execute_approved_packet as fn  # type: ignore
     except Exception:  # noqa: BLE001
         try:
@@ -137,18 +149,44 @@ def _try_execute_bridge(goal, env) -> Tuple[bool, str]:
         except Exception:  # noqa: BLE001
             fn = None
     if fn is None:
-        return False, ""
+        return _BRIDGE_ABSENT, None
     try:
-        result = fn(goal, env=env)
-        return True, f"실행 bridge 호출됨: {result}"
+        return "ok", fn(goal, env=env)
     except Exception as exc:  # noqa: BLE001 - bridge failure must not corrupt the decision
-        return False, f"실행 bridge 오류: {exc}"
+        return _BRIDGE_FAILED, str(exc)
+
+
+def _outcome_tail(state: str, payload) -> str:
+    """Render the REAL execution state for the operator — never a fake "executed"."""
+
+    if state == _BRIDGE_ABSENT:
+        return "승인됨(실행 대기 — GW4-B 실행 bridge 미배포)"
+    if state == _BRIDGE_FAILED:
+        return f"승인됨(실행 bridge 오류: {payload} — 실행 미수행)"
+    o = payload  # ExecuteOutcome
+    kind = getattr(o, "outcome", "")
+    if kind == "executed":
+        who = getattr(o, "executor_id", "") or "executor"
+        return f"실행됨(safe·게이트 통과 · execution+verification 기록 · executor={who})"
+    if kind == "blocked":
+        reasons = ", ".join(getattr(o, "reasons", ()) or ()) or getattr(o, "action_class", "gate")
+        return f"실행 거부(게이트: {reasons}) — decision 기록, 가짜 실행 없음"
+    if kind == "awaiting":
+        return "승인됨(실행 가능한 packet 없음 — 실행 대기)"
+    # error / unknown
+    detail = getattr(o, "detail", "") or "실행 불가"
+    return f"승인됨(실행 불가: {detail})"
 
 
 def apply_approve(env: Optional[Mapping[str, str]], gid: str, note: str = "") -> Tuple[bool, str]:
-    """Approve an awaiting goal: ``awaiting_approval -> active`` + decision evidence.
+    """Approve an awaiting goal: ``awaiting_approval -> active`` + decision evidence,
+    then run the GW4-B execution bridge and surface its REAL outcome.
 
-    Attempts the GW4-B execution bridge; if absent, returns "승인됨(실행 대기)" honestly."""
+    Persist order matters: the decision is saved FIRST (so it survives even when the
+    bridge is absent / errors / writes nothing), then the bridge runs and persists its
+    own execution+verification evidence. We RELOAD the authoritative goal afterward
+    instead of re-saving a stale copy — otherwise the bridge's real execution evidence
+    would be overwritten (a "fake status"). No fabricated execution, ever."""
 
     st = _store(env)
     g = st.get((gid or "").strip())
@@ -162,12 +200,10 @@ def apply_approve(env: Optional[Mapping[str, str]], gid: str, note: str = "") ->
     except transitions.InvalidTransition as exc:
         return False, str(exc)
     g2 = g2.add_evidence("decision", _decision_summary("승인", note))
-    executed, bridge_note = _try_execute_bridge(g2, env)
-    if executed:
-        g2 = g2.add_evidence("execution", bridge_note)
-    st.save(g2)
-    tail = bridge_note if executed else "승인됨(실행 대기 — GW4-B 실행 bridge 미연결)"
-    return True, f"{g2.id} 승인 -> {g2.status.value}  · {tail}"
+    st.save(g2)                                  # decision persisted unconditionally
+    state, payload = _run_execute_bridge(g2, env)
+    final = st.get(g2.id) or g2                  # bridge may have written richer evidence
+    return True, f"{final.id} 승인 -> {final.status.value}  · {_outcome_tail(state, payload)}"
 
 
 def apply_deny(env: Optional[Mapping[str, str]], gid: str, note: str = "") -> Tuple[bool, str]:

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -31,7 +31,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | toolchain verify/drift (required vs ACTIVE, mise; no manager→honest) | working (needs mise to verify; manager-missing surfaced) | `/toolchain verify\|drift [<loadout>]` | `test_toolchain` |
 | toolchain switch (mise; global/install **approval-gated**, no fake switch) | working (local 적용; gated 액션은 `--approve`) | `/toolchain switch [global] [--approve]` | `test_toolchain` |
 | goal control plane (장기 목표 model/transition/append-only evidence/packet·child linkage, 영속) | working (surface CRUD; tick=runtime/GW4) | `/goal [list\|new <제목>\|show <id>\|activate <id>\|evidence <id>]` | `examples/goal/`, `test_goal_core`·`test_goal_surface`·`test_goal_tick` |
-| in-console approve/deny (awaiting_approval goal + linked packets → operator 결정) | working (legal transition + decision evidence; 실행=GW4-B 머지 시, 미연결이면 "실행 대기" 정직) | `/goal awaiting` · `/goal approve <id> [메모]` · `/goal deny <id> [메모]` | `examples/goal/approval.txt`, `test_goal_approval` |
+| in-console approve/deny + GW4-B 실행 연결 (awaiting_approval goal → operator 결정 → 실제 게이트 실행) | working (legal transition + decision evidence → GW4-B execute_approved_packet 호출: safe=실행됨(execution+verification 보존, surface 는 reload·비덮어쓰기), risky/blocked=실행 거부, 가짜 실행 0) | `/goal awaiting` · `/goal approve <id> [메모]` · `/goal deny <id> [메모]` | `examples/goal/approval.txt`, `test_goal_approval`·`test_execute_bridge` |
 
 ## Provider reality matrix
 | provider | connection | live submit | usage basis | mode influence |

--- a/tests/forgekit/test_goal_approval.py
+++ b/tests/forgekit/test_goal_approval.py
@@ -105,6 +105,36 @@ class GoalApprovalTest(unittest.TestCase):
             self.assertNotIn("safe·게이트 통과", e.summary)
             self.assertNotIn("실행 인가", e.summary)
 
+    def test_approve_executed_packet_preserves_bridge_evidence(self) -> None:
+        # A safe, executable packet → GW4-B runs the real gate and writes
+        # execution+verification evidence + persists. The surface must RELOAD that
+        # authoritative goal, NOT overwrite it with a stale copy (the integration bug
+        # this guards). Reload must show the bridge's real evidence + the operator decision.
+        import tempfile
+
+        from forgekit_runtime.selfimprove import goal_tick
+
+        class _Sig:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        repo = tempfile.mkdtemp()
+        g = Goal.create("self-manage ForgeKit", mode="auto")
+        g = transitions.apply(g, GoalStatus.ACTIVE)
+        res = goal_tick.tick_goal(g, repo, signals=[_Sig("콘솔 도움말 문구 개선")])
+        self.assertEqual(len(res.goal.packets), 1)               # a real linked packet
+        parked = transitions.apply(res.goal, GoalStatus.AWAITING_APPROVAL)
+        GoalStore(env=self.env).save(parked)
+
+        out = _route(f"/goal approve {parked.id}", self.env)
+        self.assertEqual(out.kind, KIND_INFO)
+        self.assertIn("실행됨", out.lines[0])                     # REAL executed outcome surfaced
+        reloaded = self._get(parked.id)
+        kinds = [e.kind for e in reloaded.evidence]
+        self.assertIn("execution", kinds)                        # bridge evidence PRESERVED
+        self.assertIn("verification", kinds)                     # (not overwritten by surface)
+        self.assertIn("decision", kinds)                         # operator decision also kept
+
     def test_approve_missing_goal_is_error(self) -> None:
         res = _route("/goal approve goal-nope", self.env)
         self.assertEqual(res.kind, KIND_ERROR)


### PR DESCRIPTION
## 목적
operator cockpit 의 acceptance #2(approve/deny 가 GW4-B 실행 결과를 operator 에게 정직히 표면) 마감.
`/goal approve` 가 GW4-B(#348) 실행 결과를 **잃지 않고** 실제 outcome 을 보여주게 한다.

## 범위 (gw3 OWN: goal_surface approve 경로 + 회귀/문서)
- `goal_surface.apply_approve`: decision 먼저 영속 → GW4-B `execute_approved_packet` 실행 → **권위본
  RELOAD**(stale g2 재저장 제거) → 실제 outcome(executed/blocked/awaiting/error) 표면.
- 비범위: `/provider budget`·`runtime install-unit` 은 병렬 lane 이 이미 main 에 머지 → 본 PR 제외(중복 회피).
  provider 정책/runtime serve 로직(gw2), forge governance(gw1) 도 범위 밖.

## 리스크
- **버그 수정**: 머지본 `apply_approve` 는 bridge 가 persist 한 execution+verification evidence 를
  stale 재저장으로 덮어써 잃고 있었음(= operator 에게 fake/누락 상태). 본 PR 이 reload 로 보존.
- 단일 파일(goal_surface) + 테스트/문서 → 충돌면 최소. router 순수성/패키지 경계 불변.

## 테스트
- `test_goal_approval`(10): executed → execution/verification/decision evidence **보존** 가드,
  blocked=실행 거부, no-packet=실행 불가, missing/non-awaiting 거부. 실 router+store+GW4-B.
- 전체 forgekit **1062 passed / 1 skipped**(기존 pilot flake 1, isolation green). commit-governance OK.
- evidence: `examples/goal/approval.txt`(safe=실행됨 4-evidence / risky=거부 캡처).

## 이슈 linkage
- final-completion wave gw3 acceptance #2 (gw0 `.claude/shared/forgekit-master/`).
- 선행: #348(GW4-B execute bridge). cockpit parity 표면은 #337(머지됨) — 본 PR 은 그 위 정합.

---
audit:
- no fake: 실행은 GW4-B 실제 게이트 경유. evidence 보존을 reload 로 보장(덮어쓰기 0). fake typing/status 0.
- operator-visible: `/goal approve` outcome 줄 + `/goal show`/`evidence` 의 execution+verification.
