### PR TITLE
✨ Nexus/discovery 누적 루프 — 영속 ledger + operator-tunable collectors

### DIFF
--- a/apps/forgekit-console/examples/discovery/README.md
+++ b/apps/forgekit-console/examples/discovery/README.md
@@ -10,6 +10,7 @@ discovery 루프 SSoT: [`docs/discovery-loop.md`](../../../../docs/discovery-loo
 | `../sources/registry.json` | sources(WT2) | live(무료 우선) vs planned(YouTube/IG/Google — fake 아님) |
 | `idea-brief.json` | idea-discovery(WT3) | ReferenceBundle + CompetitorGapMap + IdeaBrief + self-improve 신호 분리 |
 | `sweep-digest.json` | discovery loop | 수집→brief→operator digest 한 패스. `entries[].why`(왜 올라왔는지) + `entries[].next_questions`(다음 질문) |
+| `ledger-accumulation.json` | 누적(ledger) | 2회 sweep: sweep1 new 3 → sweep2 new 0/dedup 3(seen_count++) → promote/park lifecycle 영속 |
 | `idea-brief-note.md` | knowledge plane | brief → retrieval-friendly authored vault note (author/role/color/cssclass + 5 섹션) |
 | `../selfimprove/scan.json` | self-improvement(WT4) | repo gap → risk-classified 패킷(safe만 자동) |
 | `../security/drill-plan.json` | red/blue(WT5) | 내 자산 plan-only 드릴(dry-run, 승인 필요) |

--- a/apps/forgekit-console/examples/discovery/ledger-accumulation.json
+++ b/apps/forgekit-console/examples/discovery/ledger-accumulation.json
@@ -1,0 +1,176 @@
+{
+  "sweep1": {
+    "new": 3,
+    "updated": 0
+  },
+  "sweep2_dedup": {
+    "new": 0,
+    "updated": 3
+  },
+  "after_decisions_summary": {
+    "total": 3,
+    "pending": 1,
+    "promoted": 1,
+    "saved": 0,
+    "parked": 1,
+    "by_status": {
+      "promoted": 1,
+      "parked": 1,
+      "seen": 1
+    }
+  },
+  "ledger": {
+    "ideas": {
+      "8ad28c86c168": {
+        "fingerprint": "8ad28c86c168",
+        "title": "아이디어: apps/sync.py: 3 TODO/FIXME 누적",
+        "problem": "apps/sync.py: 3 TODO/FIXME 누적",
+        "score": 4.0,
+        "source_id": "repo-local",
+        "why": "pain 신호 · 출처 repo-local · score 4.0",
+        "status": "promoted",
+        "first_seen": "2026-06-22T10:00:00",
+        "last_seen": "2026-06-22T11:00:00",
+        "seen_count": 2,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — 'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ],
+        "note_path": "",
+        "brief": {
+          "title": "아이디어: apps/sync.py: 3 TODO/FIXME 누적",
+          "problem": "apps/sync.py: 3 TODO/FIXME 누적",
+          "target_user": "일반 사용자",
+          "differentiation": {
+            "hypothesis": "'apps/sync.py: 3 TODO/FIXME 누적' 를 기존 대체재보다 더 단순/저비용으로 해결",
+            "rationale": "경쟁 1개 대비 gap 2개 관측"
+          },
+          "next_experiment": {
+            "experiment": "'apps/sync.py: 3 TODO/FIXME 누적' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+            "success_metric": "핵심 작업 완료율 / 재방문 의향"
+          },
+          "references": [
+            {
+              "source_id": "repo-local",
+              "title": "apps/sync.py: 3 TODO/FIXME 누적",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "노트 동기화 느려서 불편",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "AI 메모 정리 트렌드 급상승",
+              "url": ""
+            }
+          ],
+          "score": 4.0
+        }
+      },
+      "c55ecfe9ea89": {
+        "fingerprint": "c55ecfe9ea89",
+        "title": "아이디어: 노트 동기화 느려서 불편",
+        "problem": "노트 동기화 느려서 불편",
+        "score": 1.0,
+        "source_id": "repo-local",
+        "why": "pain 신호 · 출처 operator · score 1.0",
+        "status": "parked",
+        "first_seen": "2026-06-22T10:00:00",
+        "last_seen": "2026-06-22T11:00:00",
+        "seen_count": 2,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — '노트 동기화 느려서 불편' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ],
+        "note_path": "",
+        "brief": {
+          "title": "아이디어: 노트 동기화 느려서 불편",
+          "problem": "노트 동기화 느려서 불편",
+          "target_user": "일반 사용자",
+          "differentiation": {
+            "hypothesis": "'노트 동기화 느려서 불편' 를 기존 대체재보다 더 단순/저비용으로 해결",
+            "rationale": "경쟁 1개 대비 gap 2개 관측"
+          },
+          "next_experiment": {
+            "experiment": "'노트 동기화 느려서 불편' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+            "success_metric": "핵심 작업 완료율 / 재방문 의향"
+          },
+          "references": [
+            {
+              "source_id": "repo-local",
+              "title": "apps/sync.py: 3 TODO/FIXME 누적",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "노트 동기화 느려서 불편",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "AI 메모 정리 트렌드 급상승",
+              "url": ""
+            }
+          ],
+          "score": 1.0
+        }
+      },
+      "253679654eb1": {
+        "fingerprint": "253679654eb1",
+        "title": "아이디어: AI 메모 정리 트렌드 급상승",
+        "problem": "AI 메모 정리 트렌드 급상승",
+        "score": 1.0,
+        "source_id": "repo-local",
+        "why": "trend 신호 · 출처 operator · score 1.0",
+        "status": "seen",
+        "first_seen": "2026-06-22T10:00:00",
+        "last_seen": "2026-06-22T11:00:00",
+        "seen_count": 2,
+        "next_questions": [
+          "핵심 사용자(target_user)는 누구인가? — 지금은 기본값 '일반 사용자'",
+          "어떤 경쟁/대체재를 기준으로 차별화 가설을 검증할까?",
+          "이 문제에 사용자가 비용을 낼 의향(pricing 가설)은?",
+          "다음 실험을 실제로 돌릴까? — 'AI 메모 정리 트렌드 급상승' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰"
+        ],
+        "note_path": "",
+        "brief": {
+          "title": "아이디어: AI 메모 정리 트렌드 급상승",
+          "problem": "AI 메모 정리 트렌드 급상승",
+          "target_user": "일반 사용자",
+          "differentiation": {
+            "hypothesis": "'AI 메모 정리 트렌드 급상승' 를 기존 대체재보다 더 단순/저비용으로 해결",
+            "rationale": "경쟁 1개 대비 gap 2개 관측"
+          },
+          "next_experiment": {
+            "experiment": "'AI 메모 정리 트렌드 급상승' 핵심 흐름의 최소 프로토타입 + 5명 사용자 인터뷰",
+            "success_metric": "핵심 작업 완료율 / 재방문 의향"
+          },
+          "references": [
+            {
+              "source_id": "repo-local",
+              "title": "apps/sync.py: 3 TODO/FIXME 누적",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "노트 동기화 느려서 불편",
+              "url": ""
+            },
+            {
+              "source_id": "operator",
+              "title": "AI 메모 정리 트렌드 급상승",
+              "url": ""
+            }
+          ],
+          "score": 1.0
+        }
+      }
+    }
+  }
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -108,7 +108,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("setup", "컨트롤플레인 부트스트랩 — provider · knowledge(nexus/vault) · toolchain 한 화면 정직 집계 + 추천 preset 저장/검증 (`/setup [apply [preset]]`)", H_SETUP, "status"),
     SlashCommand("toolchain", "language/runtime 버전 전환 — `/toolchain [detect|recommend <loadout>|switch [global] [--approve]|verify|drift]` (repo-local 감지·mise 기반, global/install 은 승인 게이트)", H_TOOLCHAIN, "status"),
     SlashCommand("nexus", "Nexus 지식 source — `/nexus [set <path>|clear]` 연결/해제 + live 상태(connected/not_connected/missing/blocked/restricted)", H_NEXUS, "status"),
-    SlashCommand("discovery", "discovery sweep — free-first 수집→idea brief→operator digest(왜 올라왔는지/다음 질문). `/discovery [promote <n> | save <n>]` (promote=PM handoff 제안, save=연결된 vault 에 authored note)", H_DISCOVERY, "status"),
+    SlashCommand("discovery", "discovery 누적 루프 — free-first 수집→idea brief→**ledger 누적**(새 vs 추적중, lifecycle)+operator digest(왜/다음 질문). `/discovery [pending | promote <n> | save <n> | park <n>]` (pending=결정대기 목록, promote=PM handoff 제안, save=연결 vault authored note, park=보류)", H_DISCOVERY, "status"),
     SlashCommand("daemon", "always-on 데몬 heartbeat — state/tick/last_tick/pid/kill-switch (`/daemon [stop]`); CLI `forgekit runtime serve|status|stop`", H_DAEMON, "status"),
     SlashCommand("goal", "장기 목표 control plane — `/goal [list|new <제목>|show <id>|activate <id>|evidence <id>|awaiting|approve <id> [메모]|deny <id> [메모]]` (forgekit_goal 영속, 승인은 awaiting_approval→active/blocked + decision evidence, tick/실행은 runtime/GW4)", H_GOAL, "status"),
     SlashCommand("pm-agent", "Product intake gate — 요구 보강·결정 질문·handoff (stub)", H_AGENT_ENTER, "agent", "product-agent"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -392,64 +392,131 @@ def _nexus_result(parsed, ctx) -> CommandResult:
         "nexus", _proj.nexus_surface_lines(env=ctx.env, config=ctx.config))
 
 
+def _discovery_now() -> str:
+    # real clock at the surface boundary (caller-supplied elsewhere — no fake clock in core)
+    from datetime import datetime
+
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _discovery_pending_idea(ledger, idx_token: str):
+    """Resolve a 1-based index into the ledger's pending queue (score-ordered)."""
+
+    pend = ledger.pending()
+    if not pend:
+        return None, "결정 대기 중인 아이디어가 없습니다 — 먼저 `/discovery` 로 수집하세요."
+    try:
+        n = int(idx_token)
+    except (TypeError, ValueError):
+        n = 1
+    if n < 1 or n > len(pend):
+        return None, f"번호 범위 밖 (1~{len(pend)}). `/discovery pending` 로 목록 확인."
+    return pend[n - 1], ""
+
+
 def _discovery_result(parsed, ctx) -> CommandResult:
-    # /discovery [promote <n> | save <n>] — run a free-first discovery sweep and show
-    # the operator digest (왜 올라왔는지/다음 질문). promote → PM handoff 제안(실행 아님),
-    # save → 연결된 Nexus vault 에 retrieval-friendly authored note (미연결이면 정직 실패).
+    # /discovery [pending | promote <n> | save <n> | park <n>] — ledger-backed loop:
+    # a sweep records ideas into a PERSISTED, deduplicated ledger so the loop accumulates
+    # (new vs already-tracked, lifecycle status). promote → PM handoff 제안(실행 아님),
+    # save → 연결된 Nexus vault 에 authored note (미연결이면 정직 실패), park → 보류.
     from .. import discovery as D
 
     repo_root = getattr(ctx, "repo_root", None) or Path(".")
+    env = getattr(ctx, "env", None)
     args = list(getattr(parsed, "args", ()) or ())
     sub = args[0].lower() if args else ""
+    ledger = D.DiscoveryLedger.load(env)
 
-    def _pick(idx_token: str):
-        sweep = D.run_discovery_sweep(repo_root)
-        briefs = sweep.briefs
-        if not briefs:
-            return sweep, None, "승격할 brief 가 없습니다 — 먼저 `/discovery` 로 신호를 수집하세요."
-        try:
-            n = int(idx_token)
-        except (TypeError, ValueError):
-            n = 1
-        if n < 1 or n > len(briefs):
-            return sweep, None, f"brief 번호 범위 밖 (1~{len(briefs)})."
-        return sweep, briefs[n - 1], ""
+    if sub == "pending":
+        pend = ledger.pending()
+        if not pend:
+            return CommandResult.info("discovery pending", ("결정 대기 아이디어 없음.",))
+        lines = [f"결정 대기 {len(pend)}건 (score 순):"]
+        for i, idea in enumerate(pend, 1):
+            lines.append(f"[{i}] {idea.title}  ({idea.status}·{idea.seen_count}회 관측)")
+            lines.append(f"    왜: {idea.why}")
+            if idea.next_questions:
+                lines.append(f"    물어볼 것: {idea.next_questions[0]}")
+        lines.append("`/discovery promote <n>` · `save <n>` · `park <n>`")
+        return CommandResult.info("discovery pending", tuple(lines))
 
     if sub == "promote":
-        sweep, brief, err = _pick(args[1] if len(args) > 1 else "1")
+        idea, err = _discovery_pending_idea(ledger, args[1] if len(args) > 1 else "1")
         if err:
             return CommandResult.error("discovery promote", (err,))
-        ho = D.promote_brief(brief)
+        ho = D.promote_brief(idea.rebuild_brief())
+        ledger.mark(idea.fingerprint, D.ST_PROMOTED)
+        ledger.save(env)
         lines = (
-            f"승격(제안): {brief.title}",
+            f"승격(제안): {idea.title}",
             f"- handoff: {ho.trace[0].handoff_from} → … → {ho.trace[-1].handoff_to} "
             f"(최종 phase {ho.trace[-1].phase})",
             f"- role tasks {len(ho.split.tasks)}개 · blocked {len(ho.split.blocked)}개",
+            "- ledger: 상태 promoted (결정 대기에서 제외, 누적 보존)",
             "주의: PM→gateway→tech-lead 제안 packet 일 뿐, 실행은 승인 게이트 통과 후.",
         )
         return CommandResult.info("discovery promote", lines)
 
     if sub == "save":
-        sweep, brief, err = _pick(args[1] if len(args) > 1 else "1")
+        idea, err = _discovery_pending_idea(ledger, args[1] if len(args) > 1 else "1")
         if err:
             return CommandResult.error("discovery save", (err,))
         from hephaistos.nexus_read import nexus_root
 
-        root = nexus_root(getattr(ctx, "env", None), getattr(ctx, "config", None))
+        root = nexus_root(env, getattr(ctx, "config", None))
         if not root:
             return CommandResult.error(
                 "discovery save",
                 ("Nexus vault 미연결 — `/nexus set <path>` 로 먼저 연결하세요 (fake-write 안 함).",))
-        path = D.persist_brief(brief, root)
+        path = D.persist_brief(idea.rebuild_brief(), root)
         if not path:
             return CommandResult.error(
                 "discovery save", (f"vault 쓰기 실패 (root={root}) — 권한/경로 확인.",))
+        ledger.mark(idea.fingerprint, D.ST_SAVED, note_path=str(path))
+        ledger.save(env)
         return CommandResult.info(
             "discovery save",
-            (f"authored note 기록: {path}", "- author user-researcher · 00-inbox/discovery (raw intake)"))
+            (f"authored note 기록: {path}",
+             "- author user-researcher · 00-inbox/discovery (raw intake)",
+             "- ledger: 상태 saved (note_path 영속)"))
 
