### PR TITLE
[Feat] Armory intake→catalog 승격 + Hephaistos 맥락 인지 선택 (#415)

### DIFF
--- a/apps/forgekit-console/examples/armory-intake/_regen_intake.py
+++ b/apps/forgekit-console/examples/armory-intake/_regen_intake.py
@@ -1,0 +1,104 @@
+"""Regenerate ``intake.txt`` — Armory intake→promotion + Hephaistos context-aware selection.
+
+Deterministic + hermetic: drives ``armory.candidate`` + ``hephaistos.resolve`` in memory
+(no repo, no store, no git). Shows (1) a discovery candidate promoting into the catalog
+overlay through the non-placeholder/attach gates, (2) a rejected candidate with its reasons,
+and (3) the Terraform→ECS scenario where project facts exclude EKS, runtime constraints +
+harness land in the packet, and every pick/exclusion carries evidence (no fake selection).
+
+Run: ``python apps/forgekit-console/examples/armory-intake/_regen_intake.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[4]
+for _rel in ("packages/armory/src", "packages/hephaistos/src", "packages/forgekit-config/src",
+             "packages/nexus/src"):
+    _p = str(_ROOT / _rel)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from armory import candidate as C
+from armory import catalog
+from armory.models import KIND_TOOL
+from hephaistos import resolve
+from hephaistos.projection import resolve_summary_lines, selection_evidence_lines
+from hephaistos.nexus_read import read_plan_sources
+
+OUT = Path(__file__).resolve().parent / "intake.txt"
+
+
+def _section(title: str) -> str:
+    return f"\n{'─' * 78}\n{title}\n{'─' * 78}"
+
+
+def main() -> None:
+    catalog.clear_overlay()
+    out: list = ["ARMORY INTAKE → PROMOTION + HEPHAISTOS CONTEXT-AWARE SELECTION (evidence)",
+                 "(hermetic regen — no repo/store/git; resolver is rule-first deterministic)"]
+
+    # 1) a discovery candidate promotes through the gates ----------------------
+    out.append(_section("1) intake candidate → Armory promotion (a CI security tool, kind=tool)"))
+    cand = C.ArmoryCandidate(
+        id="trivy-scan", name="Trivy (image/IaC scan)", kind=KIND_TOOL, category="security",
+        summary="컨테이너 이미지·IaC 취약점 스캔", domains=("security", "devops"),
+        topics=("scan", "vulnerability", "container", "iac"), signals=("trivy", "이미지 스캔"),
+        when_to_use=("CI 에서 이미지/IaC 취약점 게이트",), when_not_to_use=("런타임 침투 테스트",),
+        required_inputs=("스캔 대상(이미지/디렉터리)",), expected_outputs=("취약점 리포트 + 심각도 게이트"),
+        unsafe_boundary=("스캔 결과 무시하고 prod push 금지",), capability_note="vulnerability scanner",
+        install_requirements=("brew install trivy",), attach_requirements=("CI step 추가",),
+        provider_affinity=("github",), commands=("trivy image <ref>",),
+        verification=("trivy --version",), related_loadouts=("devops-cloud-local",),
+        related_roles=("security-engineer", "devops-engineer"),
+        source="discovery", source_ref="brief-trivy-001")
+    res = C.promote_candidate(cand)
+    out.append(f"candidate: {cand.id} (kind={cand.kind}, source={cand.source}:{cand.source_ref})")
+    out.append(f"accepted : {res.accepted}")
+    for e in res.evidence:
+        out.append(f"  gate ✓ {e}")
+    if res.accepted:
+        catalog.register_promoted(res.spec)
+        out.append(f"registered → catalog now has {len(catalog.all_skills())} skills "
+                   f"(overlay: {[s.id for s in catalog.promoted_skills()]})")
+
+    # 2) a stub candidate is rejected (no half-promotion) ----------------------
+    out.append(_section("2) incomplete candidate → rejected (no placeholder enters the catalog)"))
+    stub = C.ArmoryCandidate(id="halfbaked", name="Halfbaked", kind=KIND_TOOL,
+                             category="devops", summary="TBD", signals=("halfbaked",))
+    rej = C.promote_candidate(stub)
+    out.append(f"candidate: {stub.id}  accepted: {rej.accepted}")
+    for r in rej.reasons:
+        out.append(f"  reject ✗ {r}")
+
+    # 3) Terraform→ECS scenario with project context --------------------------
+    out.append(_section("3) Hephaistos selection — Terraform→ECS with project facts + constraints"))
+    request = "Terraform으로 ECS 배포 환경 구성해야 돼. Claude Code한테 맡길 프롬프트 만들어줘."
+    facts = ("EKS는 제외", "dev 환경부터", "기존 구조 보존")
+    plan = resolve(request, project_facts=facts,
+                   runtime_constraints=("production apply 금지",), harness="claude-code")
+    read = read_plan_sources(plan, env={})  # not_connected (hermetic) — honest source state
+    out.append(f"request  : {request}")
+    out.append(f"facts    : {', '.join(facts)}")
+    out.extend(resolve_summary_lines(plan, read))
+    out.append("")
+    out.append("work packet (execution-ready draft):")
+    pk = plan.packet_draft
+    out.append(f"  goal       : {pk.goal}")
+    out.append(f"  tools      : {', '.join(pk.selected_tools)}")
+    out.append(f"  constraints: {', '.join(pk.constraints)}")
+    out.append(f"  harness    : {pk.harness}")
+    out.append(f"  approval   : {pk.approval_level}")
+    out.append(f"  forbidden  :")
+    for f in pk.forbidden_scope:
+        out.append(f"    - {f}")
+
+    catalog.clear_overlay()
+    OUT.write_text("\n".join(out) + "\n", encoding="utf-8")
+    print(f"wrote {OUT.relative_to(_ROOT)} ({len(out)} lines)")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/forgekit-console/examples/armory-intake/intake.txt
+++ b/apps/forgekit-console/examples/armory-intake/intake.txt
@@ -1,0 +1,77 @@
+ARMORY INTAKE → PROMOTION + HEPHAISTOS CONTEXT-AWARE SELECTION (evidence)
+(hermetic regen — no repo/store/git; resolver is rule-first deterministic)
+
+──────────────────────────────────────────────────────────────────────────────
+1) intake candidate → Armory promotion (a CI security tool, kind=tool)
+──────────────────────────────────────────────────────────────────────────────
+candidate: trivy-scan (kind=tool, source=discovery:brief-trivy-001)
+accepted : True
+  gate ✓ kind=tool
+  gate ✓ summary 실체 있음
+  gate ✓ signals 2개
+  gate ✓ when_to_use 명시
+  gate ✓ unsafe_boundary 선언
+  gate ✓ capability_note vendor-neutral
+  gate ✓ 검증 경로 있음
+  gate ✓ install/attach requirements 명시
+  gate ✓ provider_affinity=github
+  gate ✓ 승격됨 (source=discovery:brief-trivy-001)
+registered → catalog now has 27 skills (overlay: ['trivy-scan'])
+
+──────────────────────────────────────────────────────────────────────────────
+2) incomplete candidate → rejected (no placeholder enters the catalog)
+──────────────────────────────────────────────────────────────────────────────
+candidate: halfbaked  accepted: False
+  reject ✗ summary 가 placeholder/너무 짧음
+  reject ✗ when_to_use 없음 — 언제 쓰는지 불명
+  reject ✗ unsafe_boundary 없음 — 위험 경계 미선언(금지)
+  reject ✗ capability_note 없음
+  reject ✗ commands/verification 둘 다 없음 — 검증 경로 없음
+  reject ✗ tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)
+
+──────────────────────────────────────────────────────────────────────────────
+3) Hephaistos selection — Terraform→ECS with project facts + constraints
+──────────────────────────────────────────────────────────────────────────────
+request  : Terraform으로 ECS 배포 환경 구성해야 돼. Claude Code한테 맡길 프롬프트 만들어줘.
+facts    : EKS는 제외, dev 환경부터, 기존 구조 보존
+hephaistos resolve — Terraform으로 ECS 배포 환경 구성해야 돼. Claude Code한테 맡길 프롬프트 만들어줘.
+  infer     : devops/-/-/terraform
+  agent     : devops-engineer
+  skills    : terraform, aws-ecs, docker, github-actions, secrets-management, trivy-scan
+  loadout   : devops-cloud-local
+  weapons   : docker, terraform, awscli, gh, actionlint
+  excluded  : kubernetes  (프로젝트 제약으로 제외)
+  nexus     : not_connected (FORGEKIT_NEXUS_ROOT 미설정 — 지식 source 미연결)
+  packet    : scope 10 / forbidden 10 / verify 10 / approval L2_internal_approve
+  tools     : docker, terraform, awscli, gh, actionlint
+  constraints: EKS는 제외, dev 환경부터, 기존 구조 보존, production apply 금지
+  harness   : claude-code
+  [dim]상세: /skills <요청> · /loadout <id> · /hephaistos · 선택근거: 아래 evidence[/dim]
+  evidence  : 선택/제외 근거 (no fake smart-selection)
+    ✓ [skill] terraform — domain=devops, topic=terraform, signals=terraform/배포
+    ✓ [skill] aws-ecs — domain=devops, signals=ecs
+    ✓ [skill] docker — domain=devops
+    ✓ [skill] github-actions — domain=devops
+    ✓ [skill] secrets-management — domain=devops
+    ✓ [skill] trivy-scan — domain=devops
+    ✗ [skill] kubernetes — project fact: EKS는 제외
+    ✓ [constraint] dev 환경부터 — project fact (Nexus/operator context)
+    … +4 more
+
+work packet (execution-ready draft):
+  goal       : Terraform으로 ECS 배포 환경 구성해야 돼. Claude Code한테 맡길 프롬프트 만들어줘.
+  tools      : docker, terraform, awscli, gh, actionlint
+  constraints: EKS는 제외, dev 환경부터, 기존 구조 보존, production apply 금지
+  harness    : claude-code
+  approval   : L2_internal_approve
+  forbidden  :
+    - production apply 금지(승인 필요)
+    - state backend 임의 변경
+    - production service 직접 변경(승인)
+    - 운영 registry/container 변경
+    - 프로덕션 배포 job 무승인 트리거
+    - secret 을 workflow 로그에 echo
+    - secret 평문 커밋
+    - 로그에 secret 출력
+    - 스캔 결과 무시하고 prod push 금지
+    - Kubernetes 미사용(프로젝트 제약으로 제외)

--- a/docs/armory.md
+++ b/docs/armory.md
@@ -14,13 +14,13 @@ armory` single direction (no cycle). Old paths kept as compat: `hephaistos.armor
 (so `from hephaistos.models import SkillSpec` still works). **Provider-neutral**: skills describe
 *capability / framework / workflow* (`capability_note` carries the capability lens), never a vendor name.
 
-## Coverage (7 categories, 25 skills, 8 loadouts)
+## Coverage (7 categories, 26 skills, 8 loadouts)
 | category | skills |
 | --- | --- |
 | backend | java-spring, kotlin-spring, node-nestjs, python-fastapi |
 | frontend | react-typescript, nextjs, vite-react |
 | database | mysql, postgres, redis |
-| devops | docker, kubernetes, terraform, aws-ecs |
+| devops | docker, kubernetes, terraform, aws-ecs, github-actions |
 | security | auth-jwt, oauth2, secrets-management, web-security-review |
 | ai | openai-api, rag-basics, eval-harness, agent-evaluation |
 | design-support | figma-read (partial — blocked when unconnected), design-system-review, ux-ui-reference-pack |
@@ -29,10 +29,55 @@ Loadouts: backend-java/python/node-local, frontend-react-local, fullstack-web-lo
 devops-cloud-local, ai-agent-local, security-review-local, design-review-local.
 
 ## Manifest contract (no placeholders)
-Each skill carries id/title/category/summary/when_to_use/commands/verify/**unsafe_boundary**/
-signals/capability_note/nexus_refs. Each loadout carries goal/recommended/optional/**blocked**_skills/
-selection_signals — so the resolver can *explain why* a combo was chosen. Validity is locked by
-`test_armory_breadth` (referential integrity + non-placeholder guard).
+Each skill carries id/title/category/summary/when_to_use/when_not_to_use/required_inputs/
+expected_outputs/commands/verify/**unsafe_boundary**/signals/capability_note/nexus_refs, plus the
+**attach contract** (`kind` / `provider_affinity` / `install_requirements` / `attach_requirements`).
+Each loadout carries goal/recommended/optional/**blocked**_skills/selection_signals — so the resolver
+can *explain why* a combo was chosen. Validity is locked by `test_armory_breadth` (referential
+integrity + non-placeholder guard).
+
+### Entry kind + attach contract
+`kind ∈ {skill, tool, plugin, mcp}` (`armory.models.ENTRY_KINDS`):
+- **skill** — knowledge / workflow / convention the executor already carries (no external attach).
+- **tool** — a CLI/binary the executor invokes → needs `install_requirements`.
+- **plugin** — a harness plugin/extension → needs `attach_requirements` + `provider_affinity`.
+- **mcp** — an MCP server → needs install/attach + `provider_affinity` (which harness it binds to).
+
+`provider_affinity` names the **attachment target** (claude-code / codex / github / mcp-host …) — an
+*attachment fact*, not a capability claim, so it MAY name a vendor. `capability_note` stays
+vendor-neutral (the breadth test guards only that field). `ATTACH_REQUIRED_KINDS = (tool, plugin, mcp)`
+cannot be equipped without an explicit install/attach step — promoting one without it would be a fake
+"available" entry, so the promotion gate rejects it.
 
 Uncovered stacks (e.g. Rust embedded) resolve **shallow** — honest, never faked. Adding a stack =
 add a manifest + signals; the resolver picks it up.
+
+## Intake → promotion (`armory.candidate`)
+New entries do not have to be hand-edited into the seed. An **`ArmoryCandidate`** (a proposal from
+discovery / a curated note / an operator, carrying its `source`/`source_ref` provenance) is gated by
+**`promote_candidate(candidate) → PromotionResult`**:
+- **Reject** (with reasons) if the contract is incomplete — placeholder/short summary, no signals, no
+  `when_to_use`, no `unsafe_boundary`, vendor-locked `capability_note`, no verify path, or a
+  tool/plugin/mcp missing its install/attach (and mcp/plugin missing `provider_affinity`).
+- **Accept** → a real `SkillSpec` plus an **evidence trail** of which gates passed. No partial
+  promotion: an incomplete candidate is rejected wholesale, so the catalog never gains a stub.
+
+A promoted spec is registered into a **runtime overlay** (`catalog.register_promoted` /
+`promoted_skills` / `clear_overlay`) that `all_skills()`/`skill()` merge over the seed — so the
+resolver picks it up immediately, re-promotion (same id) updates in place, and tests `clear_overlay()`
+for isolation. Evidence: `apps/forgekit-console/examples/armory-intake/intake.txt`.
+
+## Context-aware selection (Hephaistos)
+`hephaistos.resolve(request, *, preferred_role="", project_facts=(), runtime_constraints=(), harness="")`
+folds project/runtime context into the existing selection surface (no new routing layer):
+- **project_facts** — Nexus/operator context. An *exclusion* fact ("EKS는 제외", "k8s 빼고") drops the
+  matching catalog skill(s) and records it as a `forbidden_scope` line; a non-exclusion fact
+  ("dev 환경부터", "기존 구조 보존") becomes a packet **constraint**.
+- **runtime_constraints** — provider/runtime limits (e.g. "production apply 금지") → packet constraints.
+- **harness** — intended executor (claude-code / codex …) recorded on the packet.
+
+Every pick *and* exclusion emits a **`SelectionEvidence`** row (target / kind / decision / reason /
+signals) — a "smart" choice with no evidence is a fake and does not ship; a shallow request renders an
+honest `(근거 없음)` rather than a fabricated rationale. The console projects this trail read-only
+(`projection.selection_evidence_lines`). Representative scenario (Terraform→ECS, EKS excluded,
+dev-first, keep-structure) is locked by `test_armory_intake_promotion`.

--- a/packages/armory/src/armory/__init__.py
+++ b/packages/armory/src/armory/__init__.py
@@ -14,18 +14,24 @@ Depends on nothing internal (leaf) → Hephaistos depends on Armory, never the r
 
 from __future__ import annotations
 
-from . import catalog, models
+from . import candidate, catalog, models
+from .candidate import ArmoryCandidate, PromotionResult, promote_candidate
 from .catalog import (
     all_loadouts,
     all_skills,
     all_weapons,
     categories,
+    clear_overlay,
     loadout,
+    promoted_skills,
+    register_promoted,
     skill,
     weapon,
 )
 
 __all__ = (
-    "catalog", "models",
+    "candidate", "catalog", "models",
     "all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon", "categories",
+    "register_promoted", "clear_overlay", "promoted_skills",
+    "ArmoryCandidate", "PromotionResult", "promote_candidate",
 )

--- a/packages/armory/src/armory/candidate.py
+++ b/packages/armory/src/armory/candidate.py
@@ -1,0 +1,203 @@
+"""armory.candidate — the intake → catalog promotion path (RWT2).
+
+An ``ArmoryCandidate`` is a *proposal* for a new catalog entry: a skill / tool / plugin /
+MCP surfaced by discovery (Nexus sweep), a curated note, or an operator. It is NOT yet in
+the catalog. ``promote_candidate`` is the gate that turns a proposal into a real
+``SkillSpec`` — but only if it carries a non-placeholder contract: summary, when_to_use,
+signals, an unsafe boundary, a capability lens, and (for tool/plugin/mcp kinds) the
+install/attach requirements needed to actually equip it.
+
+Promotion is **explainable and honest**: a rejection lists every missing gate; an accept
+carries the evidence of which gates passed. There is no silent "looks fine" — an
+incomplete candidate is rejected, never half-promoted with placeholder fields. Pure /
+stdlib-only; depends only on ``armory.models`` (no Hephaistos import → no cycle).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+from .models import (
+    ATTACH_REQUIRED_KINDS,
+    ENTRY_KINDS,
+    KIND_SKILL,
+    NexusSourceRef,
+    SkillSpec,
+)
+
+# placeholder tokens that disqualify a "contract" field — a candidate that still carries
+# these is a stub, not a real entry, and must not enter the catalog.
+_PLACEHOLDERS = ("tbd", "todo", "fixme", "xxx", "placeholder", "...", "내용 없음", "(미정)")
+
+# vendor names that may not appear in capability_note (matches the breadth test guard).
+_VENDOR_TOKENS = ("claude", "codex", "gemini", "gpt-4", "openai gpt")
+
+_MIN_SUMMARY = 6   # a real summary is at least a few chars, not "x"
+
+
+def _is_placeholder(text: str) -> bool:
+    t = (text or "").strip().lower()
+    if not t:
+        return True
+    return any(p in t for p in _PLACEHOLDERS)
+
+
+@dataclass(frozen=True)
+class ArmoryCandidate:
+    """A proposed catalog entry awaiting promotion (intake side)."""
+
+    id: str
+    name: str
+    kind: str = KIND_SKILL
+    category: str = ""
+    summary: str = ""
+    domains: Tuple[str, ...] = ()
+    languages: Tuple[str, ...] = ()
+    frameworks: Tuple[str, ...] = ()
+    topics: Tuple[str, ...] = ()
+    signals: Tuple[str, ...] = ()
+    when_to_use: Tuple[str, ...] = ()
+    when_not_to_use: Tuple[str, ...] = ()
+    required_inputs: Tuple[str, ...] = ()
+    expected_outputs: Tuple[str, ...] = ()
+    unsafe_boundary: Tuple[str, ...] = ()        # → SkillSpec.forbidden
+    capability_note: str = ""
+    provider_affinity: Tuple[str, ...] = ()
+    install_requirements: Tuple[str, ...] = ()
+    attach_requirements: Tuple[str, ...] = ()
+    commands: Tuple[str, ...] = ()
+    verification: Tuple[str, ...] = ()
+    rules: Tuple[str, ...] = ()
+    related_weapons: Tuple[str, ...] = ()
+    related_loadouts: Tuple[str, ...] = ()
+    related_roles: Tuple[str, ...] = ()
+    nexus_refs: Tuple[NexusSourceRef, ...] = ()
+    status: str = "ready"
+    # provenance — where this candidate came from (discovery brief id / curated note / operator).
+    source: str = "operator"
+    source_ref: str = ""
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "name": self.name, "kind": self.kind, "category": self.category,
+                "summary": self.summary, "signals": list(self.signals),
+                "when_to_use": list(self.when_to_use), "unsafe_boundary": list(self.unsafe_boundary),
+                "capability_note": self.capability_note,
+                "install_requirements": list(self.install_requirements),
+                "attach_requirements": list(self.attach_requirements),
+                "source": self.source, "source_ref": self.source_ref}
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    """The verdict of one promotion attempt — accepted (with spec) or rejected (with reasons)."""
+
+    candidate_id: str
+    accepted: bool
+    spec: Optional[SkillSpec] = None
+    reasons: Tuple[str, ...] = ()        # why rejected (empty if accepted)
+    evidence: Tuple[str, ...] = ()       # which gates passed / which fields carried the entry
+
+    def to_dict(self) -> dict:
+        return {"candidate_id": self.candidate_id, "accepted": self.accepted,
+                "spec": self.spec.to_dict() if self.spec else None,
+                "reasons": list(self.reasons), "evidence": list(self.evidence)}
+
+
+def _validate(c: ArmoryCandidate) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """Return (reasons_to_reject, evidence_of_passed_gates). Deterministic + explainable."""
+
+    reasons: list = []
+    evidence: list = []
+
+    if not c.id or not c.id.strip():
+        reasons.append("id 없음")
+    if c.kind not in ENTRY_KINDS:
+        reasons.append(f"kind 불명: {c.kind!r} (skill/tool/plugin/mcp 중 하나)")
+    else:
+        evidence.append(f"kind={c.kind}")
+
+    if not c.category:
+        reasons.append("category 없음")
+    if _is_placeholder(c.summary) or len(c.summary.strip()) < _MIN_SUMMARY:
+        reasons.append("summary 가 placeholder/너무 짧음")
+    else:
+        evidence.append("summary 실체 있음")
+
+    if not c.signals:
+        reasons.append("signals 없음 — resolver 가 고를 신호가 없다")
+    else:
+        evidence.append(f"signals {len(c.signals)}개")
+
+    if not c.when_to_use:
+        reasons.append("when_to_use 없음 — 언제 쓰는지 불명")
+    else:
+        evidence.append("when_to_use 명시")
+
+    if not c.unsafe_boundary:
+        reasons.append("unsafe_boundary 없음 — 위험 경계 미선언(금지)")
+    else:
+        evidence.append("unsafe_boundary 선언")
+
+    if not c.capability_note:
+        reasons.append("capability_note 없음")
+    else:
+        low = c.capability_note.lower()
+        vendor = next((v for v in _VENDOR_TOKENS if v in low), "")
+        if vendor:
+            reasons.append(f"capability_note 가 vendor 명시({vendor}) — provider-neutral 위반")
+        else:
+            evidence.append("capability_note vendor-neutral")
+
+    if not (c.commands or c.verification):
+        reasons.append("commands/verification 둘 다 없음 — 검증 경로 없음")
+    else:
+        evidence.append("검증 경로 있음")
+
+    # attach contract: a tool/plugin/mcp must declare how it is installed/attached, else
+    # it cannot be equipped — promoting it would be a fake "available" entry.
+    if c.kind in ATTACH_REQUIRED_KINDS:
+        if not (c.install_requirements or c.attach_requirements):
+            reasons.append(f"{c.kind} 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)")
+        else:
+            evidence.append("install/attach requirements 명시")
+        if c.kind in ("mcp", "plugin") and not c.provider_affinity:
+            reasons.append(f"{c.kind} 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명")
+        elif c.provider_affinity:
+            evidence.append(f"provider_affinity={','.join(c.provider_affinity)}")
+
+    return tuple(reasons), tuple(evidence)
+
+
+def _to_spec(c: ArmoryCandidate) -> SkillSpec:
+    return SkillSpec(
+        id=c.id, name=c.name, domains=c.domains, languages=c.languages,
+        frameworks=c.frameworks, topics=c.topics, rules=c.rules, commands=c.commands,
+        verification=c.verification, forbidden=c.unsafe_boundary,
+        related_weapons=c.related_weapons, related_loadouts=c.related_loadouts,
+        related_roles=c.related_roles, nexus_refs=c.nexus_refs, category=c.category,
+        summary=c.summary, when_to_use=c.when_to_use, when_not_to_use=c.when_not_to_use,
+        required_inputs=c.required_inputs, expected_outputs=c.expected_outputs,
+        signals=c.signals, capability_note=c.capability_note, status=c.status,
+        kind=c.kind, provider_affinity=c.provider_affinity,
+        install_requirements=c.install_requirements, attach_requirements=c.attach_requirements,
+    )
+
+
+def promote_candidate(c: ArmoryCandidate) -> PromotionResult:
+    """Gate one candidate: validate its contract → accept (SkillSpec) or reject (reasons).
+
+    No partial promotion — an incomplete contract is rejected wholesale so the catalog
+    never gains a placeholder entry. The evidence trail records which gates passed.
+    """
+
+    reasons, evidence = _validate(c)
+    if reasons:
+        return PromotionResult(candidate_id=c.id, accepted=False, reasons=reasons, evidence=evidence)
+    spec = _to_spec(c)
+    src = f" (source={c.source}{':' + c.source_ref if c.source_ref else ''})"
+    return PromotionResult(candidate_id=c.id, accepted=True, spec=spec,
+                           evidence=evidence + (f"승격됨{src}",))
+
+
+__all__ = ("ArmoryCandidate", "PromotionResult", "promote_candidate")

