### PR TITLE
✨ process feed active-state — 진행 중 단계 가시성

### DIFF
--- a/apps/forgekit-console/examples/tui-process-feed/active-state.txt
+++ b/apps/forgekit-console/examples/tui-process-feed/active-state.txt
@@ -1,0 +1,13 @@
+forgekit process feed — active-state 가시성 (running ▸ vs done •)
+재현: tests/forgekit/test_tui_process_feed.py (ProcessFeedRenderTests)
+======================================================================
+turn mid-flight — Generating 이 진행 중(active), 앞 단계는 완료:
+
+  [#00d8f0]•[/#00d8f0] [dim]Routing /usage[/dim] [dim](0.2s)[/dim]
+  [#00d8f0]•[/#00d8f0] [dim]Routed[/dim] [dim]usage[/dim]
+  [#00d8f0]•[/#00d8f0] [dim]Submitting to ollama[/dim] [dim](0.3s)[/dim]
+  [#00d8f0]•[/#00d8f0] [dim]Sent[/dim] [dim]Ollama[/dim]
+  [b #00d8f0]▸[/b #00d8f0] [#00d8f0]Generating[/#00d8f0] [dim]…[/dim]
+
+관찰: 완료 단계 = dim • + dim 라벨(+실측 (N.Ns)); 진행 단계 = bold accent ▸ + 밝은 라벨 + … (가짜 duration 없음).
+순수 status==RUNNING 기반 · 가짜 spinner/typing 0.

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -750,22 +750,28 @@ def result_block(title: str, lines: Sequence[str]) -> Tuple[str, ...]:
 
 
 def process_feed_lines(events: Sequence) -> Tuple[str, ...]:
-    """Render process events as compact, dim timeline lines (Claude tone, ForgeKit verbs).
+    """Render process events as compact timeline lines (Claude tone, ForgeKit verbs).
 
-    `• <label> <detail> (<dur>s)  <status>` — the dot colour is the severity, the whole
-    line is dim (a step lighter than the assistant body). Running → `…`; blocked/error
-    → `— <reason>`; done → a quiet `done`. Duration only shows when it was measured."""
+    The ACTIVE (running) step stands out — a bold accent ``▸`` marker + a NON-dim label —
+    so the operator sees "what's happening now" at a glance; finished steps stay quiet
+    (a dim ``•`` + dim label). The dot colour is the severity. Running → ``…``; blocked/error
+    → ``— <reason>``; done → quiet. Duration only shows when it was MEASURED (no fake ~1s).
+    The active distinction is purely ``status``-driven — never a fake spinner/typing."""
 
     from . import process_events as pe
 
     out = []
     for ev in events:
-        dot = {pe.SEV_WARN: _WARN, pe.SEV_ERROR: _ERR}.get(ev.severity, _ACCENT)
         detail = f" [dim]{ev.detail}[/dim]" if ev.detail else ""
         dur = f" [dim]({ev.duration_ms / 1000:.1f}s)[/dim]" if ev.duration_ms else ""
         if ev.status == pe.ST_RUNNING:
-            tail = " [dim]…[/dim]"
-        elif ev.status == pe.ST_BLOCKED:
+            # active step: bold accent marker + bright label (the "now" line).
+            out.append(
+                f"[b {_ACCENT}]▸[/b {_ACCENT}] [{_ACCENT}]{ev.label}[/{_ACCENT}]"
+                f"{detail}{dur} [dim]…[/dim]")
+            continue
+        dot = {pe.SEV_WARN: _WARN, pe.SEV_ERROR: _ERR}.get(ev.severity, _ACCENT)
+        if ev.status == pe.ST_BLOCKED:
             tail = f" [{_WARN}]— {ev.detail or 'blocked'}[/{_WARN}]"
             detail = ""  # the reason is in the tail
         elif ev.status == pe.ST_FAILED:

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -230,5 +230,9 @@ ForgeKit 콘솔은 **full-screen Textual TUI** (alternate screen + mouse capture
   반영. 가짜 typing 애니메이션 없음.
 - **history**: turn 단위 group(새 입력 시 reset), 최근 ~6개만 노출 — 무한 누적 없음. idle→빈
   surface(0행). clear 시 feed 도 정리.
+- **active-state 가시성**: 실행 중(running) 이벤트는 **bold accent `▸` 마커 + 밝은 라벨**로
+  도드라지고(=지금 일어나는 일), 끝난 이벤트는 조용한 dim `•` + dim 라벨로 가라앉는다. 순수
+  `status==RUNNING` 기반 — 가짜 spinner/typing 아님. running 은 실측 duration 이 없으므로 정직하게
+  `…` 만(가짜 ~1초 없음), 끝나면 실측 `(N.Ns)`. 검증 `test_tui_process_feed`(ProcessFeedRenderTests).
 
 증거: `examples/tui-process-feed/timeline.txt`, 테스트 `test_tui_process_feed`.

--- a/tests/forgekit/test_tui_process_feed.py
+++ b/tests/forgekit/test_tui_process_feed.py
@@ -155,5 +155,51 @@ class ProcessFeedPilotTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn("copy_failed", self._kinds(app))
 
 
+class ProcessFeedRenderTests(unittest.TestCase):
+    """The feed render must make the ACTIVE (running) step stand out from finished steps,
+    purely from real status — never a fake spinner/typing."""
+
+    def _feed(self):
+        from forgekit_console.tui import process_events as pe
+        t = {"v": 0.0}
+        feed = pe.ProcessFeed(clock=lambda: t["v"])
+        return feed, t, pe
+
+    def test_running_event_is_visually_active(self):
+        from forgekit_console.tui import render, theme
+        feed, t, pe = self._feed()
+        feed.start(pe.KIND_SUBMIT_START, "Submitting to ollama")
+        line = render.process_feed_lines(feed.recent())[0]
+        # active marker (▸) + accent-coloured label + the honest running ellipsis
+        self.assertIn("▸", line)
+        self.assertIn(theme.ACCENT_PRIMARY, line)
+        self.assertIn("…", line)
+        # the active label is NOT wrapped in dim (it is the bright "now" line)
+        self.assertNotIn(f"[dim]Submitting to ollama", line)
+
+    def test_finished_event_is_quiet_dim(self):
+        from forgekit_console.tui import render
+        feed, t, pe = self._feed()
+        ev = feed.start(pe.KIND_SUBMIT_START, "Submitting")
+        t["v"] = 1.0
+        feed.finish(ev, pe.ST_DONE)
+        line = render.process_feed_lines(feed.recent())[0]
+        self.assertIn("•", line)            # quiet dot, not the active marker
+        self.assertNotIn("▸", line)
+        self.assertIn("[dim]Submitting[/dim]", line)
+        self.assertIn("(1.0s)", line)       # measured duration shown
+
+    def test_running_vs_done_render_differently(self):
+        from forgekit_console.tui import render
+        feed, t, pe = self._feed()
+        done = feed.start(pe.KIND_ROUTE_START, "Routing")
+        t["v"] = 0.4
+        feed.finish(done, pe.ST_DONE)
+        feed.start(pe.KIND_GENERATE_START, "Generating")   # still running
+        lines = render.process_feed_lines(feed.recent())
+        self.assertIn("•", lines[0])   # finished route = quiet dot
+        self.assertIn("▸", lines[1])   # active generate = active marker
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #402

## ✨ 과제 내용
process event feed 의 **active-state 가시성** — operator 가 "지금 무슨 일이 일어나는지" 한눈에.

feed(`#livestatus`)는 이미 실제 이벤트(route/submit/generate/copy/…)를 렌더하지만 모든 줄을 `• [dim]label[/dim]` 로 그려 running 과 done 이 거의 구분 안 됐다. 이제:
- **running** = bold accent `▸` 마커 + 밝은 라벨 + `…` (지금 일어나는 일)
- **done/instant** = 기존 조용한 dim `•` + dim 라벨 + 실측 `(N.Ns)`
- **blocked/failed** = 기존 warn/err tail 유지

**honesty rails:** 순수 `status==RUNNING` 기반(가짜 spinner/typing 0). running 은 실측 duration 이 없으니 `…` 만(가짜 ~1초 없음), 끝나면 실측 `(N.Ns)`. 이벤트 모델·순서·duration 실측은 그대로 — 색/마커만 변경.

**테스트:** `ProcessFeedRenderTests` 3개 — running=▸+accent 라벨+…(non-dim), done=•+dim+실측, 동시 렌더 시 마커 구분. 기존 모델/pilot 테스트 그대로 통과. 타깃 회귀 105 OK.

## :camera_with_flash: 스크린샷(선택)
`apps/forgekit-console/examples/tui-process-feed/active-state.txt` — turn mid-flight 렌더 실측(running `▸ Generating` vs done `•`).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs: `forgekit-console-ui.md` §7 에 active-state 규칙 기술.