-    sweep = D.run_discovery_sweep(repo_root)
-    return CommandResult.info("discovery", sweep.digest.lines())
+    if sub == "park":
+        idea, err = _discovery_pending_idea(ledger, args[1] if len(args) > 1 else "1")
+        if err:
+            return CommandResult.error("discovery park", (err,))
+        ledger.mark(idea.fingerprint, D.ST_PARKED)
+        ledger.save(env)
+        return CommandResult.info(
+            "discovery park",
+            (f"보류: {idea.title}", "- ledger: 상태 parked (결정 대기에서 제외, 다시 안 올라옴)"))
+
+    # default: sweep → record into ledger → accumulating digest
+    sweep = D.run_discovery_sweep(repo_root, config=getattr(ctx, "config", None))
+    new, updated = ledger.record_sweep(sweep, now=_discovery_now())
+    ledger.save(env)
+    s = ledger.summary()
+    lines = [
+        "discovery — 누적 digest (ledger-backed)",
+        f"- live 수집원(무료 우선): {', '.join(sweep.digest.live_sources) or '(없음)'}",
+        f"- planned(미연결 — fake-live 아님): {', '.join(sweep.digest.planned_sources) or '(없음)'}",
+        f"- 누적 추적: 총 {s['total']}건 · 결정대기 {s['pending']} · promoted {s['promoted']} · "
+        f"saved {s['saved']} · parked {s['parked']}",
+        f"- 이번 sweep: 새 아이디어 {len(new)}건 · 다시 관측 {len(updated)}건",
+    ]
+    for i, idea in enumerate(new[:5], 1):
+        lines.append(f"새[{i}] {idea.title}")
+        lines.append(f"    왜: {idea.why}")
+        if idea.next_questions:
+            lines.append(f"    물어볼 것: {idea.next_questions[0]}")
+    if not new:
+        lines.append("  (새 아이디어 없음 — `/discovery pending` 으로 결정 대기 목록 확인)")
+    # nexus connection hint — saving needs a connected vault (honest)
+    from hephaistos.nexus_read import nexus_root
+
+    root = nexus_root(env, getattr(ctx, "config", None))
+    lines.append(f"- vault: {'연결됨 ' + str(root) if root else '미연결 — /nexus set <path> 후 /discovery save 가능'}")
+    lines.append("`/discovery pending` 으로 결정 대기 아이디어를 보고 promote/save/park 하세요.")
+    return CommandResult.info("discovery", tuple(lines))
 
 
 def _daemon_result(parsed, ctx) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/discovery/__init__.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/__init__.py
