### PR TITLE
✨ console cockpit status line — 승인대기 goal/budget 한눈에

### DIFF
--- a/apps/forgekit-console/examples/cockpit-status/README.md
+++ b/apps/forgekit-console/examples/cockpit-status/README.md
@@ -1,0 +1,27 @@
+# cockpit-status — operator cockpit status line (GW5)
+
+The console issue line already showed the runtime **mode posture** (routing/usage/approval/loop).
+The remaining operator-cockpit gap was that the two control-plane facts an operator most needs —
+how many goals are **parked awaiting their approval**, and how much of today's **token budget** is
+spent — were only reachable by polling (`/goal awaiting`, `/usage`). They are now surfaced as
+badges on the persistent issue line, refreshed at every turn boundary.
+
+Honesty rails (no fakes):
+- `awaiting` is a REAL count from the goal store (reuses `goal_continuity_status` — the same
+  snapshot `forgekit runtime status` shows), never a fabricated number;
+- `budget` is REAL: today's ledger spend ÷ configured `daily_token_budget`;
+- a store / ledger read failure degrades to NO badge (0 / None) — never a guess;
+- badges default OFF, so `runtime_mode_line`'s existing callers/tests are unchanged;
+- the awaiting badge is warn-coloured + carries the `/goal awaiting` action pointer so it
+  can't be missed; the budget badge turns warn at ≥90%.
+
+## Regenerate
+```
+python3 -c "from tests.forgekit import _SRC; exec(open('apps/forgekit-console/examples/cockpit-status/_regen.py').read())" \
+  > apps/forgekit-console/examples/cockpit-status/cockpit-status-evidence.txt
+```
+
+## Verify
+`tests/forgekit/test_tui_cockpit_status.py` — pure render badges (backward compatible),
+`ForgekitConsoleApp._cockpit_badges()` reading the live goal store + usage ledger, and a
+mounted pilot proving the `#issue` widget shows the awaiting badge.

