### PR TITLE
✨ ForgeKit Armory intake — 외부 후보 도입 검토(adopt/collect/hold) + doc-quality loadout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ docs/
 | packages/* 분류 / 네이밍 충돌 / 새 기능 위치 / transitional debt | `docs/package-topology.md` (18 package 분류표 · migration matrix · 결정 트리 SSoT) |
 | control-plane 방향 / 외부 프로젝트 흡수 / onboarding bootstrap / P0~P2 / Mac mini host | `docs/control-plane-architecture.md` (역할 · 소유 경계 · 우선순위 로드맵 SSoT) |
 | Nexus discovery 루프 / free-first 수집→idea brief→operator digest→PM packet·vault note / planned seam | `docs/discovery-loop.md` (+ 코드 SSoT `apps/forgekit-console/src/forgekit_console/discovery/sweep.py`) |
+| 외부 plugin/skill/tool Armory 도입 검토 / adopt-now·collect-first·hold / 8축+3축 / adopted≠equipped | `docs/armory-intake-adoption.md` (+ 코드 SSoT `packages/armory/src/armory/adoption.py` + `adoption_registry.py`) |
 
 규칙:
 - 위 표에 없는 토픽이면 그 작업과 가장 가까운 디렉터리의 `CLAUDE.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@
 | ForgeKit 플랫폼 경계 / console=operator app / 코어 packages 분리(WT1~4) | + `docs/forgekit-architecture-ownership.md` (owner 매트릭스·import 경계·이전 우선순위 SSoT) |
 | packages/* 분류 / 네이밍 충돌 / 어디에 새 기능 추가 / transitional debt | + `docs/package-topology.md` (18 package 분류표·migration matrix·결정 트리 SSoT) |
 | control-plane 방향 / OpenClaw·Harness·Hermes 흡수 / onboarding bootstrap / P0~P2 우선순위 / Mac mini host | + `docs/control-plane-architecture.md` (역할·소유 경계·우선순위 로드맵 SSoT) |
+| 외부 plugin/skill/tool 후보 Armory 도입 검토 / adopt-now·collect-first·hold / 8축 artifact + 3축 검토 / adopted≠equipped | + `docs/armory-intake-adoption.md` (SSoT — `armory.adoption`(검토/게이트) + `adoption_registry`(평가 데이터). fake adoption 금지, collect-first=Nexus 근거만. 코드: `packages/armory/src/armory/adoption.py`) |
 
 전체 매핑은 `AGENTS.md` §2.
 

--- a/apps/forgekit-console/examples/armory-intake/adoption-catalog.json
+++ b/apps/forgekit-console/examples/armory-intake/adoption-catalog.json
@@ -1,0 +1,503 @@
+{
+  "round": "armory-intake-wave",
+  "summary": {
+    "total": 13,
+    "adopt_now": 1,
+    "collect_first": 8,
+    "hold": 4
+  },
+  "doc_quality_loadout": {
+    "loadout_id": "doc-quality-review-local",
+    "anchor": "vale (adopt-now)",
+    "members": [
+      "vale",
+      "proselint",
+      "write-good",
+      "alex",
+      "textlint"
+    ],
+    "note": "Vale=required(adopt-now), 나머지=optional(collect-first). adopted≠installed."
+  },
+  "reviews": [
+    {
+      "candidate_id": "vale",
+      "name": "Vale",
+      "kind": "tool",
+      "source": "https://github.com/errata-ai/vale",
+      "artifact": {
+        "current_pain": "vault/문서 품질이 사람 리뷰에만 의존 — '왜' 깊이/문체/용어 일관성을 기계로 강제할 표준 도구가 없다.",
+        "expected_benefit": "style-guide(YAML) 기반 prose lint 를 CI/로컬에서 결정적으로 강제 — 문서 회귀를 사람 전에 잡는다.",
+        "overlap": "Nexus vault-curate 는 구조(frontmatter/5섹션)를 보지만 prose 문체/용어는 안 본다 — 보완재(중복 아님).",
+        "operational_cost": "단일 Go 바이너리(brew/직접 다운로드) + style 패키지 sync. 런타임 의존 없음 — 가장 낮은 부담.",
+        "maintenance_risk": "활발히 유지(errata-ai), config 안정적. 낮음 — style 패키지 버전만 핀.",
+        "provider_runtime_fit": "provider-neutral CLI — 어느 backend 든 executor 가 호출. ForgeKit toolchain 으로 버전 관리 가능.",
+        "governance_security": "로컬 파일만 읽고 네트워크 없음(style sync 제외). 위험 낮음, 가드 불필요."
+      },
+      "verdict": "adopt-now",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "adopt-now",
+          "rationale": "문서 품질은 ForgeKit 핵심 가치(vault) — 즉시 카탈로그화할 가치 충분."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "adopt-now",
+          "rationale": "단일 바이너리·config 기반이라 도입 리스크 최소. attach contract 명확."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "adopt-now",
+          "rationale": "knowledge-engineer: style-guide 로 '왜' 깊이/용어 강제가 vault 규칙과 정합."
+        }
+      ],
+      "install_plan": [
+        "brew install vale",
+        "vale sync (.vale.ini 의 style 패키지)",
+        "검증: vale --version"
+      ],
+      "loadout_id": "doc-quality-review-local",
+      "notes": "adopted=카탈로그 등록(available). 실제 설치/장착은 install_plan 선언일 뿐 — 미설치."
+    },
+    {
+      "candidate_id": "proselint",
+      "name": "proselint",
+      "kind": "tool",
+      "source": "https://github.com/amperser/proselint",
+      "artifact": {
+        "current_pain": "문서의 상투구/중복/약한 표현을 기계로 잡을 보조 린터가 없다.",
+        "expected_benefit": "Vale 보완 — 영어 prose 의 검증된 규칙(중복/jargon) 추가 커버.",
+        "overlap": "Vale 규칙과 상당 부분 겹침 — Vale 채택 후 한계가 드러나면 그때 보강.",
+        "operational_cost": "Python 패키지(pip/uv) — Python 런타임 의존. Vale 대비 추가 부담.",
+        "maintenance_risk": "유지보수 빈도 낮은 편 — 중간. Vale 가 있으면 필수 아님.",
+        "provider_runtime_fit": "CLI, provider-neutral. doc-quality loadout 의 optional 멤버로 적합.",
+        "governance_security": "로컬 파일만 — 위험 낮음."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "Vale 로 시작하고 효과 측정 후 보강 — 동시 도입은 과함."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "Vale 와 규칙 중복 — 한계 evidence 누적 후 결정."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "knowledge-engineer: loadout optional 로만 노출, 강제 X."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "doc-quality-review-local 의 optional 멤버 후보 — Nexus 근거 누적, 미설치."
+    },
+    {
+      "candidate_id": "write-good",
+      "name": "write-good",
+      "kind": "tool",
+      "source": "https://github.com/btford/write-good",
+      "artifact": {
+        "current_pain": "수동태/약한 표현 같은 흔한 글쓰기 안티패턴을 기계로 못 잡는다.",
+        "expected_benefit": "가벼운 영어 문체 힌트 — 빠른 1차 패스.",
+        "overlap": "Vale/proselint 와 규칙 겹침 — naive linter 라 정확도 낮음.",
+        "operational_cost": "npm 패키지 — Node 런타임 의존. 멀티 Node 도구는 toolchain 부담 누적.",
+        "maintenance_risk": "유지보수 정체(최근 커밋 드묾) — 중상.",
+        "provider_runtime_fit": "CLI, provider-neutral. 단 Node 의존이 Vale 단일바이너리보다 불리.",
+        "governance_security": "로컬 파일만 — 위험 낮음."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "정확도/유지보수가 약해 즉시 도입 가치 낮음."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "Node 의존 + 유지보수 정체 — 사실상 hold 에 가까움, loadout 노출만."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "knowledge-engineer: Vale 로 대체 가능, evidence 만."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "loadout optional 후보(약). 미설치."
+    },
+    {
+      "candidate_id": "alex",
+      "name": "alex",
+      "kind": "tool",
+      "source": "https://github.com/get-alex/alex",
+      "artifact": {
+        "current_pain": "둔감/배제적 표현(insensitive writing)을 사람이 일일이 못 잡는다.",
+        "expected_benefit": "포용적 글쓰기 자동 점검 — 공개 문서/README 톤 관리.",
+        "overlap": "Vale 에도 inclusive-language 스타일 팩(예: alex 포팅)이 있어 부분 중복.",
+        "operational_cost": "npm 패키지 — Node 런타임 의존.",
+        "maintenance_risk": "유지보수 양호하나 영어 전용 — 한국어 문서엔 제한적. 중간.",
+        "provider_runtime_fit": "CLI, provider-neutral. 한국어 비중 높은 vault 엔 적용 범위 좁음.",
+        "governance_security": "로컬 파일만 — 위험 낮음."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "공개 문서 톤엔 가치 — 단 한국어 vault 비중 고려해 선검증."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "Vale inclusive 팩과 비교 evidence 필요."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "knowledge-engineer: 영어 산출물 한정 optional."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "영어 산출물 한정 optional 후보. 미설치."
+    },
+    {
+      "candidate_id": "textlint",
+      "name": "textlint",
+      "kind": "tool",
+      "source": "https://github.com/textlint/textlint",
+      "artifact": {
+        "current_pain": "규칙을 직접 짜야 하는 문서 영역(한국어 포함)에 플러그형 린터가 없다.",
+        "expected_benefit": "플러그인 생태계로 한국어/마크다운 규칙까지 확장 가능 — Vale 가 약한 영역 보완.",
+        "overlap": "Vale 와 목적 겹치나 plugin 모델/한국어 커버는 차별점.",
+        "operational_cost": "npm + 플러그인 다수 — 설정/유지 부담 가장 큼.",
+        "maintenance_risk": "코어는 유지되나 플러그인 품질 편차 — 중상.",
+        "provider_runtime_fit": "CLI, provider-neutral. 한국어 vault 에는 Vale 보다 적합할 수 있음(검증 필요).",
+        "governance_security": "로컬 파일만 — 위험 낮음."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "한국어 커버 가능성은 매력 — 단 설정 부담 커서 PoC 먼저."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "플러그인 의존 트리 평가 후. 지금 adopt 는 과투자."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "knowledge-engineer: 한국어 규칙 PoC 로 Vale 와 비교."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "한국어 vault 커버 PoC 후보. 미설치."
+    },
+    {
+      "candidate_id": "ponytail",
+      "name": "ponytail",
+      "kind": "skill",
+      "source": "https://github.com/example/ponytail",
+      "artifact": {
+        "current_pain": "새 모듈/계층 추가 시 과설계를 막을 일관된 단순성 검토 렌즈가 코드화돼 있지 않다.",
+        "expected_benefit": "ponytail 식 단순성 검토(keep/simplify/use-existing/reduce-surface/reject)를 표준 스킬로.",
+        "overlap": "ForgeKit 은 이미 council/consult + lane readiness 로 설계 검토 레인을 가짐 — 상당 부분 겹침.",
+        "operational_cost": "외부 도구라기보다 검토 절차 — 도입 부담 낮으나 repo 실체/성숙도 불명확.",
+        "maintenance_risk": "repo 정체성/유지보수 불확실 — 외부 의존보다 '렌즈를 스킬로 내재화'가 안전.",
+        "provider_runtime_fit": "skill(절차) — provider-neutral. 단 외부 repo 채택보다 내부 스킬화가 fit.",
+        "governance_security": "검토 절차라 보안 위험 낮음 — 외부 코드 실행 아님."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "단순성 렌즈 자체는 이미 우리 lane 이 적용 중 — 외부 채택보다 evidence."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "council/consult 와 겹침 — 외부 repo 의존 만들 이유 약함."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "tech-lead specialist: 내부 스킬화로 충분, 외부 도입은 보류."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "이미 본 wave 의 consult 렌즈로 사용 중 — 외부 repo 채택은 근거 누적 후."
+    },
+    {
+      "candidate_id": "context7",
+      "name": "Context7",
+      "kind": "mcp",
+      "source": "https://github.com/upstash/context7",
+      "artifact": {
+        "current_pain": "LLM 이 라이브러리 최신 API 를 모르고 환각 — 버전 맞는 docs/예제 주입 경로가 없다.",
+        "expected_benefit": "최신 라이브러리 docs/snippet 을 MCP 로 주입 — 코드 생성 정확도 향상.",
+        "overlap": "Nexus 는 *내부* 지식(vault) — 외부 라이브러리 docs 는 미커버라 보완재. 단 역할 경계 정리 필요.",
+        "operational_cost": "MCP 서버 + (호스티드) 의존/키 가능성 — 외부 서비스 의존 도입.",
+        "maintenance_risk": "3rd-party 호스티드 서비스 의존 — 가용성/정책 변화 리스크 중상.",
+        "provider_runtime_fit": "MCP 라 claude/codex/gemini(mcp-host)에 attach — provider-neutral SSoT 가능. ollama 제외.",
+        "governance_security": "외부 서버로 쿼리 송신 — outbound/데이터 노출 검토 필요. integrations/mcp 가드 경유 필수."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "adopt-now",
+          "rationale": "환각 감소 효과 크다 — 가능하면 빨리."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "호스티드 의존 + outbound 정책 정리 전엔 adopt 불가 — PoC 먼저."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "platform-runtime: integrations/mcp 가드+키 처리 검증 후."
+        }
+      ],
+      "install_plan": [
+        "integrations/mcp/context7.json 정의(transport/auth.env)",
+        "mcp projection 생성",
+        "키는 env 참조만"
+      ],
+      "loadout_id": "",
+      "notes": "가장 유망한 collect-first — outbound/키 가드 검증되면 adopt 재평가."
+    },
+    {
+      "candidate_id": "mcp-fetch",
+      "name": "MCP Fetch (official)",
+      "kind": "mcp",
+      "source": "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+      "artifact": {
+        "current_pain": "에이전트가 임의 URL 본문을 표준 경로로 가져올 reference MCP 가 미배선.",
+        "expected_benefit": "공식 reference 서버라 신뢰도 높은 fetch capability — 리서치 보강.",
+        "overlap": "discovery sources(RSS/HN/GitHub collectors)와 기능 겹침 — 단 임의 URL fetch 는 미커버.",
+        "operational_cost": "공식 서버 설치/attach — 경량이나 MCP host 연결 필요.",
+        "maintenance_risk": "공식 레포라 유지보수 양호 — 낮음.",
+        "provider_runtime_fit": "MCP, mcp-host attach. provider-neutral SSoT 가능.",
+        "governance_security": "임의 URL fetch = SSRF/내부망 접근 위험 — allowlist/sandbox 정책 필수. 가드 전 도입 금지."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "리서치엔 유용하나 보안 가드가 선행."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "collect-first",
+          "rationale": "SSRF allowlist 정책 설계 후 — 지금 adopt 위험."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "security-engineer: outbound allowlist 없이는 hold."
+        }
+      ],
+      "install_plan": [
+        "integrations/mcp/fetch.json",
+        "URL allowlist/sandbox 정책 첨부",
+        "mcp projection"
+      ],
+      "loadout_id": "",
+      "notes": "공식이라 품질 높음 — SSRF 가드 설계가 adopt 전제."
+    },
+    {
+      "candidate_id": "mcp-memory",
+      "name": "MCP Memory (official)",
+      "kind": "mcp",
+      "source": "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+      "artifact": {
+        "current_pain": "세션 간 기억의 표준 MCP 경로가 없다.",
+        "expected_benefit": "공식 memory 서버로 표준화된 기억 capability.",
+        "overlap": "Nexus(vault) + troubleshooting ledger + claude-mem 으로 이미 기억 레인 보유 — 중복 큼.",
+        "operational_cost": "서버 설치/attach + 저장소 관리 — 기존 기억 레인과 이중화 비용.",
+        "maintenance_risk": "공식 유지보수 양호하나 우리 기억 SSoT 와 충돌 위험 — 중간.",
+        "provider_runtime_fit": "MCP attach 가능 — 단 우리 기억은 vault/ledger 가 SSoT 라 fit 약함.",
+        "governance_security": "기억 저장 위치/내용 거버넌스 — 기존 메모리 정책과 정합 필요."
+      },
+      "verdict": "collect-first",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "collect-first",
+          "rationale": "기억은 이미 vault/ledger 로 충당 — 굳이 지금 아님."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "Nexus/ledger 와 SSoT 중복 — 사실상 hold 성격."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "collect-first",
+          "rationale": "knowledge-engineer: 우리 기억 모델과 비교 evidence 만."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "중복 큼 — Nexus/ledger 한계 드러날 때 재평가."
+    },
+    {
+      "candidate_id": "mcp-filesystem",
+      "name": "MCP Filesystem (official)",
+      "kind": "mcp",
+      "source": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+      "artifact": {
+        "current_pain": "에이전트의 파일 접근을 표준 MCP 로 노출하고 싶을 수 있다.",
+        "expected_benefit": "표준 파일 접근 capability.",
+        "overlap": "executor 는 이미 파일 도구를 가짐 — 기능 거의 전부 중복.",
+        "operational_cost": "추가 서버 + 권한 범위 관리.",
+        "maintenance_risk": "공식 유지보수는 양호하나 우리 가드와 충돌 관리 비용.",
+        "provider_runtime_fit": "MCP attach 가능하나 ForgeKit 파일 경로 안전(git_path_safety)과 경합.",
+        "governance_security": "광범위 FS 접근 MCP 는 git-write hard rail / 경로 안전 SSoT 를 우회 — 거버넌스 충돌(금지)."
+      },
+      "verdict": "hold",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "hold",
+          "rationale": "기존 파일 도구로 충분 — 추가 가치 없음."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "경로 안전 hard rail 우회 위험 — 도입 불가."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "security-engineer: broad FS MCP 는 가드 우회, hold."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "governance 충돌 + 중복 — 이번 라운드 제외."
+    },
+    {
+      "candidate_id": "mcp-git",
+      "name": "MCP Git (official)",
+      "kind": "mcp",
+      "source": "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+      "artifact": {
+        "current_pain": "git 작업을 MCP 로 노출하려는 유혹.",
+        "expected_benefit": "표준 git capability.",
+        "overlap": "ForgeKit 은 git-write 를 git_path_safety/repo_write_policy 로 강하게 통제 — 전면 중복.",
+        "operational_cost": "추가 서버 + 권한.",
+        "maintenance_risk": "우리 git hard rail 과 이중 경로 유지 비용.",
+        "provider_runtime_fit": "MCP attach 가능하나 우리 git 거버넌스와 정면 충돌.",
+        "governance_security": "MCP 가 git write 를 수행하면 `git -C + 명시 pathspec` hard rail / commit-governance 를 우회 — 금지."
+      },
+      "verdict": "hold",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "hold",
+          "rationale": "git 안전은 우리 핵심 가드 — 외부 MCP 로 우회 불가."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "repo_write_policy SSoT 우회 — 도입 금지."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "security-engineer: hard rail 충돌, hold."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "git hard rail 우회 위험 — 제외."
+    },
+    {
+      "candidate_id": "mcp-sequential-thinking",
+      "name": "MCP Sequential Thinking (official)",
+      "kind": "mcp",
+      "source": "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+      "artifact": {
+        "current_pain": "구조화된 단계적 추론을 도구로 강제하고 싶을 수 있다.",
+        "expected_benefit": "단계적 사고 스캐폴딩.",
+        "overlap": "decision_lane(readiness/council/handoff) + 에이전트 자체 추론과 겹침 — 한계 효용.",
+        "operational_cost": "추가 서버 + 프롬프트 표면 증가.",
+        "maintenance_risk": "효용 대비 유지 비용 — 중간.",
+        "provider_runtime_fit": "MCP attach 가능하나 모델 내장 추론과 중복.",
+        "governance_security": "위험 낮으나 도입 정당성(효용) 부족이 더 큰 문제."
+      },
+      "verdict": "hold",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "hold",
+          "rationale": "추론은 모델/lane 이 이미 함 — 추가 가치 미미."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "프롬프트 표면만 늘림 — hold."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "decision_lane 과 중복 — hold."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "효용 낮음 — 제외."
+    },
+    {
+      "candidate_id": "browser-use",
+      "name": "browser-use",
+      "kind": "tool",
+      "source": "https://github.com/browser-use/browser-use",
+      "artifact": {
+        "current_pain": "실제 브라우저 자동화(로그인-게이트 사이트 등) capability 가 없다.",
+        "expected_benefit": "LLM 주도 브라우저 자동화 — 일부 리서치/검증 시나리오 확장.",
+        "overlap": "discovery 의 YouTube/Figma/Google 은 planned seam — 그쪽과 목적 일부 겹침(미연결).",
+        "operational_cost": "Python + 헤드리스 브라우저(Playwright) 의존 — 무거운 런타임.",
+        "maintenance_risk": "빠르게 바뀌는 신생 프로젝트 — API 불안정, 중상.",
+        "provider_runtime_fit": "라이브러리/에이전트 — 무거운 의존이 ForgeKit 경량 toolchain 과 어긋남.",
+        "governance_security": "실 브라우저 구동 = 자격증명/exfiltration/자동 액션 위험 매우 큼 — 강한 sandbox/승인 게이트 없이는 금지."
+      },
+      "verdict": "hold",
+      "reviewers": [
+        {
+          "axis": "pm",
+          "verdict": "hold",
+          "rationale": "위험·비용 대비 당장 필요 시나리오 없음."
+        },
+        {
+          "axis": "tech-lead",
+          "verdict": "hold",
+          "rationale": "무거운 의존 + 불안정 API — hold."
+        },
+        {
+          "axis": "specialist",
+          "verdict": "hold",
+          "rationale": "security-engineer: 브라우저 자동화 위험, sandbox 설계 전 hold."
+        }
+      ],
+      "install_plan": [],
+      "loadout_id": "",
+      "notes": "고위험 — planned browser seam 과 함께 별도 보안 설계 후 재평가."
+    }
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -28,6 +28,7 @@ H_BLOCKED = "blocked"
 H_WHOAMI = "whoami"
 H_RESOLVE = "resolve"
 H_HEPHAISTOS = "hephaistos"
+H_ARMORY = "armory"
 H_SKILLS = "skills"
 H_LOADOUT = "loadout"
 H_PROVIDER = "provider"
@@ -104,6 +105,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("council", "PM→tech-lead→specialist lane readiness — 실행 전에 무엇이 확정돼야 하는지(replay 가능 decision log). `/council <session>` (없으면 사용법)", H_COUNCIL, "status"),
     SlashCommand("handoff", "specialist work order — 목표/제안 스택/선택 이유/탈락안/컨벤션/디자인·API·infra/scope/test/acceptance (`/handoff <session>`, replay 된 handoff packet)", H_HANDOFF, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
+    SlashCommand("armory", "Armory intake 도입 검토 — 외부 plugin/skill/tool 후보의 adopt-now/collect-first/hold 결정 + 8축 artifact + 3축 검토. `/armory [review <id>]` (id 없으면 verdict 별 요약 + doc-quality loadout)", H_ARMORY, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
     SlashCommand("provider", "provider 설정/연결 — `/provider [set|link|unlink|connect <id>|disconnect <id>|test <id>|recommended|preset four-brain|route show|route set <slot> <id>|budget <id> <limit>|budget show|list|doctor]`", H_PROVIDER, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -34,6 +34,7 @@ from .registry import (
     H_WHOAMI,
     H_RESOLVE,
     H_HEPHAISTOS,
+    H_ARMORY,
     H_SKILLS,
     H_LOADOUT,
     H_PROVIDER,
@@ -176,6 +177,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _whoami_result(parsed)
     if handler in (H_RESOLVE, H_HEPHAISTOS, H_SKILLS, H_LOADOUT):
         return _hephaistos_result(handler, parsed, ctx)
+    if handler == H_ARMORY:
+        return _armory_result(parsed, ctx)
     if handler == H_PROVIDER:
         return _provider_result(parsed, ctx)
     if handler == H_SETUP:
@@ -389,6 +392,25 @@ def _toolchain_result(parsed, ctx) -> CommandResult:
         ok, lines = ts.apply_switch(root, loadout, approve=approve, scope=scope)
         return (CommandResult.info if ok else CommandResult.error)("toolchain switch", lines)
     return CommandResult.info("toolchain detect", ts.detect_lines(root))
+
+
+def _armory_result(parsed, ctx) -> CommandResult:
+    # /armory [review <id>] — 외부 후보 도입 검토(adopt-now/collect-first/hold) 요약 또는 상세.
+    # 카탈로그 자체(skills/loadouts)는 /skills · /loadout · /resolve 가 본다 — 여기는 intake 결정.
+    from armory import adoption_registry_reviews
+    from ..tui import render as _r
+
+    reviews = adoption_registry_reviews()
+    args = list(getattr(parsed, "args", ()) or ())
+    sub = args[0].lower() if args else ""
+    if sub == "review":
+        cid = (args[1] if len(args) > 1 else "").lower()
+        match = next((r for r in reviews if r.candidate_id == cid), None)
+        if not match:
+            ids = ", ".join(r.candidate_id for r in reviews)
+            return CommandResult.error("armory review", (f"후보 '{cid}' 없음. 가능: {ids}",))
+        return CommandResult.info(f"armory review {cid}", _r.armory_intake_lines(reviews, detail=match))
+    return CommandResult.info("armory", _r.armory_intake_lines(reviews))
 
 
 def _nexus_result(parsed, ctx) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -638,6 +638,57 @@ def discovery_lines(result) -> Tuple[str, ...]:
     return tuple(lines)
 
 
+def armory_intake_lines(reviews, *, detail=None) -> Tuple[str, ...]:
+    """Render the Armory intake 도입 검토 — verdict별 요약, 또는 한 후보의 8축 artifact.
+
+    ``reviews`` = AdoptionReview 시퀀스. ``detail`` = 한 AdoptionReview(상세) 또는 None(요약).
+    """
+
+    _V = {"adopt-now": _OK, "collect-first": _WARN, "hold": _ERR}
+    if detail is not None:
+        r = detail
+        tag = _V.get(r.verdict, _MUTED)
+        lines = [
+            f"[b {_ACCENT}]» armory intake · {r.name}[/b {_ACCENT}]  [dim]({r.kind})[/dim]",
+            f"  verdict: [{tag}]{r.verdict}[/{tag}]   [dim]{r.source}[/dim]",
+            f"  현재 pain: {r.current_pain}",
+            f"  기대 효과: {r.expected_benefit}",
+            f"  기존 중복: {r.overlap}",
+            f"  운영 비용: {r.operational_cost}",
+            f"  유지 리스크: {r.maintenance_risk}",
+            f"  provider/runtime: {r.provider_runtime_fit}",
+            f"  governance/security: {r.governance_security}",
+            "  3축 검토:",
+        ]
+        for rv in r.reviewers:
+            lines.append(f"    - {rv.axis}: [{_V.get(rv.verdict, _MUTED)}]{rv.verdict}[/{_V.get(rv.verdict, _MUTED)}] — {rv.rationale}")
+        if r.install_plan:
+            lines.append(f"  install plan(선언, 미설치): {' · '.join(r.install_plan)}")
+        if r.loadout_id:
+            lines.append(f"  catalog loadout: {r.loadout_id} (adopted=available, not installed)")
+        return tuple(lines)
+
+    buckets = {"adopt-now": [], "collect-first": [], "hold": []}
+    for r in reviews:
+        buckets.get(r.verdict, buckets.setdefault(r.verdict, [])).append(r)
+    lines = [
+        f"[b {_ACCENT}]» armory intake — 외부 후보 도입 검토[/b {_ACCENT}]",
+        f"  adopt-now {len(buckets['adopt-now'])} · collect-first {len(buckets['collect-first'])} · hold {len(buckets['hold'])}"
+        f"  [dim](총 {len(reviews)}건, 8축 artifact + PM/tech-lead/specialist 3축)[/dim]",
+    ]
+    for v, label, tag in (("adopt-now", "adopt-now", _OK),
+                          ("collect-first", "collect-first", _WARN),
+                          ("hold", "hold", _ERR)):
+        if not buckets[v]:
+            continue
+        lines.append(f"  [b][{tag}]{label}[/{tag}][/b]")
+        for r in buckets[v]:
+            extra = f" → {r.loadout_id}" if r.loadout_id else ""
+            lines.append(f"    [{tag}]•[/{tag}] {r.name} [dim]({r.kind}){extra}[/dim]")
+    lines.append("  [dim]adopted=카탈로그 등록(available) ≠ equipped/installed · collect-first=근거만 누적 · `/armory review <id>`[/dim]")
+    return tuple(lines)
+
+
 def video_watch_lines(result) -> Tuple[str, ...]:
     """Render a video-watch ingest result — live summary or honest reference_only."""
 
@@ -840,6 +891,6 @@ __all__ = (
     "palette_lines", "palette_panel_lines", "mode_badge", "mode_pill",
     "status_pill", "hint_line", "help_sections", "selection_copy_lines",
     "help_panel_document", "help_tab_strip", "help_body", "default_help_tab",
-    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
+    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "armory_intake_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
     "RESPONSE_MARKER", "mark_response_chunks",
 )

--- a/docs/armory-intake-adoption.md
+++ b/docs/armory-intake-adoption.md
@@ -1,0 +1,116 @@
+# Armory intake — 외부 후보 도입 효율 검토 (SSoT)
+
+> 외부 plugin / skill / MCP / tool 후보를 "좋아 보인다"만으로 들이지 않는다. ForgeKit
+> 관점의 **8축 도입 효율 artifact** + **PM / tech-lead / specialist 3축 검토**를 거쳐
+> **adopt-now / collect-first / hold** 중 하나로 귀결시키고, 그 결과를 Hephaistos 가
+> 읽는 catalog 와 연결한다.
+>
+> 코드 SSoT: [`packages/armory/src/armory/adoption.py`](../packages/armory/src/armory/adoption.py)
+> (모델 + 게이트) · [`adoption_registry.py`](../packages/armory/src/armory/adoption_registry.py)
+> (평가된 후보 데이터). 카탈로그 promotion 게이트는 [`armory.candidate`](../packages/armory/src/armory/candidate.py),
+> 카탈로그 자체는 [`armory.catalog`](../packages/armory/src/armory/catalog.py).
+> 사람용 카탈로그 SSoT: [`armory.md`](armory.md). 회귀: `python -m unittest tests.forgekit.test_armory_adoption`.
+
+## 0. 한 문장 요약
+
+**intake 후보 → 8축 도입 검토 + 3축 review → adopt-now / collect-first / hold.**
+adopt-now 만 catalog 에 올리고(adopted=available), **장착/설치(equipped)는 별개**다.
+
+```
+외부 후보 (ponytail / Context7 / MCP servers / Vale / textlint / alex / write-good / proselint / browser-use)
+        ▼ armory.adoption.AdoptionReview (8축 artifact + 3축 검토)
+        ▼ validate_review (honesty gate)
+   ┌───────────────┬────────────────────┬──────────────────┐
+ adopt-now       collect-first          hold
+   │               │                     │
+ catalog 등록     Nexus 근거만 누적       제외(governance/overlap/security 사유)
+ (available,      (즉시 활성화 X)
+  미설치)
+        ▼ (adopt-now) armory.catalog (SkillSpec/WeaponSpec/LoadoutSpec)
+        ▼ Hephaistos resolver = equip plan (suggestion-only, **설치 안 함**)
+```
+
+## 1. 8축 도입 효율 artifact (후보마다 필수)
+
+`AdoptionReview` 가 후보마다 다음 8개를 **빈칸/placeholder 없이** 채운다(`validate_review` 강제):
+
+1. `current_pain` — 지금 무엇이 아픈가
+2. `expected_benefit` — 도입 시 기대 효과
+3. `overlap` — 기존 Armory/Nexus/Hephaistos capability 와의 겹침
+4. `operational_cost` — install/runtime 부담
+5. `maintenance_risk` — 유지보수 리스크
+6. `provider_runtime_fit` — provider/runtime 적합성
+7. `governance_security` — governance/security 영향
+8. `verdict` — adopt-now / collect-first / hold
+
+## 2. 3축 검토 (최소 PM / tech-lead / specialist)
+
+각 후보는 `reviewers` 에 PM·tech-lead·specialist 세 축의 `ReviewerVerdict`(verdict + rationale)
+를 담는다. **adopt-now 는 3축 합의 필수** — 한 축이라도 collect-first/hold 면 adopt-now 불가
+(`validate_review` 가 거부). specialist 축은 후보 성격에 따라 knowledge-engineer(문서 도구) /
+platform-runtime(MCP) / security-engineer(fetch·browser·git) 로 달라진다.
+
+## 3. adopted ≠ equipped (fake adoption 금지)
+
+- **adopt-now** = 카탈로그에 올린다(available). **설치/장착이 아니다.**
+- attach 류(tool/plugin/mcp)는 `install_plan` 으로 설치 경로만 **선언**한다 — install_plan
+  없는 attach 류는 adopt-now 될 수 없다(`validate_review` 거부). WeaponSpec 도 `install_hint`/
+  `verify_command` 로 "어떻게 설치/확인하는가"만 담고 실제 설치는 하지 않는다.
+- Hephaistos resolver 는 equip plan 을 **제안**할 뿐 설치하지 않는다 → "installed" 로 보고 금지.
+- **collect-first** 는 Nexus 에 근거(evidence)만 누적하고 즉시 활성화하지 않는다.
+
+## 4. 이번 라운드 verdict (13 후보)
+
+| 후보 | kind | verdict | 핵심 사유 |
+| --- | --- | --- | --- |
+| **Vale** | tool | **adopt-now** | 단일 바이너리·config 기반 prose lint, vault 문서 품질과 정합, 위험 낮음. doc-quality loadout anchor. |
+| proselint | tool | collect-first | Vale 규칙과 겹침 + Python 의존 — 한계 드러나면 보강. |
+| write-good | tool | collect-first | naive·유지보수 정체 + Node 의존. loadout optional(약). |
+| alex | tool | collect-first | 포용적 글쓰기 — 영어 한정, Vale inclusive 팩과 겹침. |
+| textlint | tool | collect-first | 플러그인으로 한국어 커버 가능성 — 설정 부담 커 PoC 먼저. |
+| ponytail | skill | collect-first | 단순성 렌즈 — 이미 council/consult 와 겹침, 외부 repo 의존보다 내부 스킬화. |
+| Context7 | mcp | collect-first | 라이브러리 docs 주입(환각↓) — 호스티드 의존 + outbound/키 가드 선행. 가장 유망. |
+| MCP Fetch | mcp | collect-first | 공식·고품질이나 SSRF allowlist/sandbox 설계가 adopt 전제. |
+| MCP Memory | mcp | collect-first | Nexus/ledger 와 중복 큼 — 한계 드러날 때 재평가. |
+| MCP Filesystem | mcp | **hold** | broad FS 접근이 경로 안전 hard rail 우회 — governance 충돌 + 중복. |
+| MCP Git | mcp | **hold** | git-write hard rail(`git -C`+pathspec)/commit-governance 우회 — 금지. |
+| MCP Sequential Thinking | mcp | **hold** | decision_lane/모델 추론과 중복, 효용 낮음. |
+| browser-use | tool | **hold** | 실 브라우저 구동 = 자격증명/exfiltration 고위험 + 무거운 의존. sandbox 설계 후 재평가. |
+
+분포: adopt-now 1 · collect-first 8 · hold 4. (인지도만으로 adopt-now 로 올리지 않는다 —
+대부분 collect-first/hold.) evidence: [`apps/forgekit-console/examples/armory-intake/adoption-catalog.json`](../apps/forgekit-console/examples/armory-intake/adoption-catalog.json).
+
+## 5. doc-quality 묶음 = 하나의 curated loadout
+
+문서 품질 도구(Vale/proselint/write-good/alex/textlint)는 **하나의 loadout** 으로 묶었다 —
+catalog 의 `doc-quality-review-local`:
+- `required_weapons=("vale",)` (adopt-now anchor) + `optional_weapons=(proselint/write-good/alex/textlint)` (collect-first).
+- `recommended_skills=("doc-quality-review",)` — style-guide 기반 prose 린트 스킬(vendor-neutral).
+- adopted=카탈로그 등록일 뿐 — weapon `install_hint` 가 설치 경로만 선언(미설치).
+
+Hephaistos resolver 가 "문서 품질/문체/prose/vale" 신호에 이 loadout 을 equip plan 으로 제안한다.
+
+## 6. ponytail consult — 설계 단순성 검토 (decision log)
+
+> 새 모듈/계층을 더하기 전에 ponytail lens 로 점검. 판정: keep / simplify /
+> use-existing-runtime / reduce-surface / reject-new-dependency.
+
+| 후보 레이어 | 판정 | 근거 |
+| --- | --- | --- |
+| `armory.adoption`(AdoptionReview + gate) | **keep** | `armory.candidate`(catalog contract 검증)도 `ExternalCandidate`(discovery metadata)도 "ForgeKit 이 들일지/언제" 전략 판단(8축+3축)을 안 담는다. 별개 단계 — 중복 아님. |
+| 새 review/council 프레임워크 | **reject-new-dependency** | 3축 검토는 plain data(ReviewerVerdict)로 표현하고 gate 가 존재/합의만 강제. decision_lane(forgekit-runtime) import 안 함 — armory 는 leaf 유지. 실제 council 배선이 필요하면 console 합성층. |
+| 별도 catalog candidate 모델 | **use-existing-runtime** | adopt-now 의 catalog 실현은 기존 `armory.catalog`(SkillSpec/WeaponSpec/LoadoutSpec) + `register_promoted`/`promote_candidate` 사용 — 새 catalog 모델 안 만듦. |
+| collect-first 영속 store | **reduce-surface (defer)** | 이번 라운드는 registry(데이터) + evidence JSON 으로 닫음. Nexus 영속 ledger 배선은 별도(자동 활성화 금지 규칙과 정합). |
+| `/armory` 표면 | **keep (minimal)** | 카탈로그는 `/skills`·`/loadout`·`/resolve` 가 본다. intake **결정**(adopt/collect/hold)은 그것들과 다른 표면이라 `/armory` 하나 추가(요약 + `review <id>` 상세). |
+
+따르지 않은 ponytail 의견: 없음. collect-first 영속 ledger 만 defer(거부 아님) — fake 영속 대신
+evidence JSON 으로 정직 표기.
+
+## 7. evidence / tests / 표면
+
+- 회귀: [`tests/forgekit/test_armory_adoption.py`](../tests/forgekit/test_armory_adoption.py)
+  — registry 전부 valid·3 verdict 분포·adopt-now 합의/install-plan 게이트·doc-quality loadout·
+  render·evidence 일치.
+- evidence: `examples/armory-intake/adoption-catalog.json` (13 review + verdict 요약 + doc-quality loadout). Hephaistos/Nexus-readable.
+- 표면: `/armory` (verdict별 요약 + doc-quality loadout) · `/armory review <id>` (8축 + 3축 상세).
+- catalog 자체: `/skills` · `/loadout doc-quality-review-local` · `/resolve <문서 품질 요청>`.

--- a/docs/armory.md
+++ b/docs/armory.md
@@ -67,6 +67,16 @@ A promoted spec is registered into a **runtime overlay** (`catalog.register_prom
 resolver picks it up immediately, re-promotion (same id) updates in place, and tests `clear_overlay()`
 for isolation. Evidence: `apps/forgekit-console/examples/armory-intake/intake.txt`.
 
+## Intake adoption review (`armory.adoption`) — adopt-now / collect-first / hold
+`promote_candidate` 는 *이미 들이기로 한* 후보의 **contract** 를 검증한다. 그 **앞단** — "외부
+plugin/skill/tool 을 ForgeKit 이 들일지/언제" 의 **전략 판단** — 은 `armory.adoption` 이 담당한다:
+후보마다 8축 도입 효율 artifact(pain/benefit/overlap/cost/risk/fit/governance/verdict) + PM/tech-lead/
+specialist **3축 검토**를 채우고 **adopt-now / collect-first / hold** 로 귀결한다. **adopt-now 는 3축
+합의 + (attach 류) install_plan 필수** (`validate_review`) — `adopted ≠ equipped/installed`, fake
+adoption 금지. collect-first 는 Nexus 에 근거만 누적(즉시 활성화 X). 평가된 후보는
+`armory.adoption_registry`, 표면은 `/armory [review <id>]`, evidence 는
+`examples/armory-intake/adoption-catalog.json`. SSoT: [`armory-intake-adoption.md`](armory-intake-adoption.md).
+
 ## Context-aware selection (Hephaistos)
 `hephaistos.resolve(request, *, preferred_role="", project_facts=(), runtime_constraints=(), harness="")`
 folds project/runtime context into the existing selection surface (no new routing layer):

--- a/packages/armory/src/armory/__init__.py
+++ b/packages/armory/src/armory/__init__.py
@@ -8,13 +8,24 @@ and ``docs/armory.md``.
 
 - ``armory.models``  — the spec vocabulary (Skill/Loadout/Weapon/Rune + NexusSourceRef).
 - ``armory.catalog`` — the catalog data + accessors (all_skills/all_loadouts/…).
+- ``armory.candidate`` — intake → catalog promotion gate (contract validation).
+- ``armory.adoption`` — ForgeKit 도입 효율 검토(8축 + 3축 검토 → adopt-now/collect-first/hold),
+  with ``adoption_registry`` holding the evaluated external-candidate set.
 
 Depends on nothing internal (leaf) → Hephaistos depends on Armory, never the reverse.
 """
 
 from __future__ import annotations
 
-from . import candidate, catalog, models
+from . import adoption, adoption_registry, candidate, catalog, models
+from .adoption import (
+    AdoptionReview,
+    ReviewerVerdict,
+    by_verdict,
+    invalid_reviews,
+    validate_review,
+)
+from .adoption_registry import adoption_registry as adoption_registry_reviews
 from .candidate import ArmoryCandidate, PromotionResult, promote_candidate
 from .catalog import (
     all_loadouts,
@@ -30,8 +41,10 @@ from .catalog import (
 )
 
 __all__ = (
-    "candidate", "catalog", "models",
+    "candidate", "catalog", "models", "adoption", "adoption_registry",
     "all_skills", "all_loadouts", "all_weapons", "skill", "loadout", "weapon", "categories",
     "register_promoted", "clear_overlay", "promoted_skills",
     "ArmoryCandidate", "PromotionResult", "promote_candidate",
+    "AdoptionReview", "ReviewerVerdict", "validate_review", "by_verdict", "invalid_reviews",
+    "adoption_registry_reviews",
 )

--- a/packages/armory/src/armory/adoption.py
+++ b/packages/armory/src/armory/adoption.py
@@ -1,0 +1,178 @@
+"""armory.adoption — ForgeKit 도입 효율 검토 (intake 후보의 adopt/collect/hold 결정).
+
+An ``AdoptionReview`` is the **strategic** evaluation that precedes catalog promotion:
+"좋아 보인다" 만으로 외부 plugin/skill/tool 을 들이지 않고, ForgeKit 관점의 8축 효율을
+명시한 뒤 PM / tech-lead / specialist 3축 검토를 거쳐 **adopt-now / collect-first / hold**
+중 하나로 귀결시킨다. This is distinct from ``armory.candidate`` (which validates the
+*catalog contract* of an already-decided entry) — adoption decides *whether* to bring a
+thing in at all, and at what speed.
+
+Honesty rails:
+- **adopted ≠ equipped/installed.** adopt-now 는 "카탈로그에 올린다(available)" 이지
+  설치/장착이 아니다. attach 류(tool/plugin/mcp)는 ``install_plan`` 으로 설치 경로만
+  *선언*한다 — install_plan 없는 attach 류는 adopt-now 될 수 없다(fake available 방지).
+- **collect-first** 는 Nexus 에 근거만 누적하고 즉시 활성화하지 않는다.
+- 3축(PM/tech-lead/specialist) 검토가 모두 있어야 하고, adopt-now 는 3축 합의 필요.
+
+Pure / stdlib-only — armory 는 leaf 라 decision_lane(forgekit-runtime)을 import 하지
+않는다. 실제 council 배선이 필요하면 console 합성층이 한다(see docs/armory-intake-adoption.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+from .models import ATTACH_REQUIRED_KINDS, ENTRY_KINDS
+
+# adoption verdict — the three terminal buckets every candidate resolves into.
+VERDICT_ADOPT_NOW = "adopt-now"
+VERDICT_COLLECT_FIRST = "collect-first"
+VERDICT_HOLD = "hold"
+ADOPTION_VERDICTS = (VERDICT_ADOPT_NOW, VERDICT_COLLECT_FIRST, VERDICT_HOLD)
+
+# the mandatory review axes (최소 3축).
+AXIS_PM = "pm"
+AXIS_TECH_LEAD = "tech-lead"
+AXIS_SPECIALIST = "specialist"
+REQUIRED_AXES = (AXIS_PM, AXIS_TECH_LEAD, AXIS_SPECIALIST)
+
+# placeholder tokens that disqualify a "filled" artifact field.
+_PLACEHOLDERS = ("tbd", "todo", "fixme", "xxx", "placeholder", "...", "내용 없음", "(미정)", "?")
+_MIN_LEN = 8   # an artifact field must be a real sentence, not "ok"
+
+
+def _is_thin(text: str) -> bool:
+    t = (text or "").strip().lower()
+    if len(t) < _MIN_LEN:
+        return True
+    return any(p in t for p in _PLACEHOLDERS)
+
+
+@dataclass(frozen=True)
+class ReviewerVerdict:
+    """One review axis's recommendation + rationale (the 3축 검토 artifact)."""
+
+    axis: str          # AXIS_*
+    verdict: str       # ADOPTION_VERDICTS (that axis's recommendation)
+    rationale: str
+
+    def to_dict(self) -> dict:
+        return {"axis": self.axis, "verdict": self.verdict, "rationale": self.rationale}
+
+
+@dataclass(frozen=True)
+class AdoptionReview:
+    """A ForgeKit 도입 효율 검토 for one external candidate — 8축 + 3축 검토 + verdict."""
+
+    candidate_id: str
+    name: str
+    kind: str            # ENTRY_KINDS: skill / tool / plugin / mcp
+    source: str          # repo / homepage URL
+    # --- the 8 ForgeKit-adoption-efficiency fields (wave-mandated artifact) ---
+    current_pain: str            # 지금 무엇이 아픈가
+    expected_benefit: str        # 도입 시 기대 효과
+    overlap: str                 # 기존 Armory/Nexus/Hephaistos capability 와 겹침
+    operational_cost: str        # install/runtime burden
+    maintenance_risk: str        # 유지보수 리스크
+    provider_runtime_fit: str    # provider/runtime 적합성
+    governance_security: str     # governance/security 영향
+    verdict: str                 # ADOPTION_VERDICTS — adopt-now/collect-first/hold
+    # --- review + routing ---
+    reviewers: Tuple[ReviewerVerdict, ...] = ()
+    install_plan: Tuple[str, ...] = ()   # attach 류의 설치/장착 경로 *선언* (실행 아님)
+    loadout_id: str = ""                 # adopt-now 가 카탈로그 loadout 으로 실현됐으면 그 id
+    notes: str = ""
+
+    @property
+    def is_attach_kind(self) -> bool:
+        return self.kind in ATTACH_REQUIRED_KINDS
+
+    def axis(self, axis: str):
+        return next((r for r in self.reviewers if r.axis == axis), None)
+
+    def to_dict(self) -> dict:
+        return {
+            "candidate_id": self.candidate_id, "name": self.name, "kind": self.kind,
+            "source": self.source,
+            "artifact": {
+                "current_pain": self.current_pain, "expected_benefit": self.expected_benefit,
+                "overlap": self.overlap, "operational_cost": self.operational_cost,
+                "maintenance_risk": self.maintenance_risk,
+                "provider_runtime_fit": self.provider_runtime_fit,
+                "governance_security": self.governance_security,
+            },
+            "verdict": self.verdict,
+            "reviewers": [r.to_dict() for r in self.reviewers],
+            "install_plan": list(self.install_plan),
+            "loadout_id": self.loadout_id, "notes": self.notes,
+        }
+
+
+def validate_review(r: AdoptionReview) -> Tuple[str, ...]:
+    """Return reasons the review is INVALID (empty tuple = valid). Deterministic.
+
+    Enforces the wave's honesty rails: every artifact field filled, 3축 검토 present,
+    a legal verdict, and the adopt-now consensus + install-plan gates (fake adoption 방지).
+    """
+
+    reasons = []
+    if not r.candidate_id.strip() or not r.name.strip():
+        reasons.append("candidate_id/name 없음")
+    if r.kind not in ENTRY_KINDS:
+        reasons.append(f"kind 불명: {r.kind!r} (skill/tool/plugin/mcp)")
+    if not r.source.strip():
+        reasons.append("source(repo/url) 없음")
+
+    # all 8 artifact fields must be real (not placeholder/too short).
+    for fname in ("current_pain", "expected_benefit", "overlap", "operational_cost",
+                  "maintenance_risk", "provider_runtime_fit", "governance_security"):
+        if _is_thin(getattr(r, fname)):
+            reasons.append(f"{fname} 가 비었거나 placeholder")
+
+    if r.verdict not in ADOPTION_VERDICTS:
+        reasons.append(f"verdict 불명: {r.verdict!r}")
+
+    # 3축 검토 mandatory.
+    axes = {rv.axis for rv in r.reviewers}
+    missing = [a for a in REQUIRED_AXES if a not in axes]
+    if missing:
+        reasons.append(f"검토 축 누락: {', '.join(missing)} (PM/tech-lead/specialist 필수)")
+    for rv in r.reviewers:
+        if rv.verdict not in ADOPTION_VERDICTS:
+            reasons.append(f"{rv.axis} verdict 불명: {rv.verdict!r}")
+        if _is_thin(rv.rationale):
+            reasons.append(f"{rv.axis} rationale 비었음")
+
+    # adopt-now gates — consensus + (attach 류) install plan.
+    if r.verdict == VERDICT_ADOPT_NOW:
+        axis_verdicts = [rv.verdict for rv in r.reviewers if rv.axis in REQUIRED_AXES]
+        if any(v != VERDICT_ADOPT_NOW for v in axis_verdicts):
+            reasons.append("adopt-now 인데 3축 합의 아님 (한 축이라도 collect-first/hold)")
+        if r.is_attach_kind and not r.install_plan:
+            reasons.append(
+                f"{r.kind} adopt-now 인데 install_plan 없음 — 설치 경로 미선언(fake available 방지)")
+
+    return tuple(reasons)
+
+
+def by_verdict(reviews: Sequence[AdoptionReview], verdict: str) -> Tuple[AdoptionReview, ...]:
+    return tuple(r for r in reviews if r.verdict == verdict)
+
+
+def invalid_reviews(reviews: Sequence[AdoptionReview]) -> Tuple[Tuple[AdoptionReview, Tuple[str, ...]], ...]:
+    """Every review that fails validation, paired with its reasons (audit surface)."""
+
+    out = []
+    for r in reviews:
+        bad = validate_review(r)
+        if bad:
+            out.append((r, bad))
+    return tuple(out)
+
+
+__all__ = (
+    "VERDICT_ADOPT_NOW", "VERDICT_COLLECT_FIRST", "VERDICT_HOLD", "ADOPTION_VERDICTS",
+    "AXIS_PM", "AXIS_TECH_LEAD", "AXIS_SPECIALIST", "REQUIRED_AXES",
+    "ReviewerVerdict", "AdoptionReview", "validate_review", "by_verdict", "invalid_reviews",
+)

--- a/packages/armory/src/armory/adoption_registry.py
+++ b/packages/armory/src/armory/adoption_registry.py
@@ -1,0 +1,288 @@
+"""armory.adoption_registry — the evaluated external candidates (data, declaration-only).
+
+The actual ForgeKit 도입 효율 검토 for this wave's candidate set. Each entry is a real
+``AdoptionReview`` (8축 artifact + PM/tech-lead/specialist 3축 검토 + verdict). This is a
+registry/declaration file by design (no branch logic) — see CLAUDE.md large-file 예외.
+
+Verdict 요약(이 라운드):
+- adopt-now   : vale (+ doc-quality-review-local loadout).
+- collect-first: proselint, write-good, alex, textlint, ponytail, context7, mcp-fetch, mcp-memory.
+- hold        : mcp-filesystem, mcp-git, mcp-sequential-thinking, browser-use.
+
+collect-first 후보는 Nexus 에 근거만 누적하고 즉시 활성화하지 않는다. hold 는 governance/
+security/overlap 사유로 이번 라운드 제외. 어느 것도 "installed" 로 보고하지 않는다.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .adoption import (
+    AXIS_PM,
+    AXIS_SPECIALIST,
+    AXIS_TECH_LEAD,
+    VERDICT_ADOPT_NOW,
+    VERDICT_COLLECT_FIRST,
+    VERDICT_HOLD,
+    AdoptionReview,
+    ReviewerVerdict,
+)
+from .models import KIND_MCP, KIND_SKILL, KIND_TOOL
+
+
+def _rv(axis, verdict, rationale):
+    return ReviewerVerdict(axis=axis, verdict=verdict, rationale=rationale)
+
+
+_REVIEWS: Tuple[AdoptionReview, ...] = (
+    # ── adopt-now ────────────────────────────────────────────────────────────
+    AdoptionReview(
+        candidate_id="vale", name="Vale", kind=KIND_TOOL,
+        source="https://github.com/errata-ai/vale",
+        current_pain="vault/문서 품질이 사람 리뷰에만 의존 — '왜' 깊이/문체/용어 일관성을 기계로 강제할 표준 도구가 없다.",
+        expected_benefit="style-guide(YAML) 기반 prose lint 를 CI/로컬에서 결정적으로 강제 — 문서 회귀를 사람 전에 잡는다.",
+        overlap="Nexus vault-curate 는 구조(frontmatter/5섹션)를 보지만 prose 문체/용어는 안 본다 — 보완재(중복 아님).",
+        operational_cost="단일 Go 바이너리(brew/직접 다운로드) + style 패키지 sync. 런타임 의존 없음 — 가장 낮은 부담.",
+        maintenance_risk="활발히 유지(errata-ai), config 안정적. 낮음 — style 패키지 버전만 핀.",
+        provider_runtime_fit="provider-neutral CLI — 어느 backend 든 executor 가 호출. ForgeKit toolchain 으로 버전 관리 가능.",
+        governance_security="로컬 파일만 읽고 네트워크 없음(style sync 제외). 위험 낮음, 가드 불필요.",
+        verdict=VERDICT_ADOPT_NOW,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_ADOPT_NOW, "문서 품질은 ForgeKit 핵심 가치(vault) — 즉시 카탈로그화할 가치 충분."),
+            _rv(AXIS_TECH_LEAD, VERDICT_ADOPT_NOW, "단일 바이너리·config 기반이라 도입 리스크 최소. attach contract 명확."),
+            _rv(AXIS_SPECIALIST, VERDICT_ADOPT_NOW, "knowledge-engineer: style-guide 로 '왜' 깊이/용어 강제가 vault 규칙과 정합."),
+        ),
+        install_plan=("brew install vale", "vale sync (.vale.ini 의 style 패키지)", "검증: vale --version"),
+        loadout_id="doc-quality-review-local",
+        notes="adopted=카탈로그 등록(available). 실제 설치/장착은 install_plan 선언일 뿐 — 미설치."),
+
+    # ── collect-first : doc-quality loadout members (optional) ────────────────
+    AdoptionReview(
+        candidate_id="proselint", name="proselint", kind=KIND_TOOL,
+        source="https://github.com/amperser/proselint",
+        current_pain="문서의 상투구/중복/약한 표현을 기계로 잡을 보조 린터가 없다.",
+        expected_benefit="Vale 보완 — 영어 prose 의 검증된 규칙(중복/jargon) 추가 커버.",
+        overlap="Vale 규칙과 상당 부분 겹침 — Vale 채택 후 한계가 드러나면 그때 보강.",
+        operational_cost="Python 패키지(pip/uv) — Python 런타임 의존. Vale 대비 추가 부담.",
+        maintenance_risk="유지보수 빈도 낮은 편 — 중간. Vale 가 있으면 필수 아님.",
+        provider_runtime_fit="CLI, provider-neutral. doc-quality loadout 의 optional 멤버로 적합.",
+        governance_security="로컬 파일만 — 위험 낮음.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "Vale 로 시작하고 효과 측정 후 보강 — 동시 도입은 과함."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "Vale 와 규칙 중복 — 한계 evidence 누적 후 결정."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "knowledge-engineer: loadout optional 로만 노출, 강제 X."),
+        ),
+        notes="doc-quality-review-local 의 optional 멤버 후보 — Nexus 근거 누적, 미설치."),
+
+    AdoptionReview(
+        candidate_id="write-good", name="write-good", kind=KIND_TOOL,
+        source="https://github.com/btford/write-good",
+        current_pain="수동태/약한 표현 같은 흔한 글쓰기 안티패턴을 기계로 못 잡는다.",
+        expected_benefit="가벼운 영어 문체 힌트 — 빠른 1차 패스.",
+        overlap="Vale/proselint 와 규칙 겹침 — naive linter 라 정확도 낮음.",
+        operational_cost="npm 패키지 — Node 런타임 의존. 멀티 Node 도구는 toolchain 부담 누적.",
+        maintenance_risk="유지보수 정체(최근 커밋 드묾) — 중상.",
+        provider_runtime_fit="CLI, provider-neutral. 단 Node 의존이 Vale 단일바이너리보다 불리.",
+        governance_security="로컬 파일만 — 위험 낮음.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "정확도/유지보수가 약해 즉시 도입 가치 낮음."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "Node 의존 + 유지보수 정체 — 사실상 hold 에 가까움, loadout 노출만."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "knowledge-engineer: Vale 로 대체 가능, evidence 만."),
+        ),
+        notes="loadout optional 후보(약). 미설치."),
+
+    AdoptionReview(
+        candidate_id="alex", name="alex", kind=KIND_TOOL,
+        source="https://github.com/get-alex/alex",
+        current_pain="둔감/배제적 표현(insensitive writing)을 사람이 일일이 못 잡는다.",
+        expected_benefit="포용적 글쓰기 자동 점검 — 공개 문서/README 톤 관리.",
+        overlap="Vale 에도 inclusive-language 스타일 팩(예: alex 포팅)이 있어 부분 중복.",
+        operational_cost="npm 패키지 — Node 런타임 의존.",
+        maintenance_risk="유지보수 양호하나 영어 전용 — 한국어 문서엔 제한적. 중간.",
+        provider_runtime_fit="CLI, provider-neutral. 한국어 비중 높은 vault 엔 적용 범위 좁음.",
+        governance_security="로컬 파일만 — 위험 낮음.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "공개 문서 톤엔 가치 — 단 한국어 vault 비중 고려해 선검증."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "Vale inclusive 팩과 비교 evidence 필요."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "knowledge-engineer: 영어 산출물 한정 optional."),
+        ),
+        notes="영어 산출물 한정 optional 후보. 미설치."),
+
+    AdoptionReview(
+        candidate_id="textlint", name="textlint", kind=KIND_TOOL,
+        source="https://github.com/textlint/textlint",
+        current_pain="규칙을 직접 짜야 하는 문서 영역(한국어 포함)에 플러그형 린터가 없다.",
+        expected_benefit="플러그인 생태계로 한국어/마크다운 규칙까지 확장 가능 — Vale 가 약한 영역 보완.",
+        overlap="Vale 와 목적 겹치나 plugin 모델/한국어 커버는 차별점.",
+        operational_cost="npm + 플러그인 다수 — 설정/유지 부담 가장 큼.",
+        maintenance_risk="코어는 유지되나 플러그인 품질 편차 — 중상.",
+        provider_runtime_fit="CLI, provider-neutral. 한국어 vault 에는 Vale 보다 적합할 수 있음(검증 필요).",
+        governance_security="로컬 파일만 — 위험 낮음.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "한국어 커버 가능성은 매력 — 단 설정 부담 커서 PoC 먼저."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "플러그인 의존 트리 평가 후. 지금 adopt 는 과투자."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "knowledge-engineer: 한국어 규칙 PoC 로 Vale 와 비교."),
+        ),
+        notes="한국어 vault 커버 PoC 후보. 미설치."),
+
+    # ── collect-first : 그 외 ─────────────────────────────────────────────────
+    AdoptionReview(
+        candidate_id="ponytail", name="ponytail", kind=KIND_SKILL,
+        source="https://github.com/example/ponytail",
+        current_pain="새 모듈/계층 추가 시 과설계를 막을 일관된 단순성 검토 렌즈가 코드화돼 있지 않다.",
+        expected_benefit="ponytail 식 단순성 검토(keep/simplify/use-existing/reduce-surface/reject)를 표준 스킬로.",
+        overlap="ForgeKit 은 이미 council/consult + lane readiness 로 설계 검토 레인을 가짐 — 상당 부분 겹침.",
+        operational_cost="외부 도구라기보다 검토 절차 — 도입 부담 낮으나 repo 실체/성숙도 불명확.",
+        maintenance_risk="repo 정체성/유지보수 불확실 — 외부 의존보다 '렌즈를 스킬로 내재화'가 안전.",
+        provider_runtime_fit="skill(절차) — provider-neutral. 단 외부 repo 채택보다 내부 스킬화가 fit.",
+        governance_security="검토 절차라 보안 위험 낮음 — 외부 코드 실행 아님.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "단순성 렌즈 자체는 이미 우리 lane 이 적용 중 — 외부 채택보다 evidence."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "council/consult 와 겹침 — 외부 repo 의존 만들 이유 약함."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "tech-lead specialist: 내부 스킬화로 충분, 외부 도입은 보류."),
+        ),
+        notes="이미 본 wave 의 consult 렌즈로 사용 중 — 외부 repo 채택은 근거 누적 후."),
+
+    AdoptionReview(
+        candidate_id="context7", name="Context7", kind=KIND_MCP,
+        source="https://github.com/upstash/context7",
+        current_pain="LLM 이 라이브러리 최신 API 를 모르고 환각 — 버전 맞는 docs/예제 주입 경로가 없다.",
+        expected_benefit="최신 라이브러리 docs/snippet 을 MCP 로 주입 — 코드 생성 정확도 향상.",
+        overlap="Nexus 는 *내부* 지식(vault) — 외부 라이브러리 docs 는 미커버라 보완재. 단 역할 경계 정리 필요.",
+        operational_cost="MCP 서버 + (호스티드) 의존/키 가능성 — 외부 서비스 의존 도입.",
+        maintenance_risk="3rd-party 호스티드 서비스 의존 — 가용성/정책 변화 리스크 중상.",
+        provider_runtime_fit="MCP 라 claude/codex/gemini(mcp-host)에 attach — provider-neutral SSoT 가능. ollama 제외.",
+        governance_security="외부 서버로 쿼리 송신 — outbound/데이터 노출 검토 필요. integrations/mcp 가드 경유 필수.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_ADOPT_NOW, "환각 감소 효과 크다 — 가능하면 빨리."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "호스티드 의존 + outbound 정책 정리 전엔 adopt 불가 — PoC 먼저."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "platform-runtime: integrations/mcp 가드+키 처리 검증 후."),
+        ),
+        install_plan=("integrations/mcp/context7.json 정의(transport/auth.env)", "mcp projection 생성", "키는 env 참조만"),
+        notes="가장 유망한 collect-first — outbound/키 가드 검증되면 adopt 재평가."),
+
+    AdoptionReview(
+        candidate_id="mcp-fetch", name="MCP Fetch (official)", kind=KIND_MCP,
+        source="https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+        current_pain="에이전트가 임의 URL 본문을 표준 경로로 가져올 reference MCP 가 미배선.",
+        expected_benefit="공식 reference 서버라 신뢰도 높은 fetch capability — 리서치 보강.",
+        overlap="discovery sources(RSS/HN/GitHub collectors)와 기능 겹침 — 단 임의 URL fetch 는 미커버.",
+        operational_cost="공식 서버 설치/attach — 경량이나 MCP host 연결 필요.",
+        maintenance_risk="공식 레포라 유지보수 양호 — 낮음.",
+        provider_runtime_fit="MCP, mcp-host attach. provider-neutral SSoT 가능.",
+        governance_security="임의 URL fetch = SSRF/내부망 접근 위험 — allowlist/sandbox 정책 필수. 가드 전 도입 금지.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "리서치엔 유용하나 보안 가드가 선행."),
+            _rv(AXIS_TECH_LEAD, VERDICT_COLLECT_FIRST, "SSRF allowlist 정책 설계 후 — 지금 adopt 위험."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "security-engineer: outbound allowlist 없이는 hold."),
+        ),
+        install_plan=("integrations/mcp/fetch.json", "URL allowlist/sandbox 정책 첨부", "mcp projection"),
+        notes="공식이라 품질 높음 — SSRF 가드 설계가 adopt 전제."),
+
+    AdoptionReview(
+        candidate_id="mcp-memory", name="MCP Memory (official)", kind=KIND_MCP,
+        source="https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+        current_pain="세션 간 기억의 표준 MCP 경로가 없다.",
+        expected_benefit="공식 memory 서버로 표준화된 기억 capability.",
+        overlap="Nexus(vault) + troubleshooting ledger + claude-mem 으로 이미 기억 레인 보유 — 중복 큼.",
+        operational_cost="서버 설치/attach + 저장소 관리 — 기존 기억 레인과 이중화 비용.",
+        maintenance_risk="공식 유지보수 양호하나 우리 기억 SSoT 와 충돌 위험 — 중간.",
+        provider_runtime_fit="MCP attach 가능 — 단 우리 기억은 vault/ledger 가 SSoT 라 fit 약함.",
+        governance_security="기억 저장 위치/내용 거버넌스 — 기존 메모리 정책과 정합 필요.",
+        verdict=VERDICT_COLLECT_FIRST,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_COLLECT_FIRST, "기억은 이미 vault/ledger 로 충당 — 굳이 지금 아님."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "Nexus/ledger 와 SSoT 중복 — 사실상 hold 성격."),
+            _rv(AXIS_SPECIALIST, VERDICT_COLLECT_FIRST, "knowledge-engineer: 우리 기억 모델과 비교 evidence 만."),
+        ),
+        notes="중복 큼 — Nexus/ledger 한계 드러날 때 재평가."),
+
+    # ── hold ─────────────────────────────────────────────────────────────────
+    AdoptionReview(
+        candidate_id="mcp-filesystem", name="MCP Filesystem (official)", kind=KIND_MCP,
+        source="https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+        current_pain="에이전트의 파일 접근을 표준 MCP 로 노출하고 싶을 수 있다.",
+        expected_benefit="표준 파일 접근 capability.",
+        overlap="executor 는 이미 파일 도구를 가짐 — 기능 거의 전부 중복.",
+        operational_cost="추가 서버 + 권한 범위 관리.",
+        maintenance_risk="공식 유지보수는 양호하나 우리 가드와 충돌 관리 비용.",
+        provider_runtime_fit="MCP attach 가능하나 ForgeKit 파일 경로 안전(git_path_safety)과 경합.",
+        governance_security="광범위 FS 접근 MCP 는 git-write hard rail / 경로 안전 SSoT 를 우회 — 거버넌스 충돌(금지).",
+        verdict=VERDICT_HOLD,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_HOLD, "기존 파일 도구로 충분 — 추가 가치 없음."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "경로 안전 hard rail 우회 위험 — 도입 불가."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "security-engineer: broad FS MCP 는 가드 우회, hold."),
+        ),
+        notes="governance 충돌 + 중복 — 이번 라운드 제외."),
+
+    AdoptionReview(
+        candidate_id="mcp-git", name="MCP Git (official)", kind=KIND_MCP,
+        source="https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+        current_pain="git 작업을 MCP 로 노출하려는 유혹.",
+        expected_benefit="표준 git capability.",
+        overlap="ForgeKit 은 git-write 를 git_path_safety/repo_write_policy 로 강하게 통제 — 전면 중복.",
+        operational_cost="추가 서버 + 권한.",
+        maintenance_risk="우리 git hard rail 과 이중 경로 유지 비용.",
+        provider_runtime_fit="MCP attach 가능하나 우리 git 거버넌스와 정면 충돌.",
+        governance_security="MCP 가 git write 를 수행하면 `git -C + 명시 pathspec` hard rail / commit-governance 를 우회 — 금지.",
+        verdict=VERDICT_HOLD,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_HOLD, "git 안전은 우리 핵심 가드 — 외부 MCP 로 우회 불가."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "repo_write_policy SSoT 우회 — 도입 금지."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "security-engineer: hard rail 충돌, hold."),
+        ),
+        notes="git hard rail 우회 위험 — 제외."),
+
+    AdoptionReview(
+        candidate_id="mcp-sequential-thinking", name="MCP Sequential Thinking (official)", kind=KIND_MCP,
+        source="https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+        current_pain="구조화된 단계적 추론을 도구로 강제하고 싶을 수 있다.",
+        expected_benefit="단계적 사고 스캐폴딩.",
+        overlap="decision_lane(readiness/council/handoff) + 에이전트 자체 추론과 겹침 — 한계 효용.",
+        operational_cost="추가 서버 + 프롬프트 표면 증가.",
+        maintenance_risk="효용 대비 유지 비용 — 중간.",
+        provider_runtime_fit="MCP attach 가능하나 모델 내장 추론과 중복.",
+        governance_security="위험 낮으나 도입 정당성(효용) 부족이 더 큰 문제.",
+        verdict=VERDICT_HOLD,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_HOLD, "추론은 모델/lane 이 이미 함 — 추가 가치 미미."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "프롬프트 표면만 늘림 — hold."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "decision_lane 과 중복 — hold."),
+        ),
+        notes="효용 낮음 — 제외."),
+
+    AdoptionReview(
+        candidate_id="browser-use", name="browser-use", kind=KIND_TOOL,
+        source="https://github.com/browser-use/browser-use",
+        current_pain="실제 브라우저 자동화(로그인-게이트 사이트 등) capability 가 없다.",
+        expected_benefit="LLM 주도 브라우저 자동화 — 일부 리서치/검증 시나리오 확장.",
+        overlap="discovery 의 YouTube/Figma/Google 은 planned seam — 그쪽과 목적 일부 겹침(미연결).",
+        operational_cost="Python + 헤드리스 브라우저(Playwright) 의존 — 무거운 런타임.",
+        maintenance_risk="빠르게 바뀌는 신생 프로젝트 — API 불안정, 중상.",
+        provider_runtime_fit="라이브러리/에이전트 — 무거운 의존이 ForgeKit 경량 toolchain 과 어긋남.",
+        governance_security="실 브라우저 구동 = 자격증명/exfiltration/자동 액션 위험 매우 큼 — 강한 sandbox/승인 게이트 없이는 금지.",
+        verdict=VERDICT_HOLD,
+        reviewers=(
+            _rv(AXIS_PM, VERDICT_HOLD, "위험·비용 대비 당장 필요 시나리오 없음."),
+            _rv(AXIS_TECH_LEAD, VERDICT_HOLD, "무거운 의존 + 불안정 API — hold."),
+            _rv(AXIS_SPECIALIST, VERDICT_HOLD, "security-engineer: 브라우저 자동화 위험, sandbox 설계 전 hold."),
+        ),
+        notes="고위험 — planned browser seam 과 함께 별도 보안 설계 후 재평가."),
+)
+
+
+def adoption_registry() -> Tuple[AdoptionReview, ...]:
+    """The evaluated external candidate set for this intake round (immutable view)."""
+
+    return _REVIEWS
+
+
+__all__ = ("adoption_registry",)

--- a/packages/armory/src/armory/catalog.py
+++ b/packages/armory/src/armory/catalog.py
@@ -46,6 +46,12 @@ _WEAPONS = (
     WeaponSpec("actionlint", "actionlint", "cli", "actionlint --version", "brew install actionlint"),
     WeaponSpec("intellij", "IntelliJ IDEA", "ide", "", "jetbrains toolbox"),
     WeaponSpec("vscode", "VS Code", "ide", "code --version", "https://code.visualstudio.com"),
+    # doc-quality 묶음 (adopted=카탈로그 등록 / 미설치 — install_hint 가 설치 경로만 선언).
+    WeaponSpec("vale", "Vale", "cli", "vale --version", "brew install vale"),
+    WeaponSpec("proselint", "proselint", "cli", "proselint --version", "uv tool install proselint"),
+    WeaponSpec("write-good", "write-good", "cli", "write-good --version", "npm i -g write-good"),
+    WeaponSpec("alex", "alex", "cli", "alex --version", "npm i -g alex"),
+    WeaponSpec("textlint", "textlint", "cli", "textlint --version", "npm i -g textlint"),
 )
 
 _SKILLS = (
@@ -334,6 +340,24 @@ _SKILLS = (
               verification=("(reference pack 생성)",), forbidden=("",),
               capability_note="design reference reader", related_loadouts=("design-review-local",),
               related_roles=("ux-ui-designer",)),
+    # --- docs (intake adopt-now: Vale anchor + optional prose linters) ----
+    SkillSpec("doc-quality-review", "Doc-quality review", category="docs",
+              domains=("docs",), topics=("prose-lint", "style-guide", "terminology"),
+              signals=("문서 품질", "문체", "prose", "vale", "lint 문서", "writing quality",
+                       "style guide", "용어 일관성"),
+              summary="vault/문서를 style-guide 기반 prose 린트로 점검(문체/용어/포용성)",
+              when_to_use=("문서/README/vault 노트 품질·문체·용어 일관성 점검",),
+              when_not_to_use=("코드 린트(언어별 린터 사용)", "구조 검증(vault-curate frontmatter/5섹션)"),
+              rules=("style-guide(.vale.ini)를 SSoT 로 — 규칙은 config 로 버전 관리",
+                     "결과는 제안 — 자동 수정 강제 금지"),
+              commands=("vale .", "proselint <file>"),
+              verification=("vale --version", "vale ."),
+              forbidden=("외부 서버로 문서 본문 송신(로컬 린트만)",),
+              capability_note="prose/style linting (style-guide enforced)",
+              related_weapons=("vale", "proselint", "write-good", "alex", "textlint"),
+              related_loadouts=("doc-quality-review-local",),
+              related_roles=("knowledge-engineer",),
+              nexus_refs=(_area("20-areas/docs/doc-quality"),)),
 )
 
 # loadout: why this combo (goal + recommended/optional/blocked + selection signals).
@@ -435,6 +459,18 @@ _LOADOUTS = (
                 default_verify_flow=("(토큰/레퍼런스 대비)",),
                 selection_signals=("디자인", "design", "figma", "ui 참고", "디자인 시스템"),
                 notes="raw design source 는 design role만, 그외 projection. Figma 미연결이면 blocked"),
+    LoadoutSpec("doc-quality-review-local", "Doc-quality review (local)",
+                intended_roles=("knowledge-engineer",),
+                required_weapons=("vale",), optional_weapons=("proselint", "write-good", "alex", "textlint"),
+                environment_assumptions=("repo/vault 읽기 접근", "vale 설치 시 .vale.ini + style 패키지"),
+                verify_commands=("vale --version",),
+                goal="문서/vault prose 품질을 style-guide 로 점검(intake adopt-now 묶음)",
+                recommended_skills=("doc-quality-review",),
+                optional_skills=(), blocked_skills=("terraform", "java-spring"),
+                default_verify_flow=("vale .",),
+                selection_signals=("문서 품질", "문체", "prose", "vale", "writing quality", "용어 일관성"),
+                notes="Vale=required(adopt-now), 나머지=optional(collect-first). adopted≠installed — "
+                      "weapon install_hint 가 설치 경로만 선언."),
 )
 
 _WEAPON_BY_ID: Dict[str, WeaponSpec] = {w.id: w for w in _WEAPONS}

--- a/tests/forgekit/test_armory_adoption.py
+++ b/tests/forgekit/test_armory_adoption.py
@@ -1,0 +1,162 @@
+"""Armory intake 도입 검토 (armory.adoption) — 8축 artifact + 3축 검토 + verdict gate.
+
+Proves the adoption registry is honest (every review fully filled + 3축 검토), the
+adopt-now gate enforces consensus + install-plan (fake adoption 방지), the doc-quality
+loadout is a real catalog entry (adopted, not installed), and the committed evidence
+catalog matches code. Pure / offline.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from armory import adoption as A
+from armory import adoption_registry as REG
+from armory import catalog
+from armory.models import KIND_MCP, KIND_TOOL
+from forgekit_console.tui import render
+
+
+def _review(**over):
+    base = dict(
+        candidate_id="x", name="X", kind=KIND_TOOL, source="https://example.com/x",
+        current_pain="구체적 현재 통증 설명 문장",
+        expected_benefit="구체적 기대 효과 설명 문장",
+        overlap="기존 capability 와의 겹침 설명",
+        operational_cost="설치/런타임 부담 설명",
+        maintenance_risk="유지보수 리스크 설명",
+        provider_runtime_fit="provider/runtime 적합성 설명",
+        governance_security="governance/security 영향 설명",
+        verdict=A.VERDICT_COLLECT_FIRST,
+        reviewers=(
+            A.ReviewerVerdict(A.AXIS_PM, A.VERDICT_COLLECT_FIRST, "pm 사유 문장"),
+            A.ReviewerVerdict(A.AXIS_TECH_LEAD, A.VERDICT_COLLECT_FIRST, "tl 사유 문장"),
+            A.ReviewerVerdict(A.AXIS_SPECIALIST, A.VERDICT_COLLECT_FIRST, "spec 사유 문장"),
+        ),
+    )
+    base.update(over)
+    return A.AdoptionReview(**base)
+
+
+class RegistryTests(unittest.TestCase):
+    def test_every_review_is_valid(self) -> None:
+        bad = A.invalid_reviews(REG.adoption_registry())
+        self.assertEqual(bad, (), f"invalid reviews: {[(r.candidate_id, why) for r, why in bad]}")
+
+    def test_all_three_verdicts_present(self) -> None:
+        reviews = REG.adoption_registry()
+        self.assertGreaterEqual(len(A.by_verdict(reviews, A.VERDICT_ADOPT_NOW)), 1)
+        self.assertGreaterEqual(len(A.by_verdict(reviews, A.VERDICT_COLLECT_FIRST)), 1)
+        self.assertGreaterEqual(len(A.by_verdict(reviews, A.VERDICT_HOLD)), 1)
+
+    def test_required_candidates_covered(self) -> None:
+        ids = {r.candidate_id for r in REG.adoption_registry()}
+        for required in ("ponytail", "context7", "mcp-fetch", "mcp-filesystem", "mcp-git",
+                         "mcp-memory", "mcp-sequential-thinking", "vale", "textlint", "alex",
+                         "write-good", "proselint", "browser-use"):
+            self.assertIn(required, ids, f"missing candidate: {required}")
+
+    def test_vale_is_adopt_now_with_install_plan(self) -> None:
+        vale = next(r for r in REG.adoption_registry() if r.candidate_id == "vale")
+        self.assertEqual(vale.verdict, A.VERDICT_ADOPT_NOW)
+        self.assertTrue(vale.install_plan)  # attach kind adopt-now must declare install
+        self.assertEqual(vale.loadout_id, "doc-quality-review-local")
+
+
+class GateTests(unittest.TestCase):
+    def test_thin_field_invalid(self) -> None:
+        self.assertTrue(A.validate_review(_review(current_pain="x")))
+
+    def test_missing_axis_invalid(self) -> None:
+        r = _review(reviewers=(A.ReviewerVerdict(A.AXIS_PM, A.VERDICT_COLLECT_FIRST, "사유 문장 길이"),))
+        self.assertTrue(any("검토 축 누락" in x for x in A.validate_review(r)))
+
+    def test_adopt_now_requires_consensus(self) -> None:
+        r = _review(
+            verdict=A.VERDICT_ADOPT_NOW,
+            install_plan=("brew install x",),
+            reviewers=(
+                A.ReviewerVerdict(A.AXIS_PM, A.VERDICT_ADOPT_NOW, "pm 사유 문장"),
+                A.ReviewerVerdict(A.AXIS_TECH_LEAD, A.VERDICT_COLLECT_FIRST, "tl 반대 사유"),
+                A.ReviewerVerdict(A.AXIS_SPECIALIST, A.VERDICT_ADOPT_NOW, "spec 사유 문장"),
+            ))
+        self.assertTrue(any("합의 아님" in x for x in A.validate_review(r)))
+
+    def test_adopt_now_attach_kind_requires_install_plan(self) -> None:
+        r = _review(
+            kind=KIND_MCP, verdict=A.VERDICT_ADOPT_NOW, install_plan=(),
+            reviewers=(
+                A.ReviewerVerdict(A.AXIS_PM, A.VERDICT_ADOPT_NOW, "pm 사유 문장"),
+                A.ReviewerVerdict(A.AXIS_TECH_LEAD, A.VERDICT_ADOPT_NOW, "tl 사유 문장"),
+                A.ReviewerVerdict(A.AXIS_SPECIALIST, A.VERDICT_ADOPT_NOW, "spec 사유 문장"),
+            ))
+        self.assertTrue(any("install_plan 없음" in x for x in A.validate_review(r)))
+
+    def test_adopt_now_valid_when_consensus_and_install(self) -> None:
+        r = _review(
+            kind=KIND_TOOL, verdict=A.VERDICT_ADOPT_NOW, install_plan=("brew install x",),
+            reviewers=(
+                A.ReviewerVerdict(A.AXIS_PM, A.VERDICT_ADOPT_NOW, "pm 사유 문장"),
+                A.ReviewerVerdict(A.AXIS_TECH_LEAD, A.VERDICT_ADOPT_NOW, "tl 사유 문장"),
+                A.ReviewerVerdict(A.AXIS_SPECIALIST, A.VERDICT_ADOPT_NOW, "spec 사유 문장"),
+            ))
+        self.assertEqual(A.validate_review(r), ())
+
+
+class CatalogIntegrationTests(unittest.TestCase):
+    def test_doc_quality_loadout_in_catalog(self) -> None:
+        lo = catalog.loadout("doc-quality-review-local")
+        self.assertIsNotNone(lo)
+        self.assertEqual(lo.required_weapons, ("vale",))
+        for w in ("proselint", "write-good", "alex", "textlint"):
+            self.assertIn(w, lo.optional_weapons)
+        self.assertIn("doc-quality-review", lo.recommended_skills)
+
+    def test_doc_quality_weapons_declare_install_not_run(self) -> None:
+        for wid in ("vale", "proselint", "write-good", "alex", "textlint"):
+            w = catalog.weapon(wid)
+            self.assertIsNotNone(w, wid)
+            self.assertTrue(w.install_hint, f"{wid} no install_hint")  # declares install
+            self.assertTrue(w.verify_command, f"{wid} no verify_command")  # how to check presence
+
+    def test_doc_quality_skill_vendor_neutral(self) -> None:
+        sk = catalog.skill("doc-quality-review")
+        self.assertIsNotNone(sk)
+        for vendor in ("claude", "codex", "gemini"):
+            self.assertNotIn(vendor, sk.capability_note.lower())
+
+
+class RenderTests(unittest.TestCase):
+    def test_summary_lines(self) -> None:
+        lines = render.armory_intake_lines(REG.adoption_registry())
+        blob = "\n".join(lines)
+        self.assertIn("armory intake", blob)
+        self.assertIn("adopt-now", blob)
+        self.assertIn("vale", blob.lower())
+
+    def test_detail_lines(self) -> None:
+        vale = next(r for r in REG.adoption_registry() if r.candidate_id == "vale")
+        lines = render.armory_intake_lines(REG.adoption_registry(), detail=vale)
+        blob = "\n".join(lines)
+        self.assertIn("현재 pain", blob)
+        self.assertIn("governance/security", blob)
+        self.assertIn("pm", blob)
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_committed_catalog_matches_code(self) -> None:
+        path = (Path(__file__).resolve().parents[2] / "apps" / "forgekit-console" /
+                "examples" / "armory-intake" / "adoption-catalog.json")
+        self.assertTrue(path.exists(), "adoption-catalog.json missing")
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(on_disk["reviews"], [r.to_dict() for r in REG.adoption_registry()])
+        self.assertEqual(on_disk["summary"]["total"], len(REG.adoption_registry()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_parser.py
+++ b/tests/forgekit/test_parser.py
@@ -51,7 +51,7 @@ class PaletteTests(unittest.TestCase):
 
     def test_prefix_multiple(self) -> None:
         names = {c.name for c in palette_matches("/a")}
-        self.assertEqual(names, {"agents", "about", "always-on", "auto", "autopilot", "attach"})
+        self.assertEqual(names, {"agents", "about", "always-on", "auto", "autopilot", "attach", "armory"})
 
     def test_substring_fallback_only_when_no_prefix(self) -> None:
         # prefix exists → exact prefix set (no widening); no prefix → substring fallback.


### PR DESCRIPTION
## 목적
외부 plugin/skill/tool 후보를 ForgeKit 관점 8축 도입 검토 + PM/tech-lead/specialist 3축 후 **adopt-now/collect-first/hold** 로 귀결시키고, adopt-now 를 Hephaistos 가 읽는 catalog 와 연결한다. SSoT: `docs/armory-intake-adoption.md`. Closes #432.

## 범위 (scope)
- `armory.adoption` (8축 artifact + 3축 검토 + adopt-now 합의/install-plan 게이트) — leaf-safe.
- `armory.adoption_registry` — 13 후보 평가(verdict + 사유).
- catalog: doc-quality 묶음(Vale anchor + proselint/write-good/alex/textlint) → `doc-quality-review-local` loadout + `doc-quality-review` skill + weapons.
- 표면 `/armory [review <id>]` + evidence `adoption-catalog.json` + docs.

## changed files
- `packages/armory/src/armory/adoption.py` (new), `adoption_registry.py` (new), `__init__.py`, `catalog.py`
- `apps/forgekit-console/.../commands/{router,registry}.py`, `tui/render.py`
- `tests/forgekit/test_armory_adoption.py` (new)
- `apps/forgekit-console/examples/armory-intake/adoption-catalog.json` (new)
- `docs/armory-intake-adoption.md` (new), `docs/armory.md`, `CLAUDE.md`, `AGENTS.md`

## verdict 결과 (artifact)
adopt-now **1**(Vale) · collect-first **8**(proselint/write-good/alex/textlint/ponytail/Context7/MCP-Fetch/MCP-Memory) · hold **4**(MCP-Filesystem/MCP-Git/MCP-SequentialThinking/browser-use). 각 후보 8축 + 3축 검토는 `adoption-catalog.json` 참조.

## tests
- `python -m unittest tests.forgekit.test_armory_adoption` — 18 cases (registry valid·verdict 분포·게이트·doc-quality loadout·render·evidence 일치). OK.
- 회귀: `test_armory_breadth` `test_armory_extraction` `test_armory_intake_promotion` `test_router` `test_render` `test_palette` `test_tui_smoke` `test_package_topology_guard` `test_app_boundary_drift` `test_nexus_read` — 전부 OK(247+ green).

## evidence
- `examples/armory-intake/adoption-catalog.json` (13 review + 요약 + doc-quality loadout, Hephaistos/Nexus-readable).
- catalog: `/loadout doc-quality-review-local` · `/resolve <문서 품질 요청>` 가 picks up.

## risks
- **adopted ≠ equipped/installed**: catalog 등록은 available 일 뿐 — WeaponSpec install_hint/install_plan 은 설치 *경로 선언*, 실제 설치/장착 안 함(fake adoption 차단, validate_review 가 attach 류 adopt-now 의 install_plan 강제).
- **governance hold 근거**: MCP Git/Filesystem 은 git-write/경로 안전 hard rail 우회 위험 → hold. browser-use 는 자격증명/exfiltration 위험 → hold.
- 패키지 경계: armory 는 leaf 유지(decision_lane import 없음). 3축은 plain data.

## issue/PR/CI/merge status
- issue #432 · PR (draft) · CI: 대기 → 아래 확인 · merge: operator 인가('merge까지 닫는다') 하에 CI green 시 진행. classifier 가 `gh pr merge` 차단하면 blocked 로 표면(owner=operator, unblock=직접 머지 지시 또는 권한).

---
### Audit
- base `main`(73814a7) · head 3 commits · app→package import 만(armory/console), package→package 신규 edge 없음. no secret / no destructive op.