### PR TITLE
✨ Specialist work order — PM→tech-lead 설계 맥락 담은 handoff packet (design 없이 바로 구현 차단)

### DIFF
--- a/apps/forgekit-console/examples/pm-techlead-lane/specialist-briefing.json
+++ b/apps/forgekit-console/examples/pm-techlead-lane/specialist-briefing.json
@@ -1,0 +1,73 @@
+{
+  "note": "specialist briefing 강제 — PM brief+decision+handoff 로 합성된 work order. 실 run_lane→record→replay 결과.",
+  "session": "design-알림",
+  "engineer_may_start": true,
+  "trace": [
+    "gateway:route→tech-lead",
+    "tech-lead:signed_off/L2_internal_approve",
+    "engineer:handoff→be",
+    "briefing:ok",
+    "engineer:start"
+  ],
+  "work_order_render": [
+    "work order handoff:decision:m1 → be",
+    "  목표: 운영자가 실패를 늦게 안다 → 실패 즉시 통지",
+    "  제안 스택: SSE — server-sent events",
+    "  선택 이유: 단방향 알림은 SSE 로 충분",
+    "  ✗ 탈락: WebSocket — 인프라 복잡; 비용",
+    "  코딩 컨벤션: ruff+black+isort",
+    "  디자인 시스템: forgekit-ds",
+    "  · API/infra: GET /events SSE 엔드포인트",
+    "  · API/infra: Redis pub/sub fanout",
+    "  · API/infra: nginx proxy_buffering off",
+    "  ☐ scope: notify/sse.py",
+    "  ☐ scope: notify/dedup.py",
+    "  ⊘ 금지: auth/",
+    "  test 전략: unit+integration",
+    "  rollback: feature flag off",
+    "  ✓ acceptance: 실패 30초내 통지",
+    "  ✓ acceptance: 중복 억제"
+  ],
+  "persisted_handoff_payload": {
+    "handoff_id": "handoff:decision:m1",
+    "executor_role": "be",
+    "decision_ref": "decision:m1",
+    "goal": "운영자가 실패를 늦게 안다 → 실패 즉시 통지",
+    "proposed_stack": "SSE",
+    "proposed_stack_summary": "server-sent events",
+    "stack_rationale": "단방향 알림은 SSE 로 충분",
+    "rejected_options": [
+      {
+        "name": "WebSocket",
+        "why_not": "인프라 복잡; 비용"
+      }
+    ],
+    "coding_conventions": "ruff+black+isort",
+    "design_system": "forgekit-ds",
+    "integration_notes": [
+      "GET /events SSE 엔드포인트",
+      "Redis pub/sub fanout",
+      "nginx proxy_buffering off"
+    ],
+    "scope": [
+      "notify/sse.py",
+      "notify/dedup.py"
+    ],
+    "forbidden_scope": [
+      "auth/"
+    ],
+    "test_strategy": "unit+integration",
+    "rollback_plan": "feature flag off",
+    "acceptance_criteria": [
+      "실패 30초내 통지",
+      "중복 억제"
+    ],
+    "operator_required": false
+  },
+  "decision_trail": [
+    " 1. ✓ [brief] product-manager: PM brief: 실시간 알림 — acceptance 2개 · metric 1개 · priority=normal",
+    " 2. ✓ [meeting] tech-lead: meeting m1 (2 참석) — 참석 [tech-lead, be]",
+    " 3. ✓ [decision] tech-lead: decision decision:m1 (signed_off/L2_internal_approve) — design=forgekit-ds · convention=ruff+black+isort · stack=SSE · approval=L2_internal_approve · tradeoff 1개",
+    " 4. ✓ [handoff] be: handoff handoff:decision:m1 → be — executor=be · scope 2개 · stack=SSE · 탈락 1개"
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -38,6 +38,7 @@ H_DISCOVERY = "discovery"
 H_DAEMON = "daemon"
 H_GOAL = "goal"
 H_COUNCIL = "council"
+H_HANDOFF = "handoff"
 H_COPY = "copy"
 H_ATTACH = "attach"
 H_PASTE = "paste"
@@ -101,6 +102,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("whoami", "agent identity — git author / vault / GitHub App 자격 (`/whoami <agent>`)", H_WHOAMI, "status"),
     SlashCommand("resolve", "Hephaistos — 요청을 skill/loadout/weapon/source/packet 으로 resolve + governance verdict (`/resolve <요청>` 미리보기, `/resolve apply <요청>` = receipt 를 ledger 에 영속, `/resolve ledger` = forge governance ledger 보기)", H_RESOLVE, "status"),
     SlashCommand("council", "PM→tech-lead→specialist lane readiness — 실행 전에 무엇이 확정돼야 하는지(replay 가능 decision log). `/council <session>` (없으면 사용법)", H_COUNCIL, "status"),
+    SlashCommand("handoff", "specialist work order — 목표/제안 스택/선택 이유/탈락안/컨벤션/디자인·API·infra/scope/test/acceptance (`/handoff <session>`, replay 된 handoff packet)", H_HANDOFF, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -44,6 +44,7 @@ from .registry import (
     H_DAEMON,
     H_GOAL,
     H_COUNCIL,
+    H_HANDOFF,
     H_LAYOUT,
     H_QUIT,
     H_RENDER,
@@ -191,6 +192,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _goal_result(parsed, ctx)
     if handler == H_COUNCIL:
         return _council_result(parsed, ctx)
+    if handler == H_HANDOFF:
+        return _handoff_result(parsed, ctx)
     if handler == H_RENDER:
         return _render_readiness_result()
     if handler == H_BLOCKED:
@@ -603,6 +606,71 @@ def _council_result(parsed, ctx=None) -> CommandResult:
     trail = decision_trail_from_log(events)
     body = readiness.lines() + ("", "── 결정 트레일 (누가 무엇을) ──") + trail
     return CommandResult.info("council", head + body)
+
+
+def _work_order_lines(p: dict) -> tuple:
+    """Render a persisted handoff/briefing payload as a specialist work order. Reads the
+    enriched briefing shape; falls back to the bare handoff fields when not enriched."""
+
+    out = [f"work order {p.get('handoff_id', '')} → {p.get('executor_role', '')}"
+           + ("  · ⚠ operator 승인 필요" if p.get("operator_required") else "")]
+    if p.get("goal"):
+        out.append(f"  목표: {p['goal']}")
+    if p.get("proposed_stack"):
+        summary = p.get("proposed_stack_summary")
+        out.append(f"  제안 스택: {p['proposed_stack']}" + (f" — {summary}" if summary else ""))
+    if p.get("stack_rationale"):
+        out.append(f"  선택 이유: {p['stack_rationale']}")
+    for r in p.get("rejected_options") or ():
+        out.append(f"  ✗ 탈락: {r.get('name', '')} — {r.get('why_not', '')}")
+    if p.get("coding_conventions"):
+        out.append(f"  코딩 컨벤션: {p['coding_conventions']}")
+    if p.get("design_system"):
+        out.append(f"  디자인 시스템: {p['design_system']}")
+    for n in p.get("integration_notes") or ():
+        out.append(f"  · API/infra: {n}")
+    for s in p.get("scope") or ():
+        out.append(f"  ☐ scope: {s}")
+    for s in p.get("forbidden_scope") or ():
+        out.append(f"  ⊘ 금지: {s}")
+    if p.get("test_strategy"):
+        out.append(f"  test 전략: {p['test_strategy']}")
+    for a in p.get("acceptance_criteria") or ():
+        out.append(f"  ✓ acceptance: {a}")
+    return tuple(out)
+
+
+def _handoff_result(parsed, ctx=None) -> CommandResult:
+    """`/handoff <session>` — the specialist work order from the replayed decision log: the
+    materialized handoff packet (goal / proposed stack + why / rejected options / coding
+    conventions / design system / API·infra / scope / test / acceptance). Reads the latest
+    handoff event's payload (enriched with the briefing). Honest if none recorded yet."""
+
+    env = getattr(ctx, "env", None)
+    args = getattr(parsed, "args", ()) or ()
+    session = (args[0] if args else "").strip()
+    if not session:
+        return CommandResult.info(
+            "handoff",
+            ("specialist work order 를 봅니다 — `/handoff <session>`.",
+             "PM brief + tech-lead decision + handoff 로 합성된 작업 지시(목표/제안 스택/선택 이유/"
+             "탈락안/컨벤션/디자인·API·infra/scope/test/acceptance)를 replay 합니다.",
+             "기록은 `decision_lane.record_lane_artifacts(handoff=..., briefing=...)` 가 남깁니다."))
+    try:
+        from forgekit_runtime.decision_lane import KIND_HANDOFF, replay_governance_log
+    except Exception:  # noqa: BLE001
+        return CommandResult.error("handoff", ("governance 런타임 미가용.",))
+    events = replay_governance_log(session, env=env)
+    handoffs = [e for e in events if e.kind == KIND_HANDOFF]
+    if not handoffs:
+        return CommandResult.info(
+            "handoff",
+            (f"handoff — session={session}: 기록된 work order 없음 "
+             "(tech-lead 서명 + handoff 발행 후 표면화).",))
+    latest = handoffs[-1]
+    head = (f"handoff packet — session={session}"
+            + ("" if latest.valid else "  · ✗ thin (설계 맥락 미비 — specialist 실행 불가)"),)
+    return CommandResult.info("handoff", head + _work_order_lines(latest.payload or {}))
 
 
 def _whoami_result(parsed) -> CommandResult:

--- a/docs/pm-techlead-lane.md
+++ b/docs/pm-techlead-lane.md
@@ -61,8 +61,10 @@ approval 분리)을 약화하지 않고 **설계 결정 표면에 구체화**한
 | `ConsultNote` | consult_id / topic / **by_role** / **to_roles**(≥1) / question | consult 를 typed artifact 로 (non-gating, anti-fake) |
 | `ParticipantPosition` | role / **stance** / position / concerns | 회의의 *실재* 단위 |
 | `MeetingRecord` | meeting_id / agenda / participants / decisions / escalated | 기록된 설계 회의 |
-| `TechLeadDecision` | meeting_ref / **design_system** / **coding_convention** / stack_decision / tradeoffs / approval_level / signoff_by / status | 기술 서명(5개 필수 필드 고정) |
-| `EngineerHandoff` | decision_ref / **executor_role**(단일) / scope / forbidden_scope / test_strategy / rollback_plan | 단일 executor 작업 지시 |
+| `TechLeadDecision` | meeting_ref / **design_system** / **coding_convention** / stack_decision / tradeoffs / **integration_notes**(API·infra) / approval_level / signoff_by / status | 기술 서명(5개 필수 필드 고정) |
+| `EngineerHandoff` | decision_ref / **executor_role**(단일) / scope / forbidden_scope / test_strategy / rollback_plan | 단일 executor 작업 지시(라우팅) |
+| `SpecialistBriefing` | goal / **proposed_stack** + 이유 / **rejected_options** / coding_conventions / design_system / integration_notes / scope / test / acceptance | specialist 가 받는 실제 work order(설계 맥락 포함) |
+| `RejectedOption` | name / **why_not** | 탈락한 스택 + 왜 (silent drop 금지) |
 
 모든 artifact 는 frozen dataclass + `to_dict` (직렬화/evidence 가능).
 
@@ -131,6 +133,29 @@ engineer 착수 (단일 executor)
 이는 autopilot 의 `can_specialist_execute`("no internal signoff, no
 execution")를 설계 결정 표면으로 옮긴 것이다. `decision=None` 또는
 `handoff=None` 이면 항상 False.
+
+### 4.2 Specialist work order (`SpecialistBriefing`) — "design 없이 바로 구현" 차단
+
+`EngineerHandoff` 는 **라우팅**(누구에게/scope/test)만 담는다. specialist 가
+실제로 받는 것은 `build_specialist_briefing(brief, decision, handoff)` 로 합성된
+**work order** 다 — PM 목표, 제안 스택 + **선택 이유**, **rejected_options**(stack
+비교에서 채택 안 된 옵션 + 왜 탈락했는지 = cons), coding conventions, design
+system, API/infra 고려(`integration_notes`), scope/forbidden_scope, test 전략,
+acceptance. 즉 specialist 는 설계 맥락을 **다시 추론하지 않고** 받는다.
+
+**Stronger gate (`can_specialist_start`)** — `can_engineer_start` 가 참이고 **그
+위에** 합성된 briefing 이 `validate_specialist_briefing == ()` 일 때만 착수.
+즉 서명된 결정 + 유효 handoff 라도 work order 에 목표/제안 스택/이유/탈락안/
+컨벤션/디자인시스템/scope/test/acceptance 중 하나라도 비면 **thin order 로
+거부**된다. 이것이 "설계 없이 바로 구현하는 흐름"을 줄이는 hard rail.
+`run_lane` 의 `engineer_may_start` 는 이 stronger gate 를 쓴다. valid 한
+decision 은 design_system/coding_convention/stack(±2 옵션, 각 pros+cons)을 이미
+보장하므로 — 정상 체인은 자동으로 briefing 도 유효(구성상 호환).
+
+`record_lane_artifacts(handoff=..., briefing=...)` 는 handoff 이벤트 payload 를
+work order 로 **풍부화**해 영속하고, console `/handoff <session>` 가 그것을
+replay 해 작업 지시를 렌더한다. evidence:
+`apps/forgekit-console/examples/pm-techlead-lane/specialist-briefing.json`.
 
 ### 4.1 approval ladder 와 operator 분리
 

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/__init__.py
@@ -24,6 +24,8 @@ from .schemas import (
     MeetingRecord,
     ParticipantPosition,
     PMBrief,
+    RejectedOption,
+    SpecialistBriefing,
     StackComparison,
     StackOption,
     TechLeadDecision,
@@ -33,13 +35,16 @@ from .validators import (
     validate_handoff,
     validate_meeting,
     validate_pm_brief,
+    validate_specialist_briefing,
     validate_stack_comparison,
     validate_tech_lead_decision,
 )
 from .lane import (
     GatewayRouting,
     LaneResult,
+    build_specialist_briefing,
     can_engineer_start,
+    can_specialist_start,
     handoff_to_engineer,
     route_to_tech_lead,
     run_lane,
@@ -105,13 +110,15 @@ __all__ = (
     # schemas
     "PMBrief", "StackOption", "StackComparison", "ConsultNote", "ParticipantPosition",
     "MeetingRecord", "TechLeadDecision", "EngineerHandoff",
+    "RejectedOption", "SpecialistBriefing",
     "DRAFT", "SIGNED_OFF", "CONDITIONAL", "BLOCKED", "ESCALATED", "NEEDS_INFO", "DISSENT_STANCES",
     # validators
     "validate_pm_brief", "validate_stack_comparison", "validate_consult", "validate_meeting",
-    "validate_tech_lead_decision", "validate_handoff",
+    "validate_tech_lead_decision", "validate_handoff", "validate_specialist_briefing",
     # lane
     "GatewayRouting", "LaneResult", "route_to_tech_lead", "tech_lead_decide",
-    "handoff_to_engineer", "can_engineer_start", "run_lane", "tech_lead_request_more_info",
+    "handoff_to_engineer", "can_engineer_start", "build_specialist_briefing",
+    "can_specialist_start", "run_lane", "tech_lead_request_more_info",
     # gateway packet (approve / reject / request-more-info)
     "GATEWAY_APPROVE", "GATEWAY_REJECT", "GATEWAY_REQUEST_INFO", "GATEWAY_VERDICTS",
     "GatewayPacket", "gateway_review", "validate_gateway_packet",

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/decision_log.py
@@ -152,6 +152,7 @@ def record_lane_artifacts(
     decision=None,
     approval=None,
     handoff=None,
+    briefing=None,
     env: Optional[Mapping[str, str]] = None,
     at: str = "",
 ) -> Tuple[GovernanceEvent, ...]:
@@ -163,7 +164,12 @@ def record_lane_artifacts(
     durable log preserves *what was decided* (design system / coding convention / stack /
     tradeoffs / acceptance), not just that a decision happened. ``payload`` is pure
     evidence — readiness keys only on ``valid``, never on the payload, so it can't fake a
-    gate. ``consult`` accepts a single :class:`ConsultNote` or an iterable of them."""
+    gate. ``consult`` accepts a single :class:`ConsultNote` or an iterable of them.
+
+    When a ``briefing`` (:class:`SpecialistBriefing`) is given, the handoff event is
+    enriched: its payload becomes the materialized work order (goal / proposed stack + why /
+    rejected options / conventions / design system / API·infra), and ``valid`` additionally
+    requires the briefing to carry that full design context (anti-thin-order)."""
 
     recorded = []
 
@@ -216,9 +222,14 @@ def record_lane_artifacts(
               getattr(approval, "decision_ref", ""), ap_payload)
     if handoff is not None:
         ok = (decision is not None) and (not validate_handoff(handoff, decision))
+        payload = _payload(handoff)
+        if briefing is not None:
+            from .validators import validate_specialist_briefing
+            ok = ok and (not validate_specialist_briefing(briefing))
+            payload = _payload(briefing)            # enrich: full work order is the payload
         _emit(KIND_HANDOFF, handoff.executor_role,
               f"handoff {handoff.handoff_id} → {handoff.executor_role}", ok,
-              handoff.handoff_id, _payload(handoff))
+              handoff.handoff_id, payload)
     return tuple(recorded)
 
 
@@ -299,6 +310,11 @@ def _trail_facts(ev: GovernanceEvent) -> str:
         return f"approved={p.get('approved', '')}"
     if k == KIND_HANDOFF:
         out = f"executor={p.get('executor_role', '')} · scope {len(p.get('scope') or [])}개"
+        # enriched (briefing) payload — surface the carried design context
+        if p.get("proposed_stack"):
+            out += f" · stack={p['proposed_stack']}"
+        if p.get("rejected_options"):
+            out += f" · 탈락 {len(p['rejected_options'])}개"
         return out + (" · operator 승인 필요" if p.get("operator_required") else "")
     return ""
 

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/lane.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/lane.py
@@ -28,6 +28,8 @@ from .schemas import (
     EngineerHandoff,
     MeetingRecord,
     PMBrief,
+    RejectedOption,
+    SpecialistBriefing,
     StackComparison,
     TechLeadDecision,
 )
@@ -35,6 +37,7 @@ from .validators import (
     validate_handoff,
     validate_meeting,
     validate_pm_brief,
+    validate_specialist_briefing,
     validate_tech_lead_decision,
 )
 
@@ -69,6 +72,7 @@ class LaneResult:
     routing: GatewayRouting
     decision: Optional[TechLeadDecision] = None
     handoff: Optional[EngineerHandoff] = None
+    briefing: Optional[SpecialistBriefing] = None
     engineer_may_start: bool = False
     operator_required: bool = False
     violations: Tuple[str, ...] = ()
@@ -79,6 +83,7 @@ class LaneResult:
             "routing": self.routing.to_dict(),
             "decision": self.decision.to_dict() if self.decision else None,
             "handoff": self.handoff.to_dict() if self.handoff else None,
+            "briefing": self.briefing.to_dict() if self.briefing else None,
             "engineer_may_start": self.engineer_may_start,
             "operator_required": self.operator_required,
             "violations": list(self.violations), "trace": list(self.trace),
@@ -113,6 +118,7 @@ def tech_lead_decide(
     *,
     design_system: str,
     coding_convention: str,
+    integration_notes: Tuple[str, ...] = (),
     risk_class: str = "",
     conditions: Tuple[str, ...] = (),
     rationale: str = "",
@@ -142,7 +148,8 @@ def tech_lead_decide(
     candidate = TechLeadDecision(
         decision_id=did, pm_brief_ref=brief.topic, meeting_ref=meeting.meeting_id,
         design_system=design_system, coding_convention=coding_convention,
-        stack_decision=stack, tradeoffs=stack.tradeoffs, risk_class=klass,
+        stack_decision=stack, tradeoffs=stack.tradeoffs,
+        integration_notes=tuple(integration_notes), risk_class=klass,
         approval_level=level, conditions=tuple(conditions),
         rationale=rationale or stack.rationale, signoff_by=signoff_by, status=status,
     )
@@ -197,6 +204,64 @@ def can_engineer_start(decision: Optional[TechLeadDecision],
     return True
 
 
+# --- specialist briefing (the materialized work order) -----------------------
+
+
+def build_specialist_briefing(
+    brief: Optional[PMBrief],
+    decision: TechLeadDecision,
+    handoff: EngineerHandoff,
+) -> SpecialistBriefing:
+    """Compose the full work order a specialist receives from the signed decision + handoff
+    (+ PM brief for the goal). The REJECTED options are derived from the stack comparison —
+    every non-recommended option, with its cons as 'why not' — so the specialist sees what
+    was weighed, not just the winner. Pure; the validator decides if it's startable."""
+
+    stack = decision.stack_decision
+    recommended = stack.recommended if stack else ""
+    rec_opt = stack.recommended_option() if stack else None
+    rejected = tuple(
+        RejectedOption(
+            name=o.name,
+            why_not="; ".join(o.cons) or o.risk or "근거 미기재",
+        )
+        for o in (stack.options if stack else ())
+        if o.name != recommended
+    )
+    goal = (f"{brief.problem} → {brief.user_value}"
+            if brief and (brief.problem or brief.user_value) else decision.rationale)
+    return SpecialistBriefing(
+        handoff_id=handoff.handoff_id, executor_role=handoff.executor_role,
+        decision_ref=decision.decision_id, goal=goal,
+        proposed_stack=recommended,
+        proposed_stack_summary=(rec_opt.summary if rec_opt else ""),
+        stack_rationale=(stack.rationale if stack else "") or decision.rationale,
+        rejected_options=rejected,
+        coding_conventions=decision.coding_convention, design_system=decision.design_system,
+        integration_notes=decision.integration_notes,
+        scope=handoff.scope, forbidden_scope=handoff.forbidden_scope,
+        test_strategy=handoff.test_strategy, rollback_plan=handoff.rollback_plan,
+        acceptance_criteria=handoff.acceptance_criteria,
+        operator_required=handoff.operator_required,
+    )
+
+
+def can_specialist_start(
+    brief: Optional[PMBrief],
+    decision: Optional[TechLeadDecision],
+    handoff: Optional[EngineerHandoff],
+) -> bool:
+    """The stronger gate: a specialist starts ONLY when :func:`can_engineer_start` holds AND
+    the materialized briefing carries the full design context (goal / stack + why / rejected
+    options / conventions / design system / scope / test / acceptance). This is what reduces
+    'design 없이 바로 구현' — a thin order without the design rationale is not startable."""
+
+    if not can_engineer_start(decision, handoff):
+        return False
+    briefing = build_specialist_briefing(brief, decision, handoff)
+    return not validate_specialist_briefing(briefing)
+
+
 def tech_lead_request_more_info(
     brief: PMBrief,
     meeting: MeetingRecord,
@@ -231,6 +296,7 @@ def run_lane(
     executor_role: str,
     scope: Tuple[str, ...],
     test_strategy: str,
+    integration_notes: Tuple[str, ...] = (),
     risk_class: str = "",
     conditions: Tuple[str, ...] = (),
     rationale: str = "",
@@ -240,8 +306,11 @@ def run_lane(
 ) -> LaneResult:
     """Run PM brief + meeting → gateway → tech-lead → engineer, end to end, with a trace.
 
-    Returns a :class:`LaneResult`; ``engineer_may_start`` is only True when every stage
-    is real and the decision cleared signoff. No fake stage can produce a startable handoff."""
+    Returns a :class:`LaneResult`; ``engineer_may_start`` is only True when every stage is
+    real, the decision cleared signoff, AND the materialized :class:`SpecialistBriefing`
+    carries the full design context (goal / stack + why / rejected options / conventions /
+    design system / scope / test / acceptance). No fake stage or thin order can produce a
+    startable handoff."""
 
     trace = []
     routing = route_to_tech_lead(brief, meeting)
@@ -252,8 +321,9 @@ def run_lane(
 
     decision = tech_lead_decide(
         brief, meeting, stack, design_system=design_system,
-        coding_convention=coding_convention, risk_class=risk_class,
-        conditions=conditions, rationale=rationale, signoff_by=signoff_by)
+        coding_convention=coding_convention, integration_notes=integration_notes,
+        risk_class=risk_class, conditions=conditions, rationale=rationale,
+        signoff_by=signoff_by)
     trace.append(f"tech-lead:{decision.status}/{decision.approval_level}")
 
     if decision.status not in (SIGNED_OFF, CONDITIONAL):
@@ -267,16 +337,21 @@ def run_lane(
         acceptance_criteria=brief.acceptance_criteria)
     trace.append(f"engineer:handoff→{executor_role}")
 
+    briefing = build_specialist_briefing(brief, decision, handoff)
+    b_viol = validate_specialist_briefing(briefing)
+    trace.append(f"briefing:{'ok' if not b_viol else 'thin'}")
+
     h_viol = validate_handoff(handoff, decision)
-    may_start = can_engineer_start(decision, handoff)
+    may_start = can_specialist_start(brief, decision, handoff)
     trace.append("engineer:start" if may_start else "engineer:blocked")
     return LaneResult(routing=routing, decision=decision, handoff=handoff,
-                      engineer_may_start=may_start,
+                      briefing=briefing, engineer_may_start=may_start,
                       operator_required=handoff.operator_required,
-                      violations=h_viol, trace=tuple(trace))
+                      violations=tuple(h_viol) + tuple(b_viol), trace=tuple(trace))
 
 
 __all__ = (
     "GatewayRouting", "LaneResult", "route_to_tech_lead", "tech_lead_decide",
-    "handoff_to_engineer", "can_engineer_start", "run_lane", "tech_lead_request_more_info",
+    "handoff_to_engineer", "can_engineer_start", "build_specialist_briefing",
+    "can_specialist_start", "run_lane", "tech_lead_request_more_info",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/schemas.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/schemas.py
@@ -195,6 +195,7 @@ class TechLeadDecision:
     coding_convention: str = ""                  # 코딩 컨벤션 결정/참조
     stack_decision: "StackComparison | None" = None
     tradeoffs: Tuple[str, ...] = ()
+    integration_notes: Tuple[str, ...] = ()      # design system / API / infra 고려사항
     risk_class: str = "safe"                     # safe / risky / blocked
     approval_level: str = ""                     # autopilot.approval L*
     conditions: Tuple[str, ...] = ()
@@ -208,7 +209,8 @@ class TechLeadDecision:
             "meeting_ref": self.meeting_ref, "design_system": self.design_system,
             "coding_convention": self.coding_convention,
             "stack_decision": self.stack_decision.to_dict() if self.stack_decision else None,
-            "tradeoffs": list(self.tradeoffs), "risk_class": self.risk_class,
+            "tradeoffs": list(self.tradeoffs), "integration_notes": list(self.integration_notes),
+            "risk_class": self.risk_class,
             "approval_level": self.approval_level, "conditions": list(self.conditions),
             "rationale": self.rationale, "signoff_by": self.signoff_by, "status": self.status,
         }
@@ -241,9 +243,95 @@ class EngineerHandoff:
                 "operator_required": self.operator_required}
 
 
+# --- specialist briefing (the materialized work order) -----------------------
+
+
+@dataclass(frozen=True)
+class RejectedOption:
+    """A stack option that was considered and NOT chosen — carried so the specialist
+    sees what was weighed and why it lost (no silent 'just use X')."""
+
+    name: str
+    why_not: str = ""                            # 왜 탈락했나 (cons/risk 요약)
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "why_not": self.why_not}
+
+
+@dataclass(frozen=True)
+class SpecialistBriefing:
+    """The full work briefing a specialist receives — composed from PM brief + tech-lead
+    decision + engineer handoff. A real-company work order, not a bare 'go build it':
+    goal, proposed stack + WHY, the REJECTED options, coding conventions, design-system,
+    API/infra considerations, scope, test strategy, and acceptance. Built by
+    :func:`build_specialist_briefing`; a briefing missing the design context is rejected by
+    :func:`validate_specialist_briefing`, so a specialist never starts off a thin order
+    (the point: reduce 'design 없이 바로 구현')."""
+
+    handoff_id: str
+    executor_role: str
+    decision_ref: str
+    goal: str = ""                               # PM 목표 (problem → user_value)
+    proposed_stack: str = ""                     # 채택된 스택/접근
+    proposed_stack_summary: str = ""
+    stack_rationale: str = ""                    # 왜 이 스택
+    rejected_options: Tuple[RejectedOption, ...] = ()   # 탈락안 + 왜
+    coding_conventions: str = ""
+    design_system: str = ""
+    integration_notes: Tuple[str, ...] = ()      # design system / API / infra 고려
+    scope: Tuple[str, ...] = ()
+    forbidden_scope: Tuple[str, ...] = ()
+    test_strategy: str = ""
+    rollback_plan: str = ""
+    acceptance_criteria: Tuple[str, ...] = ()
+    operator_required: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "handoff_id": self.handoff_id, "executor_role": self.executor_role,
+            "decision_ref": self.decision_ref, "goal": self.goal,
+            "proposed_stack": self.proposed_stack,
+            "proposed_stack_summary": self.proposed_stack_summary,
+            "stack_rationale": self.stack_rationale,
+            "rejected_options": [r.to_dict() for r in self.rejected_options],
+            "coding_conventions": self.coding_conventions, "design_system": self.design_system,
+            "integration_notes": list(self.integration_notes), "scope": list(self.scope),
+            "forbidden_scope": list(self.forbidden_scope), "test_strategy": self.test_strategy,
+            "rollback_plan": self.rollback_plan,
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "operator_required": self.operator_required,
+        }
+
+    def lines(self) -> Tuple[str, ...]:
+        """Operator/specialist-readable work order."""
+        out = [f"work order {self.handoff_id} → {self.executor_role}"
+               + ("  · ⚠ operator 승인 필요" if self.operator_required else ""),
+               f"  목표: {self.goal}",
+               f"  제안 스택: {self.proposed_stack}"
+               + (f" — {self.proposed_stack_summary}" if self.proposed_stack_summary else ""),
+               f"  선택 이유: {self.stack_rationale}"]
+        for r in self.rejected_options:
+            out.append(f"  ✗ 탈락: {r.name} — {r.why_not}")
+        out.append(f"  코딩 컨벤션: {self.coding_conventions}")
+        out.append(f"  디자인 시스템: {self.design_system}")
+        for n in self.integration_notes:
+            out.append(f"  · API/infra: {n}")
+        for s in self.scope:
+            out.append(f"  ☐ scope: {s}")
+        for s in self.forbidden_scope:
+            out.append(f"  ⊘ 금지: {s}")
+        out.append(f"  test 전략: {self.test_strategy}")
+        if self.rollback_plan:
+            out.append(f"  rollback: {self.rollback_plan}")
+        for a in self.acceptance_criteria:
+            out.append(f"  ✓ acceptance: {a}")
+        return tuple(out)
+
+
 __all__ = (
     "PMBrief", "StackOption", "StackComparison", "ConsultNote", "ParticipantPosition",
     "MeetingRecord", "TechLeadDecision", "EngineerHandoff",
+    "RejectedOption", "SpecialistBriefing",
     "DISSENT_STANCES", "ALL_STANCES",
     "DRAFT", "SIGNED_OFF", "CONDITIONAL", "BLOCKED", "ESCALATED", "NEEDS_INFO", "DECISION_STATUSES",
 )

--- a/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/validators.py
+++ b/packages/forgekit-runtime/src/forgekit_runtime/decision_lane/validators.py
@@ -33,6 +33,7 @@ from .schemas import (
     EngineerHandoff,
     MeetingRecord,
     PMBrief,
+    SpecialistBriefing,
     StackComparison,
     TechLeadDecision,
 )
@@ -229,8 +230,52 @@ def validate_handoff(handoff: EngineerHandoff, decision: TechLeadDecision) -> Tu
     return tuple(v)
 
 
+# --- specialist briefing (the materialized work order) -----------------------
+
+
+def validate_specialist_briefing(briefing: SpecialistBriefing) -> Tuple[str, ...]:
+    """Reject a thin work order. A real briefing carries the design context the specialist
+    needs to execute WITHOUT re-deriving it: goal, proposed stack + why, ≥1 rejected option,
+    coding conventions, design system, scope, test strategy, acceptance. ``()`` = the
+    specialist may start off it.
+
+    ``integration_notes`` (API/infra 고려) is carried through but not hard-required — its
+    presence depends on whether the decision recorded it; the design-context that a valid
+    :class:`TechLeadDecision` already guarantees IS required here."""
+
+    v = []
+    if _blank(briefing.handoff_id):
+        v.append("briefing: handoff_id 비어 있음")
+    if _blank(briefing.executor_role):
+        v.append("briefing: executor_role 비어 있음")
+    if _blank(briefing.goal):
+        v.append("briefing: goal(목표) 비어 있음 — 무엇을 왜 만드는지 없음")
+    if _blank(briefing.proposed_stack):
+        v.append("briefing: proposed_stack(제안 스택) 비어 있음")
+    if _blank(briefing.stack_rationale):
+        v.append("briefing: stack_rationale(선택 이유) 비어 있음")
+    if not briefing.rejected_options:
+        v.append("briefing: rejected_options 없음 — 비교 없이 단정한 스택")
+    else:
+        for r in briefing.rejected_options:
+            if _blank(r.name) or _blank(r.why_not):
+                v.append("briefing: 탈락안에 name/why_not 누락 — 근거 없는 탈락")
+                break
+    if _blank(briefing.coding_conventions):
+        v.append("briefing: coding_conventions 비어 있음")
+    if _blank(briefing.design_system):
+        v.append("briefing: design_system 비어 있음")
+    if not briefing.scope:
+        v.append("briefing: scope 비어 있음")
+    if _blank(briefing.test_strategy):
+        v.append("briefing: test_strategy 비어 있음")
+    if not briefing.acceptance_criteria:
+        v.append("briefing: acceptance_criteria 비어 있음 — 완료 기준 없는 인계 금지")
+    return tuple(v)
+
+
 __all__ = (
     "validate_pm_brief", "validate_stack_comparison", "validate_consult",
     "validate_meeting", "validate_tech_lead_decision", "validate_handoff",
-    "NON_EXECUTOR_ROLES",
+    "validate_specialist_briefing", "NON_EXECUTOR_ROLES",
 )

--- a/tests/forgekit/test_specialist_briefing.py
+++ b/tests/forgekit/test_specialist_briefing.py
@@ -1,0 +1,205 @@
+"""Specialist work order ENFORCEMENT — the materialized handoff packet.
+
+The lane proves the chain is real/replay-able; this proves the specialist receives a
+**full design briefing**, not a thin 'go build it'. The goal: reduce 'design 없이 바로 구현'
+by refusing to start a specialist off an order that lacks the design context.
+
+- **the briefing carries the design context** — goal, proposed stack + WHY, the REJECTED
+  options (derived from the stack comparison), coding conventions, design system, API/infra
+  notes, scope, test strategy, acceptance;
+- **a thin order is not startable** — ``can_specialist_start`` is stronger than
+  ``can_engineer_start``: a valid signed decision + handoff whose materialized briefing is
+  missing design context cannot start (anti 'just build it');
+- **rejected options are real** — every non-recommended stack option appears with its cons
+  as 'why not', so the loser isn't silently dropped;
+- **the work order is persisted + replay-able** — ``record_lane_artifacts(briefing=...)``
+  enriches the handoff event payload so ``/handoff`` can replay the full packet;
+- **integration_notes (API/infra) flow through** end to end.
+
+Hermetic: a tmp FORGEKIT_HOME isolates the log; identities via the registry SSoT.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _rel in (
+    "packages/forgekit-runtime/src",
+    "packages/forgekit-config/src",
+    "packages/forgekit-provider/src",
+    "packages/forgekit-contracts/src",
+    "packages/forgekit-goal/src",
+    "packages/nexus/src",
+    "apps/forgekit-console/src",
+):
+    _p = str(_ROOT / _rel)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from forgekit_runtime import decision_lane as D
+
+
+def _brief():
+    return D.PMBrief(topic="실시간 알림", problem="운영자가 실패를 늦게 안다",
+                     user_value="실패 즉시 통지", acceptance_criteria=("30초내 통지",),
+                     success_metrics=("MTTA<1m",))
+
+
+def _meeting():
+    parts = (D.ParticipantPosition("tech-lead", "support", "SSE 가자"),
+             D.ParticipantPosition("be", "conditional", "백프레셔 조건", concerns=("재연결",)))
+    return D.MeetingRecord(meeting_id="m1", topic="전송", agenda=("전송",),
+                           participants=parts, decisions=("SSE 채택",))
+
+
+def _stack():
+    return D.StackComparison(
+        decision_topic="전송", recommended="SSE",
+        options=(D.StackOption("SSE", summary="server-sent events", pros=("단순",), cons=("단방향",)),
+                 D.StackOption("WebSocket", pros=("양방향",), cons=("인프라 복잡", "비용"))),
+        rationale="단방향 알림은 SSE 로 충분", tradeoffs=("양방향 포기",))
+
+
+def _run(**kw):
+    return D.run_lane(_brief(), _meeting(), _stack(), design_system="forgekit-ds",
+                      coding_convention="ruff+black", executor_role="be",
+                      scope=("notify/sse.py",), test_strategy="unit+integration", **kw)
+
+
+# --- briefing composition ----------------------------------------------------
+
+
+class BriefingCompositionTests(unittest.TestCase):
+    def test_briefing_carries_full_design_context(self):
+        res = _run(integration_notes=("GET /events SSE", "Redis pub/sub"))
+        b = res.briefing
+        self.assertEqual(D.validate_specialist_briefing(b), ())
+        self.assertEqual(b.proposed_stack, "SSE")
+        self.assertIn("→", b.goal)                            # problem → user_value
+        self.assertEqual(b.coding_conventions, "ruff+black")
+        self.assertEqual(b.design_system, "forgekit-ds")
+        self.assertEqual(b.integration_notes, ("GET /events SSE", "Redis pub/sub"))
+        self.assertIn("30초내 통지", b.acceptance_criteria)
+
+    def test_rejected_options_derived_with_reasons(self):
+        b = _run().briefing
+        names = {r.name for r in b.rejected_options}
+        self.assertEqual(names, {"WebSocket"})                # everything not recommended
+        ws = next(r for r in b.rejected_options if r.name == "WebSocket")
+        self.assertIn("인프라 복잡", ws.why_not)               # cons carried as 'why not'
+
+    def test_work_order_lines_render(self):
+        joined = "\n".join(_run(integration_notes=("GET /events",)).briefing.lines())
+        for token in ("목표:", "제안 스택: SSE", "선택 이유:", "✗ 탈락: WebSocket",
+                      "코딩 컨벤션:", "디자인 시스템:", "API/infra: GET /events",
+                      "✓ acceptance:"):
+            self.assertIn(token, joined)
+
+
+# --- anti-thin-order gate ----------------------------------------------------
+
+
+class SpecialistGateTests(unittest.TestCase):
+    def test_full_lane_specialist_may_start(self):
+        res = _run()
+        self.assertTrue(res.engineer_may_start)
+        self.assertTrue(D.can_specialist_start(_brief(), res.decision, res.handoff))
+
+    def test_thin_briefing_blocks_start(self):
+        # a signed decision + valid handoff, but strip the design context off the briefing →
+        # can_engineer_start is True, can_specialist_start is False (the stronger gate).
+        res = _run()
+        self.assertTrue(D.can_engineer_start(res.decision, res.handoff))
+        thin = replace(res.briefing, proposed_stack="", stack_rationale="",
+                       rejected_options=(), coding_conventions="", design_system="")
+        self.assertTrue(D.validate_specialist_briefing(thin))   # rejected as thin
+
+    def test_briefing_validator_flags_each_missing_piece(self):
+        res = _run()
+        for field in ("goal", "proposed_stack", "stack_rationale", "coding_conventions",
+                      "design_system", "test_strategy"):
+            bad = replace(res.briefing, **{field: ""})
+            self.assertTrue(D.validate_specialist_briefing(bad), f"{field} 누락이 통과됨")
+        self.assertTrue(D.validate_specialist_briefing(replace(res.briefing, rejected_options=())))
+        self.assertTrue(D.validate_specialist_briefing(replace(res.briefing, scope=())))
+        self.assertTrue(D.validate_specialist_briefing(replace(res.briefing, acceptance_criteria=())))
+
+
+# --- persistence + replay ----------------------------------------------------
+
+
+class BriefingPersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+        self.env = {"FORGEKIT_HOME": self._home}
+
+    def test_briefing_enriches_handoff_payload(self):
+        res = _run(integration_notes=("GET /events",))
+        D.record_lane_artifacts("s1", brief=_brief(), meeting=_meeting(),
+                                decision=res.decision, handoff=res.handoff,
+                                briefing=res.briefing, env=self.env)
+        events = D.replay_governance_log("s1", env=self.env)
+        ho = next(e for e in events if e.kind == D.KIND_HANDOFF)
+        self.assertTrue(ho.valid)
+        self.assertEqual(ho.payload.get("proposed_stack"), "SSE")
+        self.assertTrue(ho.payload.get("rejected_options"))
+        self.assertEqual(ho.payload.get("integration_notes"), ["GET /events"])
+
+    def test_thin_briefing_recorded_invalid(self):
+        res = _run()
+        thin = replace(res.briefing, proposed_stack="", rejected_options=())
+        recs = D.record_lane_artifacts("s2", decision=res.decision, handoff=res.handoff,
+                                       briefing=thin, env=self.env)
+        ho = next(r for r in recs if r.kind == D.KIND_HANDOFF)
+        self.assertFalse(ho.valid)                            # thin order logged invalid
+
+    def test_trail_surfaces_stack_and_rejected(self):
+        res = _run()
+        D.record_lane_artifacts("s3", brief=_brief(), meeting=_meeting(),
+                                decision=res.decision, handoff=res.handoff,
+                                briefing=res.briefing, env=self.env)
+        events = D.replay_governance_log("s3", env=self.env)
+        trail = "\n".join(D.decision_trail_from_log(events))
+        self.assertIn("stack=SSE", trail)
+        self.assertIn("탈락", trail)
+
+
+# --- console /handoff surface ------------------------------------------------
+
+
+class HandoffSurfaceTests(unittest.TestCase):
+    def setUp(self):
+        self._home = tempfile.mkdtemp()
+
+    def _route(self, line):
+        import os
+        os.environ["FORGEKIT_HOME"] = self._home
+        from forgekit_console.commands.parser import parse_input
+        from forgekit_console.commands.router import build_default_context, route
+        return route(parse_input(line), build_default_context(Path(".")))
+
+    def test_handoff_renders_work_order(self):
+        res = _run(integration_notes=("GET /events",))
+        D.record_lane_artifacts("sh", brief=_brief(), meeting=_meeting(),
+                                decision=res.decision, handoff=res.handoff,
+                                briefing=res.briefing, env={"FORGEKIT_HOME": self._home})
+        joined = "\n".join(self._route("/handoff sh").lines)
+        self.assertIn("제안 스택: SSE", joined)
+        self.assertIn("✗ 탈락: WebSocket", joined)
+        self.assertIn("API/infra: GET /events", joined)
+
+    def test_handoff_usage_without_session(self):
+        self.assertIn("work order", "\n".join(self._route("/handoff").lines))
+
+    def test_handoff_no_record_is_honest(self):
+        joined = "\n".join(self._route("/handoff nope").lines)
+        self.assertIn("work order 없음", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #396

## 목적
ForgeKit 이 "명령 체계"가 아니라 "팀 운영 체계"가 되도록, specialist 가 받는 handoff 를 **설계 맥락이 담긴 work order** 로 강제한다. PM/tech-lead 가 "무엇을 어떤 스택으로 왜 구현할지"를 artifact 로 남긴 뒤에만 specialist 가 착수한다.

## 범위
- `packages/forgekit-runtime/src/forgekit_runtime/decision_lane/` — schemas / validators / lane / decision_log / __init__
- `apps/forgekit-console/.../commands/` — `/handoff` work order surface
- `tests/forgekit/test_specialist_briefing.py` · `docs/pm-techlead-lane.md` 4.2 · evidence

### 주요 변경
1. **`SpecialistBriefing` + `RejectedOption`** — specialist 가 받는 work order: 목표 / 제안 스택 + 이유 / **rejected options(+왜)** / coding conventions / design system / **integration_notes(API·infra)** / scope / test / acceptance. `lines()` 렌더 포함.
2. **`TechLeadDecision.integration_notes`** — API/infra 고려사항 필드 (design_system/coding_convention 형제).
3. **`build_specialist_briefing(brief, decision, handoff)`** — rejected_options 를 stack 비교에서 파생(cons=why_not), goal 은 brief problem→user_value.
4. **`validate_specialist_briefing`** — thin order 거부(설계 맥락 누락).
5. **`can_specialist_start`** — `can_engineer_start` + briefing 유효(stronger gate). `run_lane.engineer_may_start` 가 이를 사용 → "design 없이 바로 구현" 차단.
6. **`record_lane_artifacts(briefing=...)`** — handoff payload 를 work order 로 풍부화 영속, trail 에 stack/탈락 수.
7. **console `/handoff <session>`** — work order replay 렌더.

## 리스크
- 낮음. 추가적(additive). valid decision 은 design_system/convention/stack(±2옵션 pros+cons)을 이미 보장하므로 정상 체인은 briefing 도 자동 유효 → **기존 회귀 불변**(lane/readiness/enforcement 77 + 전체 green).
- anti-fake 보존: briefing payload 는 evidence 일 뿐 gate 아님(readiness 는 valid 로만 판단).

## 테스트
- `test_specialist_briefing.py` 신규 12 케이스 (carry / rejected 파생 / 렌더 / can_specialist_start vs can_engineer_start / 누락 필드별 거부 / payload 풍부화·thin=invalid / trail / `/handoff` surface)
- forgekit 1179 통과. 단 1 실패(`test_inline_flow_is_content_driven_not_a_fixed_box`)는 **본 변경 무관** 기존 TUI inline 높이 환경 flake — #384 에서 CI(no-TTY ubuntu) green 확인됨.

## 이슈 linkage
- Closes #396 · 후속: #380/#384(payload·consult·trail) 위에 쌓음
- SSoT: `docs/pm-techlead-lane.md` 4.2, evidence: `apps/forgekit-console/examples/pm-techlead-lane/specialist-briefing.json`

## Audit
- 5 commit (✨ schema · ✨ validate/build/gate · ✨ payload+surface · ✅ tests · 📝 docs+evidence), 모두 commit-governance 가드 통과
- no fake meeting/signoff/thin-order, no auto-merge (draft 까지만)