### PR TITLE
✅ inline 레이아웃 테스트 격리 — full-discover setup-blocked 오염 제거

### DIFF
--- a/tests/forgekit/test_tui_inline_mode.py
+++ b/tests/forgekit/test_tui_inline_mode.py
@@ -94,12 +94,34 @@ class LaunchWiringTests(unittest.TestCase):
 # --------------------------------------------------------------------------- #
 @unittest.skipUnless(_TEXTUAL, "textual 필요")
 class InlineLayoutTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        # Isolate FORGEKIT_HOME to a tempdir so this layout test never reads or writes the
+        # developer's real ~/.forgekit (issue-line cockpit badges read the goal store +
+        # usage ledger from there). The provider is pinned via `config=` in `_app` so an
+        # empty home does NOT make setup-blocked (which would write the setup-required
+        # block into the transcript and grow the "empty" flow past the compact cap — the
+        # full-suite ordering flake where a leaked unconfigured home flipped setup-blocked).
+        import os
+        import tempfile
+        from unittest import mock
+
+        home = tempfile.TemporaryDirectory()
+        self.addCleanup(home.cleanup)
+        ctx = mock.patch.dict(os.environ, {"FORGEKIT_HOME": home.name})
+        ctx.start()
+        self.addCleanup(ctx.stop)
+
     def _app(self, inline):
         from forgekit_console.commands.registry import load_agents, load_commands
         from forgekit_console.commands.router import ConsoleContext
         from forgekit_console.tui.app import ForgekitConsoleApp
         ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(), commands=load_commands())
-        return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, inline=inline)
+        # Pin a configured provider so setup is NOT blocked — otherwise an unconfigured
+        # home makes the app write the multi-line setup-required block into the transcript,
+        # so the "empty" session is no longer empty (flow grows past the compact cap).
+        return ForgekitConsoleApp(
+            repo_root=Path("/tmp/repo"), context=ctx, inline=inline,
+            config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
 
     async def test_inline_flow_is_content_driven_not_a_fixed_box(self):
         from forgekit_console.tui.session_flow import SessionFlow


### PR DESCRIPTION
## 목적
`test_tui_inline_mode.test_inline_flow_is_content_driven_not_a_fixed_box` 의 full-discover 순서의존 실패(empty_h 17 ≥ 14)를 root-cause 에서 제거 — main 을 full `discover` 에서도 green 으로.

## 범위
- `tests/forgekit/test_tui_inline_mode.py` (InlineLayoutTests) 만. product 코드 무변경.

## 리스크
- 낮음. 테스트 격리 강화(config 핀 + FORGEKIT_HOME tempdir)만. product 동작/다른 테스트 영향 없음. 미설정 home→setup-blocked 표시는 정상 동작이며 그대로 유지.

## 테스트
- 원인: 테스트가 not-blocked 전제를 고정하지 않아 다른 테스트의 FORGEKIT_HOME 누수로 setup-blocked→setup-required 블록 7줄이 transcript 에 써져 빈 세션 flow 가 cap(14) 초과. intro=compact(hero/cockpit-badge 무관 확인).
- 단독 8/8 OK, **full discover 6979 OK (이전 failures=1 → 0)**. commit-governance dry-run OK.

## 이슈 linkage
- Closes #388

---
### Audit
- base: main(62b0330) · branch: fix/forgekit-tui-inline-test-isolation · 1 commit(663e3b9)
- 실행자: gw0-coordinator (integration-QA 안정화). 머지는 operator gate(no-auto-merge).