### PR TITLE
✨ G2 forge governance ledger persist + view (/resolve apply|ledger)

### DIFF
--- a/apps/forgekit-console/examples/forge-ledger/persist.txt
+++ b/apps/forgekit-console/examples/forge-ledger/persist.txt
@@ -1,0 +1,60 @@
+=== forge governance ledger — persist + view operator path ===
+
+--- 1) preview (default, persist=False) — verdict 표시, ledger 미기록 ---
+$ /resolve Spring Boot JWT refresh token 구현
+  [info] resolve
+  hephaistos resolve — Spring Boot JWT refresh token 구현
+    infer     : backend/java/spring-boot/auth-jwt
+    agent     : backend-engineer
+    skills    : auth-jwt, java-spring, docker, mysql, oauth2, postgres, redis
+    loadout   : backend-java-local
+    weapons   : openjdk, gradle, docker, mysql, postgres, redis
+    nexus     : not_connected (FORGEKIT_NEXUS_ROOT 미설정 — 지식 source 미연결)
+    packet    : scope 15 / forbidden 8 / verify 12 / approval L2_internal_approve
+    [dim]상세: /skills <요청> · /loadout <id> · /hephaistos[/dim]
+  
+  ── governance ──
+  forge execution receipt — 인가됨 / executed
+  - request : Spring Boot JWT refresh token 구현
+  - equip   : agent=backend-engineer loadout=backend-java-local
+  - class   : safe (L2_internal_approve)
+  - approval: decision=Spring Boot JWT refresh token 구현;level=L2_internal_approve;signoff=tech-lead
+
+--- 2) ledger 보기 — 아직 비어 있음 (honest) ---
+$ /resolve ledger
+  [info] resolve ledger
+  forge governance ledger — 기록된 receipt 없음 (`/resolve apply <요청>` 로 영속)
+
+--- 3) apply — operator 가 명시적으로 receipt 를 ledger 에 영속 ---
+$ /resolve apply Spring Boot JWT refresh token 구현
+  [info] resolve apply
+  forge receipt 를 governance ledger 에 영속함 → /private/var/folders/sp/kccsmqn50pj0t48h0wvzgh880000gn/T/tmp0ylyiox2/state/forge_receipts.jsonl
+  forge execution receipt — 인가됨 / executed
+  - request : Spring Boot JWT refresh token 구현
+  - equip   : agent=backend-engineer loadout=backend-java-local
+  - class   : safe (L2_internal_approve)
+  - approval: decision=Spring Boot JWT refresh token 구현;level=L2_internal_approve;signoff=tech-lead
+
+--- 4) ledger 보기 — 영속된 receipt 표시 ---
+$ /resolve ledger
+  [info] resolve ledger
+  forge governance ledger — 최근 1건 (오래된→최신):
+     1. 인가/executed [safe/L2_internal_approve] req='Spring Boot JWT refresh token 구현' signoff=decision=Spring Boot JWT refresh token 구
+
+--- 5) apply (destructive) — 미인가 → 가짜 성공 영속 거부 (honest) ---
+$ /resolve apply 프로덕션 DB 스키마 마이그레이션 배포 및 secret 교체
+  [error] resolve apply
+  forge plan 미인가 — ledger 에 영속하지 않음 (가짜 성공 금지).
+  forge execution receipt — 차단됨 / blocked
+  - request : 프로덕션 DB 스키마 마이그레이션 배포 및 secret 교체
+  - equip   : agent=security-engineer loadout=devops-cloud-local
+  - class   : destructive (L4_restricted)
+  - approval: -
+  - blocked : destructive(L4) — 자동 실행 금지, operator + runbook 전용; tech-lead 내부 승인(can_execute) 없음; safe class 아님(blocked) — 자동 실행 금지; 내부 chain 승인(can_execute) 없음 — safe-class 자동 실행만
+
+--- 6) ledger 보기 — blocked 는 기록되지 않음 (여전히 1건) ---
+$ /resolve ledger
+  [info] resolve ledger
+  forge governance ledger — 최근 1건 (오래된→최신):
+     1. 인가/executed [safe/L2_internal_approve] req='Spring Boot JWT refresh token 구현' signoff=decision=Spring Boot JWT refresh token 구
+

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -97,7 +97,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("attach", "첨부 staging — `/attach [<path>|status|clear]` 또는 이미지 붙여넣기. 실제 stage(미전송 staged_only — provider 텍스트 전용)", H_ATTACH, "status"),
     SlashCommand("paste", "보존된 large paste 조작 — `/paste [list|expand <id>|resend <id>]` (원문 보존, placeholder 아님)", H_PASTE, "status"),
     SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
