### PR TITLE
✨ slash palette substring fallback — 의미있는 단어 dead-end 제거

### DIFF
--- a/apps/forgekit-console/examples/tui-palette-below/_regen_matching.py
+++ b/apps/forgekit-console/examples/tui-palette-below/_regen_matching.py
@@ -1,0 +1,37 @@
+"""Regenerate palette-matching.txt — prefix-first + substring fallback (deterministic, pure).
+
+Proves the slash palette is no longer prefix-only: a meaningful word that no command STARTS
+with previously dead-ended to an empty palette and now reaches the command that CONTAINS it,
+WITHOUT widening any prefix result (zero regression). Pure (no terminal).
+재현: tests/forgekit/test_palette.py · tests/forgekit/test_parser.py
+"""
+
+from __future__ import annotations
+
+from forgekit_console.commands.parser import palette_matches
+
+
+def names(q):
+    return [c.name for c in palette_matches(q)]
+
+
+def banner(t):
+    print("\n" + "=" * 78 + f"\n{t}\n" + "=" * 78)
+
+
+print("ForgeKit console — slash palette matching (prefix-first + substring fallback)")
+print("재현: tests/forgekit/test_palette.py · test_parser.py")
+
+banner("PREFIX (기존 동작·순서 유지 — fallback 이 넓히지 않음)")
+for q in ("/st", "/he", "/p", "/a"):
+    print(f"  {q:<10} → {names(q)}")
+
+banner("SUBSTRING FALLBACK (prefix 0건 → 이전엔 빈 palette = dead-end)")
+for q in ("/improve", "/blue", "/observer"):
+    print(f"  {q:<10} → {names(q)}")
+
+banner("NONSENSE (정직 — 여전히 빈 결과)")
+for q in ("/zzz", "/qqqq"):
+    print(f"  {q:<10} → {names(q)}")
+
+print("\n(끝) — prefix 우선, prefix 0건일 때만 substring · 회귀 0 · 가짜 0")

--- a/apps/forgekit-console/examples/tui-palette-below/palette-matching.txt
+++ b/apps/forgekit-console/examples/tui-palette-below/palette-matching.txt
@@ -1,0 +1,25 @@
+ForgeKit console — slash palette matching (prefix-first + substring fallback)
+재현: tests/forgekit/test_palette.py · test_parser.py
+
+==============================================================================
+PREFIX (기존 동작·순서 유지 — fallback 이 넓히지 않음)
+==============================================================================
+  /st        → ['status']
+  /he        → ['help', 'hephaistos']
+  /p         → ['paste', 'provider', 'pm-agent', 'planning-agent']
+  /a         → ['about', 'agents', 'always-on', 'auto', 'autopilot', 'attach']
+
+==============================================================================
+SUBSTRING FALLBACK (prefix 0건 → 이전엔 빈 palette = dead-end)
+==============================================================================
+  /improve   → ['self-improve']
+  /blue      → ['red-blue']
+  /observer  → ['ops-observer']
+
+==============================================================================
+NONSENSE (정직 — 여전히 빈 결과)
+==============================================================================
+  /zzz       → []
+  /qqqq      → []
+
+(끝) — prefix 우선, prefix 0건일 때만 substring · 회귀 0 · 가짜 0

