### PR TITLE
📝 [Docs] I-1 ForgeKit company-style agent 조직 블루프린트 SSoT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ docs/
 | packages/* 분류 / 네이밍 충돌 / 새 기능 위치 / transitional debt | `docs/package-topology.md` (18 package 분류표 · migration matrix · 결정 트리 SSoT) |
 | control-plane 방향 / 외부 프로젝트 흡수 / onboarding bootstrap / P0~P2 / Mac mini host | `docs/control-plane-architecture.md` (역할 · 소유 경계 · 우선순위 로드맵 SSoT) |
 | Nexus discovery 루프 / free-first 수집→idea brief→operator digest→PM packet·vault note / planned seam | `docs/discovery-loop.md` (+ 코드 SSoT `apps/forgekit-console/src/forgekit_console/discovery/sweep.py`) |
+| 대규모 agent 조직 모델 / CEO·forge-master·C-level office / office↔부서 매핑 / 네이밍 / 단계 로드맵 | `docs/company/forgekit-company-model.md` (+ `agent-office-map.md` · `naming-convention.md` · `staged-agent-organization-roadmap.md`). engineering 4→8→12 은 `team_topology` 링크(중복 금지) |
 
 규칙:
 - 위 표에 없는 토픽이면 그 작업과 가장 가까운 디렉터리의 `CLAUDE.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@
 | ForgeKit 플랫폼 경계 / console=operator app / 코어 packages 분리(WT1~4) | + `docs/forgekit-architecture-ownership.md` (owner 매트릭스·import 경계·이전 우선순위 SSoT) |
 | packages/* 분류 / 네이밍 충돌 / 어디에 새 기능 추가 / transitional debt | + `docs/package-topology.md` (18 package 분류표·migration matrix·결정 트리 SSoT) |
 | control-plane 방향 / OpenClaw·Harness·Hermes 흡수 / onboarding bootstrap / P0~P2 우선순위 / Mac mini host | + `docs/control-plane-architecture.md` (역할·소유 경계·우선순위 로드맵 SSoT) |
+| 대규모 agent 조직 모델 / CEO·forge-master·10 C-level office / office↔부서 매핑 / 조직 네이밍 / 단계 로드맵 | + `docs/company/forgekit-company-model.md` (+ `agent-office-map`·`naming-convention`·`staged-agent-organization-roadmap`). engineering 성장 경로는 `team_topology` 링크 |
 
 전체 매핑은 `AGENTS.md` §2.
 

--- a/docs/company/agent-office-map.md
+++ b/docs/company/agent-office-map.md
@@ -1,0 +1,77 @@
+# Agent Office Map — Office ↔ 부서/역할 매핑
+
+> 본 문서는 [`forgekit-company-model.md`](forgekit-company-model.md) 의 10개
+> C-level office 를, **현재 실재하는** `agents/<dept>/` 부서/역할에 매핑하는 SSoT 다.
+> "이상적 office 모델" 과 "현재 런타임 reality" 사이의 간극을 정직하게 표시한다.
+>
+> 현재 부서 reality 의 1차 매트릭스는
+> [`policies/runtime/agents/corporate-org-chart.md`](../../policies/runtime/agents/corporate-org-chart.md)
+> (CTO/CPO/CMO/CHRO/CFO/CRO/GC + Planning Ops). 본 문서는 그것을 **office 모델로
+> 확장·재배치** 한다 — 부서를 옮기지 않고 매핑만.
+
+## 1. Office ↔ 부서 매핑표
+
+| Office | director (제안) | 현재 부서(`agents/`) | 부서 manifest 상태 | 비고 |
+|---|---|---|---|---|
+| CEO / forge-master | forge-master | **없음(신규)** | — | 최상위 오케스트레이터, 신규 |
+| COO / operations | operations-director | `planning-agent` | manifest 있음(type/members 미설정) | cross-dept 운영 |
+| CTO / engineering | engineering-director | `engineering-agent` | ✅ 완비(type=department, members 7+aux 3) | **유일하게 런타임 실재** |
+| CPO / product-goal | product-goal-director | `product-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CDO / knowledge-data | knowledge-data-director | **없음(신규)** | — | 현재 knowledge-engineer 가 engineering 내부 |
+| CMO / content-growth | content-growth-director | `marketing-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CRO / revenue-opportunity | revenue-opportunity-director | `sales-cs-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CFO / finance-investment | finance-investment-director | `finance-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CHRO / personal-growth | personal-growth-director | `hr-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CLO / legal-risk | legal-risk-director | `legal-agent` | ❌ 부서 manifest 없음 | 역할 폴더만 존재 |
+| CSO / strategy-intelligence | strategy-intelligence-director | **없음(신규)** | — | discovery/Nexus 는 forgekit-console 코드에 존재 |
+
+> **정직한 reality**: 부서 레벨 `manifest.json` 을 가진 건 `engineering-agent`
+> 하나뿐이다. 나머지는 역할 폴더 또는 문서상 정의만 있다. office 모델은 목표이고,
+> 매핑을 채우는 작업은 roadmap Stage 1(I-2)에서 부서 manifest 부터 시작한다.
+
+## 2. 현재 역할 → office 배치
+
+corporate-org-chart 의 현재 역할들을 office 로 배치(부서 폴더는 유지, 논리 배치만):
+
+| office | 현재 역할(`agents/`) |
+|---|---|
+| CTO/engineering | engineering-agent/{tech-lead, backend-engineer, frontend-engineer, qa-engineer, devops-engineer, ai-engineer, product-designer, security-engineer, platform-runtime-engineer, knowledge-engineer*, ops-observer} |
+| CPO/product-goal | product-agent/{product-manager, user-researcher, growth-analyst} |
+| CMO/content-growth | marketing-agent/{growth-marketer, content-strategist, seo-specialist, brand-manager} |
+| CHRO/personal-growth | hr-agent/{recruiter, people-ops, culture-coach} |
+| CFO/finance-investment | finance-agent/{budget-analyst} |
+| CRO/revenue-opportunity | sales-cs-agent/{sales-rep, customer-success} |
+| CLO/legal-risk | legal-agent/{contract-reviewer, privacy-officer} |
+| COO/operations | planning-agent/* |
+| CDO/knowledge-data | (목표) knowledge-engineer 가 장기적으로 여기로 분기 가능 |
+| CSO/strategy-intelligence | (목표) discovery sweep 로직(forgekit-console)이 office 로 형식화 |
+
+`*` knowledge-engineer: 현재 engineering 내부 auxiliary. CDO 신설 시 분기 후보
+(company-model §2.5). **지금 옮기지 않는다** — 매핑 의도만 표시.
+
+## 3. 교차 관계 (cross-office)
+
+| 협업 축 | office 흐름 |
+|---|---|
+| goal → 구현 | CEO → CPO(brief) → CTO(구현) |
+| signal → 아이디어 → 제품 | CSO → CDO(지식화) → CPO/CRO |
+| 콘텐츠 파이프라인 | CSO(트렌드) → CMO(제작) |
+| 자율 운영 루프 | CEO → COO(tick) → CTO(실행) → reality-check |
+| 도입 리스크 | CSO/CTO(후보) → CLO(리스크 verdict) → operator |
+| 비용/투자 | COO(/cost) → CFO(예산·리서치) → operator |
+
+## 4. Engineering Office 내부 (링크, 중복 금지)
+
+CTO/engineering 의 4→8→12 팀 구조는 **본 문서에서 재정의하지 않는다.** SSoT:
+
+- machine-readable: [`agents/engineering-agent/manifest.json`](../../agents/engineering-agent/manifest.json) `team_topology`
+- 사람용: [`team-structure.md`](../../policies/runtime/agents/engineering-agent/team-structure.md)
+- 현재 land 중(logical MVP only): **PR #454**
+
+reality-check-team 은 이 office 의 **required future team**(company-model §3 역량 9,
+roadmap I-7). qa-governance 산하에서 출발해 Target 단계에서 독립.
+
+## 5. 동기화
+
+- office↔부서 매핑이 바뀌면 본 문서 + [`forgekit-company-model.md`](forgekit-company-model.md) §2.
+- 부서 manifest 가 채워지면 [`corporate-org-chart.md`](../../policies/runtime/agents/corporate-org-chart.md) 와 일치 확인.

--- a/docs/company/forgekit-company-model.md
+++ b/docs/company/forgekit-company-model.md
@@ -1,0 +1,185 @@
+# ForgeKit Company Model — 대규모 Agent 조직 SSoT
+
+> 본 문서는 ForgeKit 을 **회사처럼 자율 운영되는 multi-agent 시스템** 으로
+> 정의하는 **최상위 조직 모델 SSoT** 다. 누가 무엇을 책임지고(office), 무엇이
+> 명시적으로 범위 밖인지(out-of-scope), 어떤 계층으로 의사결정이 흐르는지를
+> 한 곳에 고정한다.
+>
+> **이 문서는 조직 *모델* 이지 런타임 *구현* 이 아니다.** dispatch 코드 / 폴더
+> 이전 / validator 는 본 문서가 land 된 뒤 별도 stage 에서 다룬다
+> ([`staged-agent-organization-roadmap.md`](staged-agent-organization-roadmap.md)).
+>
+> 동기 문서: 부서↔office 매핑은 [`agent-office-map.md`](agent-office-map.md),
+> 네이밍 규칙은 [`naming-convention.md`](naming-convention.md), 단계 로드맵은
+> [`staged-agent-organization-roadmap.md`](staged-agent-organization-roadmap.md).
+> 기존 부서 매트릭스(현재 reality)는
+> [`policies/runtime/agents/corporate-org-chart.md`](../../policies/runtime/agents/corporate-org-chart.md).
+
+## 0. 한 줄 요약
+
+- **operator(유찬)** = 인간 최종 승인자. 모든 L4(secret/deploy/merge) 게이트의 종착점.
+- **CEO / forge-master** = 최상위 오케스트레이터. goal 을 office 로 라우팅하고
+  일/주 단위로 종합한다. **직접 코드를 쓰지 않는다.**
+- **C-level office** = 도메인 책임 단위(10개). 각 office 는 division → team →
+  agent 로 내려간다.
+- **Engineering(CTO) 만 현재 런타임 실재** — 나머지 office 는 본 모델에서 정의되되
+  데이터/문서부터 채운다(roadmap 참조).
+
+## 1. 계층 (Hierarchy)
+
+```text
+operator / 유찬                      인간. 최종 승인(L4). 방향 설정.
+└── CEO / forge-master               최상위 오케스트레이터 (goal 라우팅·종합)
+    └── C-level Office (10)           도메인 책임 단위
+        └── Division                  office 내부 큰 책임 묶음
+            └── Team                   실행 단위 (lead + member agents)
+                └── Agent (role)       단일 도메인 실행/자문 주체
+```
+
+각 계층의 책임 경계:
+
+| 계층 | 결정하는 것 | 하지 않는 것 |
+|---|---|---|
+| operator | 방향, L4 승인, 정책 변경 승인 | 일상 실행 |
+| CEO/forge-master | goal→office 라우팅, 우선순위, 일/주 종합 | 코드 작성, office 내부 실행 |
+| C-level office | 도메인 전략, division 간 조율, technical/operator 승인 표면 | 다른 office 의 owns 침범 |
+| division | 팀 간 실행 순서, 산출물 통합 | 팀 전문 실행 대행 |
+| team | 작업 분해, lead 라우팅, evidence 생산 | 다른 팀 owns 침범, 자동 머지 |
+| agent (role) | 단일 도메인 draft/실행/리뷰 | 외부 직접 회신(gateway 경유), 단독 write 정책 위반 |
+
+## 2. C-level Office 정의 (10)
+
+각 office 의 mission / owned domains / out-of-scope / escalation. division·team·
+role 의 상세 계약은 roadmap 의 Stage 1~2 에서 office 별로 확장한다. **Engineering
+은 이미 4→8→12 성장 경로가 정의돼 있으므로 여기서 중복하지 않고 링크만 한다.**
+
+### 2.1 CEO / forge-master
+- **mission**: goal 을 받아 office 로 라우팅하고, office 산출물을 일/주 단위로
+  종합해 operator 에게 보고. 자율 운영의 척추.
+- **owned domains**: goal intake, office routing, daily/weekly synthesis, cross-office 우선순위.
+- **out-of-scope**: 코드 작성, office 내부 실행 결정, operator approval 대행.
+- **escalation**: → operator.
+
+### 2.2 COO / operations-director
+- **mission**: 24h 운영과 goal review 루프. scheduler/queue/alert 가 끊기지 않게.
+- **owned domains**: 시간 tick 운영, goal periodic review, blocked queue triage, alert.
+- **out-of-scope**: 제품 도메인 코드, 콘텐츠 생산.
+- **escalation**: → CEO → operator.
+
+### 2.3 CTO / engineering-director
+- **mission**: 코드·런타임·플랫폼·품질. ForgeKit self-improvement 의 실행 엔진.
+- **owned domains**: forgekit core, platform/runtime, skill R&D, QA/governance,
+  reality-check (4→8→12 팀 — 아래 링크).
+- **성장 경로(중복 금지, 링크)**: machine-readable SSoT =
+  [`agents/engineering-agent/manifest.json`](../../agents/engineering-agent/manifest.json)
+  의 `team_topology`, 사람용 =
+  [`team-structure.md`](../../policies/runtime/agents/engineering-agent/team-structure.md),
+  현재 land 중인 logical MVP topology = **PR #454** (4-core-team 한정).
+- **out-of-scope**: 콘텐츠 생산, 투자 리서치, 법률 판단.
+- **escalation**: technical=tech-lead, operator=gateway → operator.
+
+### 2.4 CPO / product-goal-director
+- **mission**: goal/PRD/제품 패턴/우선순위. 문제와 수용 기준을 고정.
+- **owned domains**: discovery→PRD, PMBrief, 제품 우선순위, 제품 패턴 분석.
+- **out-of-scope**: 기술 결정/구현(→CTO), 마케팅.
+- **escalation**: → CTO(구현), CEO.
+
+### 2.5 CDO / knowledge-data-director
+- **mission**: 지식 데이터화. vault/Nexus/retrieval 품질.
+- **owned domains**: vault schema, Nexus ingest, retrieval eval, canonical knowledge,
+  compact→vault.
+- **out-of-scope**: 기능 코드, 배포.
+- **escalation**: → CTO/CSO.
+
+### 2.6 CMO / content-growth-director
+- **mission**: 콘텐츠·YouTube 자동화·그로스.
+- **owned domains**: 영상 기획, 스크립트, SEO, 배포 자동화, 그로스 실험.
+- **out-of-scope**: 코어 코드, 투자/법률.
+- **escalation**: → CEO.
+
+### 2.7 CRO / revenue-opportunity-director
+- **mission**: 수익 클론 프로젝트·제품 기회·시장 적합 분석.
+- **owned domains**: opportunity scout, 클론 후보 spec, 제품 패턴→수익 가설.
+- **out-of-scope**: 코어 보안 게이트, 법률 최종 판단.
+- **escalation**: → CPO/CTO.
+
+### 2.8 CFO / finance-investment-director
+- **mission**: 예산·토큰 비용·투자(주식/시장/부동산) 리서치.
+- **owned domains**: 비용 추적(/cost), 예산 리포트, 시장/부동산 리서치 brief.
+- **out-of-scope**: 실거래 실행, 코드 작성.
+- **escalation**: → operator.
+
+### 2.9 CHRO / personal-growth-director
+- **mission**: operator 의 백엔드/DevOps 커리어 성장.
+- **owned domains**: 학습 경로, 커리큘럼, 1:1 코칭 산출물, 스킬 갭 분석.
+- **out-of-scope**: 코어 실행, 외부 채용(개인 성장 한정).
+- **escalation**: → operator.
+
+### 2.10 CLO / legal-risk-director
+- **mission**: 라이선스·프라이버시·리스크 게이트.
+- **owned domains**: OSS 라이선스 검토, 프라이버시, 외부 도입 리스크 verdict.
+- **out-of-scope**: 실행, 구현.
+- **escalation**: → operator.
+
+### 2.11 CSO / strategy-intelligence-director
+- **mission**: 시그널 수집·아이디어 생성·전략 인텔리전스.
+- **owned domains**: discovery sweep, 트렌드 digest, IdeaBrief, 전략 가설.
+- **out-of-scope**: 실행, 구현.
+- **escalation**: → CEO.
+
+## 3. goal 역량 → office 매핑
+
+operator 가 요구한 9개 역량이 어느 office 로 흐르는지(primary/보조):
+
+| goal 역량 | primary | 보조 |
+|---|---|---|
+| 1. ForgeKit self-improvement | CTO | CSO |
+| 2. 24h goal review / 자율 운영 | COO | CEO |
+| 3. signal 수집 / 아이디어 생성 | CSO | CDO |
+| 4. 백엔드/DevOps 커리어 성장 | CHRO | CTO |
+| 5. 주식/시장/부동산 리서치 | CFO | CSO |
+| 6. 콘텐츠/YouTube 자동화 | CMO | CDO |
+| 7. skill/tool 리서치(Claude Code·Codex·MCP·OpenClaw·Hermes·Harness·Ponytail) | CTO(skill-rnd) | CDO |
+| 8. 수익 클론/제품 패턴 분석 | CRO | CPO |
+| 9. strict reality-check | CTO(reality-check-team) | CLO |
+
+## 4. 명시적 Out-of-Scope (이 문서 / 이 단계)
+
+- ❌ 런타임 dispatch 구현 (office→team→role resolver) — Stage 4.
+- ❌ 폴더 physical migration (role→team/office 폴더) — Stage 5, 별도 제안서.
+- ❌ CODEOWNERS / GitHub native enforcement — 후속 단계.
+- ❌ 신규 validator / ownership engine / registry 프레임워크.
+- ❌ goal runtime 수정 — 본 문서는 **target behavior 만 기술**(§5), 구현 안 함.
+- ❌ Engineering 성장 경로 중복 정의 — manifest `team_topology` + PR #454 가 SSoT, 본 문서는 링크.
+- ❌ 비-engineering office 의 즉시 런타임화 — 데이터/문서부터.
+
+## 5. Target Behavior — Goal Closed-Loop (구현 아님, 목표 기술)
+
+reality-check 의 기준선. goal 은 "저장+조회" 가 아니라 아래 **closed-loop** 여야
+한다. 본 문서는 이를 **목표 동작** 으로 고정하되 구현하지 않는다 — 실제 어디까지
+닫혔는지는 reality-check-team 의 evidence 감사가 판정한다([roadmap I-7](staged-agent-organization-roadmap.md)).
+
+```text
+goal 생성
+  → scheduler 등록
+  → periodic goal review
+  → next action 생성
+  → agent assignment (office→team→role)
+  → agent run
+  → evidence 저장
+  → blocked / approval queue
+  → daily / weekly report
+```
+
+**reality-check 원칙**: "저장됐지만 실행 안 됨"(stored-not-executed)은 done 이
+아니다. 각 단계는 evidence 로 증명돼야 한다(코드 존재 ≠ 동작).
+
+## 6. 동기화
+
+본 문서를 변경하면 다음만 갱신(중복 회피):
+
+- [`agent-office-map.md`](agent-office-map.md) — office↔부서 매핑이 바뀌면
+- [`naming-convention.md`](naming-convention.md) — 네이밍 규칙이 바뀌면
+- [`staged-agent-organization-roadmap.md`](staged-agent-organization-roadmap.md) — 단계/issue 가 바뀌면
+- [`AGENTS.md`](../../AGENTS.md) §2 / root [`CLAUDE.md`](../../CLAUDE.md) — 새 SSoT 등록(읽기 우선순위)
+- [`policies/runtime/agents/corporate-org-chart.md`](../../policies/runtime/agents/corporate-org-chart.md) — 현재 부서 reality 와 어긋나면

--- a/docs/company/naming-convention.md
+++ b/docs/company/naming-convention.md
@@ -1,0 +1,67 @@
+# Agent Organization Naming Convention
+
+> 본 문서는 ForgeKit company 모델([`forgekit-company-model.md`](forgekit-company-model.md))
+> 의 office / division / team / role(agent) **네이밍 규칙 SSoT** 다. 식별자가
+> 흩어지면 dispatch·문서·테스트가 silently 어긋나므로 한 곳에 고정한다.
+>
+> 식별자(역할) 정규화의 코드 SSoT 는 기존
+> `forgekit_config.identity.registry`(`be`→`backend-engineer`) — 본 문서는 그
+> 위의 조직 레벨 명명 규칙을 더한다. 충돌 시 registry 가 우선.
+
+## 1. 계층별 명명 규칙
+
+| 계층 | 형식 | 예 | 비고 |
+|---|---|---|---|
+| office | `<C-level> / <role-noun>-director` | `CTO / engineering-director` | C-level 약어 + 사람용 director 명 |
+| office id | `<kebab>-office` 또는 부서 id | `engineering-agent` | 현재 부서 id 와 호환 유지 |
+| director | `<domain>-director` | `operations-director`, `forge-master`(CEO 예외) | CEO 만 `forge-master` |
+| division | `<domain>-division` | `platform-runtime-division` | office 내부 큰 묶음 |
+| team | `<domain>-team` 또는 `<domain>-lab` | `forgekit-core-team`, `revenue-product-lab` | 실험 성격은 `-lab` 허용 |
+| role (agent) | `<domain>-<function>` | `backend-engineer`, `tech-lead`, `reality-checker` | registry 정규화 대상 |
+
+### 규칙 디테일
+- **office**: 사람용 표기는 `CTO / engineering-director` 처럼 약어+director 병기.
+  머신 식별자는 기존 부서 id(`engineering-agent`)를 그대로 쓴다 — 폴더를 안 옮기므로.
+- **CEO 예외**: 최상위는 `forge-master`(브랜드명). director 접미사 안 씀.
+- **team**: 기본 `-team`. 탐색/실험 성격이 본질인 팀만 `-lab`(예: `revenue-product-lab`).
+  이미 `team_topology` 에 박힌 id 가 SSoT — 새로 만들 때만 본 규칙 적용.
+- **role**: 소문자 kebab, `<domain>-<function>`. 1 역할 = 1 책임 axis(corporate-org-chart 단일책임 원칙).
+
+## 2. 예약/특수 식별자
+
+| 식별자 | 의미 | 규칙 |
+|---|---|---|
+| `forge-master` | CEO | 유일. director 접미사 없음 |
+| `tech-lead` | engineering technical 승인자 | `-engineer` 안 붙임(lead 역할) |
+| `gateway` | 부서 operator/라우팅 표면 | role 이 아니라 표면. council seat 아님 |
+| `reality-checker` | reality-check 실행 role | reality-check-team 소속(미래) |
+| `ops-observer` | cross-cutting 관측 | council seat 아님(auxiliary) |
+
+## 3. 충돌 회피 규칙
+
+- 같은 도메인 단어를 office/team/role 에 동시에 쓸 때 **접미사로 계층을 구분**한다:
+  `platform-runtime-division`(div) vs `platform-runtime-team`(team) vs
+  `platform-runtime-engineer`(role).
+- team 과 division 이 1:1 로 승격되는 경우(Growth→Target) id 접미사만 `-team`→`-division`.
+  내용 중복 정의 금지 — `team_topology.growth_path` 가 4→8→12 승격을 표현한다(SSoT).
+- 부서 id(`<x>-agent`)와 office 표기(`<x>-director`)는 **다른 레이어** — 혼용 금지.
+
+## 4. 머신 vs 사람 표기
+
+| 맥락 | 표기 |
+|---|---|
+| 폴더/manifest/코드 식별자 | 머신 id (`engineering-agent`, `backend-engineer`, `forgekit-core-team`) |
+| 문서/리포트/대화 | 사람용 (`CTO / engineering-director`, `백엔드 엔지니어`) |
+| decision log / trail | registry 정규화 id (`tech-lead`, `backend-engineer`) |
+
+## 5. 신규 식별자 추가 절차
+
+1. 본 문서 §1 형식 확인.
+2. 머신 id 가 기존 `team_topology` / `forgekit_config.identity.registry` 와 충돌 안 하는지 확인.
+3. office/team 추가면 [`agent-office-map.md`](agent-office-map.md) 매핑표 갱신.
+4. role 추가면 해당 부서 manifest `members` + corporate-org-chart 매트릭스 갱신.
+
+## 6. 동기화
+
+- 네이밍 규칙 변경 → 본 문서 + [`forgekit-company-model.md`](forgekit-company-model.md) §1.
+- 머신 id 규칙은 `forgekit_config.identity.registry` 가 코드 SSoT — 본 문서는 조직 레이어만.

--- a/docs/company/staged-agent-organization-roadmap.md
+++ b/docs/company/staged-agent-organization-roadmap.md
@@ -1,0 +1,80 @@
+# Staged Agent Organization Roadmap
+
+> 본 문서는 ForgeKit company 모델([`forgekit-company-model.md`](forgekit-company-model.md))
+> 을 **무리 없이 단계적으로** 실재화하는 로드맵 SSoT 다. 핵심 원칙:
+> **logical-first, physical-deferred** — 데이터/문서/계약을 먼저 고정하고,
+> dispatch 코드와 폴더 이전은 그 위에 마지막으로.
+>
+> 각 stage 는 독립 issue 로 쪼갠다. 본 문서(I-1)는 **Stage 1 의 문서 산출물** 이다.
+
+## 0. 원칙
+
+- **선언 ≠ 동작.** topology/office 를 문서에 쓴 것은 "정의" 일 뿐, dispatch 코드가
+  해석하기 전까지 런타임은 모른다.
+- **reduce-surface.** 기존 council/lane/goal_governance 위에 얇게 얹는다. 신규
+  dispatch 엔진/registry 프레임워크/validator 금지.
+- **reality-check first.** "구현했다" 보다 "동작을 evidence 로 증명했다" 가 우선.
+
+## 1. Stage 개요
+
+| Stage | 이름 | 산출물 | 코드 변경 | 상태 |
+|---|---|---|---|---|
+| 0 | Inventory | 현재 agents/manifest/policy/test 목록 | 없음 | ✅ 완료(design report) |
+| 1 | Company model design | 본 4개 문서(company-model/office-map/naming/roadmap) | 없음(문서만) | ⏳ **이 issue (I-1)** |
+| 2 | Agent contract model | trigger/input/output/permission/gate 계약 문서 | 없음(문서만) | 예정(I-3) |
+| 3 | Team topology alignment | role→team 매핑 데이터 확장(engineering 8/12) | 데이터만 | 부분(PR #454=MVP 4) |
+| 4 | Runtime dispatch | office→team→role resolver + work packet + 테스트 | 코드(얇게) | 예정(I-5/I-6) |
+| 5 | Physical folder migration | 폴더 이전 **제안서** → 승인 시 이전 | 별도 PR | 보류(dispatch 동작 후) |
+
+## 2. Issue 목록 (I-1 ~ I-8)
+
+| # | issue | stage | office | 선행 | 종류 |
+|---|---|---|---|---|---|
+| **I-1** | Company model 블루프린트 land(본 4개 문서) | 1 | CEO | — | **docs (현재)** |
+| I-2 | 비-engineering 6개 부서 manifest 채우기(type/members) | 3 | 각 office | I-1 | data |
+| I-3 | Agent contract model 문서(trigger/input/output/permission/gate) | 2 | CTO | I-1 | docs |
+| I-4 | engineering 8/12 topology 데이터 확장 | 3 | CTO | PR #454 | data |
+| I-5 | team→role resolver + TeamWorkPacket + 테스트 | 4 | CTO | I-4 | code |
+| I-6 | office→team 라우팅(goal_governance 위에 얹기) | 4 | COO/CEO | I-5 | code |
+| I-7 | reality-check-team 계약 + goal 9단계 closed-loop evidence 감사 | 2/4 | qa-gov | I-3 | docs+audit |
+| I-8 | 폴더 physical migration 제안서 | 5 | CTO | I-5 동작 후 | proposal |
+
+## 3. Stage 1 (I-1) 완료 기준
+
+본 issue 가 land 되면:
+
+- [x] operator → CEO → C-level → Office → Division → Team → Agent 계층 문서화
+      ([`forgekit-company-model.md`](forgekit-company-model.md) §1).
+- [x] 10개 C-level office mission/owned/out-of-scope/escalation 정의(§2).
+- [x] office↔부서 매핑 + 현재 reality 정직 표시
+      ([`agent-office-map.md`](agent-office-map.md)).
+- [x] office/division/team/role 네이밍 규칙([`naming-convention.md`](naming-convention.md)).
+- [x] Engineering 4→8→12 성장 경로는 **링크(중복 금지)** — manifest `team_topology` + PR #454.
+- [x] reality-check-team 을 **required future team** 으로 정의(company-model §3, 본 문서 I-7).
+- [x] goal closed-loop 을 **target behavior 로 기술**(구현 아님 — company-model §5).
+- [x] PR #454 는 **logical-only** 로 유지, 확장하지 않음.
+
+## 4. reality-check-team (required future team)
+
+Stage 2/4(I-7)에서 계약을 확정할 **필수 미래 팀**. company-model §5 의 goal
+closed-loop 을 기준선으로 쓴다.
+
+- **소속**: 출발은 qa-governance-team, Target(12팀)에서 독립 가능.
+- **mission**: surface-level 구현 차단, user intent vs 실제 runtime behavior 대조.
+- **hard rule**: "stored-not-executed" 거부, evidence 없으면 done 불가.
+- **output**: `RealityVerdict{intent, observed_behavior, gap[], evidence_required[], verdict: real/surface/stored-not-executed}`.
+- **첫 과제**: goal 9단계 중 실제로 어디까지 closed-loop 인지 evidence 로 증명
+  (코드 `goal_governance.py`/`goal_scheduler_tick.py`/`goal_exec_tick.py` 존재 ≠ 동작).
+
+## 5. 이 단계에서 하지 않는 것 (명시)
+
+- ❌ 런타임 dispatch 구현(Stage 4).
+- ❌ 폴더 이전(Stage 5, 별도 제안서).
+- ❌ CODEOWNERS / validator / ownership engine / registry 프레임워크.
+- ❌ goal runtime 수정.
+- ❌ PR #454 확장.
+
+## 6. 동기화
+
+- stage/issue 가 바뀌면 본 문서 + [`forgekit-company-model.md`](forgekit-company-model.md) §4.
+- 새 SSoT 등록은 [`AGENTS.md`](../../AGENTS.md) §2 + root [`CLAUDE.md`](../../CLAUDE.md) 읽기 우선순위.


### PR DESCRIPTION
## 📌 관련 이슈
- close #455

## 🎯 목적
대규모 ForgeKit company-style agent 조직 블루프린트를 새 SSoT로 land한다 (**문서 전용**). 기존 `team_topology`(engineering 내부 4팀 분류)를 회사 규모(CEO/forge-master + 10 C-level office) 모델로 끌어올린다.

## 📐 범위 (docs only)
| 파일 | 내용 |
|---|---|
| `docs/company/forgekit-company-model.md` | operator→CEO→10 office→division→team→agent 계층, office별 mission/owned/out-of-scope/escalation, goal 9역량→office 매핑, goal closed-loop **target behavior** |
| `docs/company/agent-office-map.md` | office↔부서 매핑 + 부서 manifest reality(engineering만 완비) 정직 표시 |
| `docs/company/naming-convention.md` | office/division/team/role 명명 규칙 |
| `docs/company/staged-agent-organization-roadmap.md` | Stage 0~5, I-1~I-8, reality-check-team 정의 |
| `AGENTS.md` / `CLAUDE.md` | 새 SSoT 읽기 우선순위 등록 (cross-link 1줄씩) |

## ✅ Acceptance Criteria
- [x] CEO/C-level/Office/Division/Team/Agent 계층 문서화
- [x] Engineering 4→8→12 은 **링크(중복 금지)** — `team_topology` + PR #454
- [x] reality-check-team = required future team 정의
- [x] goal closed-loop = target behavior 문서화(구현 X)
- [x] PR #454 logical-only 유지, 확장 안 함

## ⚠️ 리스크
- LOW. 문서만. 코드/런타임/폴더/CODEOWNERS/validator 변경 0.

## 🚫 Out of scope (명시)
- 런타임 dispatch, 폴더 physical migration, CODEOWNERS, validator, goal runtime 수정.

## 🤖 Agent WorkOS Audit
- branch: `docs/forgekit-company-model-blueprint` (from `origin/main` 86d06d8)
- role: engineering-agent/tech-lead | stage 1 (company model design)
- commits: 3 (model+map / naming+roadmap / AGENTS·CLAUDE 등록)
- merge: **operator 승인 전까지 머지 안 함** (no auto-merge)