--- a/apps/forgekit-console/examples/cockpit-status/_regen.py
+++ b/apps/forgekit-console/examples/cockpit-status/_regen.py
@@ -1,0 +1,55 @@
+"""Regenerate cockpit-status-evidence.txt — deterministic (pure render + tempdir stores).
+
+Operator-cockpit status line: the persistent issue line surfaces the runtime mode posture
+PLUS the two control-plane facts an operator otherwise had to poll for — goals parked in
+awaiting_approval (real goal-store count) and today's budget spend (real usage ledger). No
+fakes: numbers come from the real stores; failures degrade to no-badge.
+
+재현: tests/forgekit/test_tui_cockpit_status.py
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from forgekit_console.tui import render
+from forgekit_goal import Goal, GoalStatus, GoalStore, transitions
+
+
+def banner(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+print("ForgeKit console — operator cockpit status line — deterministic evidence")
+print("재현: tests/forgekit/test_tui_cockpit_status.py")
+
+base = dict(label="auto", policy_mode="balanced", usage_mode="live",
+            approval="internal", loop=True)
+
+banner("STEP 1 — 기본(승인대기 0 · budget 미설정): 기존과 동일, 배지 없음")
+print(render.runtime_mode_line(**base))
+
+banner("STEP 2 — 승인대기 goal 1 (warn 배지 + 행동 포인터)")
+print(render.runtime_mode_line(**base, awaiting=1))
+
+banner("STEP 3 — budget 42% (여유 → dim) vs 95% (한계 근접 → warn)")
+print(render.runtime_mode_line(**base, budget_ratio=0.42))
+print(render.runtime_mode_line(**base, budget_ratio=0.95))
+
+banner("STEP 4 — 둘 다: 승인대기 2 + budget 93% (operator 가 한눈에)")
+print(render.runtime_mode_line(**base, awaiting=2, budget_ratio=0.93))
+
+banner("STEP 5 — 실제 goal store 카운트 (재구현 없이 goal_continuity_status 재사용)")
+with tempfile.TemporaryDirectory() as home:
+    env = {"FORGEKIT_HOME": home}
+    st = GoalStore(env=env)
+    for title in ("harden auth flow", "rotate signing keys"):
+        g = transitions.apply(Goal.create(title), GoalStatus.ACTIVE)
+        g = transitions.apply(g, GoalStatus.AWAITING_APPROVAL)
+        st.save(g)
+    from forgekit_runtime.runtime.goal_status import goal_continuity_status
+    snap = goal_continuity_status(env=env)
+    print(f"goal store awaiting_approval 실측: {snap.awaiting_approval}")
+    print(render.runtime_mode_line(**base, awaiting=snap.awaiting_approval))
+
+print("\n(끝) — 모든 숫자는 실제 store/ledger 에서 측정 · CSS 아닌 구조 · 가짜 0")

--- a/apps/forgekit-console/examples/cockpit-status/cockpit-status-evidence.txt
+++ b/apps/forgekit-console/examples/cockpit-status/cockpit-status-evidence.txt
@@ -1,0 +1,31 @@
+ForgeKit console — operator cockpit status line — deterministic evidence
+재현: tests/forgekit/test_tui_cockpit_status.py
+
+==============================================================================
+STEP 1 — 기본(승인대기 0 · budget 미설정): 기존과 동일, 배지 없음
+==============================================================================
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim]
+
+==============================================================================
+STEP 2 — 승인대기 goal 1 (warn 배지 + 행동 포인터)
+==============================================================================
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim] [#e0b020]· 1 승인대기 (/goal awaiting)[/#e0b020]
+
+==============================================================================
+STEP 3 — budget 42% (여유 → dim) vs 95% (한계 근접 → warn)
+==============================================================================
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim] [dim]· budget 42%[/dim]
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim] [#e0b020]· budget 95%[/#e0b020]
+
+==============================================================================
+STEP 4 — 둘 다: 승인대기 2 + budget 93% (operator 가 한눈에)
+==============================================================================
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim] [#e0b020]· budget 93%[/#e0b020] [#e0b020]· 2 승인대기 (/goal awaiting)[/#e0b020]
+
+==============================================================================
+STEP 5 — 실제 goal store 카운트 (재구현 없이 goal_continuity_status 재사용)
+==============================================================================
+goal store awaiting_approval 실측: 2
+[#00d8f0]◆[/#00d8f0] [b]auto[/b] [dim]· routing balanced · usage live · approval internal · loop on[/dim] [#e0b020]· 2 승인대기 (/goal awaiting)[/#e0b020]
+
+(끝) — 모든 숫자는 실제 store/ledger 에서 측정 · CSS 아닌 구조 · 가짜 0

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -1475,6 +1475,13 @@ class ForgekitConsoleApp(App):
 
         self._sink.finalize_turn()
         self._turns_finalized += 1
+        # a turn boundary is the natural refresh point for the cockpit issue line: the
+        # runtime may have parked a goal in awaiting_approval, or spend may have crossed a
+        # budget mark, out-of-band — refresh so the operator SEES it without polling.
+        try:
+            self._refresh_issue()
+        except Exception:  # noqa: BLE001 - status refresh must never break a turn close
+            pass
 
     # --- chrome / status ----------------------------------------------------
 
@@ -1503,15 +1510,31 @@ class ForgekitConsoleApp(App):
             return
         pol = self._effective_policy
         if pol is not None:
+            awaiting, budget_ratio = self._cockpit_badges()
             self.query_one("#issue", Static).update(
                 render.runtime_mode_line(
                     pol.mode_label, pol.provider_policy_mode, pol.usage.usage_mode,
                     pol.approval, loop=pol.background_loop,
+                    awaiting=awaiting, budget_ratio=budget_ratio,
                 )
             )
             return
         summary = self.context.load_operator()
         self.query_one("#issue", Static).update(render.issue_line(summary))
+
+    def _cockpit_badges(self):
+        """Real operator-cockpit facts for the issue line: (awaiting_count, budget_ratio).
+
+        Delegates to the pure :mod:`tui.cockpit` helper (textual-free, unit-testable in CI)
+        which reads the LIVE goal store + usage ledger and degrades to no-badge on failure —
+        never a fabricated number."""
+
+        from .cockpit import cockpit_badges
+
+        return cockpit_badges(
+            env=getattr(self.context, "env", None) or None,
+            config=self._config, ledger_path=self._usage_ledger_path,
+        )
 
     # --- runtime mode (Shift+Tab → real policy change) ----------------------
 

--- a/apps/forgekit-console/src/forgekit_console/tui/cockpit.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/cockpit.py
@@ -1,0 +1,53 @@
+"""Operator-cockpit status facts — the real numbers behind the issue-line badges.
+
+Pure (no textual / no widget) so it is unit-testable everywhere, including CI without a
+TUI installed. The app's issue line delegates here for the two control-plane facts an
+operator otherwise had to poll for:
+
+* ``awaiting`` — goals parked in ``awaiting_approval`` (the operator must decide). REUSES
+  ``goal_continuity_status`` — the SAME snapshot ``forgekit runtime status`` reads — so the
+  console never re-implements the count.
+* ``budget_ratio`` — today's token spend ÷ the configured ``daily_token_budget``, from the
+  real usage ledger. ``None`` when no budget is configured (unbounded).
+
+Honesty rail: a goal-store / ledger read failure degrades to NO badge (0 / None), never a
+fabricated number. All heavy imports are lazy so importing this module is cheap + dep-free.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Tuple
+
+
+def cockpit_badges(
+    *, env: Optional[Mapping[str, str]] = None, config: Optional[Mapping] = None,
+    ledger_path=None,
+) -> Tuple[int, Optional[float]]:
+    """Return ``(awaiting_count, budget_ratio)`` from the LIVE stores (best-effort).
+
+    Both reads are defensive: any failure degrades to no-badge so the status line can never
+    break — and never shows a guessed number."""
+
+    awaiting = 0
+    try:
+        from forgekit_runtime.runtime.goal_status import goal_continuity_status
+
+        st = goal_continuity_status(env=env or None)
+        awaiting = st.awaiting_approval if st.available else 0
+    except Exception:  # noqa: BLE001 - goal store read is best-effort
+        awaiting = 0
+
+    budget_ratio: Optional[float] = None
+    try:
+        from ..usage import budget_from_config, read_events, rollup, today
+
+        budget = budget_from_config(config)
+        if budget > 0:
+            spent = rollup(read_events(path=ledger_path, day=today())).total_tokens
+            budget_ratio = spent / budget
+    except Exception:  # noqa: BLE001 - ledger read is best-effort
+        budget_ratio = None
+    return awaiting, budget_ratio
+
+
+__all__ = ("cockpit_badges",)

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -152,19 +152,37 @@ def submit_held_line(mode_label: str, action: str) -> str:
 
 
 def runtime_mode_line(
-    label: str, policy_mode: str, usage_mode: str, approval: str, *, loop: bool
+    label: str, policy_mode: str, usage_mode: str, approval: str, *, loop: bool,
+    awaiting: int = 0, budget_ratio: Optional[float] = None,
 ) -> str:
     """A compact one-line summary of the current runtime mode + its real posture.
 
     Shown on the operator surface (issue line / mode change) so Shift+Tab is never
     "just a label" — the resolved routing / usage / approval / loop are visible.
+
+    Operator-cockpit badges (GW5) extend the line with the two control-plane facts an
+    operator otherwise had to POLL for: ``awaiting`` (goals parked in awaiting_approval —
+    a real count from the goal store) and ``budget_ratio`` (today's token spend ÷ budget,
+    real from the usage ledger). Both default OFF so existing callers/tests are unchanged;
+    the awaiting badge is warn-coloured + carries the action pointer so it can't be missed,
+    and the budget badge turns warn at ≥90%. Numbers only — never a fabricated posture.
     """
 
     loop_s = "loop on" if loop else "loop off"