--- a/packages/armory/src/armory/catalog.py
+++ b/packages/armory/src/armory/catalog.py
@@ -43,6 +43,7 @@ _WEAPONS = (
     WeaponSpec("terraform", "Terraform", "cli", "terraform version", "brew install terraform"),
     WeaponSpec("awscli", "AWS CLI", "cli", "aws --version", "brew install awscli"),
     WeaponSpec("gh", "GitHub CLI", "cli", "gh --version", "brew install gh"),
+    WeaponSpec("actionlint", "actionlint", "cli", "actionlint --version", "brew install actionlint"),
     WeaponSpec("intellij", "IntelliJ IDEA", "ide", "", "jetbrains toolbox"),
     WeaponSpec("vscode", "VS Code", "ide", "code --version", "https://code.visualstudio.com"),
 )
@@ -177,8 +178,8 @@ _SKILLS = (
               related_weapons=("docker",), related_loadouts=("backend-java-local", "devops-cloud-local"),
               related_roles=("backend-engineer", "devops-engineer")),
     SkillSpec("kubernetes", "Kubernetes", category="devops",
-              domains=("devops",), topics=("kubernetes", "k8s", "deploy", "orchestration"),
-              signals=("kubernetes", "k8s", "kubectl"), summary="K8s manifest/deploy",
+              domains=("devops",), topics=("kubernetes", "k8s", "eks", "deploy", "orchestration"),
+              signals=("kubernetes", "k8s", "kubectl", "eks"), summary="K8s manifest/deploy (EKS 포함)",
               when_to_use=("컨테이너 오케스트레이션, 배포 manifest",), when_not_to_use=("단일 로컬 실행",),
               rules=("resource limit 명시", "secret 은 secret 리소스"),
               commands=("kubectl apply --dry-run=client -f .",),
@@ -201,11 +202,32 @@ _SKILLS = (
               domains=("devops",), topics=("aws", "ecs", "deploy", "container"),
               signals=("ecs", "aws", "fargate"), summary="AWS ECS 배포 가이드",
               when_to_use=("ECS/Fargate 컨테이너 배포",), when_not_to_use=("on-prem k8s",),
+              required_inputs=("대상 환경(dev/stg/prod)", "컨테이너 이미지", "task 정의/리소스"),
+              expected_outputs=("ECS service/task 정의", "배포 전략(rolling/blue-green) 문서"),
               rules=("task role 최소권한", "rolling/blue-green 전략 명시"),
               commands=("aws ecs describe-services",), verification=("aws --version",),
               forbidden=("production service 직접 변경(승인)",), capability_note="cloud deploy",
               related_weapons=("awscli", "docker"), related_loadouts=("devops-cloud-local",),
               related_roles=("devops-engineer",)),
+    SkillSpec("github-actions", "GitHub Actions (CI/CD)", category="devops",
+              domains=("devops",), topics=("ci", "cd", "pipeline", "workflow", "deploy", "container"),
+              signals=("github actions", "github-actions", "actions", "ci/cd", "ci 파이프라인",
+                       "워크플로우", "workflow", "파이프라인", "deploy pipeline"),
+              summary="GitHub Actions CI/CD 워크플로우 작성·검증",
+              when_to_use=("빌드/테스트/배포 파이프라인, IaC plan→apply 게이트, 이미지 push",),
+              when_not_to_use=("런타임 오케스트레이션(→kubernetes/aws-ecs)", "로컬 단발 빌드"),
+              required_inputs=("배포 대상/트리거(브랜치·태그)", "필요 secret 목록", "빌드/테스트 명령"),
+              expected_outputs=(".github/workflows/*.yml", "환경별 job 분리(dev→prod gate)"),
+              rules=("secret 은 repo/environment secret(평문 금지)", "prod 배포는 manual approval gate",
+                     "OIDC 권장(장기 키 금지)"),
+              commands=("actionlint .github/workflows",),
+              verification=("actionlint .github/workflows", "gh workflow list"),
+              forbidden=("프로덕션 배포 job 무승인 트리거", "secret 을 workflow 로그에 echo"),
+              capability_note="ci/cd pipeline authoring", provider_affinity=("github",),
+              install_requirements=("gh", "actionlint"),
+              related_weapons=("gh", "actionlint", "docker"),
+              related_loadouts=("devops-cloud-local",), related_roles=("devops-engineer",),
+              nexus_refs=(_area("20-areas/devops/github-actions"),)),
     # --- auth / security -------------------------------------------------
     SkillSpec("auth-jwt", "Auth / JWT", category="security",
               domains=("backend", "security"), topics=("auth-jwt", "auth", "jwt", "refresh-token", "security"),
@@ -252,7 +274,7 @@ _SKILLS = (
     # --- ai / agent ------------------------------------------------------
     SkillSpec("openai-api", "LLM API (openai-compatible)", category="ai",
               domains=("ai",), topics=("llm", "api", "completion", "embedding"),
-              signals=("llm api", "openai", "completion", "embedding", "프롬프트"),
+              signals=("llm api", "openai", "completion", "embedding", "프롬프트 엔지니어링"),
               summary="openai-compatible LLM API 연동",
               when_to_use=("LLM 호출/임베딩, provider-neutral 연동",), when_not_to_use=("로컬 모델 학습",),
               rules=("usage/cost 추적", "키는 env"), verification=("(연결 smoke)",),
@@ -376,10 +398,11 @@ _LOADOUTS = (
                 verify_commands=("terraform version", "docker --version"),
                 goal="클라우드 IaC/배포 plan 작성",
                 recommended_skills=("terraform", "aws-ecs", "docker"),
-                optional_skills=("kubernetes", "secrets-management"),
+                optional_skills=("kubernetes", "secrets-management", "github-actions"),
                 blocked_skills=("java-spring", "react-typescript"),
                 default_verify_flow=("terraform validate", "terraform plan"),
-                selection_signals=("terraform", "ecs", "kubernetes", "배포", "iac"),
+                selection_signals=("terraform", "ecs", "kubernetes", "배포", "iac",
+                                   "github actions", "ci/cd", "파이프라인"),
                 notes="apply 는 항상 승인+runbook (plan-first)"),
     LoadoutSpec("ai-agent-local", "AI Agent (local)", intended_roles=("ai-engineer",),
                 required_weapons=("python", "uv"), optional_weapons=("docker",),
@@ -418,9 +441,38 @@ _WEAPON_BY_ID: Dict[str, WeaponSpec] = {w.id: w for w in _WEAPONS}
 _SKILL_BY_ID: Dict[str, SkillSpec] = {s.id: s for s in _SKILLS}
 _LOADOUT_BY_ID: Dict[str, LoadoutSpec] = {l.id: l for l in _LOADOUTS}
 
+# ─── promotion overlay ────────────────────────────────────────────────────────
+# Candidates promoted at runtime (intake → ``armory.candidate.promote_candidate`` →
+# ``register_promoted``) land here, so the resolver picks them up without editing the
+# seed. Process-local + resettable (``clear_overlay``) — tests register into it and clear,
+# never leaking across cases. A promoted id overrides the seed entry of the same id
+# (re-promotion = update), and base order is preserved with overlay appended after.
+_OVERLAY: "list[SkillSpec]" = []
+
+
+def register_promoted(spec: SkillSpec) -> None:
+    """Add (or replace) a promoted SkillSpec in the runtime overlay. Idempotent by id."""
+
+    global _OVERLAY
+    _OVERLAY = [s for s in _OVERLAY if s.id != spec.id] + [spec]
+
+
+def clear_overlay() -> None:
+    """Drop all runtime-promoted entries (test isolation / re-seed)."""
+
+    _OVERLAY.clear()
+
+
+def promoted_skills() -> Tuple[SkillSpec, ...]:
+    return tuple(_OVERLAY)
+
 
 def all_skills() -> Tuple[SkillSpec, ...]:
-    return _SKILLS
+    if not _OVERLAY:
+        return _SKILLS
+    overridden = {s.id for s in _OVERLAY}
+    base = tuple(s for s in _SKILLS if s.id not in overridden)
+    return base + tuple(_OVERLAY)
 
 
 def all_loadouts() -> Tuple[LoadoutSpec, ...]:
@@ -432,6 +484,9 @@ def all_weapons() -> Tuple[WeaponSpec, ...]:
 
 
 def skill(skill_id: str) -> Optional[SkillSpec]:
+    for s in _OVERLAY:
+        if s.id == skill_id:
+            return s
     return _SKILL_BY_ID.get(skill_id)
 
 
@@ -444,7 +499,8 @@ def weapon(weapon_id: str) -> Optional[WeaponSpec]:
 
 
 def categories() -> Tuple[str, ...]:
-    return tuple(dict.fromkeys(s.category for s in _SKILLS if s.category))
+    return tuple(dict.fromkeys(s.category for s in all_skills() if s.category))
 
 
-__all__ = ("all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon", "categories")
+__all__ = ("all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon",
+           "categories", "register_promoted", "clear_overlay", "promoted_skills")

--- a/packages/armory/src/armory/models.py
+++ b/packages/armory/src/armory/models.py
@@ -35,6 +35,17 @@ SRC_RESTRICTED = "restricted"        # present but raw read gated → projection
 WEAPON_SAFE = "safe"
 WEAPON_RISKY = "risky"
 
+# entry kind — what *shape* of capability a catalog entry is. The selection contract
+# differs by kind: a tool/mcp/plugin needs install/attach requirements before it can be
+# equipped, while a pure skill is knowledge/workflow the executor already carries.
+KIND_SKILL = "skill"     # knowledge / workflow / convention (no external attach)
+KIND_TOOL = "tool"       # a CLI / binary the executor invokes (needs install)
+KIND_PLUGIN = "plugin"   # a harness plugin / extension (needs attach to a harness)
+KIND_MCP = "mcp"         # an MCP server (needs connect/attach + transport)
+ENTRY_KINDS = (KIND_SKILL, KIND_TOOL, KIND_PLUGIN, KIND_MCP)
+# kinds that cannot be equipped without an explicit install/attach step.
+ATTACH_REQUIRED_KINDS = (KIND_TOOL, KIND_PLUGIN, KIND_MCP)
+
 
 @dataclass(frozen=True)
 class NexusSourceRef:
@@ -101,10 +112,23 @@ class SkillSpec:
     signals: Tuple[str, ...] = ()          # keyword/intent signals the resolver scores on
     capability_note: str = ""              # vendor-neutral capability (NOT a provider name)
     status: str = "ready"                  # ready / partial / shallow
+    # entry-kind + attach contract (RWT2 intake) — a tool/mcp/plugin is only equippable
+    # once its install/attach requirements are met. ``provider_affinity`` names the
+    # harness/runtime an entry attaches to (claude-code / codex / mcp-host …) — this is
+    # an *attachment target*, NOT a capability claim, so it is allowed to name a vendor
+    # (``capability_note`` stays vendor-neutral; the breadth test guards only that field).
+    kind: str = KIND_SKILL
+    provider_affinity: Tuple[str, ...] = ()   # harness/runtime targets (claude-code/codex/…)
+    install_requirements: Tuple[str, ...] = ()  # what must exist locally (weapon/cli/runtime)
+    attach_requirements: Tuple[str, ...] = ()   # how to attach (mcp connect / plugin enable …)
 
     @property
     def title(self) -> str:
         return self.name
+
+    @property
+    def needs_attach(self) -> bool:
+        return self.kind in ATTACH_REQUIRED_KINDS
 
     @property
     def unsafe_boundary(self) -> Tuple[str, ...]:
@@ -139,7 +163,16 @@ class SkillSpec:
                 "forbidden": list(self.forbidden), "related_weapons": list(self.related_weapons),
                 "related_loadouts": list(self.related_loadouts),
                 "related_roles": list(self.related_roles),
-                "nexus_refs": [r.to_dict() for r in self.nexus_refs]}
+                "nexus_refs": [r.to_dict() for r in self.nexus_refs],
+                "category": self.category, "summary": self.summary,
+                "when_to_use": list(self.when_to_use), "when_not_to_use": list(self.when_not_to_use),
+                "required_inputs": list(self.required_inputs),
+                "expected_outputs": list(self.expected_outputs),
+                "signals": list(self.signals), "capability_note": self.capability_note,
+                "status": self.status, "kind": self.kind,
+                "provider_affinity": list(self.provider_affinity),
+                "install_requirements": list(self.install_requirements),
+                "attach_requirements": list(self.attach_requirements)}
 
 
 @dataclass(frozen=True)
@@ -193,5 +226,6 @@ __all__ = (
     "NEXUS_AREA", "NEXUS_PATTERN", "NEXUS_SNIPPET", "NEXUS_TROUBLESHOOTING", "NEXUS_DECISION",
     "SRC_AVAILABLE", "SRC_NOT_CONNECTED", "SRC_PLANNED", "SRC_UNKNOWN", "SRC_EXISTS",
     "SRC_MISSING", "SRC_BLOCKED", "SRC_RESTRICTED", "WEAPON_SAFE", "WEAPON_RISKY",
+    "KIND_SKILL", "KIND_TOOL", "KIND_PLUGIN", "KIND_MCP", "ENTRY_KINDS", "ATTACH_REQUIRED_KINDS",
     "NexusSourceRef", "WeaponSpec", "SkillSpec", "LoadoutSpec", "RuneSpec",
 )

--- a/packages/hephaistos/src/hephaistos/armory.py
+++ b/packages/hephaistos/src/hephaistos/armory.py
@@ -12,9 +12,13 @@ from armory.catalog import (  # noqa: F401
     all_skills,
     all_weapons,
     categories,
+    clear_overlay,
     loadout,
+    promoted_skills,
+    register_promoted,
     skill,
     weapon,
 )
 
-__all__ = ("all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon", "categories")
+__all__ = ("all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon",
+           "categories", "register_promoted", "clear_overlay", "promoted_skills")

--- a/packages/hephaistos/src/hephaistos/models.py
+++ b/packages/hephaistos/src/hephaistos/models.py
@@ -15,8 +15,30 @@ from armory.models import (  # noqa: F401  (re-export catalog vocab for compat)
     NEXUS_AREA, NEXUS_PATTERN, NEXUS_SNIPPET, NEXUS_TROUBLESHOOTING, NEXUS_DECISION,
     SRC_AVAILABLE, SRC_NOT_CONNECTED, SRC_PLANNED, SRC_UNKNOWN, SRC_EXISTS,
     SRC_MISSING, SRC_BLOCKED, SRC_RESTRICTED, WEAPON_SAFE, WEAPON_RISKY,
+    KIND_SKILL, KIND_TOOL, KIND_PLUGIN, KIND_MCP, ENTRY_KINDS, ATTACH_REQUIRED_KINDS,
     NexusSourceRef, WeaponSpec, SkillSpec, LoadoutSpec, RuneSpec,
 )
+
+
+@dataclass(frozen=True)
+class SelectionEvidence:
+    """Why one item was (de)selected — the anti-fake trail behind every Hephaistos pick.
+
+    ``target`` is a skill/loadout/weapon id; ``kind`` is what it is; ``decision`` is
+    selected/excluded; ``reason`` + ``signals`` say WHAT in the request/context drove it.
+    No selection ships without a row here — a "smart" pick with no evidence is a fake.
+    """
+
+    target: str
+    kind: str                 # skill / loadout / weapon / agent / constraint
+    decision: str             # selected / excluded
+    reason: str = ""
+    signals: Tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"target": self.target, "kind": self.kind, "decision": self.decision,
+                "reason": self.reason, "signals": list(self.signals)}
+
 
 @dataclass(frozen=True)
 class WorkPacketDraft:
@@ -30,6 +52,10 @@ class WorkPacketDraft:
     approval_level: str = "L2_internal_approve"
     evidence_path: str = ""
     nexus_refs: Tuple[NexusSourceRef, ...] = ()
+    # work-packet quality fields — concrete + execution-ready.
+    selected_tools: Tuple[str, ...] = ()       # weapon ids the executor must have/attach
+    constraints: Tuple[str, ...] = ()          # project-fact constraints (dev-first / keep-structure …)
+    harness: str = ""                          # intended executor harness (claude-code / codex …)
 
     def to_dict(self) -> dict:
         return {"goal": self.goal, "scope": list(self.scope),
@@ -37,7 +63,9 @@ class WorkPacketDraft:
                 "required_areas": list(self.required_areas), "commands": list(self.commands),
                 "verification": list(self.verification), "acceptance": list(self.acceptance),
                 "approval_level": self.approval_level, "evidence_path": self.evidence_path,
-                "nexus_refs": [r.to_dict() for r in self.nexus_refs]}
+                "nexus_refs": [r.to_dict() for r in self.nexus_refs],
+                "selected_tools": list(self.selected_tools), "constraints": list(self.constraints),
+                "harness": self.harness}
 
 
 @dataclass(frozen=True)
@@ -57,6 +85,11 @@ class ResolvedForgePlan:
     nexus_refs: Tuple[NexusSourceRef, ...] = ()
     verification_commands: Tuple[str, ...] = ()
     packet_draft: WorkPacketDraft = None  # type: ignore[assignment]
+    # anti-fake selection trail + what context shaped it.
+    selection_evidence: Tuple[SelectionEvidence, ...] = ()
+    excluded_skills: Tuple[str, ...] = ()      # dropped by a project fact (e.g. "EKS 제외")
+    project_facts: Tuple[str, ...] = ()        # Nexus/operator facts fed into selection
+    runtime_constraints: Tuple[str, ...] = ()  # provider/runtime constraints fed in
 
     def to_dict(self) -> dict:
         return {"request": self.request, "domain": self.domain, "language": self.language,
@@ -66,7 +99,11 @@ class ResolvedForgePlan:
                 "required_weapons": list(self.required_weapons),
                 "nexus_refs": [r.to_dict() for r in self.nexus_refs],
                 "verification_commands": list(self.verification_commands),
-                "packet_draft": self.packet_draft.to_dict() if self.packet_draft else None}
+                "packet_draft": self.packet_draft.to_dict() if self.packet_draft else None,
+                "selection_evidence": [e.to_dict() for e in self.selection_evidence],
+                "excluded_skills": list(self.excluded_skills),
+                "project_facts": list(self.project_facts),
+                "runtime_constraints": list(self.runtime_constraints)}
 
 
 
