### PR TITLE
provider route show 를 slot 별 declared→actual 로 해소 (non-chat fallback 가시화)

### DIFF
--- a/apps/forgekit-console/examples/provider-route/README.md
+++ b/apps/forgekit-console/examples/provider-route/README.md
@@ -1,0 +1,23 @@
+# `/provider route show` — declared → actual route resolution evidence
+
+`route-resolution-evidence.txt` proves that `/provider route show`
+(`forgekit_provider.policy.provider_surface.route_show_lines`) resolves **each** slot to
+its ACTUAL live provider via the explicit fallback — instead of printing a bare
+`unsupported_in_console` on every work slot that declares a CLI brain (claude/codex).
+
+- **[A]** four-brain — `execution → codex` is shown reaching **gemini** (fallback live), so
+  the operator doesn't read a routing-only declaration as "broken".
+- **[B]** a slot whose declared + entire fallback are all routing-only shows an honest
+  `○ (live 경로 없음)` plus the exact next action — no fake live, no dead-end.
+- **[C]** no primary → `setup-required` with the `/setup` hint.
+
+Regenerate (deterministic, pure, no net):
+
+```
+PYTHONPATH=$(for d in packages/*/src apps/*/src; do printf '%s:' "$PWD/$d"; done) \
+  python3 apps/forgekit-console/examples/provider-route/_regen.py \
+  > apps/forgekit-console/examples/provider-route/route-resolution-evidence.txt
+```
+
+Regression: `tests/forgekit/test_provider_surface.py::RouteShowResolutionTests`.
+SSoT doc: `docs/forgekit-provider-policy.md` §2.2.

