### PR TITLE
✨ always-on runtime status 에 goal-continuity 가시성 추가 (#372)

### DIFF
--- a/apps/forgekit-console/examples/goal-visibility/README.md
+++ b/apps/forgekit-console/examples/goal-visibility/README.md
@@ -1,0 +1,20 @@
+# always-on runtime — goal-continuity 가시성 (evidence)
+
+`goal-visibility-evidence.txt` 는 `forgekit runtime status`/`/daemon` 이 goal-driven continuity 를
+operator-visible 하게 표면하는지 deterministic(tempdir goal store)으로 캡처. Issue #372. 코드
+`packages/forgekit-runtime/src/forgekit_runtime/runtime/goal_status.py` + `surface.py`,
+회귀 `tests/forgekit/test_goal_status_visibility.py`.
+
+증명:
+1. **goal 없음** → 정직 표기(`활성 goal 없음`), fake 진행 없음.
+2. **active(진행) + awaiting(승인 필요)** → runtime status 에 `goal-loop : active N · awaiting N ·
+   blocked · done` + **action-needed**(`/goal approve <id>`) + **last work**(실제 execution/verification
+   evidence) 표면. serve 가 자동 진행하는 active goal 과 operator 승인 대기 goal 이 한 화면에서 보임.
+3. store 없음/읽기 불가 → 정직 "없음"(no fake).
+
+재생성:
+```
+PYTHONPATH=<packages/*/src> python3 \
+  apps/forgekit-console/examples/goal-visibility/_regen.py \
+  > apps/forgekit-console/examples/goal-visibility/goal-visibility-evidence.txt
+```

--- a/apps/forgekit-console/examples/goal-visibility/_regen.py
+++ b/apps/forgekit-console/examples/goal-visibility/_regen.py
@@ -1,0 +1,31 @@
+"""Regenerate goal-visibility-evidence.txt — deterministic (tempdir goal store).
+always-on runtime status 가 goal-continuity(active/awaiting/last-exec)를 operator-visible 하게 표면.
+재현: tests/forgekit/test_goal_status_visibility.py
+"""
+from __future__ import annotations
+import tempfile
+from forgekit_goal import Goal, GoalStatus, GoalStore, transitions
+from forgekit_runtime.runtime import surface
+from forgekit_runtime.runtime.goal_status import goal_continuity_status
+def clk():
+    n={"i":0}
+    def now(): n["i"]+=1; return f"2026-06-22T07:30:{n['i']:02d}+00:00"
+    return now
+def banner(t): print("\n"+"="*78+f"\n{t}\n"+"="*78)
+print("ForgeKit always-on runtime — goal-continuity 가시성 (operator-visible) — deterministic evidence")
+print("재현: tests/forgekit/test_goal_status_visibility.py")
+with tempfile.TemporaryDirectory() as home:
+    env={"FORGEKIT_HOME":home}; now=clk(); st=GoalStore(env=env)
+    banner("STEP 1 — goal 없음: 정직 표기(fake 진행 없음)")
+    for ln in surface.daemon_status_lines(env=env):
+        if "goal-loop" in ln or "always-on" in ln: print(ln)
+    # active goal with real execution evidence + a risky goal awaiting operator
+    g=transitions.apply(Goal.create("ship console help polish",now=now),GoalStatus.ACTIVE,now=now)
+    g=g.add_evidence("execution","safe packet 실행 — 콘솔 도움말 문구 개선",ref="p1",now=now)
+    g=g.add_evidence("verification","bounded write 재읽기 검증 통과",ref="p1",now=now); st.save(g)
+    gw=transitions.apply(Goal.create("harden auth flow",now=now),GoalStatus.ACTIVE,now=now)
+    gw=transitions.apply(gw,GoalStatus.AWAITING_APPROVAL,now=now); st.save(gw)
+    banner("STEP 2 — active(진행) 1 + awaiting(승인 필요) 1: runtime status 가 둘 다 표면")
+    for ln in surface.daemon_status_lines(env=env): print(ln)
+    banner("STEP 3 — machine-readable status")
+    print(goal_continuity_status(env=env).to_dict())

--- a/apps/forgekit-console/examples/goal-visibility/goal-visibility-evidence.txt
+++ b/apps/forgekit-console/examples/goal-visibility/goal-visibility-evidence.txt
@@ -1,0 +1,27 @@
+ForgeKit always-on runtime — goal-continuity 가시성 (operator-visible) — deterministic evidence
+재현: tests/forgekit/test_goal_status_visibility.py
+
+==============================================================================
+STEP 1 — goal 없음: 정직 표기(fake 진행 없음)
+==============================================================================
+forgekit always-on daemon — stopped
+  goal-loop : 활성 goal 없음 (`/goal new <제목>` → `/goal activate <id>` 로 시작)
+
+==============================================================================
+STEP 2 — active(진행) 1 + awaiting(승인 필요) 1: runtime status 가 둘 다 표면
+==============================================================================
+forgekit always-on daemon — stopped
+  status    : stopped · tick 0
+  last tick : -
+  last note : no heartbeat
+  kill-switch: clear
+  (데몬 미가동 — `forgekit runtime serve --interval 300 --max-ticks N` 로 bounded 시작)
+  goal-loop : active 1 (serve 가 자동 진행) · awaiting 1 (operator 승인 필요) · blocked 0 · done 0
+      ⚠ action-needed: 1 goal awaiting_approval — `/goal awaiting` → `/goal approve <id>`
+      last work: bounded write 재읽기 검증 통과 (goal-dc8d57609f6f)
+  [dim]제어: CLI `forgekit runtime serve|once|status|stop` · 콘솔 `/daemon stop`(kill-switch)[/dim]
+
+==============================================================================
+STEP 3 — machine-readable status
+==============================================================================
+{'available': True, 'total': 2, 'active': 1, 'awaiting_approval': 1, 'blocked': 0, 'done': 0, 'last_work': 'bounded write 재읽기 검증 통과', 'last_work_goal': 'goal-dc8d57609f6f', 'reason': 'ok'}

--- a/docs/runtime-operator-surfaces.md
+++ b/docs/runtime-operator-surfaces.md
@@ -58,5 +58,15 @@ yule harness eval [--slug <slug>] [--date <YYYY-MM-DD>] [--json]
   schema 변경 없이 추가된다 — 후속 디자인 품질 축(reference adherence 등)을 여기 붙인다.
 - cost/latency 는 proxy/fixture — 변형 간 *상대* 비교용.
 
+## 4.1 always-on runtime — goal-continuity 가시성 (#372)
+
+`forgekit runtime status` / `/daemon`(`runtime/surface.daemon_status_lines`)은 daemon heartbeat
+뿐 아니라 **goal-driven continuity** 도 표면한다(`runtime/goal_status.goal_continuity_lines`):
+`goal-loop : active N(serve 자동 진행) · awaiting N(operator 승인 필요) · blocked · done` + awaiting
+시 **action-needed**(`/goal approve <id>`) + **last work**(실제 execution/verification evidence).
+goal store 를 직접 읽어 정직(없으면 "활성 goal 없음" / store 없음 — fake 진행 표기 없음). 즉 always-on
+loop 이 goal 을 진행하는지·무엇이 승인 대기인지 operator 가 runtime status 한 곳에서 본다. 회귀
+`test_goal_status_visibility`, evidence `examples/goal-visibility/`.
+
 ## 5. 관련
 - [`provider-capability-matrix.md`](provider-capability-matrix.md) · [`llm-minimization-policy.md`](llm-minimization-policy.md) · [`operations.md`](operations.md) · [`m13-readiness.md`](m13-readiness.md)

--- a/packages/forgekit-runtime/src/forgekit_runtime/runtime/goal_status.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/runtime/goal_status.py
@@ -1,0 +1,106 @@
+"""Goal-continuity status — operator-visible view of what the always-on runtime is doing.
+
+The serve loop physically advances ACTIVE goals (``goal_exec_tick.GoalExecTicker``), but the
+runtime status surface only showed the daemon heartbeat — an operator could not see, from the
+runtime, whether goals are *progressing*, how many are *awaiting approval* (action-needed), or
+what was *last executed*. This module reads the real ``GoalStore`` and answers exactly that, so
+``forgekit runtime status`` / ``/daemon`` surface the goal-driven continuity honestly.
+
+Honesty rails:
+- reads the REAL goal store; no goal package / no store → an honest "store 없음" status (no fake).
+- ``awaiting_approval`` goals are surfaced as **action-needed** (the operator decides via
+  ``/goal approve``); ``blocked`` separately. We never invent progress.
+- "last executed" is the most recent ``execution``/``verification`` evidence across goals —
+  what the bounded loop ACTUALLY did, not a projection.
+
+``forgekit_goal`` is imported lazily so the runtime stays importable standalone. Pure given a
+store → unit-testable with a tempdir store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Mapping, Optional, Tuple
+
+# evidence kinds that represent real runtime work done toward a goal.
+_WORK_KINDS = ("execution", "verification")
+
+
+@dataclass(frozen=True)
+class GoalContinuityStatus:
+    """Honest snapshot of goal-driven continuity for the runtime status surface."""
+
+    available: bool = True                 # goal store readable (else honest "no store")
+    total: int = 0
+    active: int = 0                        # ACTIVE — the serve loop auto-advances these
+    awaiting_approval: int = 0             # action-needed: operator /goal approve
+    blocked: int = 0
+    done: int = 0
+    last_work: str = ""                    # most recent execution/verification summary (trimmed)
+    last_work_goal: str = ""               # the goal id that work belongs to
+    reason: str = ""
+
+    def to_dict(self) -> dict:
+        return {"available": self.available, "total": self.total, "active": self.active,
+                "awaiting_approval": self.awaiting_approval, "blocked": self.blocked,
+                "done": self.done, "last_work": self.last_work,
+                "last_work_goal": self.last_work_goal, "reason": self.reason}
+
+
+def goal_continuity_status(*, env: Optional[Mapping[str, str]] = None,
+                           store=None) -> GoalContinuityStatus:
+    """Read the goal store and summarise goal-driven continuity (honest; no fake)."""
+
+    if store is None:
+        try:
+            from forgekit_goal import GoalStore  # lazy / best-effort
+        except Exception:  # noqa: BLE001 - goal package absent
+            return GoalContinuityStatus(available=False, reason="goal 패키지 없음")
+        store = GoalStore(env=env)
+    try:
+        from forgekit_goal import GoalStatus
+        goals = store.load_all()
+    except Exception:  # noqa: BLE001 - store unreadable → honest unavailable
+        return GoalContinuityStatus(available=False, reason="goal store 읽기 불가")
+
+    counts = {GoalStatus.ACTIVE: 0, GoalStatus.AWAITING_APPROVAL: 0,
+              GoalStatus.BLOCKED: 0, GoalStatus.DONE: 0}
+    last_ts = ""
+    last_work = ""
+    last_goal = ""
+    for g in goals:
+        if g.status in counts:
+            counts[g.status] += 1
+        for ev in g.evidence:
+            if ev.kind in _WORK_KINDS and ev.ts >= last_ts:   # ISO ts → lexicographic max = newest
+                last_ts, last_work, last_goal = ev.ts, ev.summary, g.id
+    return GoalContinuityStatus(
+        available=True, total=len(goals),
+        active=counts[GoalStatus.ACTIVE], awaiting_approval=counts[GoalStatus.AWAITING_APPROVAL],
+        blocked=counts[GoalStatus.BLOCKED], done=counts[GoalStatus.DONE],
+        last_work=(last_work[:80] if last_work else ""), last_work_goal=last_goal,
+        reason="ok")
+
+
+def goal_continuity_lines(*, env: Optional[Mapping[str, str]] = None, store=None) -> Tuple[str, ...]:
+    """Operator-visible goal-continuity lines for the runtime/daemon status surface."""
+
+    st = goal_continuity_status(env=env, store=store)
+    if not st.available:
+        return (f"  goal-loop : (goal store 없음 — {st.reason})",)
+    if st.total == 0:
+        return ("  goal-loop : 활성 goal 없음 (`/goal new <제목>` → `/goal activate <id>` 로 시작)",)
+    head = (f"  goal-loop : active {st.active} (serve 가 자동 진행) · "
+            f"awaiting {st.awaiting_approval} (operator 승인 필요) · "
+            f"blocked {st.blocked} · done {st.done}")
+    lines: List[str] = [head]
+    if st.awaiting_approval:
+        lines.append(f"      ⚠ action-needed: {st.awaiting_approval} goal awaiting_approval — `/goal awaiting` → `/goal approve <id>`")
+    if st.last_work:
+        lines.append(f"      last work: {st.last_work}" + (f" ({st.last_work_goal})" if st.last_work_goal else ""))
+    elif st.active:
+        lines.append("      (아직 실행 evidence 없음 — 다음 serve tick 에서 safe packet 진행)")
+    return tuple(lines)
+
+
+__all__ = ("GoalContinuityStatus", "goal_continuity_status", "goal_continuity_lines")

--- a/packages/forgekit-runtime/src/forgekit_runtime/runtime/surface.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/runtime/surface.py
@@ -45,6 +45,10 @@ def daemon_status_lines(*, env: Optional[Mapping[str, str]] = None) -> Tuple[str
     elif beat.tick > 0:
         # honest resume hint: the next serve continues tick numbering from here (launchd KeepAlive 등).
         lines.append(f"  resume    : 다음 serve 는 tick {beat.tick + 1} 부터 이어집니다 (resume on; cooldown 연속성 유지)")
+    # goal-driven continuity visibility — what the serve loop is actually progressing + what
+    # needs operator approval (the daemon DRIVES goals; the status must show it, not hide it).
+    from .goal_status import goal_continuity_lines
+    lines.extend(goal_continuity_lines(env=env))
     lines.append("  [dim]제어: CLI `forgekit runtime serve|once|status|stop` · 콘솔 `/daemon stop`(kill-switch)[/dim]")
     return tuple(lines)
 

--- a/tests/forgekit/test_goal_status_visibility.py
+++ b/tests/forgekit/test_goal_status_visibility.py
@@ -1,0 +1,97 @@
+"""Goal-continuity visibility in the always-on runtime status surface (#372). Pure / stdlib.
+
+Proves the operator can SEE, from `forgekit runtime status` / `/daemon`, what the serve loop is
+doing to long-term goals: how many are ACTIVE (auto-advanced), how many are awaiting_approval
+(action-needed), blocked/done, and what was last executed — read from the REAL goal store, honest
+(no store → honest "없음", never fake progress).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_goal import Goal, GoalStatus, GoalStore, transitions
+from forgekit_runtime.runtime import surface
+from forgekit_runtime.runtime.goal_status import goal_continuity_lines, goal_continuity_status
+
+
+def _clock():
+    n = {"i": 0}
+
+    def now() -> str:
+        n["i"] += 1
+        return f"2026-06-22T07:00:{n['i']:02d}+00:00"
+
+    return now
+
+
+class GoalContinuityStatusTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._home = tempfile.TemporaryDirectory()
+        self.addCleanup(self._home.cleanup)
+        self.env = {"FORGEKIT_HOME": self._home.name}
+        self.store = GoalStore(env=self.env)
+        self.now = _clock()
+
+    def _active(self, title: str) -> Goal:
+        g = transitions.apply(Goal.create(title, now=self.now), GoalStatus.ACTIVE, now=self.now)
+        self.store.save(g)
+        return g
+
+    def test_no_goals_is_honest_empty(self) -> None:
+        st = goal_continuity_status(env=self.env)
+        self.assertTrue(st.available)
+        self.assertEqual(st.total, 0)
+        self.assertIn("활성 goal 없음", "\n".join(goal_continuity_lines(env=self.env)))
+
+    def test_counts_active_awaiting_and_last_work(self) -> None:
+        g = self._active("ship feature")
+        g = g.add_evidence("execution", "safe packet 실행 — 콘솔 문구 개선", ref="p1", now=self.now)
+        self.store.save(g)
+        # a second goal parked at awaiting_approval (risky proposal → operator decision)
+        gw = self._active("harden auth")
+        gw = transitions.apply(gw, GoalStatus.AWAITING_APPROVAL, now=self.now)
+        self.store.save(gw)
+
+        st = goal_continuity_status(env=self.env)
+        self.assertEqual(st.active, 1)
+        self.assertEqual(st.awaiting_approval, 1)
+        self.assertIn("콘솔 문구 개선", st.last_work)      # real last execution, not a projection
+        self.assertEqual(st.last_work_goal, g.id)
+
+    def test_lines_surface_action_needed_for_awaiting(self) -> None:
+        gw = self._active("harden auth")
+        gw = transitions.apply(gw, GoalStatus.AWAITING_APPROVAL, now=self.now)
+        self.store.save(gw)
+        text = "\n".join(goal_continuity_lines(env=self.env))
+        self.assertIn("awaiting 1", text)
+        self.assertIn("action-needed", text)               # operator told what to do
+        self.assertIn("/goal approve", text)
+
+    def test_no_store_is_honest_not_fake(self) -> None:
+        # an unreadable/absent store must report honestly, never invent progress.
+        class _BadStore:
+            def load_all(self):
+                raise OSError("boom")
+        st = goal_continuity_status(store=_BadStore())
+        self.assertFalse(st.available)
+        self.assertIn("goal store", "\n".join(goal_continuity_lines(store=_BadStore())))
+
+
+class DaemonStatusWiringTests(unittest.TestCase):
+    def test_daemon_status_includes_goal_loop_line(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            env = {"FORGEKIT_HOME": home}
+            now = _clock()
+            g = transitions.apply(Goal.create("ship feature", now=now), GoalStatus.ACTIVE, now=now)
+            GoalStore(env=env).save(g)
+            text = "\n".join(surface.daemon_status_lines(env=env))
+            self.assertIn("goal-loop", text)               # always-on status now surfaces goals
+            self.assertIn("active 1", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
always-on runtime 의 **goal-driven continuity 를 operator-visible** 하게 만든다. serve 루프는
ACTIVE goal 을 물리 진행하지만(`GoalExecTicker`), `forgekit runtime status`/`/daemon` 은 daemon
heartbeat 만 보여줘 운영자가 goal 진행/awaiting 를 볼 수 없었다(#372).

Closes #372

## 범위 (owner boundary: packages/forgekit-runtime/runtime/**)
- `runtime/goal_status.py` (신규) — `goal_continuity_status`/`goal_continuity_lines`: GoalStore 읽어
  active/awaiting_approval/blocked/done count + 최근 execution/verification(last work). lazy forgekit_goal.
- `runtime/surface.daemon_status_lines` — goal-loop 라인 append(active/awaiting + **action-needed**
  `/goal approve` + last work).
- 비범위: console tui/goal_surface(gw3), provider/governance.

## 정직 (no fake)
- goal store 직접 read. goal 없음 → "활성 goal 없음", store 불가 → 정직 표기. **fake 진행 없음.**
- awaiting_approval = action-needed(operator 결정), serve 가 자동 실행하지 않음.

## 테스트 / evidence
- `tests/forgekit/test_goal_status_visibility.py` (5): 없음 정직 / active·awaiting count + last work /
  awaiting action-needed 표면 / store 불가 정직 / daemon_status_lines goal-loop 포함.
- forgekit green, 전체 repo **6906 OK**, commit-governance 4 OK.
- evidence: `examples/goal-visibility/`(deterministic).

---
audit: 브랜치 `feat/forgekit-runtime-goal-visibility`, base `main`, 4 commit. issue #372 anchored. CI green 후 merge(operator: issue→PR→CI→QA→merge까지 닫기).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