@@ -74,6 +111,7 @@ __all__ = (
     "NEXUS_AREA", "NEXUS_PATTERN", "NEXUS_SNIPPET", "NEXUS_TROUBLESHOOTING", "NEXUS_DECISION",
     "SRC_AVAILABLE", "SRC_NOT_CONNECTED", "SRC_PLANNED", "SRC_UNKNOWN", "SRC_EXISTS",
     "SRC_MISSING", "SRC_BLOCKED", "SRC_RESTRICTED", "WEAPON_SAFE", "WEAPON_RISKY",
+    "KIND_SKILL", "KIND_TOOL", "KIND_PLUGIN", "KIND_MCP", "ENTRY_KINDS", "ATTACH_REQUIRED_KINDS",
     "NexusSourceRef", "WeaponSpec", "SkillSpec", "LoadoutSpec", "RuneSpec",
-    "WorkPacketDraft", "ResolvedForgePlan",
+    "WorkPacketDraft", "ResolvedForgePlan", "SelectionEvidence",
 )

--- a/packages/hephaistos/src/hephaistos/projection.py
+++ b/packages/hephaistos/src/hephaistos/projection.py
@@ -43,14 +43,43 @@ def resolve_summary_lines(plan: ResolvedForgePlan, read: nx.NexusReadResult) -> 
         f"  loadout   : {plan.selected_loadout or '-'}",
         f"  weapons   : {', '.join(plan.required_weapons) or '-'}",
     ]
