### PR TITLE
✨ ForgeKit discovery 루프 강화 — 수집→idea brief→digest→PM packet/vault note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ docs/
 | ForgeKit 플랫폼 경계 / console=operator app / 코어 packages 분리 | `docs/forgekit-architecture-ownership.md` (owner 매트릭스 · import 경계 · 이전 우선순위 SSoT) |
 | packages/* 분류 / 네이밍 충돌 / 새 기능 위치 / transitional debt | `docs/package-topology.md` (18 package 분류표 · migration matrix · 결정 트리 SSoT) |
 | control-plane 방향 / 외부 프로젝트 흡수 / onboarding bootstrap / P0~P2 / Mac mini host | `docs/control-plane-architecture.md` (역할 · 소유 경계 · 우선순위 로드맵 SSoT) |
+| Nexus discovery 루프 / free-first 수집→idea brief→operator digest→PM packet·vault note / planned seam | `docs/discovery-loop.md` (+ 코드 SSoT `apps/forgekit-console/src/forgekit_console/discovery/sweep.py`) |
 
 규칙:
 - 위 표에 없는 토픽이면 그 작업과 가장 가까운 디렉터리의 `CLAUDE.md`,

--- a/apps/forgekit-console/examples/discovery/README.md
+++ b/apps/forgekit-console/examples/discovery/README.md
@@ -2,12 +2,15 @@
 
 forgekit 의 discovery 프로그램(무료 우선 수집 → 아이디어 → 자체 개선 → 보안 드릴)이
 실제로 닫히고, 위험한 것은 전부 gated/planned 라는 evidence. 재생성/검증:
-`python -m unittest tests.forgekit.test_discovery_e2e`.
+`python -m unittest tests.forgekit.test_discovery_e2e tests.forgekit.test_discovery_sweep`.
+discovery 루프 SSoT: [`docs/discovery-loop.md`](../../../../docs/discovery-loop.md).
 
 | 파일 | 단계 | 무엇 |
 | --- | --- | --- |
 | `../sources/registry.json` | sources(WT2) | live(무료 우선) vs planned(YouTube/IG/Google — fake 아님) |
 | `idea-brief.json` | idea-discovery(WT3) | ReferenceBundle + CompetitorGapMap + IdeaBrief + self-improve 신호 분리 |
+| `sweep-digest.json` | discovery loop | 수집→brief→operator digest 한 패스. `entries[].why`(왜 올라왔는지) + `entries[].next_questions`(다음 질문) |
+| `idea-brief-note.md` | knowledge plane | brief → retrieval-friendly authored vault note (author/role/color/cssclass + 5 섹션) |
 | `../selfimprove/scan.json` | self-improvement(WT4) | repo gap → risk-classified 패킷(safe만 자동) |
 | `../security/drill-plan.json` | red/blue(WT5) | 내 자산 plan-only 드릴(dry-run, 승인 필요) |
 | `../security/blocked-public.json` | red/blue(WT5) | 공용 대상 → BLOCKED(공격 흐름 거부) |

--- a/apps/forgekit-console/examples/discovery/idea-brief-note.md
+++ b/apps/forgekit-console/examples/discovery/idea-brief-note.md
@@ -1,0 +1,44 @@
+---
+title: "아이디어: apps/sync.py: 3 TODO/FIXME 누적"
+kind: idea-brief
+status: draft
+created_at: 2026-06-22
+tags: [forgekit, discovery, idea-brief]
+related: []
+agent_author: user-researcher
+agent_role: User Researcher
+handoff_from: discovery
+handoff_to: pm
+phase: discovery
+source_flow: discovery-sweep
+cssclasses: [fk-user-research]
+agent_color: "#c084fc"
+---
+
+> [!fk-user-research] User Researcher · phase: discovery · discovery → pm
+
+## 핵심 요약
+- 아이디어: apps/sync.py: 3 TODO/FIXME 누적 (score 4.0)
+- 대상 사용자: 일반 사용자
+
+## 문제 · 근거
+- 문제: apps/sync.py: 3 TODO/FIXME 누적
+- 근거: 경쟁 1개 대비 gap 2개 관측
+
+## 차별화 가설
+- 'apps/sync.py: 3 TODO/FIXME 누적' 를 기존 대체재보다 더 단순/저비용으로 해결
+
+## 다음 실험
+- 'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰
+- 성공 지표: 핵심 작업 완료율 / 재방문 의향
+
+## operator 결정 대기
+- 핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'
+- 어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?
+- 이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?
+- 다음 실험을 실제로 돌릴까? — 'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰
+
+## 참고
+- [repo-local] apps/sync.py: 3 TODO/FIXME 누적
+- [operator] AI 메모 정리 트렌드가 급상승
+- [operator] 기존 제품 Notion 은 오프라인이 약함

--- a/apps/forgekit-console/examples/discovery/sweep-digest.json
+++ b/apps/forgekit-console/examples/discovery/sweep-digest.json
@@ -1,0 +1,268 @@
+{
+  "result": {
+    "reference_bundle": {
+      "title": "discovery sweep",
+      "items": [
+        {
+          "source_id": "repo-local",
+          "title": "apps/sync.py: 3 TODO/FIXME 누적",
+          "url": ""
+        },
+        {
+          "source_id": "operator",
+          "title": "AI 메모 정리 트렌드가 급상승",
+          "url": ""
+        },
+        {
+          "source_id": "operator",
+          "title": "기존 제품 Notion 은 오프라인이 약함",
+          "url": ""
+        },
+        {
+          "source_id": "operator",
+          "title": "노트 동기화가 느려서 불편",
+          "url": ""
+        },
+        {
+          "source_id": "operator",
+          "title": "forgekit 콘솔 도움말이 부족하다",
+          "url": ""
+        }
+      ],
+      "summary": "5개 참고 신호 수집"
+    },
+    "gap_map": {
+      "competitors": [
+        "기존 제품 Notion 은 오프라인이 약함"
+      ],
+      "gaps": [
+        "apps/sync.py: 3 TODO/FIXME 누적",
+        "노트 동기화가 느려서 불편"
+      ]
+    },
+    "idea_briefs": [
+      {
+        "title": "아이디어: apps/sync.py: 3 TODO/FIXME 누적",
+        "problem": "apps/sync.py: 3 TODO/FIXME 누적",
+        "target_user": "일반 사용자",
+        "differentiation": {
+          "hypothesis": "'apps/sync.py: 3 TODO/FIXME 누적' 를 기존 대체재보다 더 단순/저비용으로 해결",
+          "rationale": "경쟁 1개 대비 gap 2개 관측"
+        },
+        "next_experiment": {
+          "experiment": "'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+          "success_metric": "핵심 작업 완료율 / 재방문 의향"
+        },
+        "references": [
+          {
+            "source_id": "repo-local",
+            "title": "apps/sync.py: 3 TODO/FIXME 누적",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "AI 메모 정리 트렌드가 급상승",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "기존 제품 Notion 은 오프라인이 약함",
+            "url": ""
+          }
+        ],
+        "score": 4.0
+      },
+      {
+        "title": "아이디어: AI 메모 정리 트렌드가 급상승",
+        "problem": "AI 메모 정리 트렌드가 급상승",
+        "target_user": "일반 사용자",
+        "differentiation": {
+          "hypothesis": "'AI 메모 정리 트렌드가 급상승' 를 기존 대체재보다 더 단순/저비용으로 해결",
+          "rationale": "경쟁 1개 대비 gap 2개 관측"
+        },
+        "next_experiment": {
+          "experiment": "'AI 메모 정리 트렌드가 급상승' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+          "success_metric": "핵심 작업 완료율 / 재방문 의향"
+        },
+        "references": [
+          {
+            "source_id": "repo-local",
+            "title": "apps/sync.py: 3 TODO/FIXME 누적",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "AI 메모 정리 트렌드가 급상승",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "기존 제품 Notion 은 오프라인이 약함",
+            "url": ""
+          }
+        ],
+        "score": 1.0
+      },
+      {
+        "title": "아이디어: 노트 동기화가 느려서 불편",
+        "problem": "노트 동기화가 느려서 불편",
+        "target_user": "일반 사용자",
+        "differentiation": {
+          "hypothesis": "'노트 동기화가 느려서 불편' 를 기존 대체재보다 더 단순/저비용으로 해결",
+          "rationale": "경쟁 1개 대비 gap 2개 관측"
+        },
+        "next_experiment": {
+          "experiment": "'노트 동기화가 느려서 불편' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+          "success_metric": "핵심 작업 완료율 / 재방문 의향"
+        },
+        "references": [
+          {
+            "source_id": "repo-local",
+            "title": "apps/sync.py: 3 TODO/FIXME 누적",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "AI 메모 정리 트렌드가 급상승",
+            "url": ""
+          },
+          {
+            "source_id": "operator",
+            "title": "기존 제품 Notion 은 오프라인이 약함",
+            "url": ""
+          }
+        ],
+        "score": 1.0
+      }
+    ],
+    "self_improve_signals": [
+      {
+        "text": "forgekit 콘솔 도움말이 부족하다",
+        "source_id": "operator",
+        "kind": "self-improve",
+        "score": 0.0
+      }
+    ]
+  },
+  "digest": {
+    "live_sources": [
+      "repo-local",
+      "hackernews",
+      "reddit",
+      "github"
+    ],
+    "planned_sources": [
+      "youtube",
+      "instagram",
+      "google"
+    ],
+    "collected": 5,
+    "competitor_count": 1,
+    "gap_count": 2,
+    "brief_count": 3,
+    "self_improve_count": 1,
+    "entries": [
+      {
+        "title": "아이디어: apps/sync.py: 3 TODO/FIXME 누적",
+        "problem": "apps/sync.py: 3 TODO/FIXME 누적",
+        "why": "pain 신호 · 출처 repo-local · score 4.0",
+        "score": 4.0,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — 'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ]
+      },
+      {
+        "title": "아이디어: AI 메모 정리 트렌드가 급상승",
+        "problem": "AI 메모 정리 트렌드가 급상승",
+        "why": "trend 신호 · 출처 operator · score 1.0",
+        "score": 1.0,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — 'AI 메모 정리 트렌드가 급상승' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ]
+      },
+      {
+        "title": "아이디어: 노트 동기화가 느려서 불편",
+        "problem": "노트 동기화가 느려서 불편",
+        "why": "pain 신호 · 출처 operator · score 1.0",
+        "score": 1.0,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — '노트 동기화가 느려서 불편' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ]
+      }
+    ]
+  },
+  "source_rows": [
+    {
+      "id": "repo-local",
+      "type": "repo-local",
+      "cost": "free",
+      "status": "live",
+      "trust": "high",
+      "ingest": "repo-scan",
+      "legal": "own repo — no external call"
+    },
+    {
+      "id": "hackernews",
+      "type": "hackernews",
+      "cost": "free",
+      "status": "live",
+      "trust": "medium",
+      "ingest": "api",
+      "legal": "Algolia HN API — free, attribution friendly"
+    },
+    {
+      "id": "reddit",
+      "type": "reddit",
+      "cost": "free",
+      "status": "live",
+      "trust": "low",
+      "ingest": "public-json",
+      "legal": "public .json — respect rate limits / no auth-walled data"
+    },
+    {
+      "id": "github",
+      "type": "github",
+      "cost": "low",
+      "status": "live",
+      "trust": "high",
+      "ingest": "api",
+      "legal": "GitHub REST search — unauth rate-limited; respect ToS"
+    },
+    {
+      "id": "youtube",
+      "type": "youtube",
+      "cost": "paid",
+      "status": "planned",
+      "trust": "medium",
+      "ingest": "future-adapter",
+      "legal": "Data API 비용/쿼터 + ToS — 이번 단계 미연결, video-watch 는 수동 ingest"
+    },
+    {
+      "id": "instagram",
+      "type": "instagram",
+      "cost": "paid",
+      "status": "planned",
+      "trust": "medium",
+      "ingest": "future-adapter",
+      "legal": "Graph API 승인/ToS 제약 — 미연결"
+    },
+    {
+      "id": "google",
+      "type": "google",
+      "cost": "paid",
+      "status": "planned",
+      "trust": "medium",
+      "ingest": "future-adapter",
+      "legal": "유료 search/API 비용 — 미연결, 무료 소스 우선"
+    }
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -34,6 +34,7 @@ H_PROVIDER = "provider"
 H_SETUP = "setup"
 H_TOOLCHAIN = "toolchain"
 H_NEXUS = "nexus"
+H_DISCOVERY = "discovery"
 H_DAEMON = "daemon"
 H_GOAL = "goal"
 H_COUNCIL = "council"
@@ -107,6 +108,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("setup", "컨트롤플레인 부트스트랩 — provider · knowledge(nexus/vault) · toolchain 한 화면 정직 집계 + 추천 preset 저장/검증 (`/setup [apply [preset]]`)", H_SETUP, "status"),
     SlashCommand("toolchain", "language/runtime 버전 전환 — `/toolchain [detect|recommend <loadout>|switch [global] [--approve]|verify|drift]` (repo-local 감지·mise 기반, global/install 은 승인 게이트)", H_TOOLCHAIN, "status"),
     SlashCommand("nexus", "Nexus 지식 source — `/nexus [set <path>|clear]` 연결/해제 + live 상태(connected/not_connected/missing/blocked/restricted)", H_NEXUS, "status"),
+    SlashCommand("discovery", "discovery sweep — free-first 수집→idea brief→operator digest(왜 올라왔는지/다음 질문). `/discovery [promote <n> | save <n>]` (promote=PM handoff 제안, save=연결된 vault 에 authored note)", H_DISCOVERY, "status"),
     SlashCommand("daemon", "always-on 데몬 heartbeat — state/tick/last_tick/pid/kill-switch (`/daemon [stop]`); CLI `forgekit runtime serve|status|stop`", H_DAEMON, "status"),
     SlashCommand("goal", "장기 목표 control plane — `/goal [list|new <제목>|show <id>|activate <id>|evidence <id>|awaiting|approve <id> [메모]|deny <id> [메모]]` (forgekit_goal 영속, 승인은 awaiting_approval→active/blocked + decision evidence, tick/실행은 runtime/GW4)", H_GOAL, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -40,6 +40,7 @@ from .registry import (
     H_SETUP,
     H_TOOLCHAIN,
     H_NEXUS,
+    H_DISCOVERY,
     H_DAEMON,
     H_GOAL,
     H_COUNCIL,
@@ -182,6 +183,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _toolchain_result(parsed, ctx)
     if handler == H_NEXUS:
         return _nexus_result(parsed, ctx)
+    if handler == H_DISCOVERY:
+        return _discovery_result(parsed, ctx)
     if handler == H_DAEMON:
         return _daemon_result(parsed, ctx)
     if handler == H_GOAL:
@@ -382,6 +385,66 @@ def _nexus_result(parsed, ctx) -> CommandResult:
         return (CommandResult.info if ok else CommandResult.error)("nexus clear", (msg,))
     return CommandResult.info(
         "nexus", _proj.nexus_surface_lines(env=ctx.env, config=ctx.config))
+
+
+def _discovery_result(parsed, ctx) -> CommandResult:
+    # /discovery [promote <n> | save <n>] — run a free-first discovery sweep and show
+    # the operator digest (왜 올라왔는지/다음 질문). promote → PM handoff 제안(실행 아님),
+    # save → 연결된 Nexus vault 에 retrieval-friendly authored note (미연결이면 정직 실패).
+    from .. import discovery as D
+
+    repo_root = getattr(ctx, "repo_root", None) or Path(".")
+    args = list(getattr(parsed, "args", ()) or ())
+    sub = args[0].lower() if args else ""
+
+    def _pick(idx_token: str):
+        sweep = D.run_discovery_sweep(repo_root)
+        briefs = sweep.briefs
+        if not briefs:
+            return sweep, None, "승격할 brief 가 없습니다 — 먼저 `/discovery` 로 신호를 수집하세요."
+        try:
+            n = int(idx_token)
+        except (TypeError, ValueError):
+            n = 1
+        if n < 1 or n > len(briefs):
+            return sweep, None, f"brief 번호 범위 밖 (1~{len(briefs)})."
+        return sweep, briefs[n - 1], ""
+
+    if sub == "promote":
+        sweep, brief, err = _pick(args[1] if len(args) > 1 else "1")
+        if err:
+            return CommandResult.error("discovery promote", (err,))
+        ho = D.promote_brief(brief)
+        lines = (
+            f"승격(제안): {brief.title}",
+            f"- handoff: {ho.trace[0].handoff_from} → … → {ho.trace[-1].handoff_to} "
+            f"(최종 phase {ho.trace[-1].phase})",
+            f"- role tasks {len(ho.split.tasks)}개 · blocked {len(ho.split.blocked)}개",
+            "주의: PM→gateway→tech-lead 제안 packet 일 뿐, 실행은 승인 게이트 통과 후.",
+        )
+        return CommandResult.info("discovery promote", lines)
+
+    if sub == "save":
+        sweep, brief, err = _pick(args[1] if len(args) > 1 else "1")
+        if err:
+            return CommandResult.error("discovery save", (err,))
+        from hephaistos.nexus_read import nexus_root
+
+        root = nexus_root(getattr(ctx, "env", None), getattr(ctx, "config", None))
+        if not root:
+            return CommandResult.error(
+                "discovery save",
+                ("Nexus vault 미연결 — `/nexus set <path>` 로 먼저 연결하세요 (fake-write 안 함).",))
+        path = D.persist_brief(brief, root)
+        if not path:
+            return CommandResult.error(
+                "discovery save", (f"vault 쓰기 실패 (root={root}) — 권한/경로 확인.",))
+        return CommandResult.info(
+            "discovery save",
+            (f"authored note 기록: {path}", "- author user-researcher · 00-inbox/discovery (raw intake)"))
+
+    sweep = D.run_discovery_sweep(repo_root)
+    return CommandResult.info("discovery", sweep.digest.lines())
 
 
 def _daemon_result(parsed, ctx) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/discovery/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/__init__.py
@@ -17,6 +17,15 @@ from .pipeline import (
     run_idea_discovery,
     shape_signals,
 )
+from .sweep import (
+    DiscoveryDigest,
+    DiscoverySweep,
+    brief_to_authored_note,
+    next_questions_for,
+    persist_brief,
+    promote_brief,
+    run_discovery_sweep,
+)
 from .video_watch import VideoIngest, VideoWatchResult, summarize_ingest
 
 __all__ = (
@@ -24,5 +33,7 @@ __all__ = (
     "ReferenceBundle",
     "build_gap_map", "build_idea_briefs", "build_reference_bundle",
     "promote_to_handoff", "run_idea_discovery", "shape_signals",
+    "DiscoveryDigest", "DiscoverySweep", "run_discovery_sweep", "next_questions_for",
+    "promote_brief", "brief_to_authored_note", "persist_brief",
     "VideoIngest", "VideoWatchResult", "summarize_ingest",
 )

--- a/apps/forgekit-console/src/forgekit_console/discovery/sweep.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/sweep.py
@@ -1,0 +1,278 @@
+"""Discovery sweep loop — wire free-first collectors → idea pipeline → operator digest.
+
+The missing seam between the source registry (cost-first live vs planned) and the
+idea-discovery pipeline (signals → gap map → idea briefs). One sweep:
+
+  1. collects from the **LIVE free-first** sources only — planned seams (YouTube /
+     Instagram / paid Google) stay honestly empty, never faked;
+  2. runs the idea-discovery pipeline over the collected signals + any operator text;
+  3. frames the result as an **operator digest** that answers
+     "어떤 아이디어가 왜 올라왔는지 / 다음에 무엇을 물어봐야 하는지".
+
+A high-value brief promotes to a PM→gateway→tech-lead handoff (:func:`promote_brief`),
+and the top brief persists as a retrieval-friendly **authored vault note** so the
+discovery output accumulates into the knowledge plane (:func:`persist_brief`).
+
+Pure + deterministic: with no ``fetcher`` the network collectors return ``[]``
+(honest), so the sweep runs offline in CI on the repo-local source alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from . import models as M
+from .pipeline import promote_to_handoff, run_idea_discovery, shape_signals
+
+
+# --- "next question" — what the operator must decide to advance a brief --------
+def next_questions_for(brief: M.IdeaBrief) -> Tuple[str, ...]:
+    """Deterministic follow-ups an operator should answer to move a brief forward.
+
+    These are decisions the brief can't make for itself — they gate promotion to a
+    real PM packet. Derived from what the brief is still *missing*, never asserting a
+    certainty the discovery pass doesn't have."""
+
+    qs: List[str] = []
+    if not brief.target_user or brief.target_user == "일반 사용자":
+        qs.append("핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'")
+    if brief.references:
+        qs.append("어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?")
+    else:
+        qs.append("근거가 될 1차 레퍼런스(경쟁/사용자 신호)를 더 모을까?")
+    qs.append("이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?")
+    if brief.next_experiment.experiment:
+        qs.append(f"다음 실험을 실제로 돌릴까? — {brief.next_experiment.experiment[:60]}")
+    return tuple(qs)
+
+
+def _why_surfaced(brief: M.IdeaBrief, by_text: Dict[str, M.OpportunitySignal]) -> str:
+    sig = by_text.get(brief.problem)
+    src = (sig.source_id if sig else "") or "operator"
+    kind = sig.kind if sig else M.SIGNAL_PAIN
+    return f"{kind} 신호 · 출처 {src} · score {brief.score}"
+
+
+# --- digest --------------------------------------------------------------------
+@dataclass(frozen=True)
+class DiscoveryDigest:
+    """Operator-facing digest: which idea surfaced, WHY, and what to ask next."""
+
+    live_sources: Tuple[str, ...] = ()
+    planned_sources: Tuple[str, ...] = ()
+    collected: int = 0
+    competitor_count: int = 0
+    gap_count: int = 0
+    brief_count: int = 0
+    self_improve_count: int = 0
+    entries: Tuple[dict, ...] = ()   # {title, problem, why, score, next_questions}
+
+    def to_dict(self) -> dict:
+        return {
+            "live_sources": list(self.live_sources),
+            "planned_sources": list(self.planned_sources),
+            "collected": self.collected,
+            "competitor_count": self.competitor_count,
+            "gap_count": self.gap_count,
+            "brief_count": self.brief_count,
+            "self_improve_count": self.self_improve_count,
+            "entries": list(self.entries),
+        }
+
+    def lines(self) -> Tuple[str, ...]:
+        out: List[str] = [
+            "discovery — operator digest",
+            f"- live 수집원(무료 우선): {', '.join(self.live_sources) or '(없음)'}",
+            f"- planned(미연결 — fake-live 아님): {', '.join(self.planned_sources) or '(없음)'}",
+            f"- 수집 신호: {self.collected}건 · 경쟁 {self.competitor_count} · gap {self.gap_count}",
+            f"- 아이디어 brief: {self.brief_count}건 · self-improve 신호: {self.self_improve_count}건",
+        ]
+        if not self.entries:
+            out.append("  (아직 승격할 brief 없음 — 수집원을 연결하거나 신호를 추가하세요)")
+        for i, e in enumerate(self.entries, 1):
+            out.append(f"[{i}] {e['title']}")
+            out.append(f"    왜: {e['why']}")
+            for q in e.get("next_questions", ()):
+                out.append(f"    물어볼 것: {q}")
+        out.append("주의: planned 수집원은 미연결이라 신호 0 — 절대 가짜로 채우지 않음. "
+                   "brief 승격은 PM→gateway→tech-lead 제안일 뿐, 실행 아님.")
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class DiscoverySweep:
+    """One discovery pass: the pipeline result + source health + operator digest."""
+
+    result: M.DiscoveryResult
+    digest: DiscoveryDigest
+    source_rows: Tuple[dict, ...] = ()
+
+    @property
+    def top_brief(self) -> Optional[M.IdeaBrief]:
+        return self.result.top_brief
+
+    @property
+    def briefs(self) -> Tuple[M.IdeaBrief, ...]:
+        return self.result.idea_briefs
+
+    def to_dict(self) -> dict:
+        return {
+            "result": self.result.to_dict(),
+            "digest": self.digest.to_dict(),
+            "source_rows": list(self.source_rows),
+        }
+
+
+def run_discovery_sweep(
+    repo_root,
+    *,
+    fetcher=None,
+    rss_feeds: Tuple[Tuple[str, str], ...] = (),
+    extra_signals: Sequence[str] = (),
+    limit_per: int = 8,
+    max_briefs: int = 3,
+    title: str = "discovery sweep",
+) -> DiscoverySweep:
+    """Collect from live free-first sources → idea-discovery → operator digest.
+
+    Network collectors use *fetcher* (None → real urllib; offline → honest empty).
+    Planned seams contribute nothing (never faked). *extra_signals* are operator
+    text folded in alongside the collected items.
+    """
+
+    from ..sources import default_registry
+
+    registry = default_registry(repo_root, fetcher=fetcher, rss_feeds=rss_feeds)
+    collected = registry.collect_all(limit_per=limit_per)
+    # free-first order is preserved by cost_ordered_live() inside collect_all().
+    items: List[object] = [it for bucket in collected.values() for it in bucket]
+    items.extend(extra_signals)
+
+    result = run_idea_discovery(items, title=title)
+    by_text = {s.text: s for s in shape_signals(items)}
+
+    entries: List[dict] = []
+    for brief in result.idea_briefs[:max_briefs]:
+        entries.append({
+            "title": brief.title,
+            "problem": brief.problem,
+            "why": _why_surfaced(brief, by_text),
+            "score": brief.score,
+            "next_questions": list(next_questions_for(brief)),
+        })
+
+    digest = DiscoveryDigest(
+        live_sources=tuple(c.spec.id for c in registry.cost_ordered_live()),
+        planned_sources=tuple(c.spec.id for c in registry.planned()),
+        collected=len(items),
+        competitor_count=len(result.gap_map.competitors),
+        gap_count=len(result.gap_map.gaps),
+        brief_count=len(result.idea_briefs),
+        self_improve_count=len(result.self_improve_signals),
+        entries=tuple(entries),
+    )
+    return DiscoverySweep(result=result, digest=digest,
+                          source_rows=registry.status_rows())
+
+
+# --- promotion + knowledge-plane persistence ----------------------------------
+def promote_brief(brief: M.IdeaBrief, *, project: str = ""):
+    """Promote a brief to a PM→gateway→tech-lead handoff packet (proposal only)."""
+
+    return promote_to_handoff(brief, project=project)
+
+
+def _slug(text: str, *, limit: int = 40) -> str:
+    bad = '<>:"/\\|?*'
+    out = "".join("-" if c in bad or c.isspace() else c for c in (text or "").strip())
+    out = "-".join(p for p in out.split("-") if p)  # collapse runs
+    return (out[:limit] or "idea").rstrip("-")
+
+
+def brief_to_authored_note(
+    brief: M.IdeaBrief,
+    *,
+    author: str = "user-researcher",
+    created_at: str = "",
+    related: Sequence[str] = (),
+) -> str:
+    """A retrieval-friendly authored vault note for a discovery brief.
+
+    Authored (author/role/color/cssclass/callout via the identity registry) so the
+    vault visibly records WHO surfaced the idea. Body keeps the repo's note shape —
+    핵심 요약 / 문제·근거 / 차별화 가설 / 다음 실험 / 참고 — with links + tags so it
+    stays retrieval-friendly (not a hollow stub)."""
+
+    from nexus.vault.note import build_authored_note
+
+    refs = brief.references or ()
+    ref_lines = [f"- [{r.get('source_id', '?')}] {r.get('title', '')}"
+                 + (f" — {r.get('url')}" if r.get("url") else "")
+                 for r in refs] or ["- (수집된 1차 레퍼런스 없음 — 추가 수집 후보)"]
+    qs = next_questions_for(brief)
+    body = "\n".join([
+        "## 핵심 요약",
+        f"- {brief.title} (score {brief.score})",
+        f"- 대상 사용자: {brief.target_user}",
+        "",
+        "## 문제 · 근거",
+        f"- 문제: {brief.problem}",
+        f"- 근거: {brief.differentiation.rationale or '(gap 관측 기반)'}",
+        "",
+        "## 차별화 가설",
+        f"- {brief.differentiation.hypothesis or '(미정)'}",
+        "",
+        "## 다음 실험",
+        f"- {brief.next_experiment.experiment or '(미정)'}",
+        f"- 성공 지표: {brief.next_experiment.success_metric or '(미정)'}",
+        "",
+        "## operator 결정 대기",
+        *[f"- {q}" for q in qs],
+        "",
+        "## 참고",
+        *ref_lines,
+    ])
+    return build_authored_note(
+        author,
+        title=brief.title,
+        body=body,
+        kind="idea-brief",
+        status="draft",
+        created_at=created_at,
+        phase="discovery",
+        source_flow="discovery-sweep",
+        handoff_from="discovery",
+        handoff_to="pm",
+        tags=("forgekit", "discovery", "idea-brief"),
+        related=tuple(related),
+    )
+
+
+def persist_brief(
+    brief: M.IdeaBrief,
+    vault_root,
+    *,
+    author: str = "user-researcher",
+    created_at: str = "",
+    subdir: str = "00-inbox/discovery",
+):
+    """Write an authored brief note under the connected vault (None if not writable).
+
+    Lands in ``00-inbox`` (raw intake — honest: not claimed as a curated note). The
+    note still carries full frontmatter + body sections so it is retrieval-friendly.
+    Returns the written path, or ``None`` if there is no vault root / write fails."""
+
+    if not vault_root:
+        return None
+    from nexus.vault.note import write_note
+
+    content = brief_to_authored_note(brief, author=author, created_at=created_at)
+    subpath = f"{subdir}/idea-{_slug(brief.problem)}.md"
+    return write_note(content, vault_root, subpath)
+
+
+__all__ = (
+    "DiscoveryDigest", "DiscoverySweep", "run_discovery_sweep",
+    "next_questions_for", "promote_brief", "brief_to_authored_note", "persist_brief",
+)

--- a/docs/discovery-loop.md
+++ b/docs/discovery-loop.md
@@ -1,0 +1,58 @@
+# Discovery loop (Nexus knowledge plane)
+
+free-first 수집 → idea brief → operator digest → PM packet/vault note 로 이어지는
+discovery 루프의 SSoT. 코드: `apps/forgekit-console/src/forgekit_console/discovery/`
+(`sweep.py` = 이 루프의 배선). 수집원 레지스트리/collector 는 `packages/nexus/src/nexus/sources/`,
+authored vault note 는 `packages/nexus/src/nexus/vault/`.
+
+## 한 패스 (run_discovery_sweep)
+```
+default_registry(repo_root, fetcher, rss_feeds)   # 수집원 레지스트리 (WT2)
+  → collect_all(limit_per)                         # LIVE 무료 우선만, planned 은 빈 결과
+  → flatten + operator extra_signals
+  → run_idea_discovery(items)                      # signals → gap map + briefs (WT3)
+  → DiscoveryDigest                                # 왜 올라왔는지 + 다음에 물을 질문
+```
+결과 `DiscoverySweep` = `result`(DiscoveryResult) + `digest`(DiscoveryDigest) +
+`source_rows`(레지스트리 health). 순수·결정적 — `fetcher` 미지정 시 network collector 는
+정직하게 빈 결과라 CI 에서 repo-local 만으로 굴러간다.
+
+## current live vs planned
+| 단계 | 상태 | surface | evidence |
+| --- | --- | --- | --- |
+| free-first 수집 (repo-local/HN/Reddit/GitHub/RSS) | **live** (network=injectable fetcher) | `/sources` | `examples/sources/` |
+| 수집 → idea-discovery 한 패스 연결 | **live** (이번 루프) | `/discovery` | `examples/discovery/sweep-digest.json` |
+| operator digest (왜/다음 질문) | **live** | `/discovery` | `sweep-digest.json` `entries[].why/next_questions` |
+| brief → PM handoff packet | **live** (제안 only) | `/discovery promote <n>` | `test_discovery_sweep` |
+| brief → authored vault note (retrieval-friendly) | **live** (연결 시) | `/discovery save <n>` | `examples/discovery/idea-brief-note.md` |
+| YouTube / Instagram / paid Google | **planned** (collect()→[] 항상) | `/sources` | `registry.py` status=planned |
+
+## honesty rails (이 루프에서 강제)
+- **planned 수집원은 절대 fake-live 아님** — `collect()` 가 항상 `[]`, digest 에 정직 표기.
+- **색은 retrieval 핵심이 아님** — authored note 의 `cssclasses`/`agent_color` 는 누가 썼는지
+  *시각 구분* 용 보조 메타일 뿐, 검색/스코어 로직에 쓰이지 않는다. 실제 색 메커니즘은 사용자가
+  vault snippet 을 깔 때만 작동(`vault_css_snippet`), Obsidian 이 임의 텍스트를 칠한다고 속이지 않음.
+- **vault note 는 hollow 금지** — `brief_to_authored_note` 는 표준 frontmatter(tags/related) +
+  5 섹션(핵심 요약/문제·근거/차별화 가설/다음 실험/참고) 을 채운다. `persist_brief` 는 `00-inbox/
+  discovery` (raw intake) 에 쓰고 status=draft — curated 라고 위조하지 않는다(curated 승격은
+  eval gate 통과 후 별도).
+- **승격은 제안일 뿐** — `/discovery promote` 는 PM→gateway→tech-lead handoff packet 을 만들고
+  멈춘다. 실행은 승인 게이트 통과 후.
+- **vault 미연결 시 정직 실패** — `/discovery save` 는 `FORGEKIT_NEXUS_ROOT`/config 없으면
+  fake-write 없이 에러를 돌려준다.
+
+## operator 흐름
+1. `/discovery` — 수집 sweep + digest. 각 top brief 의 "왜 올라왔는지(신호 kind·출처·score)" 와
+   "다음에 물어볼 질문(target_user/경쟁 검증/pricing/실험 실행)" 을 본다.
+2. `/discovery promote <n>` — n 번 brief 를 PM handoff packet 으로 승격(제안).
+3. `/discovery save <n>` — 연결된 Nexus vault 에 authored idea-brief note 영속(retrieval-friendly).
+
+## 재생성/검증
+- `python -m unittest tests.forgekit.test_discovery_sweep` (루프·digest·note·승격·surface)
+- `python -m unittest tests.forgekit.test_discovery_e2e` (전체 discovery 프로그램 체인)
+
+## planned seam 붙이는 법 (YouTube/Google/Instagram)
+`registry.default_registry` 의 planned 블록은 `PlannedCollector(_planned_spec(...))` 로 등록돼
+있고 `collect()` 가 항상 빈 결과다. 실제 연결 시: (1) `collectors.py` 에 해당 어댑터(injectable
+fetcher) 추가 → (2) spec `status=STATUS_LIVE` + cost/legal 갱신 → (3) 회귀에 fake fetcher 파싱
+테스트 추가. 그 전까지는 planned 로 두어 digest 에 "미연결" 로 정직하게 보인다.

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -19,6 +19,9 @@ Honest status of each console surface (working / partial / planned). Code:
 | daemon heartbeat in console (state/tick/pid/kill-switch) | working | `/daemon` · `/daemon stop` | `examples/runtime-daemon/`, `test_runtime_daemon_surface` |
 | agent identity (git author / app status) | working | `/whoami` | `test_identity_attribution` |
 | discovery collectors (free-first) | working; YouTube/IG/Google planned | `/sources` | `examples/sources/` |
+| discovery sweep → digest (왜/다음 질문) | working | `/discovery` | `examples/discovery/sweep-digest.json`, `test_discovery_sweep` |
+| discovery brief → PM handoff (제안) | working | `/discovery promote <n>` | `test_discovery_sweep` |
+| discovery brief → authored vault note | working (연결 시; 미연결 정직 실패) | `/discovery save <n>` | `examples/discovery/idea-brief-note.md` |
 | design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |
 | red/blue planning (owned assets) | working (plan-only) | `/red-blue` | `examples/security/` |
 | `/provider` console config (set primary / list / doctor) | working | `/provider [set <id>\|list\|doctor]` | `test_provider_surface` |

--- a/tests/forgekit/test_discovery_sweep.py
+++ b/tests/forgekit/test_discovery_sweep.py
@@ -1,0 +1,135 @@
+"""Discovery sweep loop — free-first collectors → idea pipeline → operator digest.
+
+Proves the wiring the lane adds: one sweep collects from LIVE free-first sources
+(planned seams stay honestly empty, never faked), runs idea-discovery, and frames it
+as an operator digest answering "왜 올라왔는지 / 다음에 무엇을 물어볼지". A brief
+promotes to a PM handoff (proposal only) and persists as a retrieval-friendly
+authored vault note (real color/css path). The `/discovery` surface is exercised via
+the pure router with an ISOLATED context (no real env / no real vault). Offline +
+deterministic → bare CI (a fake fetcher makes the network collectors return []).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console import discovery as D
+from forgekit_console.commands.parser import parse_input
+from forgekit_console.commands.router import ConsoleContext, route
+
+
+def _empty_fetcher(_url: str) -> str:
+    # network collectors parse this → no items (honest empty), so the sweep is
+    # deterministic and offline (only repo-local + operator signals contribute).
+    return "{}"
+
+
+class DiscoverySweepTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        (self.tmp / "apps").mkdir()
+        (self.tmp / "apps" / "m.py").write_text(
+            "# TODO a\n# TODO b\n# FIXME c\n", encoding="utf-8")
+
+    # --- core sweep -----------------------------------------------------------
+    def test_sweep_wires_free_first_collectors_to_briefs(self) -> None:
+        sw = D.run_discovery_sweep(
+            self.tmp, fetcher=_empty_fetcher,
+            extra_signals=["AI 메모 트렌드 급상승", "forgekit 콘솔 자체 개선 필요"])
+        # free-first live ordering: repo-local is the no-cost first source
+        self.assertEqual(sw.digest.live_sources[0], "repo-local")
+        # planned seams are listed but contributed nothing (no fake live)
+        self.assertEqual(set(sw.digest.planned_sources), {"youtube", "instagram", "google"})
+        self.assertTrue(sw.briefs)                              # repo-local gap → brief
+        self.assertGreaterEqual(sw.digest.gap_count, 1)
+        # the self-improve signal splits out (not turned into a product brief)
+        self.assertEqual(sw.digest.self_improve_count, 1)
+
+    def test_digest_explains_why_and_next_questions(self) -> None:
+        sw = D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher)
+        self.assertTrue(sw.digest.entries)
+        top = sw.digest.entries[0]
+        self.assertIn("score", top["why"])                     # WHY it surfaced
+        self.assertTrue(top["next_questions"])                 # what to ask next
+        # the digest renders a planned-source honesty note (never fake-live)
+        joined = "\n".join(sw.digest.lines())
+        self.assertIn("fake-live 아님", joined)
+        self.assertIn("물어볼 것", joined)
+
+    def test_next_questions_deterministic_and_targeted(self) -> None:
+        sw = D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher)
+        qs = D.next_questions_for(sw.top_brief)
+        self.assertEqual(qs, D.next_questions_for(sw.top_brief))   # deterministic
+        self.assertTrue(any("target_user" in q for q in qs))      # missing → asked
+
+    def test_planned_sources_never_fake(self) -> None:
+        from forgekit_console.sources import default_registry
+
+        reg = default_registry(self.tmp, fetcher=_empty_fetcher)
+        self.assertTrue(all(c.collect() == [] for c in reg.planned()))
+
+    # --- knowledge plane: authored vault note ---------------------------------
+    def test_authored_note_carries_real_color_css(self) -> None:
+        sw = D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher)
+        note = D.brief_to_authored_note(sw.top_brief, created_at="2026-06-22")
+        # real Obsidian color/css path (cssclasses + agent_color + typed callout)
+        self.assertIn("cssclasses: [fk-user-research]", note)
+        self.assertIn('agent_color: "#c084fc"', note)
+        self.assertIn("> [!fk-user-research]", note)
+        # retrieval-friendly: tags + the standard note sections (not hollow)
+        self.assertIn("tags: [forgekit, discovery, idea-brief]", note)
+        for section in ("## 핵심 요약", "## 문제 · 근거", "## 차별화 가설",
+                        "## 다음 실험", "## 참고"):
+            self.assertIn(section, note)
+
+    def test_css_snippet_includes_author_color(self) -> None:
+        from nexus.vault.authorship import vault_css_snippet
+
+        snippet = vault_css_snippet()
+        self.assertIn(".fk-user-research", snippet)
+        self.assertIn("#c084fc", snippet)
+
+    def test_persist_brief_writes_under_inbox_and_is_honest(self) -> None:
+        sw = D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher)
+        vault = self.tmp / "vault"
+        path = D.persist_brief(sw.top_brief, vault, created_at="2026-06-22")
+        self.assertIsNotNone(path)
+        self.assertIn("00-inbox/discovery", str(path))          # raw intake, honest
+        self.assertTrue(path.exists())
+        # no vault root → honest None (never a fake write)
+        self.assertIsNone(D.persist_brief(sw.top_brief, None))
+
+    # --- promotion ------------------------------------------------------------
+    def test_promote_brief_to_pm_handoff(self) -> None:
+        sw = D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher)
+        ho = D.promote_brief(sw.top_brief)
+        self.assertEqual(ho.trace[-1].phase, "tech-lead")       # PM→gateway→tech-lead
+
+    # --- /discovery surface (pure router, isolated ctx) -----------------------
+    def _ctx(self) -> ConsoleContext:
+        # isolated: empty env/config so /discovery save is honestly "not connected"
+        return ConsoleContext(repo_root=self.tmp, env={}, config={})
+
+    def test_router_discovery_digest(self) -> None:
+        res = route(parse_input("/discovery"), self._ctx())
+        self.assertEqual(res.title, "discovery")
+        self.assertIn("operator digest", "\n".join(res.lines))
+
+    def test_router_promote(self) -> None:
+        res = route(parse_input("/discovery promote 1"), self._ctx())
+        self.assertEqual(res.title, "discovery promote")
+        self.assertIn("tech-lead", "\n".join(res.lines))
+
+    def test_router_save_not_connected_is_honest(self) -> None:
+        res = route(parse_input("/discovery save 1"), self._ctx())
+        self.assertEqual(res.kind, "error")                     # no vault → honest error
+        self.assertIn("미연결", "\n".join(res.lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적
free-first 수집원 레지스트리와 idea-discovery 파이프라인을 한 패스로 잇고, operator 가 "어떤 아이디어가 왜 올라왔는지 / 다음에 무엇을 물어볼지" 보고 PM packet/authored vault note 로 승격할 수 있게 한다. Nexus 를 local read 에서 knowledge plane 으로. (closes #382)

## 범위
- `discovery/sweep.py` 신규: `run_discovery_sweep` = default_registry.collect_all(LIVE 무료 우선, planned 빈 결과) → run_idea_discovery → `DiscoveryDigest`(왜/다음 질문).
- `brief_to_authored_note` / `persist_brief`: brief → retrieval-friendly authored vault note(00-inbox raw intake, 미연결 None).
- `/discovery [promote <n> | save <n>]` 순수 router surface.
- docs/discovery-loop.md SSoT + examples evidence + operator-surfaces/AGENTS 매핑.

## 리스크
- 낮음. 추가 surface/모듈이며 기존 동작 변경 없음. network collector 는 injectable fetcher(미지정 시 정직 빈 결과)라 CI offline.
- `/discovery` 는 operator-triggered 시 network 수집(각 10s timeout, 예외 가드) — TUI 에서 잠깐 블록 가능, 정직하게 문서화.
- planned seam(YouTube/IG/Google) 은 그대로 빈 결과 — fake-live 없음.

## 테스트
- `tests/forgekit/test_discovery_sweep.py` 11 케이스 (루프/digest/next_questions/authored note color·css/persist 정직성/PM 승격/router 3 경로). 전부 green.
- 회귀: test_discovery / test_discovery_e2e / test_router / test_palette / test_nexus_* green.
- commit-governance(`scripts/ci_check_commit_messages.py main HEAD`) OK.
- 알려진 flaky: `test_tui_inline_mode`(textual async layout) — 단독 통과, full-suite 부하에서 간헐 실패(사전 존재, 본 변경 무관, CI 는 textual 미설치 시 skip).

## 이슈 linkage
- closes #382

## audit block
- author: forgekit Nexus/discovery lane (codwithyc)
- branch: feat/forgekit-nexus-discovery-loop (4 commit)
- no-fake: planned seam 빈 결과 / vault 미연결 정직 실패 / 승격=제안 only / 색은 retrieval 보조
- evidence: examples/discovery/sweep-digest.json, idea-brief-note.md