--- a/apps/forgekit-console/src/forgekit_console/commands/parser.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/parser.py
@@ -40,6 +40,14 @@ def palette_matches(
 
     Empty when the line isn't a slash. For ``/`` it returns every command; for
     ``/st`` it returns commands whose name starts with ``st``.
+
+    Matching is **prefix-first with a substring fallback**: prefix matches are returned
+    as-is (so ``/st`` → ``status`` and ``/p`` → the p-prefixed set keep their order). Only
+    when NO command name starts with the query does it fall back to substring matches — so a
+    meaningful word that previously dead-ended to an EMPTY palette now reaches the command
+    that contains it (``/improve`` → ``self-improve``, ``/blue`` → ``red-blue``,
+    ``/observer`` → ``ops-observer``). The fallback never shadows prefix results, so existing
+    prefix behaviour is unchanged — it only turns dead-ends into hits.
     """
 
     raw = (raw or "").strip()
@@ -49,7 +57,11 @@ def palette_matches(
     cmds = tuple(commands) if commands is not None else load_commands()
     if not prefix:
         return cmds
-    return tuple(c for c in cmds if c.name.startswith(prefix))
+    starts = tuple(c for c in cmds if c.name.startswith(prefix))
+    if starts:
+        return starts
+    # no prefix hit → substring fallback (dead-end → reachable), source order preserved.
+    return tuple(c for c in cmds if prefix in c.name)
 
 
 __all__ = ("parse_input", "palette_matches")

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -43,6 +43,12 @@ flow 를 **14줄 고정 박스**로 잘라, 출력이 길어지면 이전 내용
   사라지지 않는다.
 - `/` 입력 시 palette 가 **입력 bar 바로 아래**(flush, gap ≈ 0)에 열리고, composer 가 위로 자란다
   (command area — bounded pane 아님). 측정: `test_tui_palette_below` · `test_inline_accumulating_flow`.
+- **매칭은 prefix-first + substring fallback** (`commands/parser.py` `palette_matches`): 이름이
+  query 로 시작하는 명령이 있으면 그 set 을 그대로(기존 동작·순서 유지), **하나도 없을 때만**
+  substring fallback 으로 넘어가 query 를 포함하는 명령을 surface 한다 — 의미 있는 단어가 빈
+  palette 로 dead-end 되던 것을 해소(`/improve`→`self-improve`, `/blue`→`red-blue`,
+  `/observer`→`ops-observer`). fallback 은 prefix 결과를 절대 넓히지 않아 회귀 0. 측정:
+  `test_palette`·`test_parser`, 증거 `examples/tui-palette-below/palette-matching.txt`.
 
 > **정직한 한계:** 이건 "viewport 까지 누적 + 그 뒤 단일 스크롤"이지 **진짜 terminal-native
 > scrollback 누적(print-flow)은 아직 아니다.** Textual inline 은 매 프레임 region 을 다시 그려서,

--- a/tests/forgekit/test_palette.py
+++ b/tests/forgekit/test_palette.py
@@ -31,6 +31,24 @@ class RefilterTests(unittest.TestCase):
         s = P.refilter("/he", _CMDS)
         self.assertEqual([c.name for c in s.matches], ["help", "hephaistos"])
 
+    def test_substring_fallback_when_no_prefix_match(self) -> None:
+        # a meaningful word that no command STARTS with previously dead-ended to an empty
+        # palette; it now reaches the command that CONTAINS it (prefix-first, then fallback).
+        self.assertIn("self-improve", {c.name for c in P.refilter("/improve", _CMDS).matches})
+        self.assertIn("red-blue", {c.name for c in P.refilter("/blue", _CMDS).matches})
+        self.assertIn("ops-observer", {c.name for c in P.refilter("/observer", _CMDS).matches})
+
+    def test_prefix_wins_over_substring(self) -> None:
+        # when a prefix match exists, the fallback must NOT widen the set (no regression):
+        # `/p` stays exactly the p-prefixed commands even though many names contain 'p'.
+        names = [c.name for c in P.refilter("/p", _CMDS).matches]
+        self.assertTrue(all(n.startswith("p") for n in names))
+        self.assertNotIn("copy", names)        # contains 'p' but is NOT surfaced (prefix wins)
+        self.assertNotIn("self-improve", names)
+
+    def test_substring_fallback_still_empty_for_nonsense(self) -> None:
+        self.assertEqual(P.refilter("/zzz", _CMDS).matches, ())
+
 
 class CycleTests(unittest.TestCase):
     def test_tab_from_empty_selects_first(self) -> None:

--- a/tests/forgekit/test_parser.py
+++ b/tests/forgekit/test_parser.py
@@ -53,6 +53,12 @@ class PaletteTests(unittest.TestCase):
         names = {c.name for c in palette_matches("/a")}
         self.assertEqual(names, {"agents", "about", "always-on", "auto", "autopilot", "attach"})
 
+    def test_substring_fallback_only_when_no_prefix(self) -> None:
+        # prefix exists → exact prefix set (no widening); no prefix → substring fallback.
+        self.assertEqual({c.name for c in palette_matches("/st")}, {"status"})  # unchanged
+        self.assertIn("self-improve", {c.name for c in palette_matches("/improve")})
+        self.assertEqual(palette_matches("/zzz"), ())  # nonsense still empty (honest)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #400

## ✨ 과제 내용
slash palette 매칭을 **prefix-first + substring fallback** 로 — Claude 처럼 단어로도 닿게.

기존 `palette_matches` 는 prefix-only 라 이름이 query 로 시작하지 않으면 빈 palette 로 dead-end 됐다. 이제 prefix 매치가 있으면 그 set 을 그대로(순서·동작 유지) 반환하고, **0건일 때만** substring fallback 으로 query 를 포함하는 명령을 surface 한다.

- `/improve` → `self-improve`, `/blue` → `red-blue`, `/observer` → `ops-observer` (이전엔 모두 빈 결과)
- prefix 매치가 있으면 fallback 이 **절대 그 set 을 넓히지 않음** → `/p` 는 여전히 p-prefixed 만(copy/self-improve 안 섞임), `/st`·`/he`·`/a` 불변 = **회귀 0**
- nonsense(`/zzz`)는 여전히 빈 결과(정직)

**범위/리스크:** 순수 매처(`commands/parser.py`) 한 함수. fallback 은 prefix 결과 비-shadow 라 기존 prefix 테스트 그대로 통과.

**테스트:** `test_palette`(substring 도달 + prefix-wins + nonsense) + `test_parser`(prefix 0건일 때만 fallback). 25 OK.

## :camera_with_flash: 스크린샷(선택)
`apps/forgekit-console/examples/tui-palette-below/palette-matching.txt` — prefix/fallback/nonsense 실측.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs: `forgekit-console-ui.md` §1 에 매칭 규칙 기술.
- prefix-first 설계로 "회귀 없이" 원칙 준수하며 dead-end 만 hits 로 전환.