+    if plan.excluded_skills:
+        lines.append(f"  excluded  : {', '.join(plan.excluded_skills)}  (프로젝트 제약으로 제외)")
     lines += list(nexus_status_lines(read))
     if plan.packet_draft:
         pk = plan.packet_draft
         lines.append(f"  packet    : scope {len(pk.scope)} / forbidden {len(pk.forbidden_scope)} / "
                      f"verify {len(pk.verification)} / approval {pk.approval_level}")
+        if pk.selected_tools:
+            lines.append(f"  tools     : {', '.join(pk.selected_tools)}")
+        if pk.constraints:
+            lines.append(f"  constraints: {', '.join(pk.constraints)}")
+        if pk.harness:
+            lines.append(f"  harness   : {pk.harness}")
     if shallow:
         lines.append(shallow)
-    lines.append("  [dim]상세: /skills <요청> · /loadout <id> · /hephaistos[/dim]")
+    lines.append("  [dim]상세: /skills <요청> · /loadout <id> · /hephaistos · 선택근거: 아래 evidence[/dim]")
+    lines += list(selection_evidence_lines(plan, limit=8))
+    return tuple(lines)
+
+
+def selection_evidence_lines(plan: ResolvedForgePlan, *, limit: int = 0) -> Tuple[str, ...]:
+    """Project the anti-fake selection trail — WHY each pick/exclusion happened. Read-only.
+
+    Reflects whatever the resolver recorded; no choice is invented here. A plan with no
+    evidence renders an honest '(근거 없음)' rather than a fabricated rationale.
+    """
+
+    ev = plan.selection_evidence
+    if not ev:
+        return ("  evidence  : (근거 없음 — shallow/미매칭)",)
+    rows = ev if not limit else ev[:limit]
+    lines = ["  evidence  : 선택/제외 근거 (no fake smart-selection)"]
+    mark = {"selected": "✓", "excluded": "✗"}
+    for e in rows:
+        lines.append(f"    {mark.get(e.decision, '·')} [{e.kind}] {e.target} — {e.reason or '-'}")
+    if limit and len(ev) > limit:
+        lines.append(f"    … +{len(ev) - limit} more")
     return tuple(lines)
 
 