-    SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve (`/resolve <요청>`)", H_RESOLVE, "status"),
+    SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve + governance verdict (`/resolve <요청>` 미리보기, `/resolve apply <요청>` = receipt 를 ledger 에 영속, `/resolve ledger` = forge governance ledger 보기)", H_RESOLVE, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -408,6 +408,14 @@ def _hephaistos_result(handler, parsed, ctx=None) -> CommandResult:
         return CommandResult.info("hephaistos", proj.hephaistos_status_lines(env=env, config=config))
     if handler == H_LOADOUT:
         return CommandResult.info("loadout", proj.loadout_lines(args[0] if args else "backend-java-local"))
+    if handler == H_RESOLVE and args:
+        sub = args[0].lower()
+        # `/resolve ledger` — VIEW the append-only forge governance ledger (read-only).
+        if sub == "ledger":
+            return _forge_ledger_result(env=env)
+        # `/resolve apply <요청>` — PERSIST the forge governance receipt (operator-triggered).
+        if sub == "apply":
+            return _forge_apply_result(" ".join(args[1:]).strip(), env=env)
     if not request:
         which = "/resolve" if handler == H_RESOLVE else "/skills"
         return CommandResult.info(handler, (f"요청을 입력하세요 — `{which} <요청>` "
@@ -434,6 +442,58 @@ def _forge_governance_lines(request: str, *, env=None) -> tuple:
     except Exception:  # noqa: BLE001 — a render must never break /resolve
         return ()
     return ("", "── governance ──") + receipt.lines()
+
+
+def _forge_apply_result(request: str, *, env=None) -> CommandResult:
+    """`/resolve apply <요청>` — PERSIST the forge governance receipt to the append-only
+    ledger (operator-triggered, never silent). Honest: a risky/blocked plan refuses to
+    persist a fake success — only a validation-passing receipt enters the durable log."""
+
+    if not request:
+        return CommandResult.info(
+            "resolve apply",
+            ("요청을 입력하세요 — `/resolve apply <요청>` (forge receipt 를 ledger 에 영속).",),
+        )
+    try:
+        from forgekit_runtime.forge import (
+            FakeReceiptRefused, forge_execute, record_forge_receipt,
+        )
+    except Exception as e:  # noqa: BLE001
+        return CommandResult.error("resolve apply", (f"forgekit_runtime 미가용: {e}",))
+
+    receipt = forge_execute(request, env=env)
+    # honest: a non-authorized (risky/blocked/error) receipt is never persisted as success.
+    if receipt.outcome != "executed" or not receipt.authorized:
+        return CommandResult.error(
+            "resolve apply",
+            ("forge plan 미인가 — ledger 에 영속하지 않음 (가짜 성공 금지).",) + receipt.lines(),
+        )
+    try:
+        path = record_forge_receipt(receipt, env=env)
+    except FakeReceiptRefused as e:  # anti-fake at the persistence boundary
+        return CommandResult.error(
+            "resolve apply",
+            (f"ledger 거부 — fake receipt: {e}",) + receipt.lines(),
+        )
+    if path is None:
+        return CommandResult.error(
+            "resolve apply",
+            ("ledger I/O 실패 — receipt 영속 못함 (verdict 는 유효).",) + receipt.lines(),
+        )
+    return CommandResult.info(
+        "resolve apply",
+        (f"forge receipt 를 governance ledger 에 영속함 → {path}",) + receipt.lines(),
+    )
+
+
+def _forge_ledger_result(*, env=None) -> CommandResult:
+    """`/resolve ledger` — VIEW the append-only forge governance ledger (read-only)."""
+
+    try:
+        from forgekit_runtime.forge import forge_ledger_lines
+    except Exception as e:  # noqa: BLE001
+        return CommandResult.error("resolve ledger", (f"forgekit_runtime 미가용: {e}",))
+    return CommandResult.info("resolve ledger", forge_ledger_lines(env=env))
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/docs/hephaistos-governance.md
+++ b/docs/hephaistos-governance.md
@@ -110,7 +110,27 @@ receipt 를 누적해 결정 로그를 **영속** 시킨다.
 - `record_forge_receipt` 는 persistence 경계에서 `validate_forge_receipt` 를 다시
   돌려 **fake receipt 를 거부**(`FakeReceiptRefused`) — 위조 승인/실행은 durable
   로그에 절대 못 들어간다. I/O 실패는 best-effort(결정 유실 없음), fake 는 hard 거부.
-- `read_forge_receipts(env=, limit=)` 로 audit 재생.
+- `read_forge_receipts(env=, limit=)` 로 audit 재생, `forge_ledger_lines(env=, limit=)`
+  로 operator 표면용 라인 렌더(빈 ledger 는 정직하게 "기록 없음").
+
+### 4.3.1 operator 가 실제로 영속/조회하는 경로 (`/resolve apply` · `/resolve ledger`)
+
+라이브러리 `persist=True` 만으로는 operator 가 ledger 에 닿을 길이 없다(기본
+`/resolve` 는 `persist=False` 미리보기). 그래서 콘솔에 **명시적 operator 트리거**
+두 개를 둔다(코드: `forgekit_console.commands.router._forge_apply_result` /
+`_forge_ledger_result`, 렌더 로직은 `forge/ledger_view.py` — router 는 얇게 유지):
+
+- `/resolve apply <요청>` → `forge_execute(persist=True)` → receipt 를 append-only
+  ledger 에 영속하고 경로 + receipt 를 확인 출력. **operator 가 명시적으로 `apply`
+  를 칠 때만** 영속 — 절대 자동/암묵 아님. 미인가(risky/destructive/error)면 **가짜
+  성공을 영속하지 않고** 차단 사유를 그대로 보여준다(honest).
+- `/resolve ledger` → append-only forge governance ledger 의 최근 receipt 목록
+  (request / decision / class·level / signoff)을 렌더. 빈 ledger 는 정직하게
+  "기록된 receipt 없음".
+- 기본 `/resolve <요청>` 는 그대로 **미리보기(`persist=False`)** — 동작 불변(회귀).
+
+증거: `apps/forgekit-console/examples/forge-ledger/persist.txt`
+(apply→영속 / preview 미영속 / blocked 거부 / ledger 보기).
 
 ## 5. 무엇을 닫았나 (axis2/axis3)
 

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/__init__.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/__init__.py
@@ -33,6 +33,7 @@ from .ledger import (
     read_forge_receipts,
     record_forge_receipt,
 )
+from .ledger_view import forge_ledger_lines
 
 __all__ = (
     "SAFE", "RISKY", "DESTRUCTIVE", "ForgeClassification", "classify_forge_plan",
@@ -41,4 +42,5 @@ __all__ = (
     "authorize_forge_plan", "forge_execute",
     "FakeReceiptRefused", "forge_receipt_ledger_path",
     "record_forge_receipt", "read_forge_receipts",
+    "forge_ledger_lines",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/forge/ledger_view.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/forge/ledger_view.py
@@ -1,0 +1,58 @@
+"""Forge governance ledger — operator-facing render (read-only projection).
+
+The append-only ledger (:mod:`forgekit_runtime.forge.ledger`) is the durable decision
+log; this module turns its raw entries into the lines an operator surface (e.g. the
+console `/resolve ledger`) shows. Pure + best-effort: a render must never raise, and an
+empty ledger renders an honest "no receipts yet" line — not a fake row.
+
+Kept here (forge/*) so the router stays thin: it calls one helper and prints the lines.
+"""
+
+from __future__ import annotations
+
+from typing import List, Mapping, Optional
+
+from .ledger import read_forge_receipts
+
+_EMPTY = "forge governance ledger — 기록된 receipt 없음 (`/resolve apply <요청>` 로 영속)"
+
+
+def _entry_line(idx: int, entry: dict) -> str:
+    """One receipt → one compact audit line (request / decision / level / signoff / ts)."""
+
+    receipt = entry.get("receipt", {}) if isinstance(entry, dict) else {}
+    request = (receipt.get("request", "") or "")[:48]
+    outcome = receipt.get("outcome", "") or "-"
+    authorized = receipt.get("authorized", False)
+    decision = ("인가" if authorized else "차단") + f"/{outcome}"
+    action_class = receipt.get("action_class", "") or "-"
+    level = receipt.get("approval_level", "") or "-"
+    signoff = (receipt.get("approval_metadata", "") or "-")[:40]
+    ts = entry.get("recorded_at", "") if isinstance(entry, dict) else ""
+    line = (f"{idx:>2}. {decision} [{action_class}/{level}] "
+            f"req={request!r} signoff={signoff}")
+    if ts:
+        line += f" @ {ts}"
+    return line
+
+
+def forge_ledger_lines(
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    limit: int = 10,
+) -> tuple:
+    """Render the append-only forge ledger (newest last). Empty → honest single line."""
+
+    try:
+        entries = read_forge_receipts(env=env, limit=limit)
+    except Exception:  # noqa: BLE001 — a render must never break the surface
+        entries = []
+    if not entries:
+        return (_EMPTY,)
+    out: List[str] = [f"forge governance ledger — 최근 {len(entries)}건 (오래된→최신):"]
+    for i, entry in enumerate(entries, start=1):
+        out.append("  " + _entry_line(i, entry))
+    return tuple(out)
+
+
+__all__ = ("forge_ledger_lines",)

--- a/tests/forgekit/test_forge_ledger_persist.py
+++ b/tests/forgekit/test_forge_ledger_persist.py
@@ -1,0 +1,103 @@
+"""G2 — forge governance ledger PERSIST + VIEW operator path (through the REAL router).
+
+`/resolve apply <요청>` persists a forge receipt to the append-only ledger;
+`/resolve <요청>` (preview) does NOT; `/resolve ledger` renders the durable log. Honest:
+a risky/blocked plan never persists a fake success. The ledger lives under a tmp
+``FORGEKIT_HOME`` so the suite never touches the operator's real state dir.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.commands.parser import parse_input
+from forgekit_console.commands.router import ConsoleContext, route
+from forgekit_runtime.forge import forge_receipt_ledger_path, read_forge_receipts
+
+# representative requests: a plain ask resolves safe→executed; a deploy/secret/schema ask
+# is classified destructive→blocked (verified once in the bridge sanity check).
+_SAFE_REQUEST = "Spring Boot JWT refresh token 구현"
+_BLOCKED_REQUEST = "프로덕션 DB 스키마 마이그레이션 배포 및 secret 교체"
+
+
+class ForgeLedgerPersistTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.home, ignore_errors=True))
+        self.env = {"FORGEKIT_HOME": str(self.home)}
+        # repo_root is only used by status loaders we don't exercise here.
+        self.ctx = ConsoleContext(repo_root=self.home, env=self.env)
+
+    def _run(self, raw: str):
+        return route(parse_input(raw), self.ctx)
+
+    def _ledger(self):
+        return read_forge_receipts(env=self.env)
+
+    # ── apply → persist ────────────────────────────────────────────────────
+    def test_apply_persists_receipt_to_ledger(self) -> None:
+        self.assertEqual(self._ledger(), [], "ledger should start empty")
+        result = self._run(f"/resolve apply {_SAFE_REQUEST}")
+        self.assertEqual(result.kind, "info", f"apply should confirm, got {result}")
+        # confirm line names the ledger path
+        joined = "\n".join(result.lines)
+        self.assertIn("ledger", joined)
+        self.assertIn("영속", joined)
+        # read back: exactly one authorized/executed receipt
+        entries = self._ledger()
+        self.assertEqual(len(entries), 1, entries)
+        receipt = entries[0]["receipt"]
+        self.assertEqual(receipt["request"], _SAFE_REQUEST)
+        self.assertTrue(receipt["authorized"])
+        self.assertEqual(receipt["outcome"], "executed")
+        self.assertTrue(forge_receipt_ledger_path(env=self.env).exists())
+
+    # ── preview → NO persist (regression) ──────────────────────────────────
+    def test_preview_does_not_persist(self) -> None:
+        result = self._run(f"/resolve {_SAFE_REQUEST}")
+        self.assertEqual(result.kind, "info")
+        # the preview still shows the governance verdict inline
+        self.assertIn("governance", "\n".join(result.lines))
+        # but NOTHING was written to the durable ledger
+        self.assertEqual(self._ledger(), [], "preview must not persist")
+        self.assertFalse(forge_receipt_ledger_path(env=self.env).exists())
+
+    # ── ledger view ────────────────────────────────────────────────────────
+    def test_ledger_view_empty_is_honest(self) -> None:
+        result = self._run("/resolve ledger")
+        self.assertEqual(result.kind, "info")
+        joined = "\n".join(result.lines)
+        self.assertIn("기록된 receipt 없음", joined)
+
+    def test_ledger_view_renders_appended_receipts(self) -> None:
+        self._run(f"/resolve apply {_SAFE_REQUEST}")
+        result = self._run("/resolve ledger")
+        self.assertEqual(result.kind, "info")
+        joined = "\n".join(result.lines)
+        self.assertIn("최근 1건", joined)
+        self.assertIn(_SAFE_REQUEST[:20], joined)
+        self.assertIn("인가", joined)
+
+    # ── honest: blocked plan never persists a fake success ─────────────────
+    def test_blocked_plan_does_not_persist(self) -> None:
+        result = self._run(f"/resolve apply {_BLOCKED_REQUEST}")
+        self.assertEqual(result.kind, "error", f"blocked plan must error, got {result}")
+        joined = "\n".join(result.lines)
+        self.assertIn("미인가", joined)
+        # nothing entered the durable log
+        self.assertEqual(self._ledger(), [], "blocked plan must not persist")
+
+    # ── apply with no request is honest, no persist ────────────────────────
+    def test_apply_without_request_is_honest(self) -> None:
+        result = self._run("/resolve apply")
+        joined = "\n".join(result.lines)
+        self.assertIn("요청을 입력", joined)
+        self.assertEqual(self._ledger(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
seam G2 마감: forge receipt 를 operator 가 ledger 에 persist+조회. /resolve apply(persist=True)+/resolve ledger. preview default 유지.
## 범위
- forge/ledger_view.py + router _forge_apply/_forge_ledger + registry help. router thin. authorize-fail→no persist(anti-fake).
## 테스트
- test_forge_ledger_persist 6 green(apply→append / preview no-persist / ledger view / authorize-fail no-persist) 실 router. 전체 1068 OK. governance 3 OK.
## 이슈 linkage
Closes https://github.com/yule-studio/forgekit/issues/365. umbrella #238.
## 감사
forge+router(/resolve region) only, G1(runtime)와 disjoint(overlap 0).