### PR TITLE
✨ PM→gateway→tech-lead governance: artifact payload 영속 + consult + 결정 트레일

### DIFF
--- a/apps/forgekit-console/examples/pm-techlead-lane/governance-artifact-trail.json
+++ b/apps/forgekit-console/examples/pm-techlead-lane/governance-artifact-trail.json
@@ -1,0 +1,85 @@
+{
+  "note": "governance artifact 강제 — payload 영속 + consult artifact + 결정 트레일 (decision_trail_from_log). 실 record→replay 결과.",
+  "session": "design-알림",
+  "recorded_kinds": [
+    "brief",
+    "consult",
+    "gateway",
+    "meeting",
+    "decision",
+    "handoff"
+  ],
+  "decision_payload_persisted": {
+    "decision_id": "decision:m1",
+    "pm_brief_ref": "알림",
+    "meeting_ref": "m1",
+    "design_system": "forgekit-ds",
+    "coding_convention": "ruff+black+isort",
+    "stack_decision": {
+      "decision_topic": "알림 전송",
+      "options": [
+        {
+          "name": "SSE",
+          "summary": "",
+          "pros": [
+            "단순",
+            "프록시 친화"
+          ],
+          "cons": [
+            "단방향"
+          ],
+          "risk": "",
+          "fit": 0
+        },
+        {
+          "name": "WebSocket",
+          "summary": "",
+          "pros": [
+            "양방향"
+          ],
+          "cons": [
+            "인프라 복잡"
+          ],
+          "risk": "",
+          "fit": 0
+        }
+      ],
+      "recommended": "SSE",
+      "rationale": "단방향 알림은 SSE 로 충분",
+      "tradeoffs": [
+        "양방향 상호작용 포기"
+      ],
+      "assumptions": []
+    },
+    "tradeoffs": [
+      "양방향 상호작용 포기"
+    ],
+    "risk_class": "safe",
+    "approval_level": "L2_internal_approve",
+    "conditions": [],
+    "rationale": "단방향 알림 → SSE",
+    "signoff_by": "tech-lead",
+    "status": "signed_off"
+  },
+  "consult_payload_persisted": {
+    "consult_id": "c1",
+    "topic": "전송 방식",
+    "by_role": "tech-lead",
+    "to_roles": [
+      "be",
+      "fe"
+    ],
+    "question": "SSE vs WebSocket — 단방향 알림에 무엇?",
+    "note": "단방향이라 SSE 충분",
+    "refs": []
+  },
+  "decision_trail": [
+    " 1. ✓ [brief] product-manager: PM brief: 알림 — acceptance 2개 · metric 1개 · priority=normal",
+    " 2. ✓ [consult] tech-lead: consult c1: tech-lead→[be, fe] (전송 방식) — → [be, fe]: SSE vs WebSocket — 단방향 알림에 무엇?",
+    " 3. ✓ [gateway] gateway: gateway approve: 알림 — verdict=approve",
+    " 4. ✓ [meeting] tech-lead: meeting m1 (2 참석) — 참석 [tech-lead, be]",
+    " 5. ✓ [decision] tech-lead: decision decision:m1 (signed_off/L2_internal_approve) — design=forgekit-ds · convention=ruff+black+isort · stack=SSE · approval=L2_internal_approve · tradeoff 1개",
+    " 6. ✓ [handoff] be: handoff handoff:decision:m1 → be — executor=be · scope 1개"
+  ],
+  "readiness_executable": true
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -517,7 +517,11 @@ def _council_result(parsed, ctx=None) -> CommandResult:
              "확정돼야 하는지'를 보여줍니다. 기록은 `decision_lane.record_lane_artifacts` 가 남깁니다.",
              "규칙: PM artifact 없으면 tech-lead lane 실행 불가, tech-lead decision 없으면 specialist 실행 불가."))
     try:
-        from forgekit_runtime.decision_lane import readiness_from_log, replay_governance_log
+        from forgekit_runtime.decision_lane import (
+            decision_trail_from_log,
+            readiness_from_log,
+            replay_governance_log,
+        )
     except Exception:  # noqa: BLE001
         return CommandResult.error("council", ("governance 런타임 미가용.",))
     events = replay_governance_log(session, env=env)
@@ -526,7 +530,11 @@ def _council_result(parsed, ctx=None) -> CommandResult:
     if not events:
         head = (f"council lane — session={session}: 기록 없음 "
                 "(decision log 가 비어 있음 → readiness 는 PM brief 부재로 실행 불가).",)
-    return CommandResult.info("council", head + readiness.lines())
+        return CommandResult.info("council", head + readiness.lines())
+    # decision trail — "누가 무엇을 결정했는지" (actor → kind → 결정 내용 from payload).
+    trail = decision_trail_from_log(events)
+    body = readiness.lines() + ("", "── 결정 트레일 (누가 무엇을) ──") + trail
+    return CommandResult.info("council", head + body)
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/docs/pm-techlead-lane.md
+++ b/docs/pm-techlead-lane.md
@@ -58,6 +58,7 @@ approval 분리)을 약화하지 않고 **설계 결정 표면에 구체화**한
 | `PMBrief` | topic / problem / user_value / **acceptance_criteria** / **success_metrics** / out_of_scope | 문제와 완료 기준을 PM 이 고정 |
 | `StackOption` | name / pros / **cons** / risk / fit | 한 후보의 정직한 장단점 |
 | `StackComparison` | options(≥2) / **recommended** / rationale / **tradeoffs** | 비교 + 권고 + 포기한 것 |