@@ -121,5 +150,6 @@ def nexus_surface_lines(*, env: Optional[Mapping[str, str]] = None,
 
 __all__ = (
     "resolve_with_sources", "nexus_status_lines", "resolve_summary_lines",
+    "selection_evidence_lines",
     "skills_lines", "loadout_lines", "hephaistos_status_lines", "nexus_surface_lines",
 )

--- a/packages/hephaistos/src/hephaistos/resolver.py
+++ b/packages/hephaistos/src/hephaistos/resolver.py
@@ -5,17 +5,25 @@ match + signal hits) with **language gating** (a java skill is excluded for a py
 request), picks the loadout by selection signals + recommended-skill overlap, and drafts
 a Work Packet. Nexus refs keep their honest status (read by nexus_read, surfaced by PR2).
 Uncovered requests resolve shallow — never faked.
+
+Selection is **evidence-bearing**: every pick (and every fact-driven exclusion) records a
+``SelectionEvidence`` row saying WHAT drove it (matched signal / facet / project fact).
+A "smart" choice with no evidence is a fake and does not ship. ``project_facts`` (Nexus /
+operator context) and ``runtime_constraints`` (provider / runtime) are folded into the
+packet as constraints + exclusions — NOT a new routing layer, just data on the existing
+selection surface.
 """
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from . import armory
 from .models import (
     SRC_NOT_CONNECTED,
     NexusSourceRef,
     ResolvedForgePlan,
+    SelectionEvidence,
     WorkPacketDraft,
 )
 
@@ -28,6 +36,7 @@ _FRAMEWORK = (("spring boot", "spring-boot"), ("springboot", "spring-boot"), ("s
 _DOMAIN = (("figma", "design"), ("디자인", "design"), ("design system", "design"),
            ("frontend", "frontend"), ("ui", "frontend"), ("레이아웃", "frontend"),
            ("devops", "devops"), ("terraform", "devops"), ("kubernetes", "devops"), ("ecs", "devops"),
+           ("github actions", "devops"), ("ci/cd", "devops"), ("파이프라인", "devops"),
            ("보안", "security"), ("security", "security"), ("auth review", "security"),
            ("llm", "ai"), ("rag", "ai"), ("agent eval", "ai"), ("embedding", "ai"),
            ("database", "database"), ("sql", "database"),
@@ -36,6 +45,7 @@ _TOPIC = (("refresh token", "auth-jwt"), ("jwt", "auth-jwt"), ("oauth", "oauth")
           ("secret", "secret"), ("rate limit", "rate-limit"), ("worker", "worker"),
           ("redis", "redis"), ("cache", "cache"), ("mysql", "mysql"), ("postgres", "postgres"),
           ("terraform", "terraform"), ("kubernetes", "k8s"), ("ecs", "ecs"), ("docker", "docker"),
+          ("github actions", "ci"), ("ci/cd", "ci"), ("파이프라인", "pipeline"),
           ("figma", "figma"), ("design system", "design-system"), ("디자인 시스템", "design-system"),
           ("spacing", "spacing"), ("간격", "spacing"), ("레이아웃", "layout"),
           ("rag", "rag"), ("llm", "llm"), ("eval", "eval"), ("transaction", "transaction"))
@@ -43,6 +53,9 @@ _TOPIC = (("refresh token", "auth-jwt"), ("jwt", "auth-jwt"), ("oauth", "oauth")
 _DOMAIN_AGENT = {"backend": "backend-engineer", "frontend": "frontend-engineer",
                  "devops": "devops-engineer", "security": "security-engineer",
                  "database": "backend-engineer", "ai": "ai-engineer", "design": "ux-ui-designer"}
+
+# markers that turn a project fact into an *exclusion* ("EKS는 제외", "k8s 빼고").
+_EXCLUDE_MARKERS = ("제외", "빼고", "말고", "없이", "제거", "exclude", "skip", "no ", "not ")
 
 
 def _first(pairs, blob: str) -> str:
@@ -69,12 +82,89 @@ def _infer(request: str):
     return domain, language, framework, topic, blob
 
 
-def resolve(request: str, *, preferred_role: str = "") -> ResolvedForgePlan:
-    """Forge an equip plan for *request* (suggestion-only; no install performed)."""
+def _skill_why(sk, *, domain, language, framework, topic, blob) -> Tuple[str, Tuple[str, ...]]:
+    """Explain (reason, matched signals) for selecting *sk* — the anti-fake trail."""
+
+    facets = []
+    if domain and domain in sk.domains:
+        facets.append(f"domain={domain}")
+    if language and language in sk.languages:
+        facets.append(f"lang={language}")
+    if framework and framework in sk.frameworks:
+        facets.append(f"fw={framework}")
+    if topic and topic in sk.topics:
+        facets.append(f"topic={topic}")
+    hits = tuple(s for s in sk.signals if s and s in blob)
+    if hits:
+        facets.append(f"signals={'/'.join(hits)}")
+    return (", ".join(facets) or "related", hits)
+
+
+def _fact_targets(fact_low: str) -> Tuple[str, ...]:
+    """Catalog skill ids a project fact refers to (by id / signal / topic match)."""
+
+    out = []
+    for sk in armory.all_skills():
+        keys = (sk.id, *sk.signals, *sk.topics)
+        if any(k and k in fact_low for k in keys):
+            out.append(sk.id)
+    return tuple(dict.fromkeys(out))
+
+
+def _apply_project_facts(selected_ids, facts: Sequence[str]):
+    """Split facts into exclusions (drop matching skills) and constraints. Explainable.
+
+    Returns (kept_ids, excluded_ids, constraint_texts, evidence_rows). An exclusion fact
+    records evidence even when its target was not selected — the constraint is documented,
+    not silently dropped.
+    """
+
+    kept = list(selected_ids)
+    excluded: list = []
+    constraints: list = []
+    evidence: list = []
+    for fact in facts:
+        f = (fact or "").strip()
+        if not f:
+            continue
+        low = f.lower()
+        is_excl = any(m in low for m in _EXCLUDE_MARKERS)
+        if is_excl:
+            targets = _fact_targets(low)
+            if targets:
+                for t in targets:
+                    if t in kept:
+                        kept.remove(t)
+                    if t not in excluded:
+                        excluded.append(t)
+                    evidence.append(SelectionEvidence(
+                        target=t, kind="skill", decision="excluded",
+                        reason=f"project fact: {f}", signals=(f,)))
+            # the exclusion is also a hard constraint regardless of catalog match
+            constraints.append(f)
+        else:
+            constraints.append(f)
+            evidence.append(SelectionEvidence(
+                target=f[:48], kind="constraint", decision="selected",
+                reason="project fact (Nexus/operator context)", signals=(f,)))
+    return tuple(kept), tuple(excluded), tuple(dict.fromkeys(constraints)), tuple(evidence)
+
+
+def resolve(request: str, *, preferred_role: str = "",
+            project_facts: Sequence[str] = (), runtime_constraints: Sequence[str] = (),
+            harness: str = "") -> ResolvedForgePlan:
+    """Forge an equip plan for *request* (suggestion-only; no install performed).
+
+    ``project_facts`` (Nexus/operator context, e.g. "EKS 제외", "dev 환경부터") and
+    ``runtime_constraints`` (provider/runtime, e.g. "no prod apply") shape selection +
+    the packet's constraints. ``harness`` (e.g. "claude-code") is recorded as the intended
+    executor. Every pick/exclusion is backed by a ``SelectionEvidence`` row.
+    """
 
     domain, language, framework, topic, blob = _infer(request)
 
     scored = []
+    evidence: list = []
     for sk in armory.all_skills():
         # LANGUAGE GATE: a language-specific skill is excluded for a different language.
         if language and sk.languages and language not in sk.languages:
@@ -85,15 +175,36 @@ def resolve(request: str, *, preferred_role: str = "") -> ResolvedForgePlan:
         if score > 0:
             scored.append((score, sk))
     scored.sort(key=lambda x: (-x[0], x[1].id))
-    selected = tuple(sk for _, sk in scored)
+    pre_ids = tuple(sk.id for _, sk in scored)
+    by_id = {sk.id: sk for _, sk in scored}
+
+    # fold in project facts (exclusions drop skills; non-exclusions become constraints).
+    kept_ids, excluded_ids, constraints, fact_ev = _apply_project_facts(pre_ids, project_facts)
+    selected = tuple(by_id[i] for i in kept_ids)
+
+    for sk in selected:
+        reason, hits = _skill_why(sk, domain=domain, language=language,
+                                  framework=framework, topic=topic, blob=blob)
+        evidence.append(SelectionEvidence(target=sk.id, kind="skill", decision="selected",
+                                          reason=reason, signals=hits))
+    evidence.extend(fact_ev)
 
     roles = [r for sk in selected for r in sk.related_roles]
     candidates = tuple(dict.fromkeys(roles))
     selected_agent = (preferred_role if preferred_role in candidates else "") \
         or _DOMAIN_AGENT.get(domain, "") or (candidates[0] if candidates else "")
+    if selected_agent:
+        evidence.append(SelectionEvidence(
+            target=selected_agent, kind="agent", decision="selected",
+            reason=(f"preferred_role" if selected_agent == preferred_role
+                    else f"domain={domain}" if _DOMAIN_AGENT.get(domain) == selected_agent
+                    else "first candidate role")))
 
-    chosen_loadout = _pick_loadout(blob, selected, selected_agent)
+    chosen_loadout, lo_reason, lo_signals = _pick_loadout(blob, selected, selected_agent)
     lo_spec = armory.loadout(chosen_loadout) if chosen_loadout else None
+    if chosen_loadout:
+        evidence.append(SelectionEvidence(target=chosen_loadout, kind="loadout",
+                                          decision="selected", reason=lo_reason, signals=lo_signals))
 
     weapons = list(lo_spec.required_weapons) if lo_spec else []
     for sk in selected:
@@ -112,35 +223,62 @@ def resolve(request: str, *, preferred_role: str = "") -> ResolvedForgePlan:
             if v not in verif:
                 verif.append(v)
 
-    packet = _packet(request, selected, lo_spec, refs, verif)
+    # runtime constraints (provider/runtime) are recorded as constraints + evidence.
+    rc = tuple(c.strip() for c in runtime_constraints if c and c.strip())
+    for c in rc:
+        evidence.append(SelectionEvidence(target=c[:48], kind="constraint", decision="selected",
+                                          reason="runtime/provider constraint", signals=(c,)))
+    all_constraints = tuple(dict.fromkeys(constraints + rc))
+
+    packet = _packet(request, selected, lo_spec, refs, verif, weapons, all_constraints,
+                     excluded_ids, harness)
     return ResolvedForgePlan(
         request=request, domain=domain, language=language, framework=framework, topic=topic,
         candidate_agents=candidates, selected_agent=selected_agent,
         selected_skills=tuple(sk.id for sk in selected), selected_loadout=chosen_loadout,
         required_weapons=tuple(weapons), nexus_refs=tuple(refs),
         verification_commands=tuple(verif), packet_draft=packet,
+        selection_evidence=tuple(evidence), excluded_skills=excluded_ids,
+        project_facts=tuple(f for f in project_facts if f and f.strip()),
+        runtime_constraints=rc,
     )
 
 
-def _pick_loadout(blob: str, selected, agent: str) -> str:
+def _pick_loadout(blob: str, selected, agent: str) -> Tuple[str, str, Tuple[str, ...]]:
     """Score loadouts by selection signals + recommended-skill overlap (explainable)."""
 
     sel_ids = {sk.id for sk in selected}
-    best, best_score = "", 0
+    best, best_score, best_reason, best_signals = "", 0, "", ()
     for lo in armory.all_loadouts():
-        score = sum(1 for s in lo.selection_signals if s and s in blob)
-        score += sum(1 for s in lo.recommended_skills if s in sel_ids) * 2
+        sig_hits = tuple(s for s in lo.selection_signals if s and s in blob)
+        rec_hits = tuple(s for s in lo.recommended_skills if s in sel_ids)
+        score = len(sig_hits) + len(rec_hits) * 2
         if agent in lo.intended_roles:
             score += 1
         if score > best_score:
+            reason_parts = []
+            if sig_hits:
+                reason_parts.append(f"signals={'/'.join(sig_hits)}")
+            if rec_hits:
+                reason_parts.append(f"recommends={'/'.join(rec_hits)}")
+            if agent in lo.intended_roles:
+                reason_parts.append(f"role={agent}")
             best, best_score = lo.id, score
-    return best
+            best_reason = ", ".join(reason_parts) or "best overlap"
+            best_signals = sig_hits
+    return best, best_reason, best_signals
 
 
-def _packet(request, selected, lo_spec, refs, verif) -> WorkPacketDraft:
+def _packet(request, selected, lo_spec, refs, verif, weapons, constraints,
+            excluded_ids, harness) -> WorkPacketDraft:
     rules = [r for sk in selected for r in sk.rules]
     forbidden = [f for sk in selected for f in sk.forbidden] or \
         ["승인 없는 schema/auth/deploy 변경 금지"]
+    # excluded skills become explicit forbidden-scope lines (no fake "we considered it").
+    for ex in excluded_ids:
+        sp = armory.skill(ex)
+        label = sp.name if sp else ex
+        forbidden.append(f"{label} 미사용(프로젝트 제약으로 제외)")
     commands = []
     for sk in selected:
         for c in sk.commands:
@@ -155,6 +293,7 @@ def _packet(request, selected, lo_spec, refs, verif) -> WorkPacketDraft:
         acceptance=("선택 skill 의 verification 통과", "unsafe 영역 미변경(승인 필요)"),
         approval_level="L2_internal_approve", evidence_path="runs/forgekit/hephaistos/",
         nexus_refs=tuple(refs),
+        selected_tools=tuple(weapons), constraints=tuple(constraints), harness=harness,
     )
 
 
@@ -166,6 +305,8 @@ def explain_lines(plan: ResolvedForgePlan) -> Tuple[str, ...]:
              f"  skills : {', '.join(plan.selected_skills) or '(매칭 없음 — armory 얕음)'}",
              f"  loadout: {plan.selected_loadout or '-'}",
              f"  weapons: {', '.join(plan.required_weapons) or '-'}"]
+    if plan.excluded_skills:
+        lines.append(f"  excluded: {', '.join(plan.excluded_skills)} (project fact)")
     return tuple(lines)
 
 

--- a/tests/forgekit/test_armory_intake_promotion.py
+++ b/tests/forgekit/test_armory_intake_promotion.py
@@ -1,0 +1,195 @@
+"""Armory intake → promotion + Hephaistos context-aware selection (RWT2 lane).
+
+Locks the real promotion path (candidate → SkillSpec, with non-placeholder + attach gates),
+the runtime overlay (a promoted candidate is picked up by the resolver, then cleared), and
+the context-aware selection: project facts drive exclusions, runtime constraints + harness
+land in the packet, and EVERY pick/exclusion carries a SelectionEvidence row (no fake
+smart-selection). The Terraform→ECS scenario (EKS 제외 / dev-first / keep-structure) is the
+representative end-to-end case.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from armory import candidate as C
+from armory import catalog
+from armory.models import KIND_MCP, KIND_SKILL, KIND_TOOL
+from hephaistos import resolve
+from hephaistos.projection import selection_evidence_lines
+
+
+def _complete_candidate(**over) -> C.ArmoryCandidate:
+    base = dict(
+        id="pulumi", name="Pulumi (IaC)", kind=KIND_SKILL, category="devops",
+        summary="Pulumi 로 타입 안전 IaC 작성·preview",
+        domains=("devops",), topics=("pulumi", "iac", "deploy"),
+        signals=("pulumi",), when_to_use=("범용 언어 기반 IaC",),
+        when_not_to_use=("HCL 고정 환경(→terraform)",),
+        required_inputs=("대상 클라우드/스택",), expected_outputs=("Pulumi program + preview"),
+        unsafe_boundary=("production up 무승인 금지",), capability_note="infra-as-code planner",
+        commands=("pulumi preview",), verification=("pulumi preview",),
+        related_loadouts=("devops-cloud-local",), related_roles=("devops-engineer",),
+        source="discovery", source_ref="brief-42",
+    )
+    base.update(over)
+    return C.ArmoryCandidate(**base)
+
+
+class PromotionGateTests(unittest.TestCase):
+    def test_complete_skill_promotes(self) -> None:
+        r = C.promote_candidate(_complete_candidate())
+        self.assertTrue(r.accepted, r.reasons)
+        self.assertIsNotNone(r.spec)
+        self.assertEqual(r.spec.id, "pulumi")
+        self.assertEqual(r.spec.forbidden, ("production up 무승인 금지",))  # unsafe → forbidden
+        self.assertTrue(any("승격됨" in e for e in r.evidence))
+
+    def test_missing_unsafe_boundary_rejected(self) -> None:
+        r = C.promote_candidate(_complete_candidate(unsafe_boundary=()))
+        self.assertFalse(r.accepted)
+        self.assertTrue(any("unsafe_boundary" in x for x in r.reasons))
+
+    def test_placeholder_summary_rejected(self) -> None:
+        r = C.promote_candidate(_complete_candidate(summary="TBD"))
+        self.assertFalse(r.accepted)
+        self.assertTrue(any("summary" in x for x in r.reasons))
+
+    def test_vendor_capability_note_rejected(self) -> None:
+        r = C.promote_candidate(_complete_candidate(capability_note="claude agent runner"))
+        self.assertFalse(r.accepted)
+        self.assertTrue(any("vendor" in x or "provider-neutral" in x for x in r.reasons))
+
+    def test_tool_without_attach_rejected(self) -> None:
+        r = C.promote_candidate(_complete_candidate(
+            id="trivy", name="Trivy", kind=KIND_TOOL, signals=("trivy",),
+            install_requirements=(), attach_requirements=()))
+        self.assertFalse(r.accepted)
+        self.assertTrue(any("install/attach" in x for x in r.reasons))
+
+    def test_tool_with_install_promotes(self) -> None:
+        r = C.promote_candidate(_complete_candidate(
+            id="trivy", name="Trivy", kind=KIND_TOOL, signals=("trivy",),
+            install_requirements=("brew install trivy",)))
+        self.assertTrue(r.accepted, r.reasons)
+        self.assertTrue(r.spec.needs_attach)
+
+    def test_mcp_needs_provider_affinity(self) -> None:
+        r = C.promote_candidate(_complete_candidate(
+            id="pw-mcp", name="Playwright MCP", kind=KIND_MCP, signals=("playwright mcp",),
+            install_requirements=("npx @playwright/mcp",), provider_affinity=()))
+        self.assertFalse(r.accepted)
+        self.assertTrue(any("provider_affinity" in x for x in r.reasons))
+
+    def test_mcp_with_affinity_promotes(self) -> None:
+        r = C.promote_candidate(_complete_candidate(
+            id="pw-mcp", name="Playwright MCP", kind=KIND_MCP, signals=("playwright mcp",),
+            install_requirements=("npx @playwright/mcp",), attach_requirements=("mcp connect",),
+            provider_affinity=("claude-code", "codex")))
+        self.assertTrue(r.accepted, r.reasons)
+        self.assertEqual(r.spec.provider_affinity, ("claude-code", "codex"))
+
+
+class OverlayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        catalog.clear_overlay()
+
+    def tearDown(self) -> None:
+        catalog.clear_overlay()
+
+    def test_promoted_candidate_resolved(self) -> None:
+        # before promotion: 'pulumi' stack is uncovered → shallow.
+        self.assertEqual(resolve("Pulumi 로 스택 구성").selected_skills, ())
+        r = C.promote_candidate(_complete_candidate())
+        catalog.register_promoted(r.spec)
+        self.assertIn("pulumi", (s.id for s in catalog.all_skills()))
+        p = resolve("Pulumi 로 스택 구성")
+        self.assertIn("pulumi", p.selected_skills)
+        # evidence row exists for the promoted pick (no fake).
+        self.assertTrue(any(e.target == "pulumi" and e.decision == "selected"
+                            for e in p.selection_evidence))
+
+    def test_clear_overlay_reverts(self) -> None:
+        catalog.register_promoted(C.promote_candidate(_complete_candidate()).spec)
+        catalog.clear_overlay()
+        self.assertNotIn("pulumi", (s.id for s in catalog.all_skills()))
+        self.assertEqual(resolve("Pulumi 로 스택 구성").selected_skills, ())
+
+    def test_promotion_idempotent_by_id(self) -> None:
+        spec = C.promote_candidate(_complete_candidate()).spec
+        catalog.register_promoted(spec)
+        catalog.register_promoted(spec)
+        self.assertEqual(sum(1 for s in catalog.all_skills() if s.id == "pulumi"), 1)
+
+
+class SchemaTests(unittest.TestCase):
+    def test_github_actions_seeded_with_kind_and_attach(self) -> None:
+        sk = catalog.skill("github-actions")
+        self.assertIsNotNone(sk)
+        self.assertEqual(sk.kind, KIND_SKILL)
+        self.assertEqual(sk.provider_affinity, ("github",))
+        self.assertIn("actionlint", sk.install_requirements)
+
+    def test_every_skill_serialises_new_fields(self) -> None:
+        for sk in catalog.all_skills():
+            d = sk.to_dict()
+            for key in ("kind", "provider_affinity", "install_requirements",
+                        "attach_requirements", "when_to_use", "required_inputs"):
+                self.assertIn(key, d, f"{sk.id} to_dict missing {key}")
+
+
+class ContextAwareSelectionTests(unittest.TestCase):
+    SCENARIO = "Terraform으로 ECS 배포 환경 구성해야 돼. Claude Code한테 맡길 프롬프트 만들어줘."
+    FACTS = ("EKS는 제외", "dev 환경부터", "기존 구조 보존")
+
+    def _scenario(self):
+        return resolve(self.SCENARIO, project_facts=self.FACTS,
+                       runtime_constraints=("production apply 금지",), harness="claude-code")
+
+    def test_terraform_ecs_loadout_and_tools(self) -> None:
+        p = self._scenario()
+        self.assertEqual(p.selected_loadout, "devops-cloud-local")
+        for s in ("terraform", "aws-ecs", "docker", "github-actions"):
+            self.assertIn(s, p.selected_skills)
+        for w in ("terraform", "docker", "gh"):
+            self.assertIn(w, p.packet_draft.selected_tools)
+
+    def test_eks_excluded_with_evidence(self) -> None:
+        p = self._scenario()
+        self.assertIn("kubernetes", p.excluded_skills)
+        self.assertNotIn("kubernetes", p.selected_skills)
+        self.assertTrue(any(e.target == "kubernetes" and e.decision == "excluded"
+                            for e in p.selection_evidence))
+        self.assertTrue(any("제외" in f for f in p.packet_draft.forbidden_scope))
+
+    def test_constraints_and_harness_in_packet(self) -> None:
+        p = self._scenario()
+        self.assertEqual(p.packet_draft.harness, "claude-code")
+        self.assertIn("dev 환경부터", p.packet_draft.constraints)
+        self.assertIn("기존 구조 보존", p.packet_draft.constraints)
+        self.assertIn("production apply 금지", p.packet_draft.constraints)
+
+    def test_every_selected_skill_has_evidence(self) -> None:
+        p = self._scenario()
+        rows = {e.target for e in p.selection_evidence if e.decision == "selected" and e.kind == "skill"}
+        self.assertEqual(set(p.selected_skills), rows)  # no pick without a reason
+
+    def test_shallow_request_has_no_fake_evidence(self) -> None:
+        p = resolve("Rust 임베디드 펌웨어 베어메탈")
+        self.assertEqual(p.selected_skills, ())
+        skill_ev = [e for e in p.selection_evidence if e.kind == "skill"]
+        self.assertEqual(skill_ev, [])  # nothing fabricated
+        self.assertIn("근거 없음", selection_evidence_lines(p)[0])
+
+    def test_backward_compatible_without_context(self) -> None:
+        # the legacy 2-arg call still works (forge bridge path) and is unaffected.
+        p = resolve("Spring Boot + JWT + MySQL 기반 관리자 API")
+        self.assertEqual(p.selected_loadout, "backend-java-local")
+        self.assertEqual(p.excluded_skills, ())
+        self.assertEqual(p.packet_draft.harness, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 관련 이슈
closed #415

## ✨ 과제 내용
**목적** — 외부 수집 후보를 Armory catalog 로 정식 등록하고, Hephaistos 가 요청/프로젝트 문맥/
런타임 제약에 따라 적절한 loadout·tool 을 골라 실무형 work packet 을 생성하는 lane 완성. Armory=catalog,
Hephaistos=forge/selection, console=projection only, no fake smart-selection(evidence 의무).

**범위**
1. Armory 스키마 + 승격 (`packages/armory`)
   - `SkillSpec` 에 `kind`(skill/tool/plugin/mcp)·`provider_affinity`·`install_requirements`·
     `attach_requirements` 추가 (기존 when_to_use/when_not_to_use/required_inputs/expected_outputs/
     forbidden=unsafe boundary 와 합쳐 선택 계약 완성).
   - `armory.candidate` 신규 — `ArmoryCandidate → promote_candidate` 게이트: placeholder/누락 unsafe/
     vendor-locked capability/검증 경로 없음/tool·mcp·plugin attach 누락 시 **거부**(부분 승격 금지),
     통과 시 SkillSpec + 통과 게이트 evidence.
   - 런타임 overlay(`register_promoted`/`promoted_skills`/`clear_overlay`) → 승격 spec 을
     `all_skills`/`skill` 가 seed 위에 merge, resolver 즉시 픽업, 재승격 idempotent.
   - `github-actions` skill seed(CI/CD, kind/provider_affinity=github/install_req) + devops 로드아웃 배선.
2. Hephaistos 맥락 인지 선택 (`packages/hephaistos`)
   - `resolve(..., project_facts, runtime_constraints, harness)` (키워드 전용, 하위호환).
     exclusion 사실("EKS 제외")은 skill 제외+forbidden 라인화, 비-exclusion 사실은 packet constraint.
   - `SelectionEvidence` — 모든 선택/제외에 target/kind/decision/reason/signals 부여(근거 없는 선택 미발행).
   - `WorkPacketDraft` 에 selected_tools/constraints/harness 추가, projection 에 evidence 투영(read-only).

**리스크** — selection 폭이 domain 매칭으로 넓을 수 있음(기존 동작, assertIn 계약 유지). overlay 는
process-local mutable → 테스트가 clear_overlay 로 격리. ponytail lens 적용: 새 routing/adapter 레이어
없이 기존 선택 표면에 project/runtime 문맥을 **data(constraint/exclusion)** 로만 표현.

**테스트** — `test_armory_intake_promotion` 신규 19(승격 accept/reject, overlay 픽업/복귀/idempotent,
스키마 직렬화, Terraform→ECS 시나리오·EKS 제외·packet 제약·skill 별 evidence·shallow no-fake·하위호환).
forgekit 전체 **1251 OK**(skip 1 무관 TUI). commit-governance CI 5 OK.

**이슈 linkage** — #415.

### Audit
- no fake live / no fake smart-selection: 선택/제외 모두 SelectionEvidence 근거, shallow 는 정직하게 빈 trail.
- Armory→Hephaistos 단방향 유지(candidate 는 armory.models 만 의존, no cycle).
- console = projection only(core 결과 그대로 반영).
- evidence: `apps/forgekit-console/examples/armory-intake/intake.txt` (hermetic 재현).

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- docs/armory.md 갱신(entry kind+attach contract / intake→promotion / 맥락 인지 선택, coverage 26 skills).
- promote_candidate 의 attach 게이트가 fake "available" 항목을 catalog 진입 전에 차단하는 것이 핵심.