### PR TITLE
🔧 .claude/shared 를 gitignore 추가 (coordinator 운영 스크래치 제외)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ __pycache__/
 .venv-*/
 .cache/
 *.egg-info/
+
+# coordinator cross-worktree 운영 스크래치 (커밋 대상 아님)
+.claude/shared/


### PR DESCRIPTION
## 목적
.claude/shared/(coordinator cross-worktree 운영 스크래치: status/poll/merge-order/acceptance)는 소스·영구문서가 아니라 실수 커밋 방지를 위해 gitignore.

## 범위
- .gitignore 에 .claude/shared/ 1 규칙 추가.

## 비고
영구 기록은 docs/forgekit-coordinator-session.md + git 히스토리에 이미 존재. 설정 chore.