### PR TITLE
✨ transcript 응답 role 마커 — free-text 응답 turn 가시성

### DIFF
--- a/apps/forgekit-console/examples/tui-ux/response-marker.txt
+++ b/apps/forgekit-console/examples/tui-ux/response-marker.txt
@@ -1,0 +1,14 @@
+forgekit transcript — turn 마커 vocabulary (› you · ● assistant · » command)
+재현: tests/forgekit/test_tui_response_marker.py
+======================================================================
+free-text 응답(전): role 마커 없이 본문만 echo 뒤에 떠서 응답 시작 구분 어려움
+free-text 응답(후): 첫 비어있지 않은 줄에 magenta ● 마커(렌더 전용, /copy 본문엔 없음)
+
+  [#00d8f0]›[/#00d8f0] 설명해줘            ← 사용자 turn (cyan ›)
+  [b #f23ccf]●[/b #f23ccf] 응답 첫 문단입니다.
+
+  두 번째 문단으로 이어집니다.
+
+  마무리 문단.
+
+관찰: ● 는 첫 비어있지 않은 줄 한 곳에만(magenta=brand kit half). 빈 줄/이후 줄 미표시. /copy 는 마커 제외 plain-text.

--- a/apps/forgekit-console/src/forgekit_console/tui/app.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/app.py
@@ -1161,7 +1161,9 @@ class ForgekitConsoleApp(App):
 
         lines = list(result.to_lines())
         receipt = lines.pop() if lines else ""   # the trailing dim receipt line
-        chunks = list(render.chunk_result_lines(lines))
+        # mark the response's first line with the assistant marker (●) so a free-text
+        # response is a distinct turn (mirrors `›` you / `»` command), then chunk-reveal.
+        chunks = list(render.mark_response_chunks(render.chunk_result_lines(lines)))
         self._gen_ev = self._feed_emit("start", _pe.KIND_GENERATE_START, "Generating")
         self._gen_chunks = 0
         # the FIRST chunk lands immediately (snappy); the rest reveal on a timer.

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -783,6 +783,33 @@ def process_feed_lines(events: Sequence) -> Tuple[str, ...]:
     return tuple(out)
 
 
+# The assistant response marker — magenta ● (the "kit" half of the brand), completing the
+# transcript turn vocabulary alongside the cyan `›` you-marker and the `»` command-result
+# header. A free-text LLM response otherwise had NO role marker (body straight after the
+# echo), so a turn's response start was hard to scan. Magenta keeps it distinct from the
+# cyan status dots / you-marker.
+RESPONSE_MARKER = f"[b {_ACCENT2}]●[/b {_ACCENT2}]"
+
+
+def mark_response_chunks(chunks: Sequence[Sequence[str]]) -> Tuple[Tuple[str, ...], ...]:
+    """Prefix the FIRST non-empty response line (across all chunks) with the assistant
+    marker, so a free-text response reads as a distinct turn. Pure: exactly one line is
+    marked; leading blank lines are left untouched; chunk shape is preserved."""
+
+    out = []
+    marked = False
+    for chunk in chunks:
+        new = []
+        for ln in chunk:
+            if not marked and (ln or "").strip():
+                new.append(f"{RESPONSE_MARKER} {ln}")
+                marked = True
+            else:
+                new.append(ln)
+        out.append(tuple(new))
+    return tuple(out)
+
+
 def chunk_result_lines(lines: Sequence[str], max_lines: int = 3) -> Tuple[Tuple[str, ...], ...]:
     """Group response lines into small reveal chunks for progressive rendering.
 
@@ -814,4 +841,5 @@ __all__ = (
     "status_pill", "hint_line", "help_sections", "selection_copy_lines",
     "help_panel_document", "help_tab_strip", "help_body", "default_help_tab",
     "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
+    "RESPONSE_MARKER", "mark_response_chunks",
 )

--- a/docs/forgekit-console-ui.md
+++ b/docs/forgekit-console-ui.md
@@ -26,6 +26,12 @@ Composer                 ← inline 에서 dock:bottom. full 에서는 1fr flow 
 child** 다. 첫 진입엔 보이고(첫 인상), 대화가 쌓여 viewport 를 넘으면 자연히 **위로 스크롤되어
 사라진다**(고정 panel 로 공간을 영구 점유하지 않음). inline 은 compact, full 은 hero→compact.
 
+**transcript turn 마커 vocabulary:** 한 turn 을 스캔하기 쉽게 역할별 마커를 둔다 — 사용자 입력은
+cyan `›`(`write_echo`), slash 결과는 `» <title>`(`result_block`), **free-text LLM 응답은 magenta
+`●`**(`render.RESPONSE_MARKER`, 응답 첫 비어있지 않은 줄에 1회). 예전엔 free-text 응답이 마커 없이
+echo 뒤에 본문만 떠서 응답 시작 구분이 어려웠다. 마커는 **렌더 전용** — `/copy` plain-text 엔 미포함.
+측정: `test_tui_response_marker`, 증거 `examples/tui-ux/response-marker.txt`.
+
 **mode 전환(Shift+Tab)은 ephemeral:** 예전엔 `_cycle_runtime_mode` 가 매 키프레스마다
 `transcript.write(runtime_mode_line)` 해서 대화 로그를 mode 줄로 도배했다. 이제 **transcript append
 0** — 현재 mode 는 **교체형 live surface** 에만: `#issue`(`◆ <mode> · routing …`) + 하단 `#hint`

--- a/tests/forgekit/test_tui_response_marker.py
+++ b/tests/forgekit/test_tui_response_marker.py
@@ -1,0 +1,110 @@
+"""Transcript turn vocabulary — free-text assistant responses get a role marker.
+
+A slash result is headed by ``»`` and a user turn by ``›``, but a free-text LLM response
+had NO role marker — its body landed straight after the echo, so the response start was
+hard to scan in a long session. ``render.mark_response_chunks`` now prefixes the response's
+first non-empty line with the assistant marker (magenta ``●``). Pure render proof + a live
+pilot proof that exactly one marker appears at the response start (not on every line).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from forgekit_console.tui import render
+
+_TEXTUAL = importlib.util.find_spec("textual") is not None
+
+
+class MarkResponseChunksTests(unittest.TestCase):
+    def test_marks_first_nonempty_line_once(self) -> None:
+        chunks = render.chunk_result_lines(["첫 줄입니다.", "", "둘째 문단."])
+        marked = render.mark_response_chunks(chunks)
+        flat = [ln for ch in marked for ln in ch]
+        joined = "\n".join(flat)
+        self.assertEqual(joined.count(render.RESPONSE_MARKER), 1)   # exactly one marker
+        self.assertTrue(flat[0].startswith(render.RESPONSE_MARKER))  # on the first line
+        self.assertIn("첫 줄입니다.", flat[0])
+
+    def test_leading_blank_lines_untouched_marker_on_first_content(self) -> None:
+        chunks = (("", "", "본문 시작"),)
+        marked = render.mark_response_chunks(chunks)
+        flat = [ln for ch in marked for ln in ch]
+        self.assertEqual(flat[0], "")                               # blank stays blank
+        self.assertTrue(any(ln.startswith(render.RESPONSE_MARKER) and "본문 시작" in ln
+                            for ln in flat))
+
+    def test_empty_input_no_marker(self) -> None:
+        self.assertEqual(render.mark_response_chunks(()), ())
+        only_blank = render.mark_response_chunks((("", ""),))
+        self.assertNotIn(render.RESPONSE_MARKER, "\n".join(only_blank[0]))
+
+    def test_marker_is_brand_secondary(self) -> None:
+        from forgekit_console.tui import theme
+        self.assertIn(theme.ACCENT_SECONDARY, render.RESPONSE_MARKER)
+
+
+def _svc():
+    """A live provider stub returning a 2-paragraph body → real chunk reveal."""
+
+    from forgekit_console.chat import models as m
+
+    body = "응답 첫 문단입니다.\n\n응답 둘째 문단입니다."
+
+    class Svc:
+        def submit(self, t, **_):
+            return m.SubmitResult(
+                ok=True, mode=m.MODE_LIVE, category=m.CAT_OK, text=body,
+                provider_id="ollama", provider_label="Ollama",
+                source=m.SOURCE_LOCAL_DEFAULT, model="g",
+            )
+    return Svc()
+
+
+@unittest.skipUnless(_TEXTUAL, "textual 필요")
+class ResponseMarkerPilotTests(unittest.IsolatedAsyncioTestCase):
+    def _app(self):
+        from forgekit_console.commands.registry import load_agents, load_commands
+        from forgekit_console.commands.router import ConsoleContext
+        from forgekit_console.tui.app import ForgekitConsoleApp
+        ctx = ConsoleContext(repo_root=Path("/tmp/repo"), agents=load_agents(),
+                             commands=load_commands())
+        return ForgekitConsoleApp(repo_root=Path("/tmp/repo"), context=ctx, submit_service=_svc(),
+                                  config={"primary_provider": "ollama", "linked_providers": ["ollama"]})
+
+    async def test_free_text_response_has_one_marker(self) -> None:
+        app = self._app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.query_one("#prompt").value = "설명해줘"
+            await pilot.press("enter")
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            for _ in range(40):
+                await pilot.pause(0.02)
+            # the response really landed (copyable store has the body, marker-free)
+            resp = app._store.last_response() or ""
+            self.assertIn("응답 첫 문단", resp)
+            self.assertNotIn("●", resp)                 # marker is render-only, not in /copy
+            # the rendered transcript shows the marker glyph exactly once (response start)
+            self.assertEqual(_rendered_text(app).count("●"), 1)
+
+
+def _rendered_text(app) -> str:
+    """Best-effort plain text of the transcript RichLog (joined strip text)."""
+
+    out = []
+    for strip in app._transcript.lines:
+        try:
+            out.append(strip.text)
+        except AttributeError:
+            out.append(str(strip))
+    return "\n".join(out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #404

## ✨ 과제 내용
transcript **turn 마커 vocabulary** 완성 — free-text LLM 응답에 role 마커 추가.

기존: 사용자 입력 `›`(cyan), slash 결과 `» <title>` 는 마커가 있지만 **free-text 응답은 role 마커가 없어** echo 뒤에 본문만 떠서 응답 시작 구분이 어려웠다. 이제 응답 첫 비어있지 않은 줄에 **magenta `●`**(brand kit half) 마커를 붙여 turn 구조를 완성한다 — `›` you · `●` assistant · `» ` command.

- `render.RESPONSE_MARKER` + `mark_response_chunks`: 첫 비어있지 않은 줄 **1회만** 마킹, 빈 줄/이후 줄 untouched, chunk 모양 보존
- `app._reveal_result` 가 chunk reveal 전 적용
- **마커는 렌더 전용** — `/copy` plain-text 본문엔 미포함. **chunk 개수 불변** → progressive reveal 회귀 영향 0

**테스트:** `MarkResponseChunksTests` 4(첫 줄 1회·빈 줄 untouched·empty 무마커·brand 색) + `ResponseMarkerPilotTests`(free-text 제출 후 렌더 transcript 에 ● 1회 + /copy 본문 제외). parity-lane chunk reveal 포함 121 OK.

## :camera_with_flash: 스크린샷(선택)
`apps/forgekit-console/examples/tui-ux/response-marker.txt` — 마킹된 응답 렌더 실측(› you / ● assistant).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs: `forgekit-console-ui.md` §1 turn 마커 vocabulary.