--- a/apps/forgekit-console/examples/provider-route/_regen.py
+++ b/apps/forgekit-console/examples/provider-route/_regen.py
@@ -1,0 +1,54 @@
+"""Regenerate route-resolution-evidence.txt — deterministic (pure, no net, no temp home).
+
+`/provider route show` resolves each slot to its ACTUAL live provider via the explicit
+fallback — so a non-chat work slot that DECLARES a CLI brain (codex/claude = routing-only)
+is shown reaching its live transport (gemini/ollama), never left looking broken. Run from
+repo root with every package src on PYTHONPATH; redirect stdout into
+route-resolution-evidence.txt. Regression: tests/forgekit/test_provider_surface.py
+(RouteShowResolutionTests).
+"""
+
+from __future__ import annotations
+
+from forgekit_provider.policy import provider_ops as ops
+from forgekit_provider.policy import provider_surface as ps
+
+
+def banner(t: str) -> None:
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+def main() -> None:
+    print("ForgeKit `/provider route show` — slot 별 declared → actual (fallback 반영) evidence")
+    print("재현: tests/forgekit/test_provider_surface.py::RouteShowResolutionTests")
+
+    banner("[A] four-brain preset — work slot 이 CLI brain 을 declare 해도 live 로 해소")
+    print("config: primary=claude · default_chat=gemini · execution=codex · safety/synthesis=claude")
+    print("        fallback: execution=[codex,gemini,ollama] · safety=[claude,gemini] · synthesis=[claude,gemini,ollama]")
+    print()
+    for ln in ps.route_show_lines(ops.preset_four_brain({})):
+        print(ln)
+    print()
+    print("→ execution/safety/synthesis 는 declared(codex/claude, routing-only)이지만 fallback 이")
+    print("  gemini 로 닿아 `declared → actual` 로 표기된다. unsupported_in_console 로 끝나지 않는다.")
+
+    banner("[B] fallback 이 전부 routing-only → 정직한 'live 경로 없음' + 다음 액션")
+    cfg = {
+        "primary_provider": "claude",
+        "linked_providers": ["claude", "codex"],
+        "slot_routing": {"safety": "claude"},
+        "fallback_policy": {"slot_fallback_orders": {"safety": ["claude", "codex"]}},
+    }
+    for ln in ps.route_show_lines(cfg):
+        if "safety" in ln or "범례" in ln:
+            print(ln)
+    print()
+    print("→ claude/codex 만으로는 live 불가 → ○ (live 경로 없음) + `/provider route set safety <gemini|ollama>`.")
+
+    banner("[C] primary 미설정 → setup-required (dead-end 아님)")
+    for ln in ps.route_show_lines({}):
+        print(ln)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/provider-route/route-resolution-evidence.txt
+++ b/apps/forgekit-console/examples/provider-route/route-resolution-evidence.txt
@@ -1,0 +1,38 @@
+ForgeKit `/provider route show` — slot 별 declared → actual (fallback 반영) evidence
+재현: tests/forgekit/test_provider_surface.py::RouteShowResolutionTests
+
+==============================================================================
+[A] four-brain preset — work slot 이 CLI brain 을 declare 해도 live 로 해소
+==============================================================================
+config: primary=claude · default_chat=gemini · execution=codex · safety/synthesis=claude
+        fallback: execution=[codex,gemini,ollama] · safety=[claude,gemini] · synthesis=[claude,gemini,ollama]
+
+slot routing — declared brain → actual live provider (explicit fallback 반영):
+  [dim]default_chat(●) = 실제 live submit 경로 · 그 외(◐/○) = 자율 non-chat work routing 선언[/dim]
+  ● default_chat   gemini   [dim]live[/dim]
+  ◐ synthesis      claude → gemini   [dim]declared routing-only → fallback live[/dim]
+  ◐ research       gemini   [dim]live[/dim]
+  ◐ execution      codex → gemini   [dim]declared routing-only → fallback live[/dim]
+  ◐ compression    ollama   [dim]live[/dim]
+  ◐ classification ollama   [dim]live[/dim]
+  ◐ safety         claude → gemini   [dim]declared routing-only → fallback live[/dim]
+  fallback: implicit_local=off (기본)
+  [dim]범례: ● live submit · ◐ routing 선언(live 도달) · ○ live 경로 없음.[/dim]
+  [dim]claude/codex 는 routing-only(brain participant) — 실제 전송은 fallback 의 live transport(gemini/ollama)가 담당.[/dim]
+
+→ execution/safety/synthesis 는 declared(codex/claude, routing-only)이지만 fallback 이
+  gemini 로 닿아 `declared → actual` 로 표기된다. unsupported_in_console 로 끝나지 않는다.
+
+==============================================================================
+[B] fallback 이 전부 routing-only → 정직한 'live 경로 없음' + 다음 액션
+==============================================================================
+  ○ safety         claude → (live 경로 없음)   [dim]routing-only, fallback 도 live 불가 — `/provider route set safety <gemini|ollama>`[/dim]
+  [dim]범례: ● live submit · ◐ routing 선언(live 도달) · ○ live 경로 없음.[/dim]
+
+→ claude/codex 만으로는 live 불가 → ○ (live 경로 없음) + `/provider route set safety <gemini|ollama>`.
+
+==============================================================================
+[C] primary 미설정 → setup-required (dead-end 아님)
+==============================================================================
+slot routing: [setup-required] primary provider 미설정
+  `/provider set <id>` 또는 `/provider preset four-brain` 후 다시 보세요.