+| `ConsultNote` | consult_id / topic / **by_role** / **to_roles**(≥1) / question | consult 를 typed artifact 로 (non-gating, anti-fake) |
 | `ParticipantPosition` | role / **stance** / position / concerns | 회의의 *실재* 단위 |
 | `MeetingRecord` | meeting_id / agenda / participants / decisions / escalated | 기록된 설계 회의 |
 | `TechLeadDecision` | meeting_ref / **design_system** / **coding_convention** / stack_decision / tradeoffs / approval_level / signoff_by / status | 기술 서명(5개 필수 필드 고정) |
@@ -294,11 +295,29 @@ meeting/미서명 decision 은 `valid=False` 로 기록돼 `readiness_from_log` 
 executable 로 복원하지 않는다 (anti-fake replay). `replay_governance_log(session)` →
 `readiness_from_log(events)` 로 사후 audit 가능.
 
+각 이벤트는 artifact 의 **payload (`to_dict()`)** 까지 함께 영속한다 — "결정이
+있었다" 만이 아니라 **무엇을 결정했는지**(design system / coding convention / stack
+recommended / tradeoff / acceptance)가 디스크에 남아 사후 추적된다. payload 는
+**evidence 일 뿐 gate 가 아니다**: readiness 는 오직 `valid` 플래그로 판단하므로,
+invalid decision 에 풍부한 payload 가 붙어도 ready 로 위조되지 않는다.
+
+### 7.5.1.a consult artifact (`ConsultNote`, non-gating)
+
+"회사처럼 consult" 를 freeform 발언이 아니라 typed artifact 로 남긴다 —
+`ConsultNote(consult_id, topic, by_role, to_roles≥1, question)`. `validate_consult`
+가 anti-fake: consult 대상(`to_roles`)이 없거나 `question` 이 비면 `valid=False`.
+consult 는 **lane 을 advance 시키지 않는다**(non-gating) — 단지 "X 에게 물었다" 가
+주장이 아니라 attributable 기록으로 남게 한다. `record_lane_artifacts(consult=...)`
+는 단일/복수 ConsultNote 를 받아 `KIND_CONSULT` 로 기록한다.
+
 ### 7.5.2 operator surface — `/council <session>`
 
 `/council <session>` 가 decision log 를 replay 해 readiness ladder 를 보여준다 —
 "실행 전에 무엇이 확정돼야 하는지". 기록 없음 → PM brief 부재로 실행 불가(정직).
