### PR TITLE
✨ Armory intake — 외부 후보 13건 실제 도입 검토(adopt/collect/hold) + doc-quality lint loadout

### DIFF
--- a/apps/forgekit-console/examples/armory-intake/adoption-catalog.json
+++ b/apps/forgekit-console/examples/armory-intake/adoption-catalog.json
@@ -1,0 +1,1168 @@
+{
+  "round": "armory-intake-real-candidates",
+  "summary": {
+    "total": 13,
+    "adopt-now": 1,
+    "collect-first": 8,
+    "hold": 4,
+    "adopted_specs": [
+      "vale"
+    ]
+  },
+  "doc_quality_loadout": {
+    "loadout_id": "doc-quality-lint-local",
+    "anchor": "vale (adopt-now)",
+    "members": [
+      "vale",
+      "proselint",
+      "write-good",
+      "alex",
+      "textlint"
+    ],
+    "note": "Vale=required(adopt-now), 나머지=optional(collect-first). tool-less docs-writing-local 과 별개. adopted≠installed."
+  },
+  "candidates": [
+    {
+      "candidate": {
+        "id": "vale",
+        "name": "Vale",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "style-guide(YAML) 기반 prose 린트 — 문서 문체/용어 일관성을 기계로 강제",
+        "signals": [
+          "vale",
+          "prose lint",
+          "문체 검사",
+          "style guide",
+          "용어 일관성",
+          "doc lint"
+        ],
+        "when_to_use": [
+          "vault/README/가이드 문체·용어 일관성을 CI/로컬에서 점검"
+        ],
+        "unsafe_boundary": [
+          "외부 서버로 문서 본문 송신 금지(로컬 린트만)",
+          "자동 수정 강제 금지(제안만)"
+        ],
+        "capability_note": "prose/style linting (style-guide enforced)",
+        "install_requirements": [
+          "brew install vale",
+          "vale sync (.vale.ini styles)"
+        ],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/errata-ai/vale"
+      },
+      "review": {
+        "candidate_id": "vale",
+        "current_pain": "vault/문서 품질이 사람 리뷰에만 의존 — 문체/용어 일관성을 기계로 강제할 표준 도구 부재.",
+        "expected_benefit": "style-guide 기반 prose 린트를 CI/로컬에서 결정적으로 강제 — 문서 회귀를 사람 전에 잡음.",
+        "overlap_with_existing": "built-in docs-quality 스킬은 구조/명료성 위주 — Vale 는 style-guide 강제(보완재). 중복 아님.",
+        "operational_cost": "단일 Go 바이너리 + style 패키지 sync. 런타임 의존 없음 — 가장 낮음.",
+        "maintenance_risk": "활발히 유지(errata-ai), config 안정. 낮음.",
+        "provider_runtime_fit": "provider-neutral CLI — 어느 backend 든 호출. toolchain 버전 관리 가능.",
+        "governance_security_impact": "로컬 파일만, 네트워크 없음(style sync 제외). 위험 낮음.",
+        "adopt_timing_reason": "비용/위험 최저 + 문서 품질은 핵심 가치 → 지금 카탈로그화(단 미설치=adopted≠equipped).",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "adopt-now",
+            "rationale": "문서 품질은 vault 핵심 — 즉시 카탈로그화 가치 충분."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "adopt-now",
+            "rationale": "단일 바이너리·config 기반, attach contract 명확 — 도입 리스크 최소."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "knowledge-engineer",
+            "position": "adopt-now",
+            "rationale": "knowledge-engineer: style-guide 로 '왜' 깊이/용어 강제가 vault 규칙과 정합."
+          }
+        ],
+        "disposition": "adopt-now",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "vale",
+        "disposition": "adopt-now",
+        "adopted": true,
+        "reasons": [],
+        "evidence": [
+          "adoption disposition=adopt-now",
+          "kind=tool",
+          "summary 실체 있음",
+          "signals 6개",
+          "when_to_use 명시",
+          "unsafe_boundary 선언",
+          "capability_note vendor-neutral",
+          "검증 경로 있음",
+          "install/attach requirements 명시",
+          "승격됨 (source=operator:https://github.com/errata-ai/vale)"
+        ],
+        "promotion": {
+          "candidate_id": "vale",
+          "accepted": true,
+          "spec": {
+            "id": "vale",
+            "name": "Vale",
+            "domains": [],
+            "languages": [],
+            "frameworks": [],
+            "topics": [],
+            "rules": [],
+            "commands": [
+              "vale ."
+            ],
+            "verification": [
+              "vale --version",
+              "vale ."
+            ],
+            "forbidden": [
+              "외부 서버로 문서 본문 송신 금지(로컬 린트만)",
+              "자동 수정 강제 금지(제안만)"
+            ],
+            "related_weapons": [
+              "vale"
+            ],
+            "related_loadouts": [
+              "doc-quality-lint-local"
+            ],
+            "related_roles": [
+              "technical-writer",
+              "knowledge-engineer"
+            ],
+            "nexus_refs": [],
+            "category": "docs",
+            "summary": "style-guide(YAML) 기반 prose 린트 — 문서 문체/용어 일관성을 기계로 강제",
+            "when_to_use": [
+              "vault/README/가이드 문체·용어 일관성을 CI/로컬에서 점검"
+            ],
+            "when_not_to_use": [
+              "코드 린트(언어별 린터)",
+              "문서 구조 검증(vault-curate frontmatter)"
+            ],
+            "required_inputs": [],
+            "expected_outputs": [],
+            "signals": [
+              "vale",
+              "prose lint",
+              "문체 검사",
+              "style guide",
+              "용어 일관성",
+              "doc lint"
+            ],
+            "capability_note": "prose/style linting (style-guide enforced)",
+            "status": "ready",
+            "kind": "tool",
+            "provider_affinity": [],
+            "install_requirements": [
+              "brew install vale",
+              "vale sync (.vale.ini styles)"
+            ],
+            "attach_requirements": []
+          },
+          "reasons": [],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음",
+            "signals 6개",
+            "when_to_use 명시",
+            "unsafe_boundary 선언",
+            "capability_note vendor-neutral",
+            "검증 경로 있음",
+            "install/attach requirements 명시",
+            "승격됨 (source=operator:https://github.com/errata-ai/vale)"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "proselint",
+        "name": "proselint",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "Vale 보완 — 검증된 영어 prose 규칙(중복/jargon) 추가 커버.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/amperser/proselint"
+      },
+      "review": {
+        "candidate_id": "proselint",
+        "current_pain": "문서의 상투구/중복/약한 표현을 잡을 보조 린터 부재.",
+        "expected_benefit": "Vale 보완 — 검증된 영어 prose 규칙(중복/jargon) 추가 커버.",
+        "overlap_with_existing": "Vale 규칙과 상당 부분 겹침 — Vale 채택 후 한계 드러나면 보강.",
+        "operational_cost": "Python 패키지 — Python 런타임 의존(Vale 대비 추가 부담).",
+        "maintenance_risk": "유지보수 빈도 낮은 편 — 중간.",
+        "provider_runtime_fit": "CLI, provider-neutral. loadout optional 멤버로 적합.",
+        "governance_security_impact": "로컬 파일만 — 위험 낮음.",
+        "adopt_timing_reason": "Vale 로 시작 후 효과 측정 → 동시 도입은 과함.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "Vale 먼저, 효과 측정 후 보강."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "규칙 중복 — 한계 evidence 누적 후."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "knowledge-engineer",
+            "position": "collect-first",
+            "rationale": "loadout optional 로만 노출, 강제 X."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "proselint",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: Vale 로 시작 후 효과 측정 → 동시 도입은 과함."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=tool",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "proselint",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)"
+          ],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "write-good",
+        "name": "write-good",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "가벼운 영어 문체 힌트 — 빠른 1차 패스.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/btford/write-good"
+      },
+      "review": {
+        "candidate_id": "write-good",
+        "current_pain": "수동태/약한 표현 등 흔한 글쓰기 안티패턴을 기계로 못 잡음.",
+        "expected_benefit": "가벼운 영어 문체 힌트 — 빠른 1차 패스.",
+        "overlap_with_existing": "Vale/proselint 와 규칙 겹침 + naive 라 정확도 낮음.",
+        "operational_cost": "npm 패키지 — Node 런타임 의존(멀티 Node 도구 부담 누적).",
+        "maintenance_risk": "유지보수 정체(최근 커밋 드묾) — 중상.",
+        "provider_runtime_fit": "CLI지만 Node 의존이 Vale 단일바이너리보다 불리.",
+        "governance_security_impact": "로컬 파일만 — 위험 낮음.",
+        "adopt_timing_reason": "정확도/유지보수 약함 → 즉시 도입 가치 낮음, 근거만 누적.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "즉시 도입 가치 낮음 — 근거만."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "Node 의존+유지보수 정체 — Vale 한계 드러나면 재평가."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "knowledge-engineer",
+            "position": "collect-first",
+            "rationale": "Vale 로 대체 가능, evidence 만."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "write-good",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 정확도/유지보수 약함 → 즉시 도입 가치 낮음, 근거만 누적."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=tool",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "write-good",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)"
+          ],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "alex",
+        "name": "alex",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "포용적 글쓰기 자동 점검 — 공개 문서/README 톤 관리.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/get-alex/alex"
+      },
+      "review": {
+        "candidate_id": "alex",
+        "current_pain": "둔감/배제적 표현(insensitive writing)을 사람이 일일이 못 잡음.",
+        "expected_benefit": "포용적 글쓰기 자동 점검 — 공개 문서/README 톤 관리.",
+        "overlap_with_existing": "Vale 의 inclusive-language 스타일 팩과 부분 중복.",
+        "operational_cost": "npm 패키지 — Node 런타임 의존.",
+        "maintenance_risk": "유지보수 양호하나 영어 전용 — 한국어 vault 엔 제한적. 중간.",
+        "provider_runtime_fit": "CLI, provider-neutral. 한국어 비중 높은 vault 엔 적용 범위 좁음.",
+        "governance_security_impact": "로컬 파일만 — 위험 낮음.",
+        "adopt_timing_reason": "공개 문서 톤엔 가치 — 한국어 비중 고려해 선검증.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "공개 문서 톤엔 가치 — 적용 범위 검증 먼저."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "Vale inclusive 팩과 비교 evidence 필요."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "knowledge-engineer",
+            "position": "collect-first",
+            "rationale": "영어 산출물 한정 optional."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "alex",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 공개 문서 톤엔 가치 — 한국어 비중 고려해 선검증."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=tool",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "alex",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)"
+          ],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "textlint",
+        "name": "textlint",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "플러그인으로 한국어/마크다운 규칙까지 확장 — Vale 약점 보완.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/textlint/textlint"
+      },
+      "review": {
+        "candidate_id": "textlint",
+        "current_pain": "한국어 포함 문서에 플러그형 린터(직접 규칙 작성) 부재.",
+        "expected_benefit": "플러그인으로 한국어/마크다운 규칙까지 확장 — Vale 약점 보완.",
+        "overlap_with_existing": "Vale 와 목적 겹치나 plugin 모델/한국어 커버는 차별점.",
+        "operational_cost": "npm + 플러그인 다수 — 설정/유지 부담 가장 큼.",
+        "maintenance_risk": "코어 유지되나 플러그인 품질 편차 — 중상.",
+        "provider_runtime_fit": "CLI. 한국어 vault 엔 Vale 보다 적합할 수 있음(검증 필요).",
+        "governance_security_impact": "로컬 파일만 — 위험 낮음.",
+        "adopt_timing_reason": "한국어 커버 매력 — 설정 부담 커 PoC 먼저.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "한국어 커버 가능성 매력 — PoC 먼저."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "플러그인 의존 트리 평가 후 — 지금 adopt 과투자."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "knowledge-engineer",
+            "position": "collect-first",
+            "rationale": "한국어 규칙 PoC 로 Vale 와 비교."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "textlint",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 한국어 커버 매력 — 설정 부담 커 PoC 먼저."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=tool",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "textlint",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)"
+          ],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "ponytail",
+        "name": "ponytail",
+        "kind": "skill",
+        "category": "",
+        "summary": "ponytail 식 단순성 검토(keep/simplify/use-existing/reduce-surface/reject)를 표준화.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/example/ponytail"
+      },
+      "review": {
+        "candidate_id": "ponytail",
+        "current_pain": "새 모듈/계층 추가 시 과설계를 막을 일관된 단순성 검토 렌즈가 코드화 안 됨.",
+        "expected_benefit": "ponytail 식 단순성 검토(keep/simplify/use-existing/reduce-surface/reject)를 표준화.",
+        "overlap_with_existing": "ForgeKit 은 이미 council/consult + ponytail consult 모듈 보유 — 상당 부분 겹침.",
+        "operational_cost": "검토 절차라 도입 부담 낮으나 repo 실체/성숙도 불명확.",
+        "maintenance_risk": "repo 유지보수 불확실 — 외부 의존보다 내부 스킬화가 안전.",
+        "provider_runtime_fit": "skill(절차) — provider-neutral, 단 외부 repo 채택보다 내부화가 fit.",
+        "governance_security_impact": "검토 절차라 외부 코드 실행 없음 — 위험 낮음.",
+        "adopt_timing_reason": "이미 consult 렌즈로 사용 중 — 외부 repo 채택은 근거 누적 후.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "단순성 렌즈는 이미 우리 lane 적용 중 — 외부 채택보다 evidence."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "council/consult 와 겹침 — 외부 repo 의존 만들 이유 약함."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "backend-engineer",
+            "position": "collect-first",
+            "rationale": "내부 스킬화로 충분 — 외부 도입은 보류."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "ponytail",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 이미 consult 렌즈로 사용 중 — 외부 repo 채택은 근거 누적 후."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=skill",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "ponytail",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음"
+          ],
+          "evidence": [
+            "kind=skill",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "context7",
+        "name": "Context7",
+        "kind": "mcp",
+        "category": "",
+        "summary": "최신 라이브러리 docs/snippet 을 MCP 로 주입 — 코드 생성 정확도 향상.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/upstash/context7"
+      },
+      "review": {
+        "candidate_id": "context7",
+        "current_pain": "LLM 이 라이브러리 최신 API 를 몰라 환각 — 버전 맞는 docs 주입 경로 부재.",
+        "expected_benefit": "최신 라이브러리 docs/snippet 을 MCP 로 주입 — 코드 생성 정확도 향상.",
+        "overlap_with_existing": "Nexus 는 내부 지식 — 외부 라이브러리 docs 는 미커버라 보완재(역할 경계 정리 필요).",
+        "operational_cost": "MCP 서버 + (호스티드) 의존/키 — 외부 서비스 의존 도입.",
+        "maintenance_risk": "3rd-party 호스티드 의존 — 가용성/정책 변화 리스크 중상.",
+        "provider_runtime_fit": "MCP → claude/codex/gemini(mcp-host) attach. ollama 제외.",
+        "governance_security_impact": "외부 서버로 쿼리 송신 — outbound/데이터 노출 검토 필요(integrations/mcp 가드 경유).",
+        "adopt_timing_reason": "유망하나 호스티드/키/outbound 가드 정리 전엔 adopt 불가 — PoC 먼저.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "환각 감소 효과 크다 — 가능하면 빨리."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "호스티드 의존+outbound 정책 정리 전 adopt 불가."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "platform-runtime-engineer",
+            "position": "collect-first",
+            "rationale": "integrations/mcp 가드+키 처리 검증 후."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "context7",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 유망하나 호스티드/키/outbound 가드 정리 전엔 adopt 불가 — PoC 먼저."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "context7",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "mcp-fetch",
+        "name": "MCP Fetch (official)",
+        "kind": "mcp",
+        "category": "",
+        "summary": "공식 reference 서버라 신뢰도 높은 fetch capability — 리서치 보강.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch"
+      },
+      "review": {
+        "candidate_id": "mcp-fetch",
+        "current_pain": "에이전트가 임의 URL 본문을 표준 경로로 가져올 reference MCP 미배선.",
+        "expected_benefit": "공식 reference 서버라 신뢰도 높은 fetch capability — 리서치 보강.",
+        "overlap_with_existing": "discovery sources(RSS/HN/GitHub)와 일부 겹침 — 임의 URL fetch 는 미커버.",
+        "operational_cost": "공식 서버 설치/attach — 경량이나 MCP host 연결 필요.",
+        "maintenance_risk": "공식 레포 유지보수 양호 — 낮음.",
+        "provider_runtime_fit": "MCP, mcp-host attach. provider-neutral.",
+        "governance_security_impact": "임의 URL fetch = SSRF/내부망 위험 — allowlist/sandbox 정책 필수.",
+        "adopt_timing_reason": "유용하나 SSRF allowlist 설계가 adopt 전제 — 그 전까지 근거만 누적.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "리서치엔 유용하나 보안 가드 선행."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "SSRF allowlist 정책 설계 후 재평가 — 지금 adopt 위험."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "security-engineer",
+            "position": "collect-first",
+            "rationale": "outbound allowlist 설계 전까지 collect-first(미활성)."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "mcp-fetch",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 유용하나 SSRF allowlist 설계가 adopt 전제 — 그 전까지 근거만 누적."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "mcp-fetch",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "mcp-memory",
+        "name": "MCP Memory (official)",
+        "kind": "mcp",
+        "category": "",
+        "summary": "공식 memory 서버로 표준화된 기억 capability.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/modelcontextprotocol/servers/tree/main/src/memory"
+      },
+      "review": {
+        "candidate_id": "mcp-memory",
+        "current_pain": "세션 간 기억의 표준 MCP 경로 부재.",
+        "expected_benefit": "공식 memory 서버로 표준화된 기억 capability.",
+        "overlap_with_existing": "Nexus(vault)+troubleshooting ledger+claude-mem 으로 이미 기억 레인 보유 — 중복 큼.",
+        "operational_cost": "서버 설치/attach + 저장소 관리 — 기존 기억 레인과 이중화.",
+        "maintenance_risk": "공식 유지보수 양호하나 기억 SSoT 와 충돌 위험 — 중간.",
+        "provider_runtime_fit": "MCP attach 가능하나 우리 기억 SSoT 는 vault/ledger 라 fit 약함.",
+        "governance_security_impact": "기억 저장 위치/내용 거버넌스 — 기존 메모리 정책과 정합 필요.",
+        "adopt_timing_reason": "기억은 vault/ledger 로 충당 — 지금 아님, 한계 드러나면 재평가.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "collect-first",
+            "rationale": "기억은 이미 충당 — 굳이 지금 아님, 근거만."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "collect-first",
+            "rationale": "Nexus/ledger 와 SSoT 중복 — 한계 드러나면 재평가."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "platform-runtime-engineer",
+            "position": "collect-first",
+            "rationale": "우리 기억 모델과 비교 evidence 만."
+          }
+        ],
+        "disposition": "collect-first",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "mcp-memory",
+        "disposition": "collect-first",
+        "adopted": false,
+        "reasons": [
+          "disposition=collect-first",
+          "timing: 기억은 vault/ledger 로 충당 — 지금 아님, 한계 드러나면 재평가."
+        ],
+        "evidence": [
+          "adoption disposition=collect-first",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "mcp-memory",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "mcp-filesystem",
+        "name": "MCP Filesystem (official)",
+        "kind": "mcp",
+        "category": "",
+        "summary": "표준 파일 접근 capability.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem"
+      },
+      "review": {
+        "candidate_id": "mcp-filesystem",
+        "current_pain": "에이전트 파일 접근을 표준 MCP 로 노출하려는 유혹.",
+        "expected_benefit": "표준 파일 접근 capability.",
+        "overlap_with_existing": "executor 가 이미 파일 도구 보유 — 기능 거의 전부 중복.",
+        "operational_cost": "추가 서버 + 권한 범위 관리.",
+        "maintenance_risk": "우리 가드와 충돌 관리 비용.",
+        "provider_runtime_fit": "ForgeKit 경로 안전(git_path_safety)과 경합.",
+        "governance_security_impact": "광범위 FS 접근 MCP 는 git-write hard rail/경로 안전 SSoT 우회 — 거버넌스 충돌(금지).",
+        "adopt_timing_reason": "기존 파일 도구로 충분 + 가드 우회 위험 → 제외.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "hold",
+            "rationale": "추가 가치 없음."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "hold",
+            "rationale": "경로 안전 hard rail 우회 — 불가."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "security-engineer",
+            "position": "hold",
+            "rationale": "broad FS MCP 가드 우회 — hold."
+          }
+        ],
+        "disposition": "hold",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "mcp-filesystem",
+        "disposition": "hold",
+        "adopted": false,
+        "reasons": [
+          "disposition=hold",
+          "timing: 기존 파일 도구로 충분 + 가드 우회 위험 → 제외."
+        ],
+        "evidence": [
+          "adoption disposition=hold",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "mcp-filesystem",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "mcp-git",
+        "name": "MCP Git (official)",
+        "kind": "mcp",
+        "category": "",
+        "summary": "표준 git capability.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/modelcontextprotocol/servers/tree/main/src/git"
+      },
+      "review": {
+        "candidate_id": "mcp-git",
+        "current_pain": "git 작업을 MCP 로 노출하려는 유혹.",
+        "expected_benefit": "표준 git capability.",
+        "overlap_with_existing": "git-write 를 git_path_safety/repo_write_policy 로 강하게 통제 — 전면 중복.",
+        "operational_cost": "추가 서버 + 권한.",
+        "maintenance_risk": "git hard rail 과 이중 경로 유지 비용.",
+        "provider_runtime_fit": "우리 git 거버넌스와 정면 충돌.",
+        "governance_security_impact": "MCP git write 는 `git -C + 명시 pathspec` hard rail/commit-governance 우회 — 금지.",
+        "adopt_timing_reason": "git 안전은 핵심 가드 — 외부 MCP 로 우회 불가.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "hold",
+            "rationale": "git 안전은 핵심 가드."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "hold",
+            "rationale": "repo_write_policy SSoT 우회 — 금지."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "security-engineer",
+            "position": "hold",
+            "rationale": "hard rail 충돌 — hold."
+          }
+        ],
+        "disposition": "hold",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "mcp-git",
+        "disposition": "hold",
+        "adopted": false,
+        "reasons": [
+          "disposition=hold",
+          "timing: git 안전은 핵심 가드 — 외부 MCP 로 우회 불가."
+        ],
+        "evidence": [
+          "adoption disposition=hold",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "mcp-git",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "mcp-sequential-thinking",
+        "name": "MCP Sequential Thinking (official)",
+        "kind": "mcp",
+        "category": "",
+        "summary": "단계적 사고 스캐폴딩.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking"
+      },
+      "review": {
+        "candidate_id": "mcp-sequential-thinking",
+        "current_pain": "구조화된 단계적 추론을 도구로 강제하려는 유혹.",
+        "expected_benefit": "단계적 사고 스캐폴딩.",
+        "overlap_with_existing": "decision_lane(readiness/council)+모델 자체 추론과 겹침 — 한계 효용.",
+        "operational_cost": "추가 서버 + 프롬프트 표면 증가.",
+        "maintenance_risk": "효용 대비 유지 비용 — 중간.",
+        "provider_runtime_fit": "MCP attach 가능하나 모델 내장 추론과 중복.",
+        "governance_security_impact": "위험 낮으나 도입 정당성(효용) 부족이 더 큰 문제.",
+        "adopt_timing_reason": "추론은 모델/lane 이 이미 함 — 추가 가치 미미.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "hold",
+            "rationale": "추가 가치 미미."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "hold",
+            "rationale": "프롬프트 표면만 늘림 — hold."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "backend-engineer",
+            "position": "hold",
+            "rationale": "decision_lane 과 중복 — hold."
+          }
+        ],
+        "disposition": "hold",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "mcp-sequential-thinking",
+        "disposition": "hold",
+        "adopted": false,
+        "reasons": [
+          "disposition=hold",
+          "timing: 추론은 모델/lane 이 이미 함 — 추가 가치 미미."
+        ],
+        "evidence": [
+          "adoption disposition=hold",
+          "kind=mcp",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "mcp-sequential-thinking",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "category 없음",
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "mcp 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)",
+            "mcp 인데 provider_affinity 없음 — 어느 harness 에 붙는지 불명"
+          ],
+          "evidence": [
+            "kind=mcp",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    },
+    {
+      "candidate": {
+        "id": "browser-use",
+        "name": "browser-use",
+        "kind": "tool",
+        "category": "docs",
+        "summary": "LLM 주도 브라우저 자동화 — 일부 리서치/검증 시나리오 확장.",
+        "signals": [],
+        "when_to_use": [],
+        "unsafe_boundary": [],
+        "capability_note": "",
+        "install_requirements": [],
+        "attach_requirements": [],
+        "source": "operator",
+        "source_ref": "https://github.com/browser-use/browser-use"
+      },
+      "review": {
+        "candidate_id": "browser-use",
+        "current_pain": "실제 브라우저 자동화(로그인-게이트 사이트 등) capability 부재.",
+        "expected_benefit": "LLM 주도 브라우저 자동화 — 일부 리서치/검증 시나리오 확장.",
+        "overlap_with_existing": "discovery 의 YouTube/Figma/Google planned seam 과 목적 일부 겹침(미연결).",
+        "operational_cost": "Python + 헤드리스 브라우저(Playwright) — 무거운 런타임.",
+        "maintenance_risk": "빠르게 바뀌는 신생 — API 불안정, 중상.",
+        "provider_runtime_fit": "무거운 의존이 ForgeKit 경량 toolchain 과 어긋남.",
+        "governance_security_impact": "실 브라우저 = 자격증명/exfiltration/자동 액션 위험 매우 큼 — 강 sandbox/승인 없이 금지.",
+        "adopt_timing_reason": "위험·비용 대비 당장 필요 시나리오 없음 — sandbox 설계 후 재평가.",
+        "axis_reviews": [
+          {
+            "axis": "pm",
+            "reviewer": "product-manager",
+            "position": "hold",
+            "rationale": "당장 필요 시나리오 없음."
+          },
+          {
+            "axis": "tech-lead",
+            "reviewer": "tech-lead",
+            "position": "hold",
+            "rationale": "무거운 의존+불안정 API — hold."
+          },
+          {
+            "axis": "specialist",
+            "reviewer": "security-engineer",
+            "position": "hold",
+            "rationale": "브라우저 자동화 위험 — hold."
+          }
+        ],
+        "disposition": "hold",
+        "review_gaps": []
+      },
+      "result": {
+        "candidate_id": "browser-use",
+        "disposition": "hold",
+        "adopted": false,
+        "reasons": [
+          "disposition=hold",
+          "timing: 위험·비용 대비 당장 필요 시나리오 없음 — sandbox 설계 후 재평가."
+        ],
+        "evidence": [
+          "adoption disposition=hold",
+          "kind=tool",
+          "summary 실체 있음"
+        ],
+        "promotion": {
+          "candidate_id": "browser-use",
+          "accepted": false,
+          "spec": null,
+          "reasons": [
+            "signals 없음 — resolver 가 고를 신호가 없다",
+            "when_to_use 없음 — 언제 쓰는지 불명",
+            "unsafe_boundary 없음 — 위험 경계 미선언(금지)",
+            "capability_note 없음",
+            "commands/verification 둘 다 없음 — 검증 경로 없음",
+            "tool 인데 install/attach requirements 없음 — 부착 불가(fake available 방지)"
+          ],
+          "evidence": [
+            "kind=tool",
+            "summary 실체 있음"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/apps/forgekit-console/src/forgekit_console/armory_intake.py
+++ b/apps/forgekit-console/src/forgekit_console/armory_intake.py
@@ -1,0 +1,268 @@
+"""Armory intake — the EVALUATED external-candidate set (this wave's curated decisions).
+
+The adoption *framework* already exists (``armory.candidate.AdoptionReview`` /
+``adopt_candidate`` — the 8-field artifact + ≥3-axis review + adopt-now/collect-first/hold
+gate). What was missing is the actual evaluation of the real candidate set, so this module
+applies that existing framework to the wave's named candidates — it does NOT define a new
+adoption model (no duplicate).
+
+Each candidate carries a real ``AdoptionReview`` (8축 + PM/tech-lead/specialist 3축) paired
+with its ``ArmoryCandidate`` catalog contract. ``adopt_candidate`` couples them: only
+adopt-now + a valid contract yields a registrable SkillSpec — **adopted ≠ equipped/installed**.
+collect-first keeps evidence (no activation); hold records the block. No fake adoption.
+
+ponytail verdict (lean): a data registry, not a new layer — reuses armory.candidate end to
+end. Lives in the console app (operator-curated data), like the company-governance examples.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from armory.candidate import (
+    ADOPT_NOW,
+    AXIS_PM,
+    AXIS_SPECIALIST,
+    AXIS_TECH_LEAD,
+    COLLECT_FIRST,
+    HOLD,
+    AdoptionResult,
+    AdoptionReview,
+    ArmoryCandidate,
+    AxisReview,
+    adopt_candidate,
+)
+from armory.models import KIND_MCP, KIND_SKILL, KIND_TOOL
+
+
+def _axes(pm, tl, spec_role, spec_pos, *, pm_pos, tl_pos, pm_r, tl_r, spec_r) -> Tuple[AxisReview, ...]:
+    return (
+        AxisReview(AXIS_PM, "product-manager", pm_pos, pm_r),
+        AxisReview(AXIS_TECH_LEAD, "tech-lead", tl_pos, tl_r),
+        AxisReview(AXIS_SPECIALIST, spec_role, spec_pos, spec_r),
+    )
+
+
+# Each entry: (ArmoryCandidate contract, AdoptionReview). disposition() is derived by the
+# review (most-conservative axis, gated on completeness) — we do not hardcode it.
+_CANDIDATES: Tuple[Tuple[ArmoryCandidate, AdoptionReview], ...] = (
+    # ── adopt-now : Vale (full contract so adopt_candidate yields a SkillSpec) ──
+    (
+        ArmoryCandidate(
+            id="vale", name="Vale", kind=KIND_TOOL, category="docs",
+            summary="style-guide(YAML) 기반 prose 린트 — 문서 문체/용어 일관성을 기계로 강제",
+            signals=("vale", "prose lint", "문체 검사", "style guide", "용어 일관성", "doc lint"),
+            when_to_use=("vault/README/가이드 문체·용어 일관성을 CI/로컬에서 점검",),
+            when_not_to_use=("코드 린트(언어별 린터)", "문서 구조 검증(vault-curate frontmatter)"),
+            unsafe_boundary=("외부 서버로 문서 본문 송신 금지(로컬 린트만)", "자동 수정 강제 금지(제안만)"),
+            capability_note="prose/style linting (style-guide enforced)",
+            install_requirements=("brew install vale", "vale sync (.vale.ini styles)"),
+            commands=("vale .",), verification=("vale --version", "vale ."),
+            related_weapons=("vale",), related_loadouts=("doc-quality-lint-local",),
+            related_roles=("technical-writer", "knowledge-engineer"),
+            source="operator", source_ref="https://github.com/errata-ai/vale"),
+        AdoptionReview(
+            candidate_id="vale",
+            current_pain="vault/문서 품질이 사람 리뷰에만 의존 — 문체/용어 일관성을 기계로 강제할 표준 도구 부재.",
+            expected_benefit="style-guide 기반 prose 린트를 CI/로컬에서 결정적으로 강제 — 문서 회귀를 사람 전에 잡음.",
+            overlap_with_existing="built-in docs-quality 스킬은 구조/명료성 위주 — Vale 는 style-guide 강제(보완재). 중복 아님.",
+            operational_cost="단일 Go 바이너리 + style 패키지 sync. 런타임 의존 없음 — 가장 낮음.",
+            maintenance_risk="활발히 유지(errata-ai), config 안정. 낮음.",
+            provider_runtime_fit="provider-neutral CLI — 어느 backend 든 호출. toolchain 버전 관리 가능.",
+            governance_security_impact="로컬 파일만, 네트워크 없음(style sync 제외). 위험 낮음.",
+            adopt_timing_reason="비용/위험 최저 + 문서 품질은 핵심 가치 → 지금 카탈로그화(단 미설치=adopted≠equipped).",
+            axis_reviews=_axes(
+                "product-manager", "tech-lead", "knowledge-engineer", ADOPT_NOW,
+                pm_pos=ADOPT_NOW, tl_pos=ADOPT_NOW,
+                pm_r="문서 품질은 vault 핵심 — 즉시 카탈로그화 가치 충분.",
+                tl_r="단일 바이너리·config 기반, attach contract 명확 — 도입 리스크 최소.",
+                spec_r="knowledge-engineer: style-guide 로 '왜' 깊이/용어 강제가 vault 규칙과 정합."),
+        ),
+    ),
+)
+
+
+def _cf(cid, name, kind, source, pain, benefit, overlap, cost, risk, fit, gov, timing,
+        spec_role, spec_pos=COLLECT_FIRST, pm_pos=COLLECT_FIRST, tl_pos=COLLECT_FIRST,
+        pm_r="", tl_r="", spec_r=""):
+    """Build a (lightweight contract, review) pair for a non-adopt-now candidate."""
+
+    cand = ArmoryCandidate(id=cid, name=name, kind=kind, category="docs" if kind == KIND_TOOL else "",
+                           summary=benefit[:80] or name, source="operator", source_ref=source)
+    review = AdoptionReview(
+        candidate_id=cid, current_pain=pain, expected_benefit=benefit, overlap_with_existing=overlap,
+        operational_cost=cost, maintenance_risk=risk, provider_runtime_fit=fit,
+        governance_security_impact=gov, adopt_timing_reason=timing,
+        axis_reviews=(
+            AxisReview(AXIS_PM, "product-manager", pm_pos, pm_r),
+            AxisReview(AXIS_TECH_LEAD, "tech-lead", tl_pos, tl_r),
+            AxisReview(AXIS_SPECIALIST, spec_role, spec_pos, spec_r),
+        ))
+    return cand, review
+
+
+_REST: Tuple[Tuple[ArmoryCandidate, AdoptionReview], ...] = (
+    _cf("proselint", "proselint", KIND_TOOL, "https://github.com/amperser/proselint",
+        "문서의 상투구/중복/약한 표현을 잡을 보조 린터 부재.",
+        "Vale 보완 — 검증된 영어 prose 규칙(중복/jargon) 추가 커버.",
+        "Vale 규칙과 상당 부분 겹침 — Vale 채택 후 한계 드러나면 보강.",
+        "Python 패키지 — Python 런타임 의존(Vale 대비 추가 부담).",
+        "유지보수 빈도 낮은 편 — 중간.", "CLI, provider-neutral. loadout optional 멤버로 적합.",
+        "로컬 파일만 — 위험 낮음.", "Vale 로 시작 후 효과 측정 → 동시 도입은 과함.",
+        "knowledge-engineer",
+        pm_r="Vale 먼저, 효과 측정 후 보강.", tl_r="규칙 중복 — 한계 evidence 누적 후.",
+        spec_r="loadout optional 로만 노출, 강제 X."),
+    _cf("write-good", "write-good", KIND_TOOL, "https://github.com/btford/write-good",
+        "수동태/약한 표현 등 흔한 글쓰기 안티패턴을 기계로 못 잡음.",
+        "가벼운 영어 문체 힌트 — 빠른 1차 패스.",
+        "Vale/proselint 와 규칙 겹침 + naive 라 정확도 낮음.",
+        "npm 패키지 — Node 런타임 의존(멀티 Node 도구 부담 누적).",
+        "유지보수 정체(최근 커밋 드묾) — 중상.", "CLI지만 Node 의존이 Vale 단일바이너리보다 불리.",
+        "로컬 파일만 — 위험 낮음.", "정확도/유지보수 약함 → 즉시 도입 가치 낮음, 근거만 누적.",
+        "knowledge-engineer",
+        pm_r="즉시 도입 가치 낮음 — 근거만.", tl_r="Node 의존+유지보수 정체 — Vale 한계 드러나면 재평가.",
+        spec_r="Vale 로 대체 가능, evidence 만."),
+    _cf("alex", "alex", KIND_TOOL, "https://github.com/get-alex/alex",
+        "둔감/배제적 표현(insensitive writing)을 사람이 일일이 못 잡음.",
+        "포용적 글쓰기 자동 점검 — 공개 문서/README 톤 관리.",
+        "Vale 의 inclusive-language 스타일 팩과 부분 중복.",
+        "npm 패키지 — Node 런타임 의존.", "유지보수 양호하나 영어 전용 — 한국어 vault 엔 제한적. 중간.",
+        "CLI, provider-neutral. 한국어 비중 높은 vault 엔 적용 범위 좁음.",
+        "로컬 파일만 — 위험 낮음.", "공개 문서 톤엔 가치 — 한국어 비중 고려해 선검증.",
+        "knowledge-engineer",
+        pm_r="공개 문서 톤엔 가치 — 적용 범위 검증 먼저.", tl_r="Vale inclusive 팩과 비교 evidence 필요.",
+        spec_r="영어 산출물 한정 optional."),
+    _cf("textlint", "textlint", KIND_TOOL, "https://github.com/textlint/textlint",
+        "한국어 포함 문서에 플러그형 린터(직접 규칙 작성) 부재.",
+        "플러그인으로 한국어/마크다운 규칙까지 확장 — Vale 약점 보완.",
+        "Vale 와 목적 겹치나 plugin 모델/한국어 커버는 차별점.",
+        "npm + 플러그인 다수 — 설정/유지 부담 가장 큼.", "코어 유지되나 플러그인 품질 편차 — 중상.",
+        "CLI. 한국어 vault 엔 Vale 보다 적합할 수 있음(검증 필요).",
+        "로컬 파일만 — 위험 낮음.", "한국어 커버 매력 — 설정 부담 커 PoC 먼저.",
+        "knowledge-engineer",
+        pm_r="한국어 커버 가능성 매력 — PoC 먼저.", tl_r="플러그인 의존 트리 평가 후 — 지금 adopt 과투자.",
+        spec_r="한국어 규칙 PoC 로 Vale 와 비교."),
+    _cf("ponytail", "ponytail", KIND_SKILL, "https://github.com/example/ponytail",
+        "새 모듈/계층 추가 시 과설계를 막을 일관된 단순성 검토 렌즈가 코드화 안 됨.",
+        "ponytail 식 단순성 검토(keep/simplify/use-existing/reduce-surface/reject)를 표준화.",
+        "ForgeKit 은 이미 council/consult + ponytail consult 모듈 보유 — 상당 부분 겹침.",
+        "검토 절차라 도입 부담 낮으나 repo 실체/성숙도 불명확.",
+        "repo 유지보수 불확실 — 외부 의존보다 내부 스킬화가 안전.",
+        "skill(절차) — provider-neutral, 단 외부 repo 채택보다 내부화가 fit.",
+        "검토 절차라 외부 코드 실행 없음 — 위험 낮음.",
+        "이미 consult 렌즈로 사용 중 — 외부 repo 채택은 근거 누적 후.",
+        "backend-engineer",
+        pm_r="단순성 렌즈는 이미 우리 lane 적용 중 — 외부 채택보다 evidence.",
+        tl_r="council/consult 와 겹침 — 외부 repo 의존 만들 이유 약함.",
+        spec_r="내부 스킬화로 충분 — 외부 도입은 보류."),
+    _cf("context7", "Context7", KIND_MCP, "https://github.com/upstash/context7",
+        "LLM 이 라이브러리 최신 API 를 몰라 환각 — 버전 맞는 docs 주입 경로 부재.",
+        "최신 라이브러리 docs/snippet 을 MCP 로 주입 — 코드 생성 정확도 향상.",
+        "Nexus 는 내부 지식 — 외부 라이브러리 docs 는 미커버라 보완재(역할 경계 정리 필요).",
+        "MCP 서버 + (호스티드) 의존/키 — 외부 서비스 의존 도입.",
+        "3rd-party 호스티드 의존 — 가용성/정책 변화 리스크 중상.",
+        "MCP → claude/codex/gemini(mcp-host) attach. ollama 제외.",
+        "외부 서버로 쿼리 송신 — outbound/데이터 노출 검토 필요(integrations/mcp 가드 경유).",
+        "유망하나 호스티드/키/outbound 가드 정리 전엔 adopt 불가 — PoC 먼저.",
+        "platform-runtime-engineer",
+        pm_r="환각 감소 효과 크다 — 가능하면 빨리.", tl_r="호스티드 의존+outbound 정책 정리 전 adopt 불가.",
+        spec_r="integrations/mcp 가드+키 처리 검증 후."),
+    _cf("mcp-fetch", "MCP Fetch (official)", KIND_MCP,
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+        "에이전트가 임의 URL 본문을 표준 경로로 가져올 reference MCP 미배선.",
+        "공식 reference 서버라 신뢰도 높은 fetch capability — 리서치 보강.",
+        "discovery sources(RSS/HN/GitHub)와 일부 겹침 — 임의 URL fetch 는 미커버.",
+        "공식 서버 설치/attach — 경량이나 MCP host 연결 필요.", "공식 레포 유지보수 양호 — 낮음.",
+        "MCP, mcp-host attach. provider-neutral.",
+        "임의 URL fetch = SSRF/내부망 위험 — allowlist/sandbox 정책 필수.",
+        "유용하나 SSRF allowlist 설계가 adopt 전제 — 그 전까지 근거만 누적.",
+        "security-engineer",
+        pm_r="리서치엔 유용하나 보안 가드 선행.", tl_r="SSRF allowlist 정책 설계 후 재평가 — 지금 adopt 위험.",
+        spec_r="outbound allowlist 설계 전까지 collect-first(미활성)."),
+    _cf("mcp-memory", "MCP Memory (official)", KIND_MCP,
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+        "세션 간 기억의 표준 MCP 경로 부재.", "공식 memory 서버로 표준화된 기억 capability.",
+        "Nexus(vault)+troubleshooting ledger+claude-mem 으로 이미 기억 레인 보유 — 중복 큼.",
+        "서버 설치/attach + 저장소 관리 — 기존 기억 레인과 이중화.",
+        "공식 유지보수 양호하나 기억 SSoT 와 충돌 위험 — 중간.",
+        "MCP attach 가능하나 우리 기억 SSoT 는 vault/ledger 라 fit 약함.",
+        "기억 저장 위치/내용 거버넌스 — 기존 메모리 정책과 정합 필요.",
+        "기억은 vault/ledger 로 충당 — 지금 아님, 한계 드러나면 재평가.",
+        "platform-runtime-engineer",
+        pm_r="기억은 이미 충당 — 굳이 지금 아님, 근거만.", tl_r="Nexus/ledger 와 SSoT 중복 — 한계 드러나면 재평가.",
+        spec_r="우리 기억 모델과 비교 evidence 만."),
+)
+
+_HOLD: Tuple[Tuple[ArmoryCandidate, AdoptionReview], ...] = (
+    _cf("mcp-filesystem", "MCP Filesystem (official)", KIND_MCP,
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+        "에이전트 파일 접근을 표준 MCP 로 노출하려는 유혹.", "표준 파일 접근 capability.",
+        "executor 가 이미 파일 도구 보유 — 기능 거의 전부 중복.",
+        "추가 서버 + 권한 범위 관리.", "우리 가드와 충돌 관리 비용.",
+        "ForgeKit 경로 안전(git_path_safety)과 경합.",
+        "광범위 FS 접근 MCP 는 git-write hard rail/경로 안전 SSoT 우회 — 거버넌스 충돌(금지).",
+        "기존 파일 도구로 충분 + 가드 우회 위험 → 제외.",
+        "security-engineer", spec_pos=HOLD, pm_pos=HOLD, tl_pos=HOLD,
+        pm_r="추가 가치 없음.", tl_r="경로 안전 hard rail 우회 — 불가.", spec_r="broad FS MCP 가드 우회 — hold."),
+    _cf("mcp-git", "MCP Git (official)", KIND_MCP,
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+        "git 작업을 MCP 로 노출하려는 유혹.", "표준 git capability.",
+        "git-write 를 git_path_safety/repo_write_policy 로 강하게 통제 — 전면 중복.",
+        "추가 서버 + 권한.", "git hard rail 과 이중 경로 유지 비용.",
+        "우리 git 거버넌스와 정면 충돌.",
+        "MCP git write 는 `git -C + 명시 pathspec` hard rail/commit-governance 우회 — 금지.",
+        "git 안전은 핵심 가드 — 외부 MCP 로 우회 불가.",
+        "security-engineer", spec_pos=HOLD, pm_pos=HOLD, tl_pos=HOLD,
+        pm_r="git 안전은 핵심 가드.", tl_r="repo_write_policy SSoT 우회 — 금지.", spec_r="hard rail 충돌 — hold."),
+    _cf("mcp-sequential-thinking", "MCP Sequential Thinking (official)", KIND_MCP,
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+        "구조화된 단계적 추론을 도구로 강제하려는 유혹.", "단계적 사고 스캐폴딩.",
+        "decision_lane(readiness/council)+모델 자체 추론과 겹침 — 한계 효용.",
+        "추가 서버 + 프롬프트 표면 증가.", "효용 대비 유지 비용 — 중간.",
+        "MCP attach 가능하나 모델 내장 추론과 중복.",
+        "위험 낮으나 도입 정당성(효용) 부족이 더 큰 문제.",
+        "추론은 모델/lane 이 이미 함 — 추가 가치 미미.",
+        "backend-engineer", spec_pos=HOLD, pm_pos=HOLD, tl_pos=HOLD,
+        pm_r="추가 가치 미미.", tl_r="프롬프트 표면만 늘림 — hold.", spec_r="decision_lane 과 중복 — hold."),
+    _cf("browser-use", "browser-use", KIND_TOOL, "https://github.com/browser-use/browser-use",
+        "실제 브라우저 자동화(로그인-게이트 사이트 등) capability 부재.",
+        "LLM 주도 브라우저 자동화 — 일부 리서치/검증 시나리오 확장.",
+        "discovery 의 YouTube/Figma/Google planned seam 과 목적 일부 겹침(미연결).",
+        "Python + 헤드리스 브라우저(Playwright) — 무거운 런타임.",
+        "빠르게 바뀌는 신생 — API 불안정, 중상.",
+        "무거운 의존이 ForgeKit 경량 toolchain 과 어긋남.",
+        "실 브라우저 = 자격증명/exfiltration/자동 액션 위험 매우 큼 — 강 sandbox/승인 없이 금지.",
+        "위험·비용 대비 당장 필요 시나리오 없음 — sandbox 설계 후 재평가.",
+        "security-engineer", spec_pos=HOLD, pm_pos=HOLD, tl_pos=HOLD,
+        pm_r="당장 필요 시나리오 없음.", tl_r="무거운 의존+불안정 API — hold.", spec_r="브라우저 자동화 위험 — hold."),
+)
+
+
+def intake_candidates() -> Tuple[Tuple[ArmoryCandidate, AdoptionReview], ...]:
+    """Every evaluated external candidate as a (catalog contract, adoption review) pair."""
+
+    return _CANDIDATES + _REST + _HOLD
+
+
+def intake_results() -> Tuple[AdoptionResult, ...]:
+    """Run the existing adopt_candidate gate over every candidate (no fake adoption)."""
+
+    return tuple(adopt_candidate(c, r) for c, r in intake_candidates())
+
+
+def by_disposition(disposition: str) -> Tuple[AdoptionResult, ...]:
+    return tuple(r for r in intake_results() if r.disposition == disposition)
+
+
+def intake_summary() -> dict:
+    res = intake_results()
+    return {
+        "total": len(res),
+        ADOPT_NOW: sum(1 for r in res if r.disposition == ADOPT_NOW),
+        COLLECT_FIRST: sum(1 for r in res if r.disposition == COLLECT_FIRST),
+        HOLD: sum(1 for r in res if r.disposition == HOLD),
+        "adopted_specs": [r.candidate_id for r in res if r.adopted],
+    }
+
+
+__all__ = ("intake_candidates", "intake_results", "by_disposition", "intake_summary")

--- a/apps/forgekit-console/src/forgekit_console/commands/registry.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/registry.py
@@ -29,6 +29,7 @@ H_WHOAMI = "whoami"
 H_RESOLVE = "resolve"
 H_FORGE = "forge"
 H_HEPHAISTOS = "hephaistos"
+H_ARMORY = "armory"
 H_SKILLS = "skills"
 H_LOADOUT = "loadout"
 H_PROVIDER = "provider"
@@ -106,6 +107,7 @@ _COMMANDS: Tuple[SlashCommand, ...] = (
     SlashCommand("handoff", "specialist work order — 목표/제안 스택/선택 이유/탈락안/컨벤션/디자인·API·infra/scope/test/acceptance (`/handoff <session>`, replay 된 handoff packet)", H_HANDOFF, "status"),
     SlashCommand("forge", "Hephaistos execution core — 요청을 equip(adopted vs equipped)·Nexus 지식·loadout/work packet·ponytail(anti-overbuild) verdict 까지 forge (`/forge <요청>`)", H_FORGE, "status"),
     SlashCommand("hephaistos", "Hephaistos skill-forge 상태 — armory/nexus/resolver/loadout", H_HEPHAISTOS, "status"),
+    SlashCommand("armory", "Armory intake — 외부 plugin/skill/tool 후보 도입 검토(adopt-now/collect-first/hold) + 8축 artifact + 3축 검토. `/armory [<id>]` (id 없으면 verdict 요약 + adopted spec)", H_ARMORY, "status"),
     SlashCommand("skills", "최근/지정 요청의 선택 skill + 선택 이유 (`/skills <요청>`)", H_SKILLS, "status"),
     SlashCommand("loadout", "loadout readiness — 실 env weapon 검증 (`/loadout <id>`)", H_LOADOUT, "status"),
     SlashCommand("provider", "provider 설정/연결 — `/provider [set|link|unlink|connect <id>|disconnect <id>|test <id>|attach <도구id>|recommended|preset four-brain|route show|route set <slot> <id>|budget <id> <limit>|budget show|list|doctor]` (attach=선택 tool 의 provider 생태계 projection/connect/verify)", H_PROVIDER, "status"),

--- a/apps/forgekit-console/src/forgekit_console/commands/router.py
+++ b/apps/forgekit-console/src/forgekit_console/commands/router.py
@@ -35,6 +35,7 @@ from .registry import (
     H_RESOLVE,
     H_FORGE,
     H_HEPHAISTOS,
+    H_ARMORY,
     H_SKILLS,
     H_LOADOUT,
     H_PROVIDER,
@@ -177,6 +178,8 @@ def route(parsed, ctx: ConsoleContext) -> CommandResult:
         return _whoami_result(parsed)
     if handler in (H_RESOLVE, H_FORGE, H_HEPHAISTOS, H_SKILLS, H_LOADOUT):
         return _hephaistos_result(handler, parsed, ctx)
+    if handler == H_ARMORY:
+        return _armory_result(parsed, ctx)
     if handler == H_PROVIDER:
         return _provider_result(parsed, ctx)
     if handler == H_SETUP:
@@ -400,6 +403,24 @@ def _toolchain_result(parsed, ctx) -> CommandResult:
         ok, lines = ts.apply_switch(root, loadout, approve=approve, scope=scope)
         return (CommandResult.info if ok else CommandResult.error)("toolchain switch", lines)
     return CommandResult.info("toolchain detect", ts.detect_lines(root))
+
+
+def _armory_result(parsed, ctx) -> CommandResult:
+    # /armory [<id>] — 외부 후보 도입 검토(adopt-now/collect-first/hold) 요약 또는 상세.
+    # adoption framework(armory.candidate)를 실제 후보 set 에 적용한 큐레이션 결정 — 카탈로그
+    # 자체는 /skills · /loadout · /resolve 가 본다. adopted ≠ equipped/installed.
+    from .. import armory_intake as AI
+    from ..tui import render as _r
+
+    pairs = AI.intake_candidates()
+    results = AI.intake_results()
+    args = list(getattr(parsed, "args", ()) or ())
+    detail = args[0].lower() if args else ""
+    if detail:
+        ids = {c.id for c, _ in pairs}
+        if detail not in ids:
+            return CommandResult.error("armory", (f"후보 '{detail}' 없음. 가능: {', '.join(sorted(ids))}",))
+    return CommandResult.info("armory", _r.armory_intake_lines(pairs, results, detail_id=detail))
 
 
 def _nexus_result(parsed, ctx) -> CommandResult:

--- a/apps/forgekit-console/src/forgekit_console/tui/render.py
+++ b/apps/forgekit-console/src/forgekit_console/tui/render.py
@@ -638,6 +638,70 @@ def discovery_lines(result) -> Tuple[str, ...]:
     return tuple(lines)
 
 
+def armory_intake_lines(pairs, results, *, detail_id="") -> Tuple[str, ...]:
+    """Render the Armory intake — evaluated external candidates by disposition / detail.
+
+    ``pairs`` = (ArmoryCandidate, AdoptionReview) tuples; ``results`` = parallel
+    AdoptionResult tuple (adopt_candidate output). ``detail_id`` shows one candidate's
+    8축 + 3축 review; else a verdict-bucket summary.
+    """
+
+    _V = {"adopt-now": _OK, "collect-first": _WARN, "hold": _ERR}
+    by_id = {c.id: (c, rv) for c, rv in pairs}
+    res_by_id = {r.candidate_id: r for r in results}
+
+    if detail_id:
+        item = by_id.get(detail_id)
+        if not item:
+            return (f"[{_ERR}]후보 '{detail_id}' 없음[/{_ERR}]",)
+        c, rv = item
+        res = res_by_id.get(detail_id)
+        disp = res.disposition if res else rv.disposition()
+        tag = _V.get(disp, _MUTED)
+        lines = [
+            f"[b {_ACCENT}]» armory intake · {c.name}[/b {_ACCENT}]  [dim]({c.kind})[/dim]",
+            f"  verdict: [{tag}]{disp}[/{tag}]"
+            + (f"  ·  [{_OK}]adopted spec[/{_OK}]" if res and res.adopted else "")
+            + f"   [dim]{c.source_ref}[/dim]",
+            f"  현재 pain: {rv.current_pain}",
+            f"  기대 효과: {rv.expected_benefit}",
+            f"  기존 중복: {rv.overlap_with_existing}",
+            f"  운영 비용: {rv.operational_cost}",
+            f"  유지 리스크: {rv.maintenance_risk}",
+            f"  provider/runtime: {rv.provider_runtime_fit}",
+            f"  governance/security: {rv.governance_security_impact}",
+            f"  도입 시점 사유: {rv.adopt_timing_reason}",
+            "  3축 검토:",
+        ]
+        for a in rv.axis_reviews:
+            atag = _V.get(a.position, _MUTED)
+            lines.append(f"    - {a.axis}({a.reviewer}): [{atag}]{a.position}[/{atag}] — {a.rationale}")
+        if res and not res.adopted and res.reasons:
+            lines.append(f"  [dim]비활성 사유: {res.reasons[0]}[/dim]")
+        return tuple(lines)
+
+    buckets = {"adopt-now": [], "collect-first": [], "hold": []}
+    for r in results:
+        buckets.setdefault(r.disposition, []).append(r)
+    adopted = [r.candidate_id for r in results if r.adopted]
+    lines = [
+        f"[b {_ACCENT}]» armory intake — 외부 후보 도입 검토[/b {_ACCENT}]",
+        f"  adopt-now {len(buckets['adopt-now'])} · collect-first {len(buckets['collect-first'])} · hold {len(buckets['hold'])}"
+        f"  [dim](총 {len(results)}건 · 8축 artifact + PM/tech-lead/specialist 3축)[/dim]",
+        f"  adopted spec(=카탈로그 등록, 미설치): {', '.join(adopted) or '(없음)'}",
+    ]
+    for v, tag in (("adopt-now", _OK), ("collect-first", _WARN), ("hold", _ERR)):
+        if not buckets[v]:
+            continue
+        lines.append(f"  [b][{tag}]{v}[/{tag}][/b]")
+        for r in buckets[v]:
+            nm = by_id.get(r.candidate_id, (None, None))[0]
+            label = nm.name if nm else r.candidate_id
+            lines.append(f"    [{tag}]•[/{tag}] {label} [dim]({r.candidate_id})[/dim]")
+    lines.append("  [dim]adopted=카탈로그 등록(available) ≠ equipped/installed · collect-first=근거만 누적 · `/armory <id>`[/dim]")
+    return tuple(lines)
+
+
 def video_watch_lines(result) -> Tuple[str, ...]:
     """Render a video-watch ingest result — live summary or honest reference_only."""
 
@@ -840,6 +904,6 @@ __all__ = (
     "palette_lines", "palette_panel_lines", "mode_badge", "mode_pill",
     "status_pill", "hint_line", "help_sections", "selection_copy_lines",
     "help_panel_document", "help_tab_strip", "help_body", "default_help_tab",
-    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
+    "handoff_summary_lines", "loop_summary_lines", "auto_decision_lines", "source_status_lines", "discovery_lines", "armory_intake_lines", "video_watch_lines", "self_improve_lines", "security_drill_lines", "autopilot_lines", "design_status_lines", "result_block", "chunk_result_lines", "process_feed_lines",
     "RESPONSE_MARKER", "mark_response_chunks",
 )

--- a/docs/armory.md
+++ b/docs/armory.md
@@ -81,6 +81,18 @@ spec (no fake adoption — evidence kept for Nexus). **adopted** (in catalog/ove
 from **equipped** (the tools are actually installed/attached for a task — checked by the execution
 core, see [hephaistos-runtime.md](hephaistos-runtime.md)).
 
+**Evaluated external-candidate set.** The framework above is *applied* to a curated external
+candidate set in [`forgekit_console.armory_intake`](../apps/forgekit-console/src/forgekit_console/armory_intake.py)
+(operator data, console layer — reuses `armory.candidate`, no new model). This round evaluated
+13 named candidates (ponytail · Context7 · MCP official Fetch/Filesystem/Git/Memory/Sequential
+Thinking · Vale · textlint · alex · write-good · proselint · browser-use): **adopt-now 1** (Vale →
+the `doc-quality-lint-local` loadout), **collect-first 8** (Nexus 근거만, 미활성), **hold 4**
+(MCP Git/Filesystem = git-write/path-safety hard-rail 우회, Sequential Thinking = 중복, browser-use
+= 자격증명/exfiltration 위험). Surface `/armory [<id>]`; evidence
+`examples/armory-intake/adoption-catalog.json`; regression `tests/forgekit/test_armory_intake_candidates.py`.
+Vale-based linting is a **distinct** tool loadout (`doc-quality-lint-local`) from the built-in
+tool-less `docs-writing-local` — different equip profiles, not a duplicate.
+
 ## Context-aware selection (Hephaistos)
 `hephaistos.resolve(request, *, preferred_role="", project_facts=(), runtime_constraints=(), harness="")`
 folds project/runtime context into the existing selection surface (no new routing layer):

--- a/packages/armory/src/armory/catalog.py
+++ b/packages/armory/src/armory/catalog.py
@@ -46,6 +46,13 @@ _WEAPONS = (
     WeaponSpec("actionlint", "actionlint", "cli", "actionlint --version", "brew install actionlint"),
     WeaponSpec("intellij", "IntelliJ IDEA", "ide", "", "jetbrains toolbox"),
     WeaponSpec("vscode", "VS Code", "ide", "code --version", "https://code.visualstudio.com"),
+    # doc-quality lint 묶음 (intake adopt-now=vale, 나머지 optional). adopted=카탈로그 등록 /
+    # install_hint 가 설치 경로만 선언 — 미설치(equipped 은 /loadout 검증에서 실 env 확인).
+    WeaponSpec("vale", "Vale", "cli", "vale --version", "brew install vale"),
+    WeaponSpec("proselint", "proselint", "cli", "proselint --version", "uv tool install proselint"),
+    WeaponSpec("write-good", "write-good", "cli", "write-good --version", "npm i -g write-good"),
+    WeaponSpec("alex", "alex", "cli", "alex --version", "npm i -g alex"),
+    WeaponSpec("textlint", "textlint", "cli", "textlint --version", "npm i -g textlint"),
 )
 
 _SKILLS = (
@@ -449,6 +456,17 @@ _LOADOUTS = (
                 default_verify_flow=("(prose 체크리스트: 구조/명료성/일관성/오타)",),
                 selection_signals=("문서", "docs", "readme", "prose", "다듬", "문서 품질"),
                 notes="tool-less skill-only loadout — adopted=docs-quality, equipped 항목 없음(built-in)"),
+    LoadoutSpec("doc-quality-lint-local", "Doc-quality lint (tools)", intended_roles=("technical-writer",),
+                required_weapons=("vale",), optional_weapons=("proselint", "write-good", "alex", "textlint"),
+                environment_assumptions=("repo/vault 읽기 접근", "vale 설치 시 .vale.ini + style 패키지"),
+                verify_commands=("vale --version",),
+                goal="style-guide 기반 prose 린트(도구) — docs-writing-local(built-in) 보다 깊은 검사",
+                recommended_skills=("docs-quality",), optional_skills=(),
+                blocked_skills=("terraform", "java-spring"),
+                default_verify_flow=("vale .",),
+                selection_signals=("vale", "prose lint", "문체 검사", "style guide", "용어 일관성", "doc lint"),
+                notes="intake adopt-now=vale(required), 나머지=collect-first(optional). tool-less docs-writing-local "
+                      "과 별개(equip profile 다름). adopted≠equipped — weapon install_hint 가 설치 경로만 선언."),
     LoadoutSpec("design-review-local", "Design Review (local)", intended_roles=("ux-ui-designer", "design-lead"),
                 required_weapons=("vscode",), optional_weapons=(),
                 environment_assumptions=("design reference(연결 시)",),

--- a/tests/forgekit/test_armory_intake_candidates.py
+++ b/tests/forgekit/test_armory_intake_candidates.py
@@ -1,0 +1,125 @@
+"""Armory intake — the evaluated external-candidate set (real candidates, not generic).
+
+Proves the wave's named candidates are each carried as a real ``armory.candidate``
+AdoptionReview (8축 + 3축, no review gaps), classified adopt-now/collect-first/hold by the
+EXISTING gate (no new model), that adopt-now Vale yields a registrable spec while
+collect-first/hold never do (no fake adoption / adopted≠equipped), that governance/security
+candidates are held, and that the committed evidence matches code. Pure / offline.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from tests.forgekit import _SRC  # noqa: F401
+
+from armory import catalog
+from armory.candidate import ADOPT_NOW, COLLECT_FIRST, HOLD
+from forgekit_console import armory_intake as AI
+from forgekit_console.tui import render
+
+_NAMED = ("ponytail", "context7", "mcp-fetch", "mcp-filesystem", "mcp-git", "mcp-memory",
+          "mcp-sequential-thinking", "vale", "textlint", "alex", "write-good", "proselint",
+          "browser-use")
+
+
+class RegistryTests(unittest.TestCase):
+    def test_named_candidates_all_evaluated(self) -> None:
+        ids = {c.id for c, _ in AI.intake_candidates()}
+        for cid in _NAMED:
+            self.assertIn(cid, ids, f"candidate not evaluated: {cid}")
+
+    def test_no_review_gaps(self) -> None:
+        for c, rv in AI.intake_candidates():
+            self.assertEqual(rv.review_gaps(), (), f"{c.id} review gaps: {rv.review_gaps()}")
+
+    def test_three_axes_each(self) -> None:
+        for c, rv in AI.intake_candidates():
+            axes = {a.axis for a in rv.axis_reviews}
+            self.assertEqual(axes, {"pm", "tech-lead", "specialist"}, f"{c.id} axes={axes}")
+
+    def test_distribution(self) -> None:
+        s = AI.intake_summary()
+        self.assertEqual(s[ADOPT_NOW], 1)
+        self.assertEqual(s[COLLECT_FIRST], 8)
+        self.assertEqual(s[HOLD], 4)
+        self.assertEqual(s["total"], 13)
+
+
+class GateTests(unittest.TestCase):
+    def test_vale_adopts_with_spec(self) -> None:
+        res = {r.candidate_id: r for r in AI.intake_results()}["vale"]
+        self.assertEqual(res.disposition, ADOPT_NOW)
+        self.assertTrue(res.adopted)
+        self.assertIsNotNone(res.spec)  # registrable SkillSpec
+
+    def test_non_adopt_now_have_no_spec(self) -> None:
+        # adopted ≠ equipped: collect-first / hold never yield a spec (no fake adoption)
+        for r in AI.intake_results():
+            if r.disposition != ADOPT_NOW:
+                self.assertIsNone(r.spec, f"{r.candidate_id} {r.disposition} leaked a spec")
+                self.assertFalse(r.adopted)
+
+    def test_governance_candidates_held(self) -> None:
+        held = {r.candidate_id for r in AI.by_disposition(HOLD)}
+        for cid in ("mcp-filesystem", "mcp-git", "mcp-sequential-thinking", "browser-use"):
+            self.assertIn(cid, held, f"{cid} should be hold")
+
+    def test_doc_linters_collect_first(self) -> None:
+        cf = {r.candidate_id for r in AI.by_disposition(COLLECT_FIRST)}
+        for cid in ("proselint", "write-good", "alex", "textlint", "context7"):
+            self.assertIn(cid, cf)
+
+
+class CatalogTests(unittest.TestCase):
+    def test_doc_quality_lint_loadout(self) -> None:
+        lo = catalog.loadout("doc-quality-lint-local")
+        self.assertIsNotNone(lo)
+        self.assertEqual(lo.required_weapons, ("vale",))
+        for w in ("proselint", "write-good", "alex", "textlint"):
+            self.assertIn(w, lo.optional_weapons)
+        self.assertIn("docs-quality", lo.recommended_skills)
+
+    def test_lint_weapons_declare_install(self) -> None:
+        for wid in ("vale", "proselint", "write-good", "alex", "textlint"):
+            w = catalog.weapon(wid)
+            self.assertIsNotNone(w, wid)
+            self.assertTrue(w.install_hint and w.verify_command, f"{wid} missing install/verify")
+
+    def test_tool_less_docs_loadout_untouched(self) -> None:
+        # the pre-existing built-in loadout stays tool-less (we added a distinct one)
+        lo = catalog.loadout("docs-writing-local")
+        self.assertIsNotNone(lo)
+        self.assertNotIn("vale", lo.required_weapons + lo.optional_weapons)
+
+
+class RenderTests(unittest.TestCase):
+    def test_summary(self) -> None:
+        blob = "\n".join(render.armory_intake_lines(AI.intake_candidates(), AI.intake_results()))
+        self.assertIn("armory intake", blob)
+        self.assertIn("adopt-now", blob)
+        self.assertIn("vale", blob.lower())
+
+    def test_detail(self) -> None:
+        blob = "\n".join(render.armory_intake_lines(
+            AI.intake_candidates(), AI.intake_results(), detail_id="browser-use"))
+        self.assertIn("governance/security", blob)
+        self.assertIn("hold", blob)
+        self.assertIn("pm", blob)
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_committed_catalog_matches_code(self) -> None:
+        path = (Path(__file__).resolve().parents[2] / "apps" / "forgekit-console" /
+                "examples" / "armory-intake" / "adoption-catalog.json")
+        self.assertTrue(path.exists(), "adoption-catalog.json missing")
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        code_reviews = [rv.to_dict() for _, rv in AI.intake_candidates()]
+        self.assertEqual([c["review"] for c in on_disk["candidates"]], code_reviews)
+        self.assertEqual(on_disk["summary"], AI.intake_summary())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/forgekit/test_parser.py
+++ b/tests/forgekit/test_parser.py
@@ -51,7 +51,7 @@ class PaletteTests(unittest.TestCase):
 
     def test_prefix_multiple(self) -> None:
         names = {c.name for c in palette_matches("/a")}
-        self.assertEqual(names, {"agents", "about", "always-on", "auto", "autopilot", "attach"})
+        self.assertEqual(names, {"agents", "about", "always-on", "auto", "autopilot", "attach", "armory"})
 
     def test_substring_fallback_only_when_no_prefix(self) -> None:
         # prefix exists → exact prefix set (no widening); no prefix → substring fallback.


### PR DESCRIPTION
## 목적
adoption framework(`armory.candidate.AdoptionReview`/`adopt_candidate`)을 wave 가 지정한 **실제 외부 후보 set** 에 적용해 adopt-now/collect-first/hold 로 분류하고, doc-quality lint 묶음을 catalog loadout 으로 실현한다. **기존 framework 재사용 — 새 adoption 모델 만들지 않음.** Closes #432.

## 범위 (scope)
- (armory) catalog: Vale/proselint/write-good/alex/textlint WeaponSpec + `doc-quality-lint-local` loadout (built-in tool-less `docs-writing-local` 과 별개).
- (app) `forgekit_console/armory_intake.py`: 13 후보를 (ArmoryCandidate, AdoptionReview) 로 평가 + `adopt_candidate` 게이트.
- 표면 `/armory [<id>]` + evidence `adoption-catalog.json` + docs/armory.md.

## changed files
- `packages/armory/src/armory/catalog.py`
- `apps/forgekit-console/src/forgekit_console/armory_intake.py` (new)
- `apps/forgekit-console/.../commands/{router,registry}.py`, `tui/render.py`
- `tests/forgekit/test_armory_intake_candidates.py` (new), `tests/forgekit/test_parser.py`
- `apps/forgekit-console/examples/armory-intake/adoption-catalog.json` (new), `docs/armory.md`

## verdict 결과 (artifact — 각 8축 + 3축)
**adopt-now 1**: Vale (→ `doc-quality-lint-local`, spec 생성). **collect-first 8**: proselint·write-good·alex·textlint·ponytail·Context7·MCP-Fetch·MCP-Memory (Nexus 근거만, 미활성). **hold 4**: MCP-Filesystem·MCP-Git (git-write/path-safety hard-rail 우회), MCP-Sequential-Thinking (중복), browser-use (자격증명/exfiltration 위험). 상세는 `adoption-catalog.json`.

## tests
- `tests.forgekit.test_armory_intake_candidates` — 16 cases (13 후보 평가·review gap 없음·3축·분포 1/8/4·Vale adopt+spec·collect-first/hold spec 없음·거버넌스 hold·loadout·render·evidence 일치). OK.
- 전체 로컬 sweep `unittest discover` — **7213 OK** (skipped 5). 회귀 없음.

## evidence
- `examples/armory-intake/adoption-catalog.json` (13 review + 요약 + doc-quality loadout, Hephaistos/Nexus-readable). `/armory` · `/armory <id>` · `/loadout doc-quality-lint-local`.

## risks
- **중복 회피(핵심)**: main 에 이미 3종 adoption 모델(#430 decision_lane / #438 armory.candidate + discovery)이 있어, 초기 `armory.adoption` 시도(구 PR #435)를 폐기하고 **기존 `armory.candidate` 모델 재사용**으로 재작성. 새 모델/표면 중복 없음.
- **adopted ≠ equipped/installed**: catalog 등록은 available 일 뿐 — weapon install_hint 는 설치 *경로 선언*, adopt_candidate 도 contract 미달 시 spec 미발급(fake adoption 차단).
- 패키지 경계: armory 는 leaf(catalog 추가만). 후보 registry 는 app 층(armory.candidate import).

## issue/PR/CI/merge status
- issue #432 · PR (draft) · CI: 아래 확인 · merge: operator 인가('merge까지 닫는다') 하 CI green 시 진행. classifier 가 `gh pr merge` 차단 시 blocked 로 표면(owner=operator, unblock=직접 머지 지시/권한).

---
### Audit
- base `main`(00d29d1) · head 3 commits · app→package import 만(console→armory). no secret / no destructive op. 구 PR #435 + 브랜치 폐기 완료.