--- a/docs/forgekit-provider-policy.md
+++ b/docs/forgekit-provider-policy.md
@@ -82,6 +82,27 @@ slot → capability 매핑(optimized): execution→`execution`, research→`rese
 `slot_for(mode, kind)` / `resolve_submit(cfg, mode, kind=WORK_CHAT)` 가 진입점. `mode_submit_slot`
 은 back-compat(=`mode_work_slot`). 회귀 `tests/forgekit/test_routing.py`.
 
+### 2.2 `/provider route show` — slot 별 declared → **actual** (fallback 반영)
+
+`/provider route show`(`provider_surface.route_show_lines`)는 각 slot 을 **선언값이 아니라
+`resolve_routing` 으로 해소한 실제 live provider**로 보여준다. 이전엔 slot 의 declared target 과
+그 transport word 만 찍어서, four-brain 처럼 work slot 이 CLI brain 을 declare 하면
+`execution → codex (unsupported_in_console)` 로 보였다 — fallback 이 gemini 로 닿는데도 **망가진
+것처럼** 보이는 게 운영자 혼란의 핵심이었다. 이제:
+
+- `default_chat`(●) — **실제 live submit 경로**(`chat/service` 가 쓰는 단 하나의 slot). 그 외
+  slot(◐/○)은 자율 **non-chat work** 의 routing 선언이며 같은 explicit fallback 으로 해소된다.
+- declared 가 routing-only(claude/codex)여도 explicit fallback 이 live transport(gemini/ollama)에
+  닿으면 `declared → actual` 로 표기(예: `execution  codex → gemini`). **fake-live 아님** —
+  `resolve_routing` 의 검증된 결과만 표기한다.
+- declared + 전체 fallback 이 전부 routing-only 면 `○ … → (live 경로 없음)` 로 **정직하게** 막힌
+  상태와 다음 액션(`/provider route set <slot> <gemini|ollama>`)을 보여준다 — dead-end 없음.
+- primary 미설정이면 `setup-required` 로 `/setup` 안내.
+
+요점: chat(live submit) 과 non-chat(routing 선언)을 **표면에서 분리**하고, non-chat slot 의
+fallback 해소를 **숨기지 않는다**. 회귀 `tests/forgekit/test_provider_surface.py`
+(`RouteShowResolutionTests`), evidence `examples/provider-route/`.
+
 ## 3. Main-provider 기본값 (`policy/main_profile.py`)
 
 setup 의 단 하나의 결정 — "어느 provider 가 네 것인가" — 에서 기본값을 파생한다.

--- a/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
+++ b/packages/forgekit-provider/src/forgekit_provider/policy/provider_surface.py
@@ -301,15 +301,55 @@ def budget_lines(cfg: Optional[Mapping], rows: Sequence[Mapping] = ()) -> Tuple[
     return tuple(lines)
 
 
+def _slot_route_line(parsed, slot: str) -> str:
+    """One honest `declared → actual` line for *slot*, resolving the EXPLICIT fallback.
+
+    The point of this surface: a non-chat work slot often DECLARES a CLI brain
+    (codex/claude = routing-only) yet has an explicit fallback to a live transport
+    (gemini/ollama). Showing only the declared target made those slots look broken
+    (`execution → codex (unsupported_in_console)`); resolving them shows the ACTUAL
+    live provider the fallback reaches — or an honest "no live path" when it can't."""
+
+    res = rt.resolve_routing(parsed, slot)
+    # default_chat is the ONE slot the live submit path actually drives today; mark it ●.
+    is_chat = slot == pc.SLOT_DEFAULT_CHAT
+    if res.status == rt.RESOLVE_FALLBACK:
+        glyph = "●" if is_chat else "◐"
+        return (f"  {glyph} {slot:<14} {res.declared_provider} → {res.actual_provider}"
+                f"   [dim]declared routing-only → fallback live[/dim]")
+    if res.is_live_capable:                      # declared provider is itself a live transport
+        glyph = "●" if is_chat else "◐"
+        return f"  {glyph} {slot:<14} {res.actual_provider}   [dim]live[/dim]"
+    if res.status == rt.RESOLVE_UNSUPPORTED:      # declared + every fallback are routing-only
+        return (f"  ○ {slot:<14} {res.declared_provider} → (live 경로 없음)"
+                f"   [dim]routing-only, fallback 도 live 불가 — `/provider route set {slot} <gemini|ollama>`[/dim]")
+    # no primary at all → setup-required (caller already guards, but stay honest per-line).
+    return f"  ○ {slot:<14} (미설정)   [dim]{res.reason}[/dim]"
+
+
 def route_show_lines(cfg: Optional[Mapping]) -> Tuple[str, ...]:
-    """`/provider route show` — slot routing + fallback policy 가시화."""
+    """`/provider route show` — slot routing resolved to the ACTUAL live provider per slot.
+
+    Each slot is resolved through :func:`routing.resolve_routing` (declared + explicit
+    fallback), so the operator sees, per slot, the real live transport — not a bare
+    `unsupported_in_console` on every CLI-declared work slot. Chat (``default_chat``) is the
+    one slot the live submit path drives today; the rest are routing DECLARATIONS for
+    autonomous non-chat work, resolved with the same honest fallback."""
 
     parsed = pc.load_provider_config(cfg)
-    lines = ["slot routing (declared → primary if unset):"]
+    if not parsed.primary_provider:
+        return (
+            "slot routing: [setup-required] primary provider 미설정",
+            "  `/provider set <id>` 또는 `/provider preset four-brain` 후 다시 보세요.",
+        )
+    lines = ["slot routing — declared brain → actual live provider (explicit fallback 반영):",
+             "  [dim]default_chat(●) = 실제 live submit 경로 · 그 외(◐/○) = 자율 non-chat work routing 선언[/dim]"]
     for slot in pc.ROUTING_SLOTS:
-        tgt = parsed.slot_target(slot)
-        lines.append(f"  {slot:<14} → {tgt} ({_live_word(tgt)})")
+        lines.append(_slot_route_line(parsed, slot))
     lines.append(f"  fallback: implicit_local={'on' if parsed.implicit_local_fallback else 'off (기본)'}")
+    lines.append("  [dim]범례: ● live submit · ◐ routing 선언(live 도달) · ○ live 경로 없음.[/dim]")
+    lines.append("  [dim]claude/codex 는 routing-only(brain participant) — 실제 전송은 fallback 의 "
+                 "live transport(gemini/ollama)가 담당.[/dim]")
     return tuple(lines)
 
 

--- a/tests/forgekit/test_provider_surface.py
+++ b/tests/forgekit/test_provider_surface.py
@@ -112,6 +112,57 @@ class LinkRouteTests(unittest.TestCase):
         self.assertIn("implicit_local", lines)
 
 
+class RouteShowResolutionTests(unittest.TestCase):
+    """`/provider route show` must resolve EACH slot to its ACTUAL live provider via the
+    explicit fallback — not print a bare `unsupported_in_console` on every CLI-declared
+    work slot. This is the non-chat slot fallback / declared-vs-actual confusion the lane
+    closes: an operator must see that `execution → codex` actually reaches gemini."""
+
+    def test_four_brain_work_slots_show_fallback_to_live(self) -> None:
+        fb = ops.preset_four_brain({})
+        lines = ps.route_show_lines(fb)
+        joined = "\n".join(lines)
+        # execution DECLARES codex (CLI, routing-only) but its fallback is [codex, gemini, ollama]
+        # → the surface must resolve it to the live transport, NOT leave it looking broken.
+        self.assertTrue(any("execution" in l and "codex → gemini" in l for l in lines),
+                        f"execution slot should resolve codex→gemini fallback:\n{joined}")
+        self.assertTrue(any("safety" in l and "claude → gemini" in l for l in lines),
+                        f"safety slot should resolve claude→gemini fallback:\n{joined}")
+        # default_chat is the one true live submit slot → marked ● and resolves to gemini.
+        self.assertTrue(any(l.lstrip().startswith("●") and "default_chat" in l and "gemini" in l
+                            for l in lines), f"default_chat should be ● live gemini:\n{joined}")
+        # no work slot may be left showing a bare unsupported word when a live fallback exists.
+        self.assertNotIn("unsupported_in_console", joined)
+        self.assertNotIn("(live 경로 없음)", joined)
+
+    def test_no_live_fallback_is_honest_no_path_with_next_action(self) -> None:
+        # safety declared claude with a fallback of ONLY routing-only brains → genuinely no live path.
+        cfg = {
+            "primary_provider": "claude",
+            "linked_providers": ["claude", "codex"],
+            "slot_routing": {"safety": "claude"},
+            "fallback_policy": {"slot_fallback_orders": {"safety": ["claude", "codex"]}},
+        }
+        lines = [l for l in ps.route_show_lines(cfg) if "safety" in l]
+        self.assertTrue(lines, "safety slot line missing")
+        line = lines[0]
+        self.assertIn("(live 경로 없음)", line)               # honest: no faked live
+        self.assertIn("/provider route set safety", line)     # actionable next step (no dead-end)
+        self.assertTrue(line.lstrip().startswith("○"))
+
+    def test_setup_required_when_no_primary(self) -> None:
+        lines = "\n".join(ps.route_show_lines({}))
+        self.assertIn("setup-required", lines)
+        self.assertIn("/provider set", lines)
+
+    def test_legend_separates_chat_vs_nonchat(self) -> None:
+        joined = "\n".join(ps.route_show_lines(ops.preset_four_brain({})))
+        # the surface explicitly tells the operator chat = live submit, others = routing declaration.
+        self.assertIn("live submit", joined)
+        self.assertIn("routing 선언", joined)
+        self.assertIn("routing-only", joined)   # claude/codex framed as brain participants, honestly
+
+
 class RoutingTests(unittest.TestCase):
     def test_provider_subcommands_route(self) -> None:
         from forgekit_console.commands.parser import parse_input


### PR DESCRIPTION
## 목적

`/provider route show` 가 slot 의 declared target 만 보여줘서, four-brain 처럼 work slot 이 CLI brain(claude/codex)을 declare 하면 fallback 이 live 로 닿는데도 `unsupported_in_console` 로 보이는 operator confusion 을 닫는다. provider/runtime lane 의 declared vs actual 표면을 7 slot 전부에서 정직하게 해소.

## 범위

- in: `route_show_lines` 가 slot 별 `resolve_routing` 으로 declared + explicit fallback 을 해소해 actual live provider 표기 (`_slot_route_line` 헬퍼). chat(●, 실제 live submit) vs non-chat(◐/○ routing 선언) 분리 + 범례. no-live-path 정직 표기 + 다음 액션.
- in: 회귀(`RouteShowResolutionTests` 4 케이스) + evidence(`examples/provider-route/`) + 문서(`forgekit-provider-policy.md` §2.2).
- out: live submit 경로 자체(chat/service)는 변경 없음 — non-chat slot 은 오늘도 routing 선언(execute phase 없음). budget/daemon/toolchain 등 다른 lane 미변경.

## 리스크

- 낮음 — 순수 표면(`provider_surface`) 변경, config schema/persist/submit 경로 불변. `resolve_routing` 은 기존 함수 재사용(신규 routing 로직 없음).
- fake-live 회피 검증: `resolve_routing` 의 검증된 결과만 표기, fallback 전부 routing-only 면 `(live 경로 없음)` 으로 정직하게 막힘.

## 테스트

- `tests/forgekit/test_provider_surface.py` — 신규 `RouteShowResolutionTests` 4 케이스(four-brain fallback 해소 / no-live-path / setup-required / chat·non-chat 범례), 기존 26 케이스 green.
- 전체 회귀 `python3 -m unittest discover -s tests/forgekit` — 1110 tests, 본 lane 0 실패. (사전 존재·lane 외 TUI inline-layout 1 건은 본 PR 무관.)
- evidence `examples/provider-route/route-resolution-evidence.txt` deterministic 재생성 확인.

## 관련 이슈

- Closes #378

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — engineering-agent runtime audit