@@ -26,6 +26,17 @@ from .sweep import (
     promote_brief,
     run_discovery_sweep,
 )
+from .ledger import (
+    DiscoveryLedger,
+    LedgerIdea,
+    ST_NEW,
+    ST_PARKED,
+    ST_PROMOTED,
+    ST_SAVED,
+    ST_SEEN,
+    discovery_ledger_path,
+    fingerprint,
+)
 from .video_watch import VideoIngest, VideoWatchResult, summarize_ingest
 
 __all__ = (
@@ -35,5 +46,7 @@ __all__ = (
     "promote_to_handoff", "run_idea_discovery", "shape_signals",
     "DiscoveryDigest", "DiscoverySweep", "run_discovery_sweep", "next_questions_for",
     "promote_brief", "brief_to_authored_note", "persist_brief",
+    "DiscoveryLedger", "LedgerIdea", "discovery_ledger_path", "fingerprint",
+    "ST_NEW", "ST_SEEN", "ST_PROMOTED", "ST_SAVED", "ST_PARKED",
     "VideoIngest", "VideoWatchResult", "summarize_ingest",
 )

--- a/apps/forgekit-console/src/forgekit_console/discovery/ledger.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/ledger.py
@@ -1,0 +1,217 @@
+"""Discovery ledger — make swept ideas **accumulate** across runs (the 누적 seam).
+
+A single `/discovery` sweep is ephemeral: run it twice and the same ideas resurface as
+"new" every time. The ledger makes the loop a real personal-assistant memory — a
+persisted, deduplicated store of every idea ever surfaced, each carrying a lifecycle
+status (new → seen → promoted / saved / parked) and accumulation evidence
+(first_seen / last_seen / seen_count).
+
+Stored as ONE JSON object under the runtime state dir (NOT the vault — that's the
+separate evidence/curated track), keyed by a stable fingerprint of the idea's problem
+text so re-seeing an idea updates it in place rather than duplicating it. Best-effort
+I/O: a store failure never crashes a sweep; the in-memory view is always returned.
+
+This mirrors the forge-receipt ledger's "make the decision log accumulate" posture,
+but ideas mutate state (an idea gets promoted), so it's a keyed store, not append-only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Tuple
+
+from forgekit_config.paths import state_dir
+
+from . import models as M
+from .sweep import next_questions_for
+
+_LEDGER_NAME = "discovery_ledger.json"
+
+# idea lifecycle ---------------------------------------------------------------
+ST_NEW = "new"            # surfaced this sweep, never seen before
+ST_SEEN = "seen"          # surfaced again in a later sweep, still undecided
+ST_PROMOTED = "promoted"  # promoted to a PM handoff packet
+ST_SAVED = "saved"        # persisted as an authored vault note
+ST_PARKED = "parked"      # operator set aside (won't resurface as pending)
+
+_PENDING = (ST_NEW, ST_SEEN)
+_DECIDED = (ST_PROMOTED, ST_SAVED, ST_PARKED)
+
+
+def discovery_ledger_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    """The accumulating discovery ledger (JSON) under the runtime state dir."""
+
+    return state_dir(env) / _LEDGER_NAME
+
+
+def fingerprint(problem: str) -> str:
+    """Stable dedup key for an idea — normalised problem text → short sha1."""
+
+    norm = " ".join((problem or "").lower().split())
+    return hashlib.sha1(norm.encode("utf-8")).hexdigest()[:12]
+
+
+@dataclass
+class LedgerIdea:
+    """One tracked idea + its lifecycle state and accumulation evidence."""
+
+    fingerprint: str
+    title: str
+    problem: str
+    score: float = 0.0
+    source_id: str = ""
+    why: str = ""
+    status: str = ST_NEW
+    first_seen: str = ""
+    last_seen: str = ""
+    seen_count: int = 1
+    next_questions: Tuple[str, ...] = ()
+    note_path: str = ""               # set when saved to vault
+    brief: dict = field(default_factory=dict)  # full IdeaBrief.to_dict() for rebuild
+
+    @property
+    def pending(self) -> bool:
+        return self.status in _PENDING
+
+    def to_dict(self) -> dict:
+        return {
+            "fingerprint": self.fingerprint, "title": self.title, "problem": self.problem,
+            "score": self.score, "source_id": self.source_id, "why": self.why,
+            "status": self.status, "first_seen": self.first_seen,
+            "last_seen": self.last_seen, "seen_count": self.seen_count,
+            "next_questions": list(self.next_questions), "note_path": self.note_path,
+            "brief": self.brief,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "LedgerIdea":
+        return cls(
+            fingerprint=d.get("fingerprint", ""), title=d.get("title", ""),
+            problem=d.get("problem", ""), score=float(d.get("score", 0.0) or 0.0),
+            source_id=d.get("source_id", ""), why=d.get("why", ""),
+            status=d.get("status", ST_NEW), first_seen=d.get("first_seen", ""),
+            last_seen=d.get("last_seen", ""), seen_count=int(d.get("seen_count", 1) or 1),
+            next_questions=tuple(d.get("next_questions", ()) or ()),
+            note_path=d.get("note_path", ""), brief=d.get("brief", {}) or {},
+        )
+
+    def rebuild_brief(self) -> M.IdeaBrief:
+        """Reconstruct the IdeaBrief for promotion / note authoring (no re-sweep)."""
+
+        if self.brief:
+            return M.IdeaBrief.from_dict(self.brief)
+        return M.IdeaBrief(title=self.title or self.problem[:40], problem=self.problem,
+                           score=self.score)
+
+
+@dataclass
+class DiscoveryLedger:
+    """The persisted, deduplicated store of every surfaced idea + its lifecycle."""
+
+    ideas: Dict[str, LedgerIdea] = field(default_factory=dict)
+
+    # --- load / save ----------------------------------------------------------
+    @classmethod
+    def load(cls, env: Optional[Mapping[str, str]] = None) -> "DiscoveryLedger":
+        try:
+            raw = discovery_ledger_path(env).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, ValueError):
+            return cls()
+        ideas = {fp: LedgerIdea.from_dict(d)
+                 for fp, d in (data.get("ideas", {}) or {}).items()}
+        return cls(ideas=ideas)
+
+    def save(self, env: Optional[Mapping[str, str]] = None) -> Optional[Path]:
+        try:
+            path = discovery_ledger_path(env)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {"ideas": {fp: i.to_dict() for fp, i in self.ideas.items()}}
+            path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+                            encoding="utf-8")
+            return path
+        except OSError:
+            return None
+
+    # --- accumulation ---------------------------------------------------------
+    def record_sweep(self, sweep, *, now: str = "") -> Tuple[List[LedgerIdea], List[LedgerIdea]]:
+        """Merge a sweep's briefs into the ledger. Returns (new, updated) ideas.
+
+        New fingerprint → tracked as ST_NEW. Re-seen pending idea → bumped (still
+        pending, status normalised to ST_SEEN) so it doesn't masquerade as brand-new.
+        Already-decided ideas (promoted/saved/parked) → last_seen bumped only; they
+        never resurface as new/pending."""
+
+        entries = {e.get("problem"): e for e in sweep.digest.entries}
+        new: List[LedgerIdea] = []
+        updated: List[LedgerIdea] = []
+        for brief in sweep.briefs:
+            fp = fingerprint(brief.problem)
+            enr = entries.get(brief.problem, {})
+            refs = brief.references or ()
+            source_id = (refs[0].get("source_id") if refs else "") or "operator"
+            why = enr.get("why") or f"score {brief.score} · 출처 {source_id}"
+            nq = tuple(enr.get("next_questions") or next_questions_for(brief))
+            existing = self.ideas.get(fp)
+            if existing is None:
+                idea = LedgerIdea(
+                    fingerprint=fp, title=brief.title, problem=brief.problem,
+                    score=brief.score, source_id=source_id, why=why, status=ST_NEW,
+                    first_seen=now, last_seen=now, seen_count=1, next_questions=nq,
+                    brief=brief.to_dict())
+                self.ideas[fp] = idea
+                new.append(idea)
+            else:
+                existing.last_seen = now or existing.last_seen
+                existing.seen_count += 1
+                existing.score = brief.score
+                existing.why = why
+                existing.next_questions = nq
+                if not existing.brief:
+                    existing.brief = brief.to_dict()
+                if existing.status == ST_NEW:
+                    existing.status = ST_SEEN
+                if existing.pending:
+                    updated.append(existing)
+        return new, updated
+
+    def mark(self, fp: str, status: str, *, note_path: str = "") -> Optional[LedgerIdea]:
+        idea = self.ideas.get(fp)
+        if idea is None:
+            return None
+        idea.status = status
+        if note_path:
+            idea.note_path = note_path
+        return idea
+
+    # --- views ----------------------------------------------------------------
+    def pending(self) -> List[LedgerIdea]:
+        """Undecided ideas, highest score first (the operator's decision queue)."""
+
+        return sorted((i for i in self.ideas.values() if i.pending),
+                      key=lambda i: (-i.score, i.first_seen, i.fingerprint))
+
+    def by_status(self, status: str) -> List[LedgerIdea]:
+        return [i for i in self.ideas.values() if i.status == status]
+
+    def summary(self) -> dict:
+        counts: Dict[str, int] = {}
+        for i in self.ideas.values():
+            counts[i.status] = counts.get(i.status, 0) + 1
+        return {
+            "total": len(self.ideas),
+            "pending": len(self.pending()),
+            "promoted": counts.get(ST_PROMOTED, 0),
+            "saved": counts.get(ST_SAVED, 0),
+            "parked": counts.get(ST_PARKED, 0),
+            "by_status": counts,
+        }
+
+
+__all__ = (
+    "ST_NEW", "ST_SEEN", "ST_PROMOTED", "ST_SAVED", "ST_PARKED",
+    "discovery_ledger_path", "fingerprint", "LedgerIdea", "DiscoveryLedger",
+)

--- a/apps/forgekit-console/src/forgekit_console/discovery/models.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/models.py
@@ -56,6 +56,11 @@ class DifferentiationHypothesis:
     def to_dict(self) -> dict:
         return {"hypothesis": self.hypothesis, "rationale": self.rationale}
 
+    @classmethod
+    def from_dict(cls, d: dict) -> "DifferentiationHypothesis":
+        d = d or {}
+        return cls(hypothesis=d.get("hypothesis", ""), rationale=d.get("rationale", ""))
+
 
 @dataclass(frozen=True)
 class NextExperiment:
@@ -64,6 +69,12 @@ class NextExperiment:
 
     def to_dict(self) -> dict:
         return {"experiment": self.experiment, "success_metric": self.success_metric}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NextExperiment":
+        d = d or {}
+        return cls(experiment=d.get("experiment", ""),
+                   success_metric=d.get("success_metric", ""))
 
 
 @dataclass(frozen=True)
@@ -84,6 +95,18 @@ class IdeaBrief:
             "next_experiment": self.next_experiment.to_dict(),
             "references": list(self.references), "score": self.score,
         }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "IdeaBrief":
+        d = d or {}
+        return cls(
+            title=d.get("title", ""), problem=d.get("problem", ""),
+            target_user=d.get("target_user", "일반 사용자"),
+            differentiation=DifferentiationHypothesis.from_dict(d.get("differentiation")),
+            next_experiment=NextExperiment.from_dict(d.get("next_experiment")),
+            references=tuple(d.get("references", ()) or ()),
+            score=float(d.get("score", 0.0) or 0.0),
+        )
 
 
 @dataclass(frozen=True)

--- a/apps/forgekit-console/src/forgekit_console/discovery/sweep.py
+++ b/apps/forgekit-console/src/forgekit_console/discovery/sweep.py
@@ -129,6 +129,7 @@ def run_discovery_sweep(
     *,
     fetcher=None,
     rss_feeds: Tuple[Tuple[str, str], ...] = (),
+    config: Optional[dict] = None,
     extra_signals: Sequence[str] = (),
     limit_per: int = 8,
     max_briefs: int = 3,
@@ -138,12 +139,22 @@ def run_discovery_sweep(
 
     Network collectors use *fetcher* (None → real urllib; offline → honest empty).
     Planned seams contribute nothing (never faked). *extra_signals* are operator
-    text folded in alongside the collected items.
+    text folded in alongside the collected items. When *config* is given, the live
+    collectors track the operator's configured topics (``discovery`` block); explicit
+    *rss_feeds* are merged on top of any configured feeds.
     """
 
-    from ..sources import default_registry
+    from ..sources import registry_from_config
 
-    registry = default_registry(repo_root, fetcher=fetcher, rss_feeds=rss_feeds)
+    registry = registry_from_config(repo_root, config, fetcher=fetcher)
+    for sid, url in rss_feeds:
+        from ..sources import RssCollector
+        from nexus.sources.contract import SourceSpec, TYPE_RSS
+
+        spec = SourceSpec(sid, sid, TYPE_RSS, cost_class="free", freshness="daily",
+                          trust_level="medium", ingest_method="rss",
+                          legal_note="operator-curated feed")
+        registry.register(RssCollector(spec, url, fetcher))
     collected = registry.collect_all(limit_per=limit_per)
     # free-first order is preserved by cost_ordered_live() inside collect_all().
     items: List[object] = [it for bucket in collected.values() for it in bucket]

--- a/docs/discovery-loop.md
+++ b/docs/discovery-loop.md
@@ -17,15 +17,49 @@ default_registry(repo_root, fetcher, rss_feeds)   # 수집원 레지스트리 (W
 `source_rows`(레지스트리 health). 순수·결정적 — `fetcher` 미지정 시 network collector 는
 정직하게 빈 결과라 CI 에서 repo-local 만으로 굴러간다.
 
+## 누적 (ledger-backed accumulation)
+한 번의 sweep 은 ephemeral — 두 번 돌리면 같은 아이디어가 매번 "새 것"으로 다시 뜬다.
+**discovery ledger**(`discovery/ledger.py`)가 이걸 개인 비서형 메모리로 만든다: 표면화된 모든
+아이디어를 problem 텍스트 fingerprint 로 dedup 해 **영속**(`state_dir()/discovery_ledger.json`,
+vault 아님 — 별도 evidence 트랙)하고, 각 아이디어에 lifecycle status 와 누적 근거를 붙인다.
+
+```
+sweep → ledger.record_sweep(now)         # 새 fingerprint=new, 기존=seen(seen_count++)
+  → DiscoveryLedger { fingerprint: LedgerIdea(status, first_seen, last_seen, seen_count, ...) }
+  → /discovery digest: 총 N · 결정대기 · promoted · saved · parked + 이번 sweep 새/다시
+```
+- lifecycle: `new → seen`(다시 관측) → operator 결정 `promoted`(PM handoff) / `saved`(vault note) /
+  `parked`(보류). 결정된 아이디어는 다시 sweep 돼도 **new/pending 으로 부활하지 않음**(last_seen 만 갱신).
+- `pending()` = 결정 대기 큐(score 내림차순, 결정적). `/discovery pending` 의 번호 = promote/save/park
+  의 `<n>` (re-sweep drift 없이 영속 큐 기준).
+- 결정 시 `LedgerIdea.rebuild_brief()` 로 저장된 brief dict 를 IdeaBrief 로 복원 → 재수집 없이 승격/영속.
+- best-effort I/O: store 실패해도 sweep 은 안 죽고 in-memory view 반환.
+
 ## current live vs planned
 | 단계 | 상태 | surface | evidence |
 | --- | --- | --- | --- |
 | free-first 수집 (repo-local/HN/Reddit/GitHub/RSS) | **live** (network=injectable fetcher) | `/sources` | `examples/sources/` |
-| 수집 → idea-discovery 한 패스 연결 | **live** (이번 루프) | `/discovery` | `examples/discovery/sweep-digest.json` |
+| **operator-tunable 수집 토픽** (HN query/subreddits/GitHub query/RSS) | **live** | config `discovery` 블록 → `registry_from_config` | `test_discovery_ledger` |
+| 수집 → idea-discovery 한 패스 연결 | **live** | `/discovery` | `examples/discovery/sweep-digest.json` |
+| **아이디어 누적/dedup/lifecycle (ledger)** | **live** | `/discovery` · `/discovery pending` | `examples/discovery/ledger-accumulation.json` |
 | operator digest (왜/다음 질문) | **live** | `/discovery` | `sweep-digest.json` `entries[].why/next_questions` |
-| brief → PM handoff packet | **live** (제안 only) | `/discovery promote <n>` | `test_discovery_sweep` |
+| brief → PM handoff packet | **live** (제안 only) | `/discovery promote <n>` | `test_discovery_ledger` |
 | brief → authored vault note (retrieval-friendly) | **live** (연결 시) | `/discovery save <n>` | `examples/discovery/idea-brief-note.md` |
+| 아이디어 보류 | **live** | `/discovery park <n>` | `test_discovery_ledger` |
 | YouTube / Instagram / paid Google | **planned** (collect()→[] 항상) | `/sources` | `registry.py` status=planned |
+
+## collector usability (operator-tunable)
+수집원의 기본 쿼리는 operator 관심사로 바꿀 수 있다. config 의 `discovery` 블록:
+```json
+{ "discovery": {
+    "hackernews_query": "AI agents OR devtools",
+    "subreddits": ["SaaS", "startups", "selfhosted"],
+    "github_query": "tui+dashboard",
+    "rss_feeds": [["lobsters", "https://lobste.rs/rss"]] } }
+```
+`registry_from_config(repo_root, config)` 가 이걸 읽어 수집원을 구성한다. 빈 쿼리/빈 리스트는 해당
+수집원을 **그냥 끈다**(fake source 안 만듦). `discovery` 블록이 없으면 안전한 기본값(`DEFAULT_HN_QUERY`
+등)으로 떨어진다. 여러 subreddit 은 각각 별도 collector 가 된다.
 
 ## honesty rails (이 루프에서 강제)
 - **planned 수집원은 절대 fake-live 아님** — `collect()` 가 항상 `[]`, digest 에 정직 표기.
@@ -42,13 +76,19 @@ default_registry(repo_root, fetcher, rss_feeds)   # 수집원 레지스트리 (W
   fake-write 없이 에러를 돌려준다.
 
 ## operator 흐름
-1. `/discovery` — 수집 sweep + digest. 각 top brief 의 "왜 올라왔는지(신호 kind·출처·score)" 와
-   "다음에 물어볼 질문(target_user/경쟁 검증/pricing/실험 실행)" 을 본다.
-2. `/discovery promote <n>` — n 번 brief 를 PM handoff packet 으로 승격(제안).
-3. `/discovery save <n>` — 연결된 Nexus vault 에 authored idea-brief note 영속(retrieval-friendly).
+1. `/discovery` — 수집 sweep + **누적 digest**: 총 추적/결정대기/promoted/saved/parked + 이번 sweep
+   의 새 아이디어(왜 올라왔는지·다음 질문) + vault 연결 상태 힌트.
+2. `/discovery pending` — 결정 대기 아이디어 큐(score 순, 번호 부여).
+3. `/discovery promote <n>` — n 번을 PM handoff packet 으로 승격(제안) → ledger status `promoted`.
+4. `/discovery save <n>` — 연결된 Nexus vault 에 authored idea-brief note 영속 → status `saved`(note_path 기록).
+5. `/discovery park <n>` — 보류 → status `parked`(다시 안 올라옴).
+
+반복 실행하면 ledger 가 쌓여 "지난번엔 새거 3개였는데 이번엔 0개 새거·5개 다시 관측, 2개는 이미 promoted"
+처럼 누적 상태를 보여준다 — 개인 비서형 수집·정리·아이디어화 루프.
 
 ## 재생성/검증
-- `python -m unittest tests.forgekit.test_discovery_sweep` (루프·digest·note·승격·surface)
+- `python -m unittest tests.forgekit.test_discovery_ledger` (누적·dedup·lifecycle·config 토픽·surface)
+- `python -m unittest tests.forgekit.test_discovery_sweep` (루프·digest·note·승격 코어)
 - `python -m unittest tests.forgekit.test_discovery_e2e` (전체 discovery 프로그램 체인)
 
 ## planned seam 붙이는 법 (YouTube/Google/Instagram)

--- a/docs/operator-surfaces.md
+++ b/docs/operator-surfaces.md
@@ -20,8 +20,11 @@ Honest status of each console surface (working / partial / planned). Code:
 | agent identity (git author / app status) | working | `/whoami` | `test_identity_attribution` |
 | discovery collectors (free-first) | working; YouTube/IG/Google planned | `/sources` | `examples/sources/` |
 | discovery sweep → digest (왜/다음 질문) | working | `/discovery` | `examples/discovery/sweep-digest.json`, `test_discovery_sweep` |
-| discovery brief → PM handoff (제안) | working | `/discovery promote <n>` | `test_discovery_sweep` |
+| discovery 아이디어 누적/dedup/lifecycle (영속 ledger) | working | `/discovery` · `/discovery pending` | `examples/discovery/ledger-accumulation.json`, `test_discovery_ledger` |
+| operator-tunable 수집 토픽 (HN/subreddits/GitHub/RSS) | working | config `discovery` 블록 | `test_discovery_ledger` |
+| discovery brief → PM handoff (제안) | working | `/discovery promote <n>` | `test_discovery_ledger` |
 | discovery brief → authored vault note | working (연결 시; 미연결 정직 실패) | `/discovery save <n>` | `examples/discovery/idea-brief-note.md` |
+| discovery 아이디어 보류 | working | `/discovery park <n>` | `test_discovery_ledger` |
 | design restricted source | blocked (real TCC) — honest | `/design` | `examples/design/` |
 | red/blue planning (owned assets) | working (plan-only) | `/red-blue` | `examples/security/` |
 | `/provider` console config (set primary / list / doctor) | working | `/provider [set <id>\|list\|doctor]` | `test_provider_surface` |

--- a/packages/nexus/src/nexus/sources/__init__.py
+++ b/packages/nexus/src/nexus/sources/__init__.py
@@ -23,12 +23,12 @@ from .collectors import (
     hackernews_collector,
     reddit_collector,
 )
-from .registry import SourceRegistry, default_registry
+from .registry import SourceRegistry, default_registry, registry_from_config
 
 __all__ = (
     "COST_FREE", "COST_LOW", "COST_PAID", "STATUS_LIVE", "STATUS_PLANNED",
     "SourceItem", "SourceSpec",
     "PlannedCollector", "RepoLocalCollector", "RssCollector",
     "github_collector", "hackernews_collector", "reddit_collector",
-    "SourceRegistry", "default_registry",
+    "SourceRegistry", "default_registry", "registry_from_config",
 )

--- a/packages/nexus/src/nexus/sources/registry.py
+++ b/packages/nexus/src/nexus/sources/registry.py
@@ -86,24 +86,41 @@ def _planned_spec(sid: str, label: str, stype: str, why: str) -> SourceSpec:
                       legal_note=why, status=STATUS_PLANNED)
 
 
+# operator-tunable defaults — what the free-first sources collect by default. The
+# operator overrides these (per their interests) via config; see registry_from_config.
+DEFAULT_HN_QUERY = "forgekit OR devtools"
+DEFAULT_SUBREDDITS: Tuple[str, ...] = ("SaaS",)
+DEFAULT_GITHUB_QUERY = "operator+console+tui"
+
+
 def default_registry(
     repo_root,
     *,
     fetcher: Optional[C.Fetcher] = None,
     rss_feeds: Tuple[Tuple[str, str], ...] = (),
+    hackernews_query: str = DEFAULT_HN_QUERY,
+    subreddits: Tuple[str, ...] = DEFAULT_SUBREDDITS,
+    github_query: str = DEFAULT_GITHUB_QUERY,
 ) -> SourceRegistry:
     """Build the default registry: live free/low sources + planned paid seams.
 
-    LIVE: repo-local (offline) · Hacker News · Reddit · GitHub · any operator RSS.
+    LIVE: repo-local (offline) · Hacker News · Reddit(s) · GitHub · any operator RSS.
     PLANNED (no live ingest, no fake): YouTube · Instagram · paid Google search.
+
+    The HN query, subreddit list, GitHub query and RSS feeds are operator-tunable so
+    collection actually tracks the operator's interests (see :func:`registry_from_config`).
     """
 
     reg = SourceRegistry()
     # --- live, free-first ---
     reg.register(C.RepoLocalCollector(repo_root))
-    reg.register(C.hackernews_collector("forgekit OR devtools", fetcher))
-    reg.register(C.reddit_collector("SaaS", fetcher))
-    reg.register(C.github_collector("operator+console+tui", fetcher))
+    if hackernews_query:
+        reg.register(C.hackernews_collector(hackernews_query, fetcher))
+    for sub in subreddits:
+        if sub:
+            reg.register(C.reddit_collector(sub, fetcher))
+    if github_query:
+        reg.register(C.github_collector(github_query, fetcher))
     for sid, url in rss_feeds:
         spec = SourceSpec(sid, sid, TYPE_RSS, cost_class="free", freshness="daily",
                           trust_level="medium", ingest_method="rss",
@@ -122,4 +139,33 @@ def default_registry(
     return reg
 
 
-__all__ = ("SourceRegistry", "default_registry")
+def registry_from_config(
+    repo_root,
+    config: Optional[Mapping] = None,
+    *,
+    fetcher: Optional[C.Fetcher] = None,
+) -> SourceRegistry:
+    """Build the registry from operator config — so collection tracks THEIR interests.
+
+    Reads the optional ``discovery`` block (all keys optional; sensible defaults):
+      * ``hackernews_query`` (str) · ``subreddits`` (list[str]) · ``github_query`` (str)
+      * ``rss_feeds`` (list of ``[id, url]`` pairs)
+    An empty query/list simply drops that collector (no fake source). Unknown keys are
+    ignored. Falls back to :func:`default_registry` defaults when ``discovery`` is absent.
+    """
+
+    disc = dict((config or {}).get("discovery", {}) or {})
+    subs = disc.get("subreddits", DEFAULT_SUBREDDITS)
+    feeds = tuple(tuple(pair) for pair in disc.get("rss_feeds", ()) if len(tuple(pair)) == 2)
+    return default_registry(
+        repo_root, fetcher=fetcher, rss_feeds=feeds,
+        hackernews_query=str(disc.get("hackernews_query", DEFAULT_HN_QUERY) or ""),
+        subreddits=tuple(s for s in subs if s),
+        github_query=str(disc.get("github_query", DEFAULT_GITHUB_QUERY) or ""),
+    )
+
+
+__all__ = (
+    "SourceRegistry", "default_registry", "registry_from_config",
+    "DEFAULT_HN_QUERY", "DEFAULT_SUBREDDITS", "DEFAULT_GITHUB_QUERY",
+)

--- a/tests/forgekit/test_discovery_ledger.py
+++ b/tests/forgekit/test_discovery_ledger.py
@@ -1,0 +1,173 @@
+"""Discovery ledger — ideas ACCUMULATE across sweeps (dedup + lifecycle + persist).
+
+Proves the 누적 seam: a sweep records ideas into a persisted, deduplicated ledger so
+re-running `/discovery` does NOT resurface the same idea as new; each idea carries a
+lifecycle status (new → seen → promoted/saved/parked) and accumulation evidence
+(seen_count). Also covers operator-tunable collectors (registry_from_config) and the
+ledger-backed `/discovery` surface via the pure router with an isolated, NETWORK-FREE
+context (empty collector queries → repo-local only → deterministic, no network in CI).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console import discovery as D
+from forgekit_console.commands.parser import parse_input
+from forgekit_console.commands.router import ConsoleContext, route
+
+
+def _empty_fetcher(_url: str) -> str:
+    return "{}"
+
+
+# network-free config: drop HN/Reddit/GitHub so only repo-local runs → deterministic
+_OFFLINE_CFG = {"discovery": {"hackernews_query": "", "subreddits": [], "github_query": ""}}
+
+
+class DiscoveryLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.home = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.home, ignore_errors=True))
+        (self.tmp / "apps").mkdir()
+        (self.tmp / "apps" / "m.py").write_text(
+            "# TODO a\n# TODO b\n# FIXME c\n", encoding="utf-8")
+        self.env = {"FORGEKIT_HOME": str(self.home)}
+
+    def _sweep(self):
+        return D.run_discovery_sweep(self.tmp, fetcher=_empty_fetcher, config=_OFFLINE_CFG,
+                                     extra_signals=["노트 동기화 느려서 불편"])
+
+    # --- accumulation / dedup -------------------------------------------------
+    def test_resweep_dedups_and_bumps_seen_count(self) -> None:
+        led = D.DiscoveryLedger()
+        new1, upd1 = led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        self.assertTrue(new1)                      # first sweep → all new
+        self.assertFalse(upd1)
+        new2, upd2 = led.record_sweep(self._sweep(), now="2026-06-22T11:00:00")
+        self.assertFalse(new2)                     # SAME ideas → none new (dedup)
+        self.assertTrue(upd2)                      # they were re-seen
+        self.assertTrue(all(i.seen_count == 2 for i in upd2))
+        self.assertTrue(all(i.status == D.ST_SEEN for i in upd2))
+
+    def test_persist_round_trip(self) -> None:
+        led = D.DiscoveryLedger.load(self.env)
+        led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        path = led.save(self.env)
+        self.assertIsNotNone(path)
+        again = D.DiscoveryLedger.load(self.env)
+        self.assertEqual(set(again.ideas), set(led.ideas))   # survived a reload
+
+    def test_lifecycle_decided_ideas_drop_from_pending(self) -> None:
+        led = D.DiscoveryLedger()
+        led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        before = len(led.pending())
+        self.assertGreaterEqual(before, 1)
+        top = led.pending()[0]
+        led.mark(top.fingerprint, D.ST_PROMOTED)
+        self.assertEqual(len(led.pending()), before - 1)     # promoted → not pending
+        # a later sweep re-seeing it must NOT resurface it as new/pending
+        new, _ = led.record_sweep(self._sweep(), now="2026-06-22T12:00:00")
+        self.assertNotIn(top.fingerprint, {i.fingerprint for i in new})
+        self.assertEqual(led.ideas[top.fingerprint].status, D.ST_PROMOTED)
+
+    def test_pending_is_score_ordered(self) -> None:
+        led = D.DiscoveryLedger()
+        led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        scores = [i.score for i in led.pending()]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_rebuild_brief_enables_promotion_without_resweep(self) -> None:
+        led = D.DiscoveryLedger()
+        led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        brief = led.pending()[0].rebuild_brief()
+        ho = D.promote_brief(brief)
+        self.assertEqual(ho.trace[-1].phase, "tech-lead")
+
+    def test_summary_counts(self) -> None:
+        led = D.DiscoveryLedger()
+        led.record_sweep(self._sweep(), now="2026-06-22T10:00:00")
+        led.mark(led.pending()[0].fingerprint, D.ST_PARKED)
+        s = led.summary()
+        self.assertEqual(s["parked"], 1)
+        self.assertEqual(s["total"], len(led.ideas))
+
+    # --- collector usability (operator-tunable topics) ------------------------
+    def test_registry_from_config_applies_topics(self) -> None:
+        from forgekit_console.sources import registry_from_config
+
+        cfg = {"discovery": {"subreddits": ["SaaS", "startups"],
+                             "hackernews_query": "AI agents", "github_query": ""}}
+        reg = registry_from_config(self.tmp, cfg, fetcher=_empty_fetcher)
+        ids = [c.spec.id for c in reg.live()]
+        self.assertEqual(ids.count("reddit"), 2)        # two subreddits → two collectors
+        self.assertIn("hackernews", ids)
+        self.assertNotIn("github", ids)                 # empty query → dropped (no fake)
+
+    def test_models_from_dict_round_trip(self) -> None:
+        from forgekit_console.discovery import models as M
+
+        b = M.IdeaBrief(title="t", problem="p",
+                        differentiation=M.DifferentiationHypothesis("h", "r"),
+                        next_experiment=M.NextExperiment("e", "m"), score=3.0)
+        self.assertEqual(M.IdeaBrief.from_dict(b.to_dict()).to_dict(), b.to_dict())
+
+    # --- ledger-backed /discovery surface (router, isolated) ------------------
+    def _ctx(self, *, config=None):
+        cfg = dict(_OFFLINE_CFG)
+        if config:
+            cfg.update(config)
+        return ConsoleContext(repo_root=self.tmp, env=self.env, config=cfg)
+
+    def test_router_digest_accumulates(self) -> None:
+        ctx = self._ctx()
+        first = route(parse_input("/discovery"), ctx)
+        self.assertIn("누적 digest", "\n".join(first.lines))
+        self.assertIn("새 아이디어", "\n".join(first.lines))
+        # second run → dedup: 0 new (same repo-local source)
+        second = route(parse_input("/discovery"), ctx)
+        self.assertIn("새 아이디어 0건", "\n".join(second.lines))
+
+    def test_router_pending_then_promote(self) -> None:
+        ctx = self._ctx()
+        route(parse_input("/discovery"), ctx)
+        pend = route(parse_input("/discovery pending"), ctx)
+        self.assertIn("결정 대기", "\n".join(pend.lines))
+        promo = route(parse_input("/discovery promote 1"), ctx)
+        self.assertIn("promoted", "\n".join(promo.lines))
+        led = D.DiscoveryLedger.load(self.env)
+        self.assertEqual(led.summary()["promoted"], 1)
+
+    def test_router_save_connected_vault_persists(self) -> None:
+        vault = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(vault, ignore_errors=True))
+        ctx = self._ctx(config={"nexus_root": str(vault)})
+        route(parse_input("/discovery"), ctx)
+        res = route(parse_input("/discovery save 1"), ctx)
+        self.assertEqual(res.kind, "info")
+        self.assertIn("authored note 기록", "\n".join(res.lines))
+        self.assertEqual(D.DiscoveryLedger.load(self.env).summary()["saved"], 1)
+
+    def test_router_save_not_connected_is_honest(self) -> None:
+        ctx = self._ctx()                              # no nexus_root
+        route(parse_input("/discovery"), ctx)
+        res = route(parse_input("/discovery save 1"), ctx)
+        self.assertEqual(res.kind, "error")
+        self.assertIn("미연결", "\n".join(res.lines))
+
+    def test_router_park_removes_from_pending(self) -> None:
+        ctx = self._ctx()
+        route(parse_input("/discovery"), ctx)
+        before = len(D.DiscoveryLedger.load(self.env).pending())
+        route(parse_input("/discovery park 1"), ctx)
+        self.assertEqual(len(D.DiscoveryLedger.load(self.env).pending()), before - 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_discovery_sweep.py
+++ b/tests/forgekit/test_discovery_sweep.py
@@ -18,8 +18,6 @@ from pathlib import Path
 from tests.forgekit import _SRC  # noqa: F401
 
 from forgekit_console import discovery as D
-from forgekit_console.commands.parser import parse_input
-from forgekit_console.commands.router import ConsoleContext, route
 
 
 def _empty_fetcher(_url: str) -> str:
@@ -110,25 +108,8 @@ class DiscoverySweepTests(unittest.TestCase):
         ho = D.promote_brief(sw.top_brief)
         self.assertEqual(ho.trace[-1].phase, "tech-lead")       # PM→gateway→tech-lead
 
-    # --- /discovery surface (pure router, isolated ctx) -----------------------
-    def _ctx(self) -> ConsoleContext:
-        # isolated: empty env/config so /discovery save is honestly "not connected"
-        return ConsoleContext(repo_root=self.tmp, env={}, config={})
-
-    def test_router_discovery_digest(self) -> None:
-        res = route(parse_input("/discovery"), self._ctx())
-        self.assertEqual(res.title, "discovery")
-        self.assertIn("operator digest", "\n".join(res.lines))
-
-    def test_router_promote(self) -> None:
-        res = route(parse_input("/discovery promote 1"), self._ctx())
-        self.assertEqual(res.title, "discovery promote")
-        self.assertIn("tech-lead", "\n".join(res.lines))
-
-    def test_router_save_not_connected_is_honest(self) -> None:
-        res = route(parse_input("/discovery save 1"), self._ctx())
-        self.assertEqual(res.kind, "error")                     # no vault → honest error
-        self.assertIn("미연결", "\n".join(res.lines))
+    # The ledger-backed `/discovery` router surface (digest/pending/promote/save/park)
+    # is covered with proper state isolation in test_discovery_ledger.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 목적
discovery sweep 을 영속 ledger 위에 올려 아이디어가 실행을 가로질러 **누적·dedup·lifecycle 추적**되게 하고, 수집원을 operator config 로 튜닝 가능하게 한다. ForgeKit 을 단순 read path 가 아니라 "수집→정리→retrieval→idea brief→evidence/vault 누적" 으로 닫히는 개인 비서형 루프로. (closes #394)

## 범위
- `discovery/ledger.py` 신규: DiscoveryLedger(fingerprint dedup, lifecycle new/seen/promoted/saved/parked, first/last_seen·seen_count, `state_dir/discovery_ledger.json` 영속). `models.*.from_dict`.
- `registry_from_config` + `default_registry` 토픽 파라미터: config `discovery` 블록(hackernews_query/subreddits/github_query/rss_feeds)으로 수집원 구성, 빈 값=collector off(no fake).
- `/discovery` 재배선: 누적 digest(총/결정대기/promoted/saved/parked + 이번 sweep 새·다시 + vault 힌트) + `/discovery pending|promote <n>|save <n>|park <n>` (영속 큐 인덱스 기반 lifecycle 갱신).
- docs/discovery-loop.md 누적·collector 섹션 + evidence + operator-surfaces matrix.

## 리스크
- 낮음. 추가 모듈/surface, 기존 sweep 코어·collector 동작 보존(파라미터는 기본값 = 기존 동작). ledger I/O 는 best-effort(실패해도 sweep 안 죽음).
- `/discovery` 는 operator-triggered 시 network 수집(injectable fetcher, 미지정 시 정직 빈 결과) → CI offline.
- planned seam(YouTube/IG/Google) 빈 결과 유지 — fake-live 없음.

## 테스트
- `tests/forgekit/test_discovery_ledger.py` 13 케이스 (dedup/seen_count/persist/lifecycle 부활금지/score 큐/rebuild_brief/summary/config 토픽/from_dict/router digest·pending·promote·save·park). green.
- 회귀: test_discovery_sweep / test_discovery / test_discovery_e2e / test_router / test_palette / test_nexus_* / test_package_topology_guard green.
- commit-governance(`scripts/ci_check_commit_messages.py main HEAD`) OK.
- 알려진 flaky: `test_tui_inline_mode`(textual async layout) — 단독 통과, full-suite 부하서 간헐 실패(사전 존재·본 변경 무관, CI 는 textual 미설치 시 skip).

## 이슈 linkage
- closes #394, builds on #383(merged)

## audit block
- author: forgekit Nexus/discovery lane (codwithyc)
- branch: feat/forgekit-discovery-ledger (5 commit)
- no-fake: planned seam 빈 결과 / vault 미연결 정직 실패 / 빈 쿼리=collector off / 승격=제안 only
- evidence: examples/discovery/ledger-accumulation.json (2-sweep dedup + lifecycle)