-코드: `forgekit_console.commands.router._council_result`. evidence:
+기록이 있으면 **결정 트레일(누가 무엇을)** 블록을 덧붙인다 — `decision_trail_from_log`
+가 actor → kind → 결정 내용(payload 기반: design/convention/stack/approval/executor)
+을 시간순으로, validator 가 거부한 artifact 는 `✗` 로 표시한다. 코드:
+`forgekit_console.commands.router._council_result`. evidence:
 `apps/forgekit-console/examples/pm-techlead-lane/lane-readiness.json`.
 
 ## 8. 한계 / 비목표

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
@@ -19,6 +19,7 @@ from .schemas import (
     NEEDS_INFO,
     SIGNED_OFF,
     DISSENT_STANCES,
+    ConsultNote,
     EngineerHandoff,
     MeetingRecord,
     ParticipantPosition,
@@ -28,6 +29,7 @@ from .schemas import (
     TechLeadDecision,
 )
 from .validators import (
+    validate_consult,
     validate_handoff,
     validate_meeting,
     validate_pm_brief,
@@ -91,6 +93,7 @@ from .decision_log import (
     KIND_HANDOFF,
     KIND_MEETING,
     GovernanceEvent,
+    decision_trail_from_log,
     governance_log_path,
     readiness_from_log,
     record_governance_event,
@@ -100,11 +103,11 @@ from .decision_log import (
 
 __all__ = (
     # schemas
-    "PMBrief", "StackOption", "StackComparison", "ParticipantPosition",
+    "PMBrief", "StackOption", "StackComparison", "ConsultNote", "ParticipantPosition",
     "MeetingRecord", "TechLeadDecision", "EngineerHandoff",
     "DRAFT", "SIGNED_OFF", "CONDITIONAL", "BLOCKED", "ESCALATED", "NEEDS_INFO", "DISSENT_STANCES",
     # validators
-    "validate_pm_brief", "validate_stack_comparison", "validate_meeting",
+    "validate_pm_brief", "validate_stack_comparison", "validate_consult", "validate_meeting",
     "validate_tech_lead_decision", "validate_handoff",
     # lane
     "GatewayRouting", "LaneResult", "route_to_tech_lead", "tech_lead_decide",
@@ -126,5 +129,5 @@ __all__ = (
     "KIND_BRIEF", "KIND_CONSULT", "KIND_GATEWAY", "KIND_MEETING", "KIND_DECISION",
     "KIND_APPROVAL", "KIND_HANDOFF", "KIND_EXECUTION", "EVENT_KINDS", "GovernanceEvent",
     "governance_log_path", "record_governance_event", "replay_governance_log",
-    "record_lane_artifacts", "readiness_from_log",
+    "record_lane_artifacts", "readiness_from_log", "decision_trail_from_log",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
@@ -31,6 +31,7 @@ from .readiness import (
 )
 from .schemas import CONDITIONAL, SIGNED_OFF
 from .validators import (
+    validate_consult,
     validate_handoff,
     validate_meeting,
     validate_pm_brief,
@@ -60,20 +61,23 @@ class GovernanceEvent:
     summary: str = ""
     valid: bool = True           # validator verdict at record time (anti-fake)
     ref: str = ""                # artifact id
+    payload: Mapping = ()        # the artifact body (to_dict) — durable decision content
     seq: int = 0                 # assigned on replay (file order)
     at: str = ""
 
     def to_dict(self) -> dict:
         return {"session_id": self.session_id, "kind": self.kind, "actor": self.actor,
                 "summary": self.summary, "valid": self.valid, "ref": self.ref,
-                "seq": self.seq, "at": self.at}
+                "payload": dict(self.payload or {}), "seq": self.seq, "at": self.at}
 
     @staticmethod
     def from_dict(d: dict, *, seq: int = 0) -> "GovernanceEvent":
+        payload = d.get("payload")
         return GovernanceEvent(
             session_id=str(d.get("session_id", "")), kind=str(d.get("kind", "")),
             actor=str(d.get("actor", "")), summary=str(d.get("summary", "")),
             valid=bool(d.get("valid", True)), ref=str(d.get("ref", "")),
+            payload=payload if isinstance(payload, dict) else {},
             seq=seq, at=str(d.get("at", "")))
 
 
@@ -123,10 +127,26 @@ def replay_governance_log(session_id: str, *, env: Optional[Mapping[str, str]] =
     return tuple(events)
 
 
+def _payload(artifact) -> dict:
+    """The artifact's own ``to_dict()`` if it has one — the durable decision content. A
+    plain object (e.g. an approval) degrades to a minimal attribute snapshot."""
+
+    fn = getattr(artifact, "to_dict", None)
+    if callable(fn):
+        try:
+            d = fn()
+            if isinstance(d, dict):
+                return d
+        except Exception:  # noqa: BLE001 — payload is evidence, never gating
+            pass
+    return {}
+
+
 def record_lane_artifacts(
     session_id: str,
     *,
     brief=None,
+    consult=None,
     gateway=None,
     meeting=None,
     decision=None,
@@ -138,44 +158,67 @@ def record_lane_artifacts(
     """Validate + record whichever artifacts are present (anti-fake ``valid`` flags).
 
     The ``valid`` flag on each event is the artifact's own validator verdict — a fake
-    meeting/decision is recorded ``valid=False`` so the replay can never show it ready."""
+    meeting/decision/consult is recorded ``valid=False`` so the replay can never show it
+    ready. Each event also carries the artifact ``payload`` (its ``to_dict()``), so the
+    durable log preserves *what was decided* (design system / coding convention / stack /
+    tradeoffs / acceptance), not just that a decision happened. ``payload`` is pure
+    evidence — readiness keys only on ``valid``, never on the payload, so it can't fake a
+    gate. ``consult`` accepts a single :class:`ConsultNote` or an iterable of them."""
 
     recorded = []
 
-    def _emit(kind, actor, summary, valid, ref):
+    def _emit(kind, actor, summary, valid, ref, payload):
         ev = GovernanceEvent(session_id=session_id, kind=kind, actor=actor,
-                             summary=summary, valid=valid, ref=ref, at=at)
+                             summary=summary, valid=valid, ref=ref,
+                             payload=payload or {}, at=at)
         record_governance_event(ev, env=env)
         recorded.append(ev)
 
     if brief is not None:
         ok = not validate_pm_brief(brief)
-        _emit(KIND_BRIEF, "product-manager", f"PM brief: {brief.topic}", ok, brief.topic)
+        _emit(KIND_BRIEF, "product-manager", f"PM brief: {brief.topic}", ok,
+              brief.topic, _payload(brief))
+    if consult is not None:
+        notes = consult if isinstance(consult, (list, tuple)) else (consult,)
+        for note in notes:
+            ok = not validate_consult(note)
+            to = ", ".join(note.to_roles) or "-"
+            _emit(KIND_CONSULT, note.by_role,
+                  f"consult {note.consult_id}: {note.by_role}→[{to}] ({note.topic})",
+                  ok, note.consult_id, _payload(note))
     if gateway is not None:
         # gateway 'valid' = the packet itself is well-formed AND it approved (forwarded);
         # a reject/request-more-info is a real, recorded verdict but not an advancing one.
         from .gateway import validate_gateway_packet
         ok = (not validate_gateway_packet(gateway)) and getattr(gateway, "forwarded", False)
         _emit(KIND_GATEWAY, "gateway",
-              f"gateway {gateway.verdict}: {gateway.topic}", ok, gateway.topic)
+              f"gateway {gateway.verdict}: {gateway.topic}", ok, gateway.topic,
+              _payload(gateway))
     if meeting is not None:
         ok = not validate_meeting(meeting)
         _emit(KIND_MEETING, "tech-lead",
-              f"meeting {meeting.meeting_id} ({len(meeting.participants)} 참석)", ok, meeting.meeting_id)
+              f"meeting {meeting.meeting_id} ({len(meeting.participants)} 참석)", ok,
+              meeting.meeting_id, _payload(meeting))
     if decision is not None:
         ok = (not validate_tech_lead_decision(decision)) and decision.status in (SIGNED_OFF, CONDITIONAL)
         _emit(KIND_DECISION, decision.signoff_by,
               f"decision {decision.decision_id} ({decision.status}/{decision.approval_level})",
-              ok, decision.decision_id)
+              ok, decision.decision_id, _payload(decision))
     if approval is not None:
         ok = bool(getattr(approval, "approved", False))
+        ap_payload = _payload(approval) or {
+            "decision_ref": getattr(approval, "decision_ref", ""),
+            "approver": getattr(approval, "approver", "operator"),
+            "approved": bool(getattr(approval, "approved", False)),
+        }
         _emit(KIND_APPROVAL, getattr(approval, "approver", "operator"),
               f"operator approval ref={getattr(approval, 'decision_ref', '')}", ok,
-              getattr(approval, "decision_ref", ""))
+              getattr(approval, "decision_ref", ""), ap_payload)
     if handoff is not None:
         ok = (decision is not None) and (not validate_handoff(handoff, decision))
         _emit(KIND_HANDOFF, handoff.executor_role,
-              f"handoff {handoff.handoff_id} → {handoff.executor_role}", ok, handoff.handoff_id)
+              f"handoff {handoff.handoff_id} → {handoff.executor_role}", ok,
+              handoff.handoff_id, _payload(handoff))
     return tuple(recorded)
 
 
@@ -216,9 +259,72 @@ def readiness_from_log(events: Tuple[GovernanceEvent, ...]) -> LaneReadiness:
                          "specialist 실행 인가 — replay 확인 완료")
 
 
+def _trail_facts(ev: GovernanceEvent) -> str:
+    """The decision content of one event, from its persisted ``payload`` — what was
+    actually decided, so the operator reads 'who decided what', not just 'who acted'."""
+
+    p = ev.payload or {}
+    k = ev.kind
+    if k == KIND_BRIEF:
+        return (f"acceptance {len(p.get('acceptance_criteria') or [])}개 · "
+                f"metric {len(p.get('success_metrics') or [])}개 · priority={p.get('priority', '')}")
+    if k == KIND_CONSULT:
+        to = ", ".join(p.get("to_roles") or []) or "-"
+        return f"→ [{to}]: {p.get('question', '')}"
+    if k == KIND_GATEWAY:
+        bits = [f"verdict={p.get('verdict', '')}"]
+        if p.get("info_requested"):
+            bits.append(f"info {len(p['info_requested'])}개")
+        if p.get("reject_reason"):
+            bits.append(f"사유={p['reject_reason']}")
+        return " · ".join(bits)
+    if k == KIND_MEETING:
+        roles = ", ".join(pp.get("role", "") for pp in (p.get("participants") or []))
+        return f"참석 [{roles}]" + (" · escalated" if p.get("escalated") else "")
+    if k == KIND_DECISION:
+        bits = []
+        if p.get("design_system"):
+            bits.append(f"design={p['design_system']}")
+        if p.get("coding_convention"):
+            bits.append(f"convention={p['coding_convention']}")
+        sd = p.get("stack_decision") or {}
+        if sd.get("recommended"):
+            bits.append(f"stack={sd['recommended']}")
+        if p.get("approval_level"):
+            bits.append(f"approval={p['approval_level']}")
+        if p.get("tradeoffs"):
+            bits.append(f"tradeoff {len(p['tradeoffs'])}개")
+        return " · ".join(bits)
+    if k == KIND_APPROVAL:
+        return f"approved={p.get('approved', '')}"
+    if k == KIND_HANDOFF:
+        out = f"executor={p.get('executor_role', '')} · scope {len(p.get('scope') or [])}개"
+        return out + (" · operator 승인 필요" if p.get("operator_required") else "")
+    return ""
+
+
+def decision_trail_from_log(events: Tuple[GovernanceEvent, ...]) -> Tuple[str, ...]:
+    """An operator-readable 'who decided what' trail from the replayed log (time order).
+
+    Each line = ``seq. ✓/✗ [kind] actor: summary — <decision facts from payload>``. The
+    ``✗`` marks an artifact the validator rejected (anti-fake: it is recorded but does NOT
+    advance the lane). Empty if the log has no events."""
+
+    out = []
+    for ev in events:
+        mark = "✓" if ev.valid else "✗"
+        line = f"{ev.seq + 1:>2}. {mark} [{ev.kind}] {ev.actor or '-'}: {ev.summary}"
+        facts = _trail_facts(ev)
+        if facts:
+            line += f" — {facts}"
+        out.append(line)
+    return tuple(out)
+
+
 __all__ = (
     "KIND_BRIEF", "KIND_CONSULT", "KIND_GATEWAY", "KIND_MEETING", "KIND_DECISION",
     "KIND_APPROVAL", "KIND_HANDOFF", "KIND_EXECUTION", "EVENT_KINDS",
     "GovernanceEvent", "governance_log_path", "record_governance_event",
     "replay_governance_log", "record_lane_artifacts", "readiness_from_log",
+    "decision_trail_from_log",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/schemas.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/schemas.py
@@ -93,6 +93,32 @@ class StackComparison:
                 "tradeoffs": list(self.tradeoffs), "assumptions": list(self.assumptions)}
 
 
+# --- consult note ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConsultNote:
+    """A recorded consult — one role asking another for input BEFORE a decision is fixed.
+
+    The "consult like a company" artifact: **non-gating** (it does not advance the lane)
+    but **real** — a topic, a requester role, ≥1 named consultee role, and a substantive
+    question. So "we consulted X" leaves a durable, attributable trace instead of a claim;
+    a consult with no consultee or no question is rejected by :func:`validate_consult`."""
+
+    consult_id: str
+    topic: str
+    by_role: str                                 # 묻는 역할 (requester)
+    to_roles: Tuple[str, ...] = ()               # consult 대상 역할 (≥1)
+    question: str = ""                            # 무엇을 묻는지 (비어 있으면 fake)
+    note: str = ""                               # 응답/논의 요약 (선택)
+    refs: Tuple[str, ...] = ()                   # 참조 artifact id (brief/meeting/decision)
+
+    def to_dict(self) -> dict:
+        return {"consult_id": self.consult_id, "topic": self.topic, "by_role": self.by_role,
+                "to_roles": list(self.to_roles), "question": self.question,
+                "note": self.note, "refs": list(self.refs)}
+
+
 # --- meeting artifact --------------------------------------------------------
 
 
@@ -216,7 +242,7 @@ class EngineerHandoff:
 
 
 __all__ = (
-    "PMBrief", "StackOption", "StackComparison", "ParticipantPosition",
+    "PMBrief", "StackOption", "StackComparison", "ConsultNote", "ParticipantPosition",
     "MeetingRecord", "TechLeadDecision", "EngineerHandoff",
     "DISSENT_STANCES", "ALL_STANCES",
     "DRAFT", "SIGNED_OFF", "CONDITIONAL", "BLOCKED", "ESCALATED", "NEEDS_INFO", "DECISION_STATUSES",

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/validators.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/validators.py
@@ -29,6 +29,7 @@ from .schemas import (
     CONDITIONAL,
     ESCALATED,
     SIGNED_OFF,
+    ConsultNote,
     EngineerHandoff,
     MeetingRecord,
     PMBrief,
@@ -92,6 +93,35 @@ def validate_stack_comparison(cmp: StackComparison) -> Tuple[str, ...]:
         v.append("stack: 권고 근거(rationale) 없음")
     if not cmp.tradeoffs:
         v.append("stack: tradeoff 최소 1개 필요 — 공짜 선택은 없음")
+    return tuple(v)
+
+
+# --- consult note (anti-fake, non-gating) ------------------------------------
+
+
+def validate_consult(note: ConsultNote) -> Tuple[str, ...]:
+    """A real consult names a requester role, ≥1 consultee role, and a substantive
+    question. Roles resolve through the registry SSoT. Non-gating (it never advances the
+    lane) but it is NOT freeform prose — an empty question or no consultee is rejected, so
+    'we consulted X' cannot be a bare claim."""
+
+    v = []
+    if _blank(note.consult_id):
+        v.append("consult: consult_id 비어 있음")
+    if _blank(note.topic):
+        v.append("consult: topic 비어 있음")
+    if _blank(note.by_role):
+        v.append("consult: by_role(요청자) 비어 있음")
+    elif not canonical_id(note.by_role):
+        v.append(f"consult: by_role '{note.by_role}' 이 식별자 레지스트리에 없음")
+    if not note.to_roles:
+        v.append("consult: to_roles(consult 대상) 최소 1개 필요 — 혼잣말은 consult 아님")
+    else:
+        for r in note.to_roles:
+            if not canonical_id(r):
+                v.append(f"consult: to_role '{r}' 이 식별자 레지스트리에 없음")
+    if _blank(note.question):
+        v.append("consult: question(무엇을 묻는지) 비어 있음 — freeform prose 금지")
     return tuple(v)
 
 
@@ -200,6 +230,7 @@ def validate_handoff(handoff: EngineerHandoff, decision: TechLeadDecision) -> Tu
 
 
 __all__ = (
-    "validate_pm_brief", "validate_stack_comparison", "validate_meeting",
-    "validate_tech_lead_decision", "validate_handoff", "NON_EXECUTOR_ROLES",
+    "validate_pm_brief", "validate_stack_comparison", "validate_consult",
+    "validate_meeting", "validate_tech_lead_decision", "validate_handoff",
+    "NON_EXECUTOR_ROLES",
 )

--- a/tests/forgekit/test_governance_artifact_trail.py
+++ b/tests/forgekit/test_governance_artifact_trail.py
@@ -1,0 +1,241 @@
+"""Governance artifact ENFORCEMENT — payload persistence + consult + decision trail.
+
+The lane already proves preconditions are enforced/replay-able (test_lane_readiness). This
+proves the *artifacts themselves are durable and attributable* — the operator's must-verify
+items for "회의한 척 / 승인한 척" being impossible AND "누가 무엇을 결정했는지" traceable:
+
+- **consult is a real, typed artifact** — a consult with no consultee or no question is
+  rejected (anti-fake); a real one records ``valid=True`` and is NON-gating (it never makes
+  an unready lane look executable);
+- **the decision content is persisted, not just its existence** — the replayed log carries
+  each artifact's payload, so design-system / coding-convention / stack / tradeoffs /
+  acceptance survive (you can audit *what* was decided, not only *that* it was);
+- **payload is evidence, never a gate** — readiness keys on the validator ``valid`` flag, so
+  a rich payload on an INVALID decision still cannot fake a ready lane;
+- **the decision trail surfaces 'who decided what'** — ``decision_trail_from_log`` renders
+  actor → kind → decision facts, marking validator-rejected artifacts with ``✗``;
+- **backward compatible** — an old log line with no ``payload`` key replays cleanly.
+
+Hermetic: a tmp FORGEKIT_HOME isolates the log; identities via the registry SSoT.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _rel in (
+    "packages/forgekit-runtime/src",
+    "packages/forgekit-config/src",
+    "packages/forgekit-provider/src",
+    "packages/forgekit-contracts/src",
+    "packages/forgekit-goal/src",
+    "packages/nexus/src",
+):
+    _p = str(_ROOT / _rel)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from forgekit_runtime import decision_lane as D
+
+
+def _brief():
+    return D.PMBrief(topic="알림", problem="p", user_value="v",
+                     acceptance_criteria=("a1", "a2"), success_metrics=("m",))
+
+
+def _meeting():
+    parts = (D.ParticipantPosition("tech-lead", "support", "ok"),
+             D.ParticipantPosition("be", "oppose", "음", concerns=("c",)))
+    return D.MeetingRecord(meeting_id="m1", topic="t", agenda=("a",),
+                           participants=parts, decisions=("go",))
+
+
+def _stack():
+    return D.StackComparison(
+        decision_topic="t", recommended="SSE",
+        options=(D.StackOption("SSE", pros=("간단",), cons=("단방향",)),
+                 D.StackOption("WS", pros=("양방향",), cons=("복잡",))),
+        rationale="r", tradeoffs=("양방향 포기",))
+
+
+def _decision():
+    return D.tech_lead_decide(_brief(), _meeting(), _stack(),
+                              design_system="forgekit-ds", coding_convention="ruff+black",
+                              rationale="알림은 단방향이라 SSE")
+
+
+# --- consult artifact (anti-fake, non-gating) --------------------------------
+
+
+class ConsultArtifactTests(unittest.TestCase):
+    def test_real_consult_passes(self):
+        note = D.ConsultNote(consult_id="c1", topic="스택", by_role="tech-lead",
+                             to_roles=("be", "fe"), question="SSE vs WS?")
+        self.assertEqual(D.validate_consult(note), ())
+
+    def test_consult_without_consultee_or_question_is_fake(self):
+        no_to = D.ConsultNote(consult_id="c", topic="t", by_role="tech-lead",
+                              to_roles=(), question="q")
+        no_q = D.ConsultNote(consult_id="c", topic="t", by_role="tech-lead",
+                             to_roles=("be",), question="")
+        self.assertTrue(D.validate_consult(no_to))
+        self.assertTrue(D.validate_consult(no_q))
+
+    def test_consult_unknown_role_rejected(self):
+        note = D.ConsultNote(consult_id="c", topic="t", by_role="not-a-role",
+                             to_roles=("be",), question="q")
+        self.assertTrue(D.validate_consult(note))
+
+
+# --- payload persistence + non-gating consult --------------------------------
+
+
+class PayloadPersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+        self.env = {"FORGEKIT_HOME": self._home}
+
+    def _record_full(self, session):
+        brief, meeting, stack = _brief(), _meeting(), _stack()
+        decision = _decision()
+        handoff = D.handoff_to_engineer(decision, "be", scope=("notify.py",),
+                                        test_strategy="unit",
+                                        acceptance_criteria=brief.acceptance_criteria)
+        gateway = D.gateway_review(brief, meeting)
+        consult = D.ConsultNote(consult_id="c1", topic="스택", by_role="tech-lead",
+                                to_roles=("be",), question="SSE vs WS?")
+        return D.record_lane_artifacts(
+            session, brief=brief, consult=consult, gateway=gateway, meeting=meeting,
+            decision=decision, handoff=handoff, env=self.env)
+
+    def test_decision_content_survives_replay(self):
+        self._record_full("s-decision")
+        events = D.replay_governance_log("s-decision", env=self.env)
+        dec = next(e for e in events if e.kind == D.KIND_DECISION)
+        # what was decided is durable — not just that a decision happened
+        self.assertEqual(dec.payload.get("design_system"), "forgekit-ds")
+        self.assertEqual(dec.payload.get("coding_convention"), "ruff+black")
+        self.assertEqual(dec.payload.get("stack_decision", {}).get("recommended"), "SSE")
+        self.assertTrue(dec.payload.get("tradeoffs"))
+
+    def test_brief_and_handoff_payload_survive(self):
+        self._record_full("s-payload")
+        events = D.replay_governance_log("s-payload", env=self.env)
+        brief = next(e for e in events if e.kind == D.KIND_BRIEF)
+        handoff = next(e for e in events if e.kind == D.KIND_HANDOFF)
+        self.assertEqual(brief.payload.get("acceptance_criteria"), ["a1", "a2"])
+        self.assertEqual(handoff.payload.get("scope"), ["notify.py"])
+
+    def test_consult_recorded_and_non_gating(self):
+        # a fake consult is recorded valid=False but the lane is STILL executable —
+        # consult never gates, and a real consult is valid=True.
+        brief, meeting, decision = _brief(), _meeting(), _decision()
+        handoff = D.handoff_to_engineer(decision, "be", scope=("x",), test_strategy="t",
+                                        acceptance_criteria=brief.acceptance_criteria)
+        fake = D.ConsultNote(consult_id="bad", topic="t", by_role="tech-lead",
+                             to_roles=(), question="")
+        recs = D.record_lane_artifacts("s-consult", brief=brief, consult=fake,
+                                       meeting=meeting, decision=decision, handoff=handoff,
+                                       env=self.env)
+        consult_ev = next(r for r in recs if r.kind == D.KIND_CONSULT)
+        self.assertFalse(consult_ev.valid)
+        events = D.replay_governance_log("s-consult", env=self.env)
+        self.assertTrue(D.readiness_from_log(events).executable)
+
+    def test_multiple_consults_each_recorded(self):
+        c1 = D.ConsultNote(consult_id="c1", topic="t", by_role="tech-lead",
+                           to_roles=("be",), question="q1")
+        c2 = D.ConsultNote(consult_id="c2", topic="t", by_role="tech-lead",
+                           to_roles=("fe",), question="q2")
+        recs = D.record_lane_artifacts("s-multi", consult=(c1, c2), env=self.env)
+        consults = [r for r in recs if r.kind == D.KIND_CONSULT]
+        self.assertEqual(len(consults), 2)
+        self.assertTrue(all(r.valid for r in consults))
+
+
+# --- payload is evidence, never a gate ---------------------------------------
+
+
+class PayloadIsEvidenceNotGateTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+        self.env = {"FORGEKIT_HOME": self._home}
+
+    def test_rich_payload_on_invalid_decision_does_not_fake_ready(self):
+        # an UNSIGNED (escalated) decision carries a full payload, yet readiness must
+        # refuse to call the lane ready — readiness keys on `valid`, not on the payload.
+        brief, meeting = _brief(), _meeting()
+        bad = D.tech_lead_decide(brief, meeting, _stack(), design_system="ds",
+                                 coding_convention="cc", rationale="",  # empty → not signed
+                                 risk_class="blocked")
+        D.record_lane_artifacts("s-evid", brief=brief, meeting=meeting, decision=bad,
+                                env=self.env)
+        events = D.replay_governance_log("s-evid", env=self.env)
+        dec = next(e for e in events if e.kind == D.KIND_DECISION)
+        self.assertTrue(dec.payload)              # payload preserved as evidence
+        self.assertFalse(dec.valid)               # but validator rejected it
+        self.assertFalse(D.readiness_from_log(events).executable)
+
+
+# --- decision trail surface --------------------------------------------------
+
+
+class DecisionTrailTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+        self.env = {"FORGEKIT_HOME": self._home}
+
+    def test_trail_surfaces_design_decision_facts(self):
+        brief, meeting, decision = _brief(), _meeting(), _decision()
+        handoff = D.handoff_to_engineer(decision, "be", scope=("x",), test_strategy="t",
+                                        acceptance_criteria=brief.acceptance_criteria)
+        D.record_lane_artifacts("s-trail", brief=brief, meeting=meeting, decision=decision,
+                                handoff=handoff, env=self.env)
+        events = D.replay_governance_log("s-trail", env=self.env)
+        trail = "\n".join(D.decision_trail_from_log(events))
+        self.assertIn("design=forgekit-ds", trail)
+        self.assertIn("stack=SSE", trail)
+        self.assertIn("approval=", trail)
+        self.assertIn("executor=be", trail)
+
+    def test_trail_marks_invalid_artifacts(self):
+        fake = D.ConsultNote(consult_id="bad", topic="t", by_role="tech-lead",
+                             to_roles=(), question="")
+        D.record_lane_artifacts("s-mark", consult=fake, env=self.env)
+        events = D.replay_governance_log("s-mark", env=self.env)
+        trail = D.decision_trail_from_log(events)
+        self.assertTrue(any("✗" in ln and "consult" in ln for ln in trail))
+
+    def test_empty_log_empty_trail(self):
+        self.assertEqual(D.decision_trail_from_log(()), ())
+
+
+# --- backward compatibility --------------------------------------------------
+
+
+class BackwardCompatTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+        self.env = {"FORGEKIT_HOME": self._home}
+
+    def test_old_log_line_without_payload_replays(self):
+        # simulate a pre-payload log line (no 'payload' key) written to disk.
+        path = D.governance_log_path("s-old", env=self.env)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        legacy = {"session_id": "s-old", "kind": D.KIND_BRIEF, "actor": "product-manager",
+                  "summary": "PM brief: 알림", "valid": True, "ref": "알림"}
+        path.write_text(json.dumps(legacy, ensure_ascii=False) + "\n", encoding="utf-8")
+        events = D.replay_governance_log("s-old", env=self.env)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].payload, {})              # tolerant default
+        # trail still renders (no payload facts, but no crash)
+        self.assertTrue(D.decision_trail_from_log(events))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_lane_readiness.py
+++ b/tests/forgekit/test_lane_readiness.py
@@ -161,6 +161,19 @@ class CouncilSurfaceTests(unittest.TestCase):
         r = self._route("/council")
         self.assertIn("readiness", "\n".join(r.lines))
 
+    def test_council_surfaces_decision_trail(self) -> None:
+        # operator can trace "누가 무엇을 결정했는지" — a full lane's design decision
+        # facts (design system / stack) appear in the /council trail block.
+        env = {"FORGEKIT_HOME": self.home}
+        decision, handoff = _full_lane()
+        D.record_lane_artifacts("st", brief=_brief(), meeting=_meeting(),
+                                decision=decision, handoff=handoff, env=env)
+        import os
+        os.environ["FORGEKIT_HOME"] = self.home
+        joined = "\n".join(self._route("/council st").lines)
+        self.assertIn("결정 트레일", joined)
+        self.assertIn("design=", joined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #380

## 목적
PM→gateway→tech-lead→specialist 흐름이 "회의한 척/승인한 척" 없이 **실 artifact chain** 으로 굴러가도록, decision lane 의 artifact 강제를 깊게 만든다. 결정 내용(design system/coding convention/stack/tradeoff/acceptance)이 디스크에 남고, consult 가 typed artifact 로 추적되고, operator 가 "누가 무엇을 결정했는지" 한 곳에서 본다.

## 범위
- `packages/forgekit-runtime/src/forgekit_runtime/decision_lane/` — schemas / validators / decision_log / __init__
- `apps/forgekit-console/.../commands/router.py` — `/council` 트레일 surface
- `tests/forgekit/` · `docs/pm-techlead-lane.md` · evidence example

### 주요 변경
1. **`ConsultNote` + `validate_consult`** — consult 를 typed, anti-fake (대상/question 없으면 거부), **non-gating** artifact 로. `KIND_CONSULT` 의 빠진 producer/스키마를 채운다.
2. **`GovernanceEvent.payload`** — `record_lane_artifacts` 가 각 artifact `to_dict()` 를 함께 영속. design system/coding convention/stack recommended/tradeoff/acceptance 가 replay 로 살아남는다. `from_dict` 는 payload 없는 구버전 라인도 관용 처리.
3. **`record_lane_artifacts(consult=...)`** — 단일/복수 ConsultNote 기록 (valid = validate_consult 재실행).
4. **`decision_trail_from_log`** — actor→kind→결정 내용(payload 기반) 시간순 트레일, validator 거부 artifact 는 `✗`.
5. **`/council <session>`** — readiness ladder 아래에 결정 트레일 블록.

## 리스크
- 낮음. 추가적(additive) — 기존 readiness/replay/enforcement 경로 시그니처 불변.
- **anti-fake 보존**: payload 는 evidence 일 뿐 gate 아님 — readiness 는 `valid` 플래그로만 판단하므로 invalid decision 에 payload 가 붙어도 ready 로 위조되지 않음 (회귀로 고정).
- consult 는 non-gating — lane 을 advance 시키지 않음 (회귀로 고정).

## 테스트
- `tests/forgekit/test_governance_artifact_trail.py` 신규 12 케이스 (consult anti-fake / payload replay 보존 / payload-not-gate / trail facts·✗ / 구버전 라인 replay)
- `tests/forgekit/test_lane_readiness.py` 에 `/council` 트레일 surface 케이스
- forgekit 전체 회귀 1119건 통과. 단 1 실패(`test_inline_flow_is_content_driven_not_a_fixed_box`)는 **본 변경과 무관**한 기존 TUI inline 높이 환경 의존 flake — clean main / 격리 실행에서 동일 재현(본 PR 은 TUI/render 코드 미변경).

## 이슈 linkage
- Closes #380
- SSoT: `docs/pm-techlead-lane.md` (7.5.1 payload / 7.5.1.a consult / 7.5.2 트레일), evidence: `apps/forgekit-console/examples/pm-techlead-lane/governance-artifact-trail.json`

## Audit
- 4 commit (✨ consult schema/validator · ✨ payload+consult+trail · ✅ surface+tests · 📝 docs+evidence), 모두 commit-governance 가드 통과
- no fake meeting/signoff, no auto-merge (draft 까지만)