-    return (
+    line = (
         f"[{_ACCENT}]◆[/{_ACCENT}] [b]{label}[/b] "
         f"[dim]· routing {policy_mode} · usage {usage_mode} · approval {approval} · {loop_s}[/dim]"
     )
+    if budget_ratio is not None:
+        pct = int(budget_ratio * 100)
+        if budget_ratio >= 0.9:
+            line += f" [{_WARN}]· budget {pct}%[/{_WARN}]"
+        else:
+            line += f" [dim]· budget {pct}%[/dim]"
+    if awaiting > 0:
+        word = "승인대기"
+        line += f" [{_WARN}]· {awaiting} {word} (/goal awaiting)[/{_WARN}]"
+    return line
 
 
 def issue_line(summary: StatusSummary) -> str:

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -32,6 +32,7 @@ Honest status of each console surface (working / partial / planned). Code:
 | toolchain switch (mise; global/install **approval-gated**, no fake switch) | working (local 적용; gated 액션은 `--approve`) | `/toolchain switch [global] [--approve]` | `test_toolchain` |
 | goal control plane (장기 목표 model/transition/append-only evidence/packet·child linkage, 영속) | working (surface CRUD; tick=runtime/GW4) | `/goal [list\|new <제목>\|show <id>\|activate <id>\|evidence <id>]` | `examples/goal/`, `test_goal_core`·`test_goal_surface`·`test_goal_tick` |
 | in-console approve/deny + GW4-B 실행 연결 (awaiting_approval goal → operator 결정 → 실제 게이트 실행) | working (legal transition + decision evidence → GW4-B execute_approved_packet 호출: safe=실행됨(execution+verification 보존, surface 는 reload·비덮어쓰기), risky/blocked=실행 거부, 가짜 실행 0) | `/goal awaiting` · `/goal approve <id> [메모]` · `/goal deny <id> [메모]` | `examples/goal/approval.txt`, `test_goal_approval`·`test_execute_bridge` |
+| cockpit status line (mode + 승인대기 goal 개수 + budget% 한눈에, polling 불필요) | working (persistent issue line; awaiting=실제 goal store 카운트(`goal_continuity_status`), budget=실제 ledger spend÷budget; turn-boundary 마다 refresh; store/ledger 실패 시 무배지로 degrade·가짜 숫자 0) | issue line (`/status`·`/mode`·Shift+Tab·매 turn) | `examples/cockpit-status/`, `test_tui_cockpit_status` |
 
 ## Provider reality matrix
 | provider | connection | live submit | usage basis | mode influence |

--- a/tests/forgekit/test_tui_cockpit_status.py
+++ b/tests/forgekit/test_tui_cockpit_status.py
@@ -1,0 +1,156 @@
+"""Operator-cockpit status line (GW5) — provider/goal/approval/budget visible at a glance.
+
+The console issue line already showed the runtime mode posture (routing/usage/approval/loop).
+The remaining operator-cockpit gap was that the two control-plane facts an operator most needs
+— how many goals are PARKED awaiting their approval, and how much of today's token budget is
+spent — were only reachable by POLLING (`/goal awaiting`, `/usage`). This lane proves those are
+now surfaced on the persistent issue line, from the REAL stores (goal store + usage ledger),
+never a fabricated number; and that the badges default OFF so existing callers are unchanged.
+
+Three layers, each measured:
+  1. pure render — runtime_mode_line badges (backward compatible by default);
+  2. real wiring — ForgekitConsoleApp._cockpit_badges() reads the live goal store + ledger;
+  3. live surface — a mounted pilot shows the awaiting badge on the #issue widget.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.tui import render
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+# --- layer 1: pure render (backward compatible by default) ------------------
+class RuntimeModeLineBadgeTests(unittest.TestCase):
+    def _base_kwargs(self):
+        return dict(label="auto", policy_mode="balanced", usage_mode="live",
+                    approval="internal", loop=True)
+
+    def test_default_has_no_cockpit_badges(self) -> None:
+        # existing callers/tests must be unchanged: no awaiting / no budget badge.
+        line = render.runtime_mode_line(**self._base_kwargs())
+        self.assertIn("auto", line)
+        self.assertNotIn("승인대기", line)
+        self.assertNotIn("budget", line)
+
+    def test_awaiting_badge_warns_and_carries_action_pointer(self) -> None:
+        line = render.runtime_mode_line(**self._base_kwargs(), awaiting=2)
+        self.assertIn("2 승인대기", line)
+        self.assertIn("/goal awaiting", line)       # actionable, not just a number
+        self.assertIn(render.theme.WARNING, line)    # warn-coloured so it can't be missed
+
+    def test_zero_awaiting_is_silent(self) -> None:
+        line = render.runtime_mode_line(**self._base_kwargs(), awaiting=0)
+        self.assertNotIn("승인대기", line)
+
+    def test_budget_badge_dim_below_threshold_warn_at_ceiling(self) -> None:
+        low = render.runtime_mode_line(**self._base_kwargs(), budget_ratio=0.42)
+        self.assertIn("budget 42%", low)
+        self.assertIn("[dim]· budget 42%[/dim]", low)   # quiet when there's headroom
+        high = render.runtime_mode_line(**self._base_kwargs(), budget_ratio=0.95)
+        self.assertIn("budget 95%", high)
+        self.assertIn(f"[{render.theme.WARNING}]· budget 95%", high)  # warn near the limit
+
+
+# --- layer 2 + 3: real wiring + live surface --------------------------------
+def _awaiting_goal(env, title="harden auth"):
+    """Park a real goal in awaiting_approval in the env's goal store (no fakes)."""
+
+    from forgekit_goal import Goal, GoalStatus, GoalStore, transitions
+
+    store = GoalStore(env=env)
+    g = transitions.apply(Goal.create(title), GoalStatus.ACTIVE)
+    g = transitions.apply(g, GoalStatus.AWAITING_APPROVAL)
+    store.save(g)
+    return g
+
+
+def _app(env):
+    """Construct the live app (textual required) for the pilot surface test only."""
+
+    from forgekit_console.commands.registry import load_agents, load_commands
+    from forgekit_console.commands.router import ConsoleContext
+    from forgekit_console.tui.app import ForgekitConsoleApp
+
+    ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(),
+                         commands=load_commands(), env=env)
+    return ForgekitConsoleApp(
+        repo_root=Path("/tmp/repo"), context=ctx, submit_service=None,
+        config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
+
+
+class CockpitBadgesWiringTests(unittest.TestCase):
+    """The REAL wiring — pure :func:`cockpit.cockpit_badges` reads the live stores. No
+    textual dependency, so this runs in CI too (the app delegates to this helper)."""
+
+    def setUp(self) -> None:
+        self._home = tempfile.TemporaryDirectory()
+        self.addCleanup(self._home.cleanup)
+        self.env = {"FORGEKIT_HOME": self._home.name}
+
+    def _badges(self, *, config=None, ledger_path=None):
+        from forgekit_console.tui.cockpit import cockpit_badges
+
+        return cockpit_badges(env=self.env, config=config, ledger_path=ledger_path)
+
+    def test_no_awaiting_no_budget_is_zero_none(self) -> None:
+        awaiting, budget_ratio = self._badges()
+        self.assertEqual(awaiting, 0)
+        self.assertIsNone(budget_ratio)   # no daily_token_budget configured → unbounded
+
+    def test_awaiting_count_reads_real_goal_store(self) -> None:
+        _awaiting_goal(self.env, "harden auth")
+        _awaiting_goal(self.env, "rotate keys")
+        awaiting, _ = self._badges()
+        self.assertEqual(awaiting, 2)     # the real parked count, from the store
+
+    def test_budget_ratio_reads_real_usage_ledger(self) -> None:
+        from forgekit_console.usage import UsageEvent, append_event, now_ts
+
+        ledger = Path(self._home.name) / "usage.jsonl"
+        append_event(
+            UsageEvent(ts=now_ts(), session_id="s1", mode="auto", provider="ollama",
+                       model="m", category="live", input_tokens=400, output_tokens=530,
+                       total_tokens=930, usage_basis="native", success=True, throttled=False),
+            path=ledger,
+        )
+        _, budget_ratio = self._badges(config={"daily_token_budget": 1000}, ledger_path=ledger)
+        self.assertIsNotNone(budget_ratio)
+        self.assertAlmostEqual(budget_ratio, 0.93, places=2)   # 930 / 1000, real spend
+
+    def test_store_read_failure_degrades_to_no_badge(self) -> None:
+        # a goal store that raises must NEVER break the status line — honest no-badge.
+        from forgekit_console.tui.cockpit import cockpit_badges
+
+        awaiting, budget_ratio = cockpit_badges(env={"FORGEKIT_HOME": "\x00not-a-path"})
+        self.assertEqual(awaiting, 0)
+        self.assertIsNone(budget_ratio)
+
+
+@unittest.skipUnless(_TEXTUAL, "textual not installed")
+class CockpitIssueLineSurfaceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_issue_line_surfaces_awaiting_badge(self) -> None:
+        from textual.widgets import Static
+
+        home = tempfile.TemporaryDirectory()
+        self.addCleanup(home.cleanup)
+        env = {"FORGEKIT_HOME": home.name}
+        _awaiting_goal(env, "harden auth")
+        app = _app(env)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app._refresh_issue()
+            await pilot.pause()
+            issue = str(app.query_one("#issue", Static).render())
+            self.assertIn("승인대기", issue)   # the operator SEES it without polling
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #386

## ✨ 과제 내용
ForgeKit console 의 persistent issue line 을 **operator cockpit status line** 으로 강화.

기존엔 runtime mode posture(routing/usage/approval/loop)만 보였고, operator 가 자주 확인해야 하는 두 control-plane 사실은 polling 해야만 보였다. 이제 issue line 에 항상 표면된다:
- **승인대기 goal 개수** — `awaiting_approval` 에 park 된 goal 수(실제 goal store 카운트). warn 색 + `(/goal awaiting)` 행동 포인터로 놓칠 수 없게.
- **budget %** — 오늘 ledger spend ÷ `daily_token_budget`. ≥90% 에서 warn 전환.

**Honesty rails (구조로 닫음, fake 0):**
- awaiting 은 `goal_continuity_status` 재사용(재구현 없음 — `forgekit runtime status` 와 동일 snapshot), budget 은 실제 usage ledger 측정.
- store/ledger 읽기 실패 시 **무배지로 degrade**(0/None) — 가짜 숫자 절대 없음.
- 배지 default OFF → `runtime_mode_line` 기존 caller/test 그대로(하위호환).
- turn boundary 마다 refresh → runtime 이 out-of-band 로 goal 을 park 해도 polling 없이 표면. 예외는 turn 종료를 막지 않음.

**범위 / 리스크:** console 표면(render + app issue line)만. goal/usage 코어 로직 변경 없음(읽기 재사용). filesystem read 는 turn boundary 한정(submit 당 usage snapshot 과 동일 패턴) — bounded.

**테스트:** `test_tui_cockpit_status.py` 9개 — 순수 render 배지(하위호환 포함) + `_cockpit_badges` 가 실제 goal store/usage ledger 를 읽음 + mounted pilot 이 `#issue` 위젯에 승인대기 배지 표면 + store read 실패 degrade. 타깃 회귀 115 OK(render/parity-lane/cockpit/goal-surface/smoke/goal-visibility).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- evidence: `apps/forgekit-console/examples/cockpit-status/`(_regen.py + evidence + README)
- docs: `docs/operator-surfaces.md` reality matrix 에 cockpit status line row 추가
- 비고: full-suite 의 `test_inline_flow_is_content_driven_not_a_fixed_box` flaky 1건은 base(변경 stash)에서도 동일 실패하는 test-pollution 으로 본 변경과 무관(단독 실행 시 통과 확인).
