### PR TITLE
✨ PM→tech-lead→specialist lane readiness gate + replay decision log + /council

### DIFF
--- a/apps/forgekit-console/examples/pm-techlead-lane/lane-readiness.json
+++ b/apps/forgekit-console/examples/pm-techlead-lane/lane-readiness.json
@@ -1,0 +1,98 @@
+{
+  "note": "PM→tech-lead→specialist readiness gate — enforced precondition ladder + replay-able decision log",
+  "no_pm_brief": {
+    "stage": "no_pm_brief",
+    "executable": false,
+    "confirmed": [],
+    "missing": [
+      "PM brief — 문제 / 사용자가치 / acceptance / 성공지표"
+    ],
+    "blocking": [],
+    "next_action": "PM 이 brief 를 확정해야 tech-lead lane 진입 가능 (PM artifact 없이는 실행 불가)",
+    "progress": "1/5"
+  },
+  "no_decision_specialist_blocked": {
+    "stage": "decision_pending",
+    "executable": false,
+    "confirmed": [
+      "PM brief: 알림",
+      "meeting: m1 (2 참석)"
+    ],
+    "missing": [
+      "tech-lead decision — design system+convention+stack+tradeoff+approval, 서명"
+    ],
+    "blocking": [],
+    "next_action": "tech-lead 서명 필요 — decision 없이는 specialist 실행 불가",
+    "progress": "3/5"
+  },
+  "full_executable": {
+    "stage": "executable",
+    "executable": true,
+    "confirmed": [
+      "PM brief: 알림",
+      "meeting: m1 (2 참석)",
+      "tech-lead decision: decision:m1 (signed_off/L2_internal_approve)",
+      "handoff: handoff:decision:m1 → be"
+    ],
+    "missing": [],
+    "blocking": [],
+    "next_action": "specialist 실행 인가 — 모든 precondition 확정, execution gate 통과 가능",
+    "progress": "5/5"
+  },
+  "replay_events": [
+    {
+      "session_id": "demo",
+      "kind": "brief",
+      "actor": "product-manager",
+      "summary": "PM brief: 알림",
+      "valid": true,
+      "ref": "알림",
+      "seq": 0,
+      "at": "2026-06-22"
+    },
+    {
+      "session_id": "demo",
+      "kind": "meeting",
+      "actor": "tech-lead",
+      "summary": "meeting m1 (2 참석)",
+      "valid": true,
+      "ref": "m1",
+      "seq": 1,
+      "at": "2026-06-22"
+    },
+    {
+      "session_id": "demo",
+      "kind": "decision",
+      "actor": "tech-lead",
+      "summary": "decision decision:m1 (signed_off/L2_internal_approve)",
+      "valid": true,
+      "ref": "decision:m1",
+      "seq": 2,
+      "at": "2026-06-22"
+    },
+    {
+      "session_id": "demo",
+      "kind": "handoff",
+      "actor": "be",
+      "summary": "handoff handoff:decision:m1 → be",
+      "valid": true,
+      "ref": "handoff:decision:m1",
+      "seq": 3,
+      "at": "2026-06-22"
+    }
+  ],
+  "readiness_from_replay": {
+    "stage": "executable",
+    "executable": true,
+    "confirmed": [
+      "PM brief: 알림",
+      "meeting m1 (2 참석)",
+      "decision decision:m1 (signed_off/L2_internal_approve)",
+      "handoff handoff:decision:m1 → be"
+    ],
+    "missing": [],
+    "blocking": [],
+    "next_action": "specialist 실행 인가 — replay 확인 완료",
+    "progress": "5/5"
+  }
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -36,6 +36,7 @@ H_TOOLCHAIN = "toolchain"
 H_NEXUS = "nexus"
 H_DAEMON = "daemon"
 H_GOAL = "goal"
+H_COUNCIL = "council"
 H_COPY = "copy"
 H_ATTACH = "attach"
 H_PASTE = "paste"
@@ -98,6 +99,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("paste", "보존된 large paste 조작 — `/paste [list|expand <id>|resend <id>]` (원문 보존, placeholder 아님)", H_PASTE, "status"),
     SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
     SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve + governance verdict (`/resolve <요청>` 미리보기, `/resolve apply <요청>` = receipt 를 ledger 에 영속, `/resolve ledger` = forge governance ledger 보기)", H_RESOLVE, "status"),
+    SlashCommand("council", "PM→tech-lead→specialist lane readiness — 실행 전에 무엇이 확정돼야 하는지(replay 가능 decision log). `/council <session>` (없으면 사용법)", H_COUNCIL, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -42,6 +42,7 @@ from .registry import (
     H_NEXUS,
     H_DAEMON,
     H_GOAL,
+    H_COUNCIL,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -185,6 +186,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _daemon_result(parsed, ctx)
     if handler == H_GOAL:
         return _goal_result(parsed, ctx)
+    if handler == H_COUNCIL:
+        return _council_result(parsed, ctx)
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:
@@ -494,6 +497,36 @@ def _forge_ledger_result(*, env=None) -> CommandResult:
     except Exception as e:  # noqa: BLE001
         return CommandResult.error("resolve ledger", (f"forgekit_runtime 미가용: {e}",))
     return CommandResult.info("resolve ledger", forge_ledger_lines(env=env))
+
+
+def _council_result(parsed, ctx=None) -> CommandResult:
+    """`/council <session>` — PM→tech-lead→specialist lane readiness from the replay-able
+    governance decision log: what's confirmed, what's still missing, and whether a
+    specialist may execute ("실행 전에 무엇이 확정돼야 하는지"). Reads the persisted log
+    (replay) and reconstructs the readiness — no live artifacts needed. Best-effort: if the
+    runtime is unavailable the surface degrades to an honest message."""
+
+    env = getattr(ctx, "env", None)
+    args = getattr(parsed, "args", ()) or ()
+    session = (args[0] if args else "").strip()
+    if not session:
+        return CommandResult.info(
+            "council",
+            ("PM→tech-lead→specialist lane readiness 를 봅니다 — `/council <session>`.",
+             "decision log(consult/meeting/decision/approval)을 replay 해 '실행 전에 무엇이 "
+             "확정돼야 하는지'를 보여줍니다. 기록은 `decision_lane.record_lane_artifacts` 가 남깁니다.",
+             "규칙: PM artifact 없으면 tech-lead lane 실행 불가, tech-lead decision 없으면 specialist 실행 불가."))
+    try:
+        from forgekit_runtime.decision_lane import readiness_from_log, replay_governance_log
+    except Exception:  # noqa: BLE001
+        return CommandResult.error("council", ("governance 런타임 미가용.",))
+    events = replay_governance_log(session, env=env)
+    readiness = readiness_from_log(events)
+    head = (f"council lane — session={session} · 기록 {len(events)}건 (replay):",)
+    if not events:
+        head = (f"council lane — session={session}: 기록 없음 "
+                "(decision log 가 비어 있음 → readiness 는 PM brief 부재로 실행 불가).",)
+    return CommandResult.info("council", head + readiness.lines())
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/docs/pm-techlead-lane.md
+++ b/docs/pm-techlead-lane.md
@@ -244,6 +244,41 @@ tech-lead 서명)을 그대로 소비하면서 §7.1~7.2 와 동일한 규칙을
 - 실제 action 등급 > 서명 등급(scope creep) → 차단(재서명).
 - 승인 메타데이터 없는 commit → `validate_execution_trailers` 거부.
 
+## 7.5 Lane readiness gate — "실행 전에 무엇이 확정돼야 하는가" (`readiness.py` + `decision_log.py`)
+
+스키마/검증/enforcement 가 있어도, **체인의 precondition 이 강제·가시화·replay**
+되지 않으면 거버넌스가 장식이다. `assess_lane_readiness(brief, meeting, decision,
+handoff)` 가 현재까지 존재하는 artifact 로 lane stage 와 `executable` 을 계산한다.
+
+체인 순서를 hard-encode 한다 (operator must-verify):
+
+| stage | 조건 | executable |
+|---|---|---|
+| `no_pm_brief` | PM brief 없음/무효 | **False** — PM artifact 없이는 tech-lead lane 진입 불가 |
+| `meeting_pending` | brief OK, meeting 없음/rubber-stamp | False |
+| `decision_pending` | meeting OK, **tech-lead decision 없음/미서명** | **False** — decision 없이는 specialist 실행 불가 |
+| `handoff_pending` | decision 서명됨, handoff 없음/무효 | False |
+| `executable` | brief→meeting→decision→handoff 전부 유효 | **True** (= `can_engineer_start`) |
+
+`LaneReadiness.lines()` 가 operator-visible 라인(✓ 확정 / ☐ 필요 / ✗ 보완 / → 다음)
+을 렌더한다. `executable` 은 `can_engineer_start(decision, handoff)` 와 **구성상 일치**.
+
+### 7.5.1 replay 가능 decision log (`decision_log.py`)
+
+consult/meeting/decision/approval/handoff 이벤트를 session 별 append-only JSONL
+(`state_dir/governance/<session>.jsonl`)로 남긴다. `record_lane_artifacts` 는 각
+artifact 의 **validator 를 record 시점에 재실행**해 `valid` 플래그를 박는다 — fake
+meeting/미서명 decision 은 `valid=False` 로 기록돼 `readiness_from_log` 가 절대
+executable 로 복원하지 않는다 (anti-fake replay). `replay_governance_log(session)` →
+`readiness_from_log(events)` 로 사후 audit 가능.
+
+### 7.5.2 operator surface — `/council <session>`
+
+`/council <session>` 가 decision log 를 replay 해 readiness ladder 를 보여준다 —
+"실행 전에 무엇이 확정돼야 하는지". 기록 없음 → PM brief 부재로 실행 불가(정직).
+코드: `forgekit_console.commands.router._council_result`. evidence:
+`apps/forgekit-console/examples/pm-techlead-lane/lane-readiness.json`.
+
 ## 8. 한계 / 비목표
 
 - 본 레인은 **결정 흐름과 그 실재성** 만 강제한다. 회의 *내용* 의 옳고

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
@@ -59,6 +59,32 @@ from .enforcement import (
     make_runtime_authorizer,
     validate_execution_trailers,
 )
+from .readiness import (
+    STAGE_DECISION_PENDING,
+    STAGE_EXECUTABLE,
+    STAGE_HANDOFF_PENDING,
+    STAGE_MEETING_PENDING,
+    STAGE_NO_PM_BRIEF,
+    STAGE_ORDER,
+    LaneReadiness,
+    assess_lane_readiness,
+)
+from .decision_log import (
+    EVENT_KINDS,
+    KIND_APPROVAL,
+    KIND_BRIEF,
+    KIND_CONSULT,
+    KIND_DECISION,
+    KIND_EXECUTION,
+    KIND_HANDOFF,
+    KIND_MEETING,
+    GovernanceEvent,
+    governance_log_path,
+    readiness_from_log,
+    record_governance_event,
+    record_lane_artifacts,
+    replay_governance_log,
+)
 
 __all__ = (
     # schemas
@@ -77,4 +103,13 @@ __all__ = (
     "classify_action", "authorize_execution", "assert_executable",
     "authorize_runtime_execution", "make_runtime_authorizer",
     "bridge_to_autopilot", "execution_commit_trailers", "validate_execution_trailers",
+    # readiness gate
+    "STAGE_NO_PM_BRIEF", "STAGE_MEETING_PENDING", "STAGE_DECISION_PENDING",
+    "STAGE_HANDOFF_PENDING", "STAGE_EXECUTABLE", "STAGE_ORDER",
+    "LaneReadiness", "assess_lane_readiness",
+    # replay-able decision log
+    "KIND_BRIEF", "KIND_CONSULT", "KIND_MEETING", "KIND_DECISION", "KIND_APPROVAL",
+    "KIND_HANDOFF", "KIND_EXECUTION", "EVENT_KINDS", "GovernanceEvent",
+    "governance_log_path", "record_governance_event", "replay_governance_log",
+    "record_lane_artifacts", "readiness_from_log",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
@@ -1,0 +1,215 @@
+"""Replay-able governance decision log — consult / meeting / decision / approval evidence.
+
+The council chain is only real if its steps leave a durable, re-readable trail. This is an
+append-only per-session JSONL (under the runtime state dir) of governance events; replay
+reconstructs the lane readiness so "what was confirmed before execution" can be audited
+after the fact, not just at the moment.
+
+Anti-fake: an event's ``valid`` flag is set by RE-RUNNING the artifact's validator at
+record time (:func:`record_lane_artifacts`), never asserted by the caller — a rubber-stamp
+meeting or an unsigned decision is logged as ``valid=False`` and the replayed readiness
+refuses to call the lane executable. There is no path to a "ready" replay off invalid
+artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from forgekit_config.paths import state_dir
+
+from .readiness import (
+    STAGE_DECISION_PENDING,
+    STAGE_EXECUTABLE,
+    STAGE_HANDOFF_PENDING,
+    STAGE_MEETING_PENDING,
+    STAGE_NO_PM_BRIEF,
+    LaneReadiness,
+)
+from .schemas import CONDITIONAL, SIGNED_OFF
+from .validators import (
+    validate_handoff,
+    validate_meeting,
+    validate_pm_brief,
+    validate_tech_lead_decision,
+)
+
+# governance event kinds
+KIND_BRIEF = "brief"           # PM product artifact
+KIND_CONSULT = "consult"       # a consult / discussion note (non-gating)
+KIND_MEETING = "meeting"       # design meeting held
+KIND_DECISION = "decision"     # tech-lead signoff
+KIND_APPROVAL = "approval"     # operator approval
+KIND_HANDOFF = "handoff"       # engineer handoff
+KIND_EXECUTION = "execution"   # execution receipt
+EVENT_KINDS: Tuple[str, ...] = (
+    KIND_BRIEF, KIND_CONSULT, KIND_MEETING, KIND_DECISION, KIND_APPROVAL,
+    KIND_HANDOFF, KIND_EXECUTION,
+)
+
+
+@dataclass(frozen=True)
+class GovernanceEvent:
+    session_id: str
+    kind: str
+    actor: str = ""              # role that produced the artifact
+    summary: str = ""
+    valid: bool = True           # validator verdict at record time (anti-fake)
+    ref: str = ""                # artifact id
+    seq: int = 0                 # assigned on replay (file order)
+    at: str = ""
+
+    def to_dict(self) -> dict:
+        return {"session_id": self.session_id, "kind": self.kind, "actor": self.actor,
+                "summary": self.summary, "valid": self.valid, "ref": self.ref,
+                "seq": self.seq, "at": self.at}
+
+    @staticmethod
+    def from_dict(d: dict, *, seq: int = 0) -> "GovernanceEvent":
+        return GovernanceEvent(
+            session_id=str(d.get("session_id", "")), kind=str(d.get("kind", "")),
+            actor=str(d.get("actor", "")), summary=str(d.get("summary", "")),
+            valid=bool(d.get("valid", True)), ref=str(d.get("ref", "")),
+            seq=seq, at=str(d.get("at", "")))
+
+
+def _safe_session(session_id: str) -> str:
+    s = "".join(c if c.isalnum() or c in "-_" else "-" for c in (session_id or "").strip())
+    return s or "session"
+
+
+def governance_log_path(session_id: str, env: Optional[Mapping[str, str]] = None) -> Path:
+    return state_dir(env) / "governance" / f"{_safe_session(session_id)}.jsonl"
+
+
+def record_governance_event(event: GovernanceEvent, *, env: Optional[Mapping[str, str]] = None
+                            ) -> Optional[Path]:
+    """Append one governance event. Unknown kind → refused (ValueError). Best-effort I/O."""
+
+    if event.kind not in EVENT_KINDS:
+        raise ValueError(f"unknown governance event kind: {event.kind!r}")
+    try:
+        path = governance_log_path(event.session_id, env)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event.to_dict(), ensure_ascii=False) + "\n")
+        return path
+    except OSError:
+        return None
+
+
+def replay_governance_log(session_id: str, *, env: Optional[Mapping[str, str]] = None
+                          ) -> Tuple[GovernanceEvent, ...]:
+    """Read the session's events in order (seq = file position). Empty if none."""
+
+    path = governance_log_path(session_id, env)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    events = []
+    for ln in raw.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            events.append(GovernanceEvent.from_dict(json.loads(ln), seq=len(events)))
+        except ValueError:
+            continue
+    return tuple(events)
+
+
+def record_lane_artifacts(
+    session_id: str,
+    *,
+    brief=None,
+    meeting=None,
+    decision=None,
+    approval=None,
+    handoff=None,
+    env: Optional[Mapping[str, str]] = None,
+    at: str = "",
+) -> Tuple[GovernanceEvent, ...]:
+    """Validate + record whichever artifacts are present (anti-fake ``valid`` flags).
+
+    The ``valid`` flag on each event is the artifact's own validator verdict — a fake
+    meeting/decision is recorded ``valid=False`` so the replay can never show it ready."""
+
+    recorded = []
+
+    def _emit(kind, actor, summary, valid, ref):
+        ev = GovernanceEvent(session_id=session_id, kind=kind, actor=actor,
+                             summary=summary, valid=valid, ref=ref, at=at)
+        record_governance_event(ev, env=env)
+        recorded.append(ev)
+
+    if brief is not None:
+        ok = not validate_pm_brief(brief)
+        _emit(KIND_BRIEF, "product-manager", f"PM brief: {brief.topic}", ok, brief.topic)
+    if meeting is not None:
+        ok = not validate_meeting(meeting)
+        _emit(KIND_MEETING, "tech-lead",
+              f"meeting {meeting.meeting_id} ({len(meeting.participants)} 참석)", ok, meeting.meeting_id)
+    if decision is not None:
+        ok = (not validate_tech_lead_decision(decision)) and decision.status in (SIGNED_OFF, CONDITIONAL)
+        _emit(KIND_DECISION, decision.signoff_by,
+              f"decision {decision.decision_id} ({decision.status}/{decision.approval_level})",
+              ok, decision.decision_id)
+    if approval is not None:
+        ok = bool(getattr(approval, "approved", False))
+        _emit(KIND_APPROVAL, getattr(approval, "approver", "operator"),
+              f"operator approval ref={getattr(approval, 'decision_ref', '')}", ok,
+              getattr(approval, "decision_ref", ""))
+    if handoff is not None:
+        ok = (decision is not None) and (not validate_handoff(handoff, decision))
+        _emit(KIND_HANDOFF, handoff.executor_role,
+              f"handoff {handoff.handoff_id} → {handoff.executor_role}", ok, handoff.handoff_id)
+    return tuple(recorded)
+
+
+def readiness_from_log(events: Tuple[GovernanceEvent, ...]) -> LaneReadiness:
+    """Reconstruct the lane readiness from a replayed event stream (audit-after-the-fact).
+
+    Uses the same stage ladder/order as :func:`assess_lane_readiness`; a stage only counts
+    as confirmed if at least one VALID event of that kind exists."""
+
+    def _has(kind: str) -> bool:
+        return any(e.kind == kind and e.valid for e in events)
+
+    def _label(kind: str) -> str:
+        for e in events:
+            if e.kind == kind and e.valid:
+                return e.summary
+        return ""
+
+    confirmed = []
+    if not _has(KIND_BRIEF):
+        return LaneReadiness(STAGE_NO_PM_BRIEF, False, (),
+                             ("PM brief (유효)",), (), "PM brief 확정 — 없으면 tech-lead lane 실행 불가")
+    confirmed.append(_label(KIND_BRIEF))
+    if not _has(KIND_MEETING):
+        return LaneReadiness(STAGE_MEETING_PENDING, False, tuple(confirmed),
+                             ("실재 meeting (유효)",), (), "design meeting 소집")
+    confirmed.append(_label(KIND_MEETING))
+    if not _has(KIND_DECISION):
+        return LaneReadiness(STAGE_DECISION_PENDING, False, tuple(confirmed),
+                             ("서명된 tech-lead decision",), (),
+                             "tech-lead 서명 — 없으면 specialist 실행 불가")
+    confirmed.append(_label(KIND_DECISION))
+    if not _has(KIND_HANDOFF):
+        return LaneReadiness(STAGE_HANDOFF_PENDING, False, tuple(confirmed),
+                             ("유효한 engineer handoff",), (), "engineer handoff 발행")
+    confirmed.append(_label(KIND_HANDOFF))
+    return LaneReadiness(STAGE_EXECUTABLE, True, tuple(confirmed), (), (),
+                         "specialist 실행 인가 — replay 확인 완료")
+
+
+__all__ = (
+    "KIND_BRIEF", "KIND_CONSULT", "KIND_MEETING", "KIND_DECISION", "KIND_APPROVAL",
+    "KIND_HANDOFF", "KIND_EXECUTION", "EVENT_KINDS",
+    "GovernanceEvent", "governance_log_path", "record_governance_event",
+    "replay_governance_log", "record_lane_artifacts", "readiness_from_log",
+)

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/readiness.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/readiness.py
@@ -1,0 +1,165 @@
+"""Lane readiness gate — "실행 전에 무엇이 확정돼야 하는가" as an enforced, visible artifact.
+
+The decision-lane has the artifacts (PMBrief / MeetingRecord / TechLeadDecision /
+EngineerHandoff) and their validators; this composes them into the ONE question an
+operator and the runtime both ask before a specialist runs: *given what exists so far,
+which preconditions are confirmed, which are still missing, and is execution permitted?*
+
+It hard-encodes the chain order so the governance is real, not decorative:
+
+* **no PM brief → the tech-lead lane is not executable** (and says so) — a specialist
+  cannot look ready off a missing product artifact;
+* **no signed tech-lead decision → specialist execution is impossible**;
+* only a valid brief → meeting → signed decision → valid handoff yields ``executable``.
+
+``executable`` agrees with :func:`can_engineer_start` by construction (both require the
+same signed decision + valid handoff). Pure — no I/O; the log/surface layers persist and
+render this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from .schemas import (
+    CONDITIONAL,
+    SIGNED_OFF,
+    EngineerHandoff,
+    MeetingRecord,
+    PMBrief,
+    TechLeadDecision,
+)
+from .validators import (
+    validate_handoff,
+    validate_meeting,
+    validate_pm_brief,
+    validate_tech_lead_decision,
+)
+
+# ordered lane stages — index = how far the chain has been confirmed
+STAGE_NO_PM_BRIEF = "no_pm_brief"
+STAGE_MEETING_PENDING = "meeting_pending"
+STAGE_DECISION_PENDING = "decision_pending"
+STAGE_HANDOFF_PENDING = "handoff_pending"
+STAGE_EXECUTABLE = "executable"
+STAGE_ORDER: Tuple[str, ...] = (
+    STAGE_NO_PM_BRIEF, STAGE_MEETING_PENDING, STAGE_DECISION_PENDING,
+    STAGE_HANDOFF_PENDING, STAGE_EXECUTABLE,
+)
+
+
+@dataclass(frozen=True)
+class LaneReadiness:
+    """What's confirmed, what's missing, and whether a specialist may execute — the
+    operator-visible precondition artifact."""
+
+    stage: str
+    executable: bool
+    confirmed: Tuple[str, ...] = ()      # preconditions already locked (in order)
+    missing: Tuple[str, ...] = ()        # what must still be confirmed before execution
+    blocking: Tuple[str, ...] = ()       # validator violations on a present-but-invalid artifact
+    next_action: str = ""
+
+    def progress(self) -> str:
+        try:
+            return f"{STAGE_ORDER.index(self.stage) + 1}/{len(STAGE_ORDER)}"
+        except ValueError:
+            return "-"
+
+    def to_dict(self) -> dict:
+        return {"stage": self.stage, "executable": self.executable,
+                "confirmed": list(self.confirmed), "missing": list(self.missing),
+                "blocking": list(self.blocking), "next_action": self.next_action,
+                "progress": self.progress()}
+
+    def lines(self) -> Tuple[str, ...]:
+        out = [
+            f"lane readiness — {self.stage} ({self.progress()}) · "
+            + ("실행 가능" if self.executable else "실행 불가"),
+        ]
+        for c in self.confirmed:
+            out.append(f"  ✓ {c}")
+        for m in self.missing:
+            out.append(f"  ☐ 필요: {m}")
+        for b in self.blocking:
+            out.append(f"  ✗ 보완: {b}")
+        if self.next_action:
+            out.append(f"  → 다음: {self.next_action}")
+        return tuple(out)
+
+
+def assess_lane_readiness(
+    *,
+    brief: Optional[PMBrief] = None,
+    meeting: Optional[MeetingRecord] = None,
+    decision: Optional[TechLeadDecision] = None,
+    handoff: Optional[EngineerHandoff] = None,
+) -> LaneReadiness:
+    """Compute the readiness from whatever artifacts exist. Enforces the chain order."""
+
+    confirmed = []
+
+    # 1. PM artifact — without it the tech-lead lane is NOT executable.
+    if brief is None:
+        return LaneReadiness(
+            STAGE_NO_PM_BRIEF, False, (),
+            ("PM brief — 문제 / 사용자가치 / acceptance / 성공지표",), (),
+            "PM 이 brief 를 확정해야 tech-lead lane 진입 가능 (PM artifact 없이는 실행 불가)")
+    bviol = validate_pm_brief(brief)
+    if bviol:
+        return LaneReadiness(
+            STAGE_NO_PM_BRIEF, False, (), ("유효한 PM brief",), bviol, "PM brief 보완")
+    confirmed.append(f"PM brief: {brief.topic}")
+
+    # 2. real meeting (no rubber-stamp consensus).
+    if meeting is None:
+        return LaneReadiness(
+            STAGE_MEETING_PENDING, False, tuple(confirmed),
+            ("실재 design meeting — ≥2 역할 · 반대/우려",), (), "design meeting 소집")
+    mviol = validate_meeting(meeting)
+    if mviol:
+        return LaneReadiness(
+            STAGE_MEETING_PENDING, False, tuple(confirmed),
+            ("유효한 meeting",), mviol, "meeting 보완 (rubber-stamp 금지)")
+    confirmed.append(f"meeting: {meeting.meeting_id} ({len(meeting.participants)} 참석)")
+
+    # 3. signed tech-lead decision — without it the specialist CANNOT execute.
+    if decision is None:
+        return LaneReadiness(
+            STAGE_DECISION_PENDING, False, tuple(confirmed),
+            ("tech-lead decision — design system+convention+stack+tradeoff+approval, 서명",), (),
+            "tech-lead 서명 필요 — decision 없이는 specialist 실행 불가")
+    dviol = validate_tech_lead_decision(decision)
+    if dviol or decision.status not in (SIGNED_OFF, CONDITIONAL):
+        block = tuple(dviol) or (f"decision status={decision.status} (미서명)",)
+        return LaneReadiness(
+            STAGE_DECISION_PENDING, False, tuple(confirmed),
+            ("서명된 tech-lead decision",), block, "tech-lead 서명/보완")
+    confirmed.append(
+        f"tech-lead decision: {decision.decision_id} ({decision.status}/{decision.approval_level})")
+
+    # 4. single-executor handoff.
+    if handoff is None:
+        return LaneReadiness(
+            STAGE_HANDOFF_PENDING, False, tuple(confirmed),
+            ("engineer handoff — 단일 executor · scope · test 전략",), (),
+            "tech-lead → engineer handoff 발행")
+    hviol = validate_handoff(handoff, decision)
+    if hviol:
+        return LaneReadiness(
+            STAGE_HANDOFF_PENDING, False, tuple(confirmed),
+            ("유효한 handoff",), hviol, "handoff 보완 (단일 engineer executor)")
+    confirmed.append(f"handoff: {handoff.handoff_id} → {handoff.executor_role}")
+
+    # 5. all preconditions confirmed → executable.
+    return LaneReadiness(
+        STAGE_EXECUTABLE, True, tuple(confirmed), (), (),
+        "specialist 실행 인가 — 모든 precondition 확정, execution gate 통과 가능")
+
+
+__all__ = (
+    "STAGE_NO_PM_BRIEF", "STAGE_MEETING_PENDING", "STAGE_DECISION_PENDING",
+    "STAGE_HANDOFF_PENDING", "STAGE_EXECUTABLE", "STAGE_ORDER",
+    "LaneReadiness", "assess_lane_readiness",
+)

--- a/tests/forgekit/test_lane_readiness.py
+++ b/tests/forgekit/test_lane_readiness.py
@@ -1,0 +1,166 @@
+"""PM→gateway→tech-lead→specialist readiness gate + replay-able decision log + /council.
+
+Proves the governance chain's preconditions are ENFORCED, REPLAY-ABLE, and OPERATOR-VISIBLE
+— the operator's must-verify items:
+
+- **no PM artifact → the tech-lead lane is not executable** (readiness.executable False,
+  stage names the missing PM brief);
+- **no signed tech-lead decision → specialist execution is impossible**;
+- a full valid chain → executable, and that agrees with ``can_engineer_start``;
+- the decision log is replay-able: ``record_lane_artifacts`` → ``replay_governance_log`` →
+  ``readiness_from_log`` reconstructs the same gate, and a rubber-stamp meeting is logged
+  ``valid=False`` so the replay refuses to call it ready (anti-fake);
+- ``/council <session>`` surfaces the readiness ladder from the persisted log.
+
+Hermetic: a tmp FORGEKIT_HOME isolates the log; identities via the registry SSoT.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _rel in (
+    "packages/forgekit-runtime/src",
+    "packages/forgekit-config/src",
+    "packages/forgekit-provider/src",
+    "packages/forgekit-contracts/src",
+    "packages/forgekit-goal/src",
+    "packages/nexus/src",
+    "apps/forgekit-console/src",
+):
+    _p = str(_ROOT / _rel)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from forgekit_runtime import decision_lane as D
+
+
+def _brief():
+    return D.PMBrief(topic="알림", problem="p", user_value="v",
+                     acceptance_criteria=("a",), success_metrics=("m",))
+
+
+def _meeting(dissent=True):
+    parts = (D.ParticipantPosition("tech-lead", "support", "ok"),
+             D.ParticipantPosition("be", "oppose" if dissent else "support", "음",
+                                   concerns=("c",) if dissent else ()))
+    return D.MeetingRecord(meeting_id="m1", topic="t", agenda=("a",),
+                           participants=parts, decisions=("go",))
+
+
+def _stack():
+    return D.StackComparison(decision_topic="t", recommended="a",
+                             options=(D.StackOption("a", pros=("p",), cons=("c",)),
+                                      D.StackOption("b", pros=("p",), cons=("c",))),
+                             rationale="r", tradeoffs=("t",))
+
+
+def _full_lane():
+    res = D.run_lane(_brief(), _meeting(), _stack(), design_system="ds",
+                     coding_convention="cc", executor_role="be", scope=("x",),
+                     test_strategy="unit", risk_class="safe")
+    return res.decision, res.handoff
+
+
+class ReadinessGateTests(unittest.TestCase):
+    def test_no_pm_brief_not_executable(self) -> None:
+        r = D.assess_lane_readiness()
+        self.assertEqual(r.stage, D.STAGE_NO_PM_BRIEF)
+        self.assertFalse(r.executable)
+        self.assertTrue(any("PM brief" in m for m in r.missing))
+
+    def test_no_decision_specialist_blocked(self) -> None:
+        r = D.assess_lane_readiness(brief=_brief(), meeting=_meeting())
+        self.assertEqual(r.stage, D.STAGE_DECISION_PENDING)
+        self.assertFalse(r.executable)
+        self.assertTrue(any("decision" in m for m in r.missing))
+
+    def test_invalid_brief_blocks(self) -> None:
+        bad = D.PMBrief(topic="t", problem="p", user_value="v")  # no acceptance/metrics
+        r = D.assess_lane_readiness(brief=bad)
+        self.assertFalse(r.executable)
+        self.assertTrue(r.blocking)
+
+    def test_full_chain_executable_agrees_with_can_start(self) -> None:
+        decision, handoff = _full_lane()
+        r = D.assess_lane_readiness(brief=_brief(), meeting=_meeting(),
+                                    decision=decision, handoff=handoff)
+        self.assertEqual(r.stage, D.STAGE_EXECUTABLE)
+        self.assertTrue(r.executable)
+        self.assertEqual(r.executable, D.can_engineer_start(decision, handoff))
+
+    def test_handoff_pending_when_no_handoff(self) -> None:
+        decision, _ = _full_lane()
+        r = D.assess_lane_readiness(brief=_brief(), meeting=_meeting(), decision=decision)
+        self.assertEqual(r.stage, D.STAGE_HANDOFF_PENDING)
+        self.assertFalse(r.executable)
+
+
+class DecisionLogReplayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = {"FORGEKIT_HOME": tempfile.mkdtemp()}
+
+    def test_replay_reconstructs_executable(self) -> None:
+        decision, handoff = _full_lane()
+        D.record_lane_artifacts("s1", brief=_brief(), meeting=_meeting(),
+                                decision=decision, handoff=handoff, env=self.env, at="2026-06-22")
+        events = D.replay_governance_log("s1", env=self.env)
+        self.assertEqual(len(events), 4)
+        self.assertEqual(events[0].kind, D.KIND_BRIEF)
+        r = D.readiness_from_log(events)
+        self.assertEqual(r.stage, D.STAGE_EXECUTABLE)
+        self.assertTrue(r.executable)
+
+    def test_replay_partial_is_blocked(self) -> None:
+        D.record_lane_artifacts("s2", brief=_brief(), meeting=_meeting(), env=self.env)
+        r = D.readiness_from_log(D.replay_governance_log("s2", env=self.env))
+        self.assertEqual(r.stage, D.STAGE_DECISION_PENDING)
+        self.assertFalse(r.executable)
+
+    def test_fake_meeting_logged_invalid_blocks_replay(self) -> None:
+        decision, handoff = _full_lane()
+        D.record_lane_artifacts("s3", brief=_brief(), meeting=_meeting(dissent=False),  # rubber-stamp
+                                decision=decision, handoff=handoff, env=self.env)
+        events = D.replay_governance_log("s3", env=self.env)
+        meeting_ev = [e for e in events if e.kind == D.KIND_MEETING][0]
+        self.assertFalse(meeting_ev.valid)                    # validator caught it at record time
+        r = D.readiness_from_log(events)
+        self.assertEqual(r.stage, D.STAGE_MEETING_PENDING)    # replay refuses to advance
+        self.assertFalse(r.executable)
+
+    def test_unknown_event_kind_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            D.record_governance_event(D.GovernanceEvent("s", "bogus"), env=self.env)
+
+
+class CouncilSurfaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = tempfile.mkdtemp()
+
+    def _route(self, line):
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+        return route(parse_input(line), build_default_context(Path(".")))
+
+    def test_council_renders_readiness_from_log(self) -> None:
+        env = {"FORGEKIT_HOME": self.home}
+        D.record_lane_artifacts("sx", brief=_brief(), meeting=_meeting(), env=env)
+        import os
+        os.environ["FORGEKIT_HOME"] = self.home
+        r = self._route("/council sx")
+        joined = "\n".join(r.lines)
+        self.assertIn("lane readiness", joined)
+        self.assertIn("실행 불가", joined)                    # no decision yet
+        self.assertIn("tech-lead", joined)
+
+    def test_council_usage_without_session(self) -> None:
+        r = self._route("/council")
+        self.assertIn("readiness", "\n".join(r.lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #369

## ✨ 과제 내용
operator 직접 지시(거버넌스 축 완성)의 핵심 gap — 체인 precondition 을 **강제·replay·operator-visible** 로 닫는다.

**목적** — schema/validator/enforcement(머지됨) 위에 '실행 전에 무엇이 확정돼야 하는지'를 1급 게이트 + surface 로.

**범위** (신규 파일 위주, 충돌 최소):
- `decision_lane/readiness.py`: assess_lane_readiness — brief→meeting→decision→handoff hard-encode. LaneReadiness operator-visible. executable == can_engineer_start.
- `decision_lane/decision_log.py`: append-only consult/meeting/decision/approval/handoff 로그. record 시점 validator 로 valid 플래그(anti-fake). replay + readiness_from_log.
- `/council <session>` (router+registry, 신규 명령).
- decision_lane/__init__ exports. 기존 파일 로직 불변.

**리스크** — 낮음. decision_lane 은 신규 모듈 2개 추가, 기존 schemas/validators/lane/enforcement 미수정. router/registry 는 신규 명령 1개만 추가(기존 명령 불변).

**must-verify (operator)** —
- PM artifact 없으면 tech-lead lane 실행 가능 상태로 안 보임 → `assess_lane_readiness()`.executable=False, stage=no_pm_brief.
- tech-lead decision 없으면 specialist 실행 불가 → stage=decision_pending, executable=False.
- consult/meeting/decision log replay 가능 → record_lane_artifacts→replay→readiness_from_log.
- operator-visible → /council.

**테스트** — `tests/forgekit/test_lane_readiness.py` 11건(readiness gate 5 / replay·anti-fake 4 / council 2). 전체 forgekit **1089 OK**. commit guard 4/4.

**이슈 linkage** — #369.

## 📚 레퍼런스
- evidence: `apps/forgekit-console/examples/pm-techlead-lane/lane-readiness.json`
- docs: `docs/pm-techlead-lane.md` 7.5

---
audit:
- base=origin/main(05d0b22), 4 commit, no-auto-merge(draft) — 실제 merge=gw0 승인 후.
- 경계 노트: gw0 가 gw1 을 forge/** 로 좁혔으나 operator 직접 지시로 decision_lane readiness 진행(신규 파일이라 forge 작업과 비충돌). 직전 G2 forge surface 는 main 에 동등 구현 머지되어 내 PR #363 은